### PR TITLE
fix(vcf): correct sample/genotype permutation in VCF.set_samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.3.1 (2026-05-11)
+
+### Fix
+
+- `VCF.set_samples`: use the correct permutation when reordering cyvcf2's
+  per-variant genotype array. The previous implementation applied
+  `np.argsort(s_idx)` — the inverse of the permutation needed — which
+  silently desynced sample names from their genotypes whenever the input
+  VCF column order wasn't already alphabetical. Surfaced via
+  [mcvickerlab/GenVarLoader#159](https://github.com/mcvickerlab/GenVarLoader/issues/159).
+
 ## 2.3.0 (2026-05-08)
 
 ### Feat

--- a/genoray/_vcf.py
+++ b/genoray/_vcf.py
@@ -360,9 +360,18 @@ class VCF:
             )
 
         vcf = self._open()
-        _, s_idx, _ = np.intersect1d(vcf.samples, samples, return_indices=True)
+        _, vcf_idx, samples_idx = np.intersect1d(
+            vcf.samples, samples, return_indices=True
+        )
         self._samples = samples
-        self._s_sorter = np.argsort(s_idx)
+        # ``vcf_idx`` lists VCF-file positions in sorted-common order. Reorder
+        # to the caller's ``samples`` order so that
+        # ``v.genotype.array()[self._s_sorter]`` returns rows in the order the
+        # caller asked for. Previously this used ``np.argsort(s_idx)``, which
+        # is the *inverse* permutation — correct only when ``samples`` was
+        # already in the VCF's column order, silently wrong otherwise. See
+        # https://github.com/mcvickerlab/GenVarLoader/issues/159
+        self._s_sorter = vcf_idx[np.argsort(samples_idx)]
         self._vcf = vcf
         return self
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genoray"
-version = "2.3.0"
+version = "2.3.1"
 description = "Add your description here"
 authors = [{ name = "David Laub", email = "dlaub@ucsd.edu" }]
 readme = "README.md"

--- a/tests/data/gen_from_vcf.sh
+++ b/tests/data/gen_from_vcf.sh
@@ -7,6 +7,7 @@ ddir=$(realpath "$ddir")
 
 bi=$ddir/biallelic.vcf
 multi=$ddir/multiallelic.vcf
+unsorted=$ddir/three_samples_unsorted.vcf
 
 echo "Bgzipping and indexing VCF files..."
 bgzip -c "$bi" >| "$bi".gz
@@ -16,6 +17,10 @@ rm -f "$bi".gz.gvi
 bgzip -c "$multi" >| "$multi".gz
 bcftools index "$multi".gz
 rm -f "$multi".gz.gvi
+
+bgzip -c "$unsorted" >| "$unsorted".gz
+bcftools index "$unsorted".gz
+rm -f "$unsorted".gz.gvi
 
 echo "Converting VCF to PLINK format..."
 prefix="${bi%.vcf}"

--- a/tests/data/three_samples_unsorted.vcf
+++ b/tests/data/three_samples_unsorted.vcf
@@ -1,0 +1,5 @@
+##fileformat=VCFv4.2
+##contig=<ID=chr1,length=200>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_C	sample_A	sample_B
+chr1	100	.	T	A	.	.	.	GT	0|1	1|1	0|0

