### PR TITLE
fix: VCF set_samples now returns genotypes in requested sample order

### DIFF
--- a/genoray/_vcf.py
+++ b/genoray/_vcf.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Literal, TypeGuard, TypeVar, cast, overload
 
 import cyvcf2
+from hirola import HashTable
 import numpy as np
 import oxbow
 import polars as pl
@@ -294,6 +295,9 @@ class VCF:
         self.available_samples = vcf.samples
         self.contigs = natsorted(vcf.seqnames)
         self._c_norm = ContigNormalizer(vcf.seqnames)
+        avail = np.asarray(self.available_samples)
+        self._s2i = HashTable(max=len(avail) * 2, dtype=avail.dtype)
+        self._s2i.add(avail)
 
         self.set_samples(None)
 
@@ -360,9 +364,8 @@ class VCF:
             )
 
         vcf = self._open()
-        _, s_idx, _ = np.intersect1d(vcf.samples, samples, return_indices=True)
         self._samples = samples
-        self._s_sorter = np.argsort(s_idx)
+        self._s_sorter = self._s2i.get(np.asarray(samples))
         self._vcf = vcf
         return self
 

--- a/tests/test_pgen.py
+++ b/tests/test_pgen.py
@@ -160,6 +160,29 @@ def test_chunk_ranges(
                 np.testing.assert_allclose(d, dosages, rtol=1e-5)
 
 
+@parametrize_with_cases("pgen", cases=".", prefix="pgen_", scope="session")
+def test_sample_reorder(pgen: PGEN):
+    # available_samples = ["sample1", "sample2"]
+    # sample1: genos [[0,-1],[1,-1]], dosages [1.0, nan]
+    # sample2: genos [[1, 0],[1, 1]], dosages [2.0, 1.0]
+    cse = "chr1", 81261, 81262
+    pgen.set_samples(["sample2", "sample1"])
+
+    g, p, d = pgen.read(*cse, PGEN.GenosPhasingDosages)
+
+    assert list(pgen.current_samples) == ["sample2", "sample1"]
+    # row 0 must be sample2, row 1 must be sample1
+    np.testing.assert_equal(
+        g, np.array([[[1, 0], [1, 1]], [[0, -1], [1, -1]]], np.int32)
+    )
+    np.testing.assert_equal(p, np.array([[1, 0], [1, 0]], np.bool_))
+    np.testing.assert_allclose(
+        d, np.array([[2.0, 1.0], [1.0, np.nan]], np.float32), rtol=1e-5
+    )
+
+    pgen.set_samples(None)  # reset for other tests
+
+
 def samples_none():
     samples = None
     return samples

--- a/tests/test_svar.py
+++ b/tests/test_svar.py
@@ -168,6 +168,16 @@ def test_read_ranges_sample_subset(
     np.testing.assert_equal(actual.offsets, desired.offsets)
 
 
+def test_read_ranges_sample_reorder(svar: SparseVar):
+    cse = "chr1", 81261, 81265
+    actual = svar.read_ranges(*cse, samples=["sample2", "sample1"])
+    desired = svar.read_ranges(*cse)[:, [1, 0]]
+
+    assert actual.shape == desired.shape
+    np.testing.assert_equal(actual.data, desired.data)
+    np.testing.assert_equal(actual.offsets, desired.offsets)
+
+
 def length_no_ext():
     cse = "chr1", 81264, 81265
     shape = (1, 2, 2, None)

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -158,15 +158,13 @@ def test_set_samples(
     if samples is None:
         samples = vcf.available_samples
         s_idx = slice(None)
-        s_sorter = slice(None)
     else:
         samples = np.atleast_1d(samples)
-        s_idx = np.intersect1d(vcf.available_samples, samples, return_indices=True)[1]
-        s_sorter = np.argsort(s_idx)
+        s_idx = vcf._s2i.get(np.asarray(samples))
 
     assert vcf.current_samples == samples
     assert vcf.n_samples == len(samples)
-    np.testing.assert_equal(vcf._s_sorter, s_sorter)
+    np.testing.assert_equal(vcf._s_sorter, s_idx)
 
     vcf.phasing = True
     gpd = vcf.read(*cse, VCF.Genos16Dosages)
@@ -180,6 +178,27 @@ def test_set_samples(
         np.testing.assert_equal(g, genos[s_idx])
         np.testing.assert_equal(p, phasing[s_idx])
         np.testing.assert_equal(d, dosages[s_idx])
+
+
+def test_sample_reorder(vcf: VCF):
+    # available_samples = ["sample1", "sample2"]
+    # sample1: genos [[0,-1],[1,-1]], dosages [1.0, nan]
+    # sample2: genos [[1, 0],[1, 1]], dosages [2.0, 1.0]
+    cse = "chr1", 81261, 81263
+    vcf.set_samples(["sample2", "sample1"])
+    vcf.phasing = True
+
+    gp, d = vcf.read(*cse, VCF.Genos8Dosages)
+    g, p = np.array_split(gp, 2, 1)
+    p = p.squeeze(1).astype(bool)
+
+    assert vcf.current_samples == ["sample2", "sample1"]
+    # row 0 must be sample2, row 1 must be sample1
+    np.testing.assert_equal(
+        g, np.array([[[1, 0], [1, 1]], [[0, -1], [1, -1]]], np.int8)
+    )
+    np.testing.assert_equal(p, np.array([[1, 0], [1, 0]], np.bool_))
+    np.testing.assert_equal(d, np.array([[2.0, 1.0], [1.0, np.nan]], np.float32))
 
 
 def length_no_ext():


### PR DESCRIPTION
Closes #41

## Summary
- `VCF.set_samples` was using `np.intersect1d` + `argsort` to compute `_s_sorter`, which always produces a sorted result — so requesting samples in non-file order silently returned them in file order instead
- Fix: build a `HashTable` over `available_samples` once at construction (matching the existing `PGEN` pattern), then call `.get()` in `set_samples` to map each requested sample to its file index in the requested order
- Adds explicit reversed-order tests for `VCF`, `PGEN`, and `SparseVar`

## Test plan
- [ ] `tests/test_vcf.py::test_sample_reorder` — was failing before fix, now passes
- [ ] `tests/test_pgen.py::test_sample_reorder` — was already passing (PGEN unaffected)
- [ ] `tests/test_svar.py::test_read_ranges_sample_reorder` — was already passing (SparseVar unaffected)
- [ ] Full `tests/test_vcf.py` and `tests/test_pgen.py` suites still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)