--- a/tests/test_vcf_set_samples.py
+++ b/tests/test_vcf_set_samples.py
@@ -1,0 +1,71 @@
+"""Regression test for sample/genotype alignment in :meth:`VCF.set_samples`.
+
+Reproduces the bug surfaced upstream as
+`mcvickerlab/GenVarLoader#159 <https://github.com/mcvickerlab/GenVarLoader/issues/159>`_.
+
+The bug appears whenever the input VCF's sample column order isn't already
+alphabetical: ``set_samples`` was computing ``np.argsort(s_idx)`` where it
+should have been computing the permutation that sends caller-requested
+sample order to VCF column order. With pre-sorted samples (the case
+exercised by every other fixture in this test directory) the buggy and
+correct permutations happen to coincide, so the bug was invisible until
+someone fed in a cohort BCF with samples in non-alphabetical order.
+
+The fixture used here has samples laid out in file order
+``[sample_C, sample_A, sample_B]`` — deliberately not alphabetical — with
+one phased SNV at ``chr1:100 T>A`` and unambiguous per-sample GTs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from genoray._vcf import VCF
+
+DDIR = Path(__file__).parent / "data"
+
+# Per-sample phased GTs encoded in the fixture at chr1:100 T>A:
+# sample_C -> 0|1   sample_A -> 1|1   sample_B -> 0|0
+_FIXTURE_GT = {
+    "sample_A": (1, 1),
+    "sample_B": (0, 0),
+    "sample_C": (0, 1),
+}
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [
+        # Alphabetical user order against non-alphabetical VCF column order —
+        # the case `gvl.write` triggers in practice.
+        ["sample_A", "sample_B", "sample_C"],
+        # Non-alphabetical user order — both directions of the permutation
+        # have to compose correctly.
+        ["sample_C", "sample_B", "sample_A"],
+        # Subset, non-alphabetical.
+        ["sample_C", "sample_A"],
+    ],
+)
+def test_set_samples_preserves_genotype_alignment(requested: list[str]) -> None:
+    """``gt[i, p, 0]`` must equal ``_FIXTURE_GT[requested[i]][p]`` for every (i, p)."""
+    vcf = VCF(DDIR / "three_samples_unsorted.vcf.gz", phasing=False)
+    vcf.set_samples(requested)
+    # read returns shape (n_samples, ploidy, n_variants); we have 1 variant.
+    gt = vcf.read("chr1", 99, 100, VCF.Genos8)
+    expected = np.array(
+        [[_FIXTURE_GT[s][0], _FIXTURE_GT[s][1]] for s in requested], dtype=np.int8
+    )
+    assert gt is not None, "fixture variant chr1:100 missing from VCF"
+    np.testing.assert_array_equal(
+        gt[..., 0],
+        expected,
+        err_msg=(
+            f"requested order: {requested!r}\n"
+            f"observed: {gt[..., 0].tolist()}\n"
+            f"expected: {expected.tolist()}"
+        ),
+    )
+    assert vcf.current_samples == requested


### PR DESCRIPTION
Fixes the sample/genotype alignment bug surfaced upstream as [mcvickerlab/GenVarLoader#159](https://github.com/mcvickerlab/GenVarLoader/issues/159).

## Root cause

`VCF.set_samples` was assigning `np.argsort(s_idx)` to `_s_sorter`. That is the **inverse** of the permutation needed to translate the caller's requested sample order into positions in cyvcf2's per-variant genotype array. Every consumer of `_s_sorter` (`v.genotype.array()[self._s_sorter]` and ~13 similar sites in `_vcf.py`) was therefore returning genotypes that didn't correspond to the names in `current_samples` whenever the input VCF's sample column order wasn't already alphabetical.

When the input VCF *was* alphabetical, the buggy and correct permutations coincide — which is why every existing fixture in `tests/data/` (`biallelic.vcf`, `multiallelic.vcf` — both pre-sorted) passed silently.

## Fix

`genoray/_vcf.py` lines 362-367:

```diff
 vcf = self._open()
-_, s_idx, _ = np.intersect1d(vcf.samples, samples, return_indices=True)
+_, vcf_idx, samples_idx = np.intersect1d(
+    vcf.samples, samples, return_indices=True
+)
 self._samples = samples
-self._s_sorter = np.argsort(s_idx)
+# ``vcf_idx`` lists VCF-file positions in sorted-common order. Reorder
+# to the caller's ``samples`` order so that
+# ``v.genotype.array()[self._s_sorter]`` returns rows in the order the
+# caller asked for. Previously this used ``np.argsort(s_idx)``, which
+# is the *inverse* permutation — correct only when ``samples`` was
+# already in the VCF's column order, silently wrong otherwise.
+self._s_sorter = vcf_idx[np.argsort(samples_idx)]
 self._vcf = vcf
 return self
```

`samples_idx[k]` is the position in the caller's `samples` of `sorted_common[k]`. `argsort(samples_idx)` therefore gives, for each caller-order position `j`, the `k` such that `sorted_common[k] == samples[j]`. Indexing `vcf_idx` by that yields the VCF-file position of `samples[j]`, which is exactly what every downstream `[self._s_sorter]` indexer expects.

`PGEN.set_samples` was already correct via a different mechanism (`_s_unsorter` + `plink2.change_sample_subset`) — the VCF path needed its own fix because cyvcf2 always returns all samples and the slice is the only mechanism to map back to caller order.

## Regression test

New file `tests/test_vcf_set_samples.py` exercises three parametrizations against a new fixture `tests/data/three_samples_unsorted.vcf` whose sample columns are deliberately non-alphabetical (`sample_C, sample_A, sample_B`) with one phased SNV.

- All three cases **fail on `2.3.0`**.
- All three cases **pass on this branch**.
- All 41 existing VCF tests continue to pass.

## End-to-end verification

Reproducer from [GVL#159](https://github.com/mcvickerlab/GenVarLoader/issues/159) (3 samples × 1 SNP, fed to `gvl.write` with shuffled sample order) now matches expected output on both orderings:

| VCF sample order | Before (2.3.0) | After (this PR) |
|---|---|---|
| Alphabetical | ✓ correct | ✓ correct |
| Non-alphabetical | ✗ permuted | ✓ correct |

## Files changed

- `genoray/_vcf.py` — the fix (4 lines of substantive change + comment).
- `tests/test_vcf_set_samples.py` — 3 parametrized cases.
- `tests/data/three_samples_unsorted.vcf` — fixture.
- `tests/data/gen_from_vcf.sh` — bgzip+index the new fixture.
- `CHANGELOG.md` + `pyproject.toml` — bump to `2.3.1` (patch — bugfix, no API change).