### PR TITLE
feat: add nbytes property to VCF/PGEN/SparseVar

### DIFF
--- a/genoray/_pgen.py
+++ b/genoray/_pgen.py
@@ -275,6 +275,24 @@ class PGEN:
         return len(self._s_unsorter)
 
     @property
+    def nbytes(self) -> int:
+        """Total in-memory footprint, in bytes, of resident (non-mmap'd) data
+        structures held by this reader. Sums the gvi variant index dataframe
+        and the StartsEndsIlens cache. Returns 0 after `_free_index()`.
+        """
+        n = 0
+        if self._index is not None:
+            n += self._index.estimated_size()
+        if self._sei is not None:
+            n += (
+                self._sei.v_starts.nbytes
+                + self._sei.v_ends.nbytes
+                + self._sei.ilens.nbytes
+                + self._sei.alt.estimated_size()
+            )
+        return n
+
+    @property
     def filter(self) -> pl.Expr | None:
         """Polars expression to filter variants. Should return True for variants to keep."""
         return self._filter

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -148,6 +148,14 @@ class SparseVar(Generic[_SRT]):
         """Number of variants in the dataset."""
         return self.index.height
 
+    @property
+    def nbytes(self) -> int:
+        """Total in-memory footprint, in bytes, of resident (non-mmap'd) data
+        held by this reader. Only the polars variant index counts; `genos`
+        and `fields` are memory-mapped and excluded.
+        """
+        return self.index.estimated_size()
+
     @overload
     def __init__(
         self: SparseVar[Ragged[V_IDX_TYPE]],

--- a/genoray/_vcf.py
+++ b/genoray/_vcf.py
@@ -327,6 +327,16 @@ class VCF:
         self._filter = filter
 
     @property
+    def nbytes(self) -> int:
+        """Total in-memory footprint, in bytes, of resident (non-mmap'd) data
+        structures held by this reader. Currently this is the gvi variant
+        index (CHROM/POS/REF/ALT/ILEN). Returns 0 before the index is loaded.
+        """
+        if self._index is None:
+            return 0
+        return self._index.estimated_size()
+
+    @property
     def current_samples(self) -> list[str]:
         """List of samples currently being read from the VCF file."""
         return self._samples

--- a/tests/test_pgen.py
+++ b/tests/test_pgen.py
@@ -396,3 +396,20 @@ def test_var_idxs(
     var_idxs, offsets = pgen.var_idxs(contig, starts, ends)
     assert np.array_equal(var_idxs, desired[0])
     assert np.array_equal(offsets, desired[1])
+
+
+def test_pgen_nbytes_positive_after_init():
+    # PGEN auto-loads the index in __init__ via _init_index
+    pgen = PGEN(ddir / "biallelic.pgen")
+    assert pgen._index is not None
+    assert pgen.nbytes > 0
+    # both the index dataframe and the StartsEndsIlens cache should contribute
+    assert pgen.nbytes >= pgen._index.estimated_size()
+
+
+def test_pgen_nbytes_zero_after_free():
+    pgen = PGEN(ddir / "biallelic.pgen")
+    pgen._free_index()
+    assert pgen._index is None
+    assert pgen._sei is None
+    assert pgen.nbytes == 0

--- a/tests/test_svar.py
+++ b/tests/test_svar.py
@@ -275,3 +275,10 @@ def test_with_fields_missing_raises():
 def test_available_fields(svar: SparseVar):
     assert "dosages" in svar.available_fields
     assert svar.available_fields["dosages"] == np.dtype(DOSAGE_TYPE)
+
+
+def test_svar_nbytes_index_only():
+    svar = SparseVar(ddir / "biallelic.vcf.svar")
+    # nbytes counts only the resident polars index, not the mmap'd genos/fields
+    assert svar.nbytes == svar.index.estimated_size()
+    assert svar.nbytes > 0

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -261,3 +261,21 @@ def test_chunk_with_length(
             np.testing.assert_equal(d, dosages)
             assert end == last_end
             assert n_ext == n_extension
+
+
+def test_nbytes_zero_before_index_loaded():
+    # _load_index is not called when with_gvi_index=False and no auto-load occurs
+    vcf = VCF(ddir / "biallelic.vcf.gz", with_gvi_index=False)
+    assert vcf._index is None
+    assert vcf.nbytes == 0
+
+
+def test_nbytes_positive_after_index_loaded():
+    vcf = VCF(ddir / "biallelic.vcf.gz")
+    if not vcf._valid_index():
+        vcf._write_gvi_index()
+    vcf._load_index()
+    assert vcf._index is not None
+    assert vcf.nbytes > 0
+    # sanity: at least one byte per row across CHROM/POS/REF/ALT
+    assert vcf.nbytes >= vcf._index.height


### PR DESCRIPTION
## Summary
- Adds a public `nbytes: int` property to `VCF`, `PGEN`, and `SparseVar` reporting the in-memory footprint of resident (non-mmap'd) data structures.
- `VCF.nbytes`: size of the loaded gvi index (0 if not loaded).
- `PGEN.nbytes`: index dataframe + `StartsEndsIlens` cache (numpy arrays + alt Series).
- `SparseVar.nbytes`: polars index only; `genos` and `fields` are memory-mapped and excluded.

Enables downstream consumers (e.g. GenVarLoader) to treat their `max_mem` budgets as true total caps by subtracting `reader.nbytes` before passing the remainder to chunked readers.

## Test plan
- [x] `pytest tests/test_vcf.py` — new `nbytes` tests pass
- [x] `pytest tests/test_pgen.py` — new `nbytes` tests pass
- [x] `pytest tests/test_svar.py` — new `nbytes` test passes
- [x] Full `pytest tests/` green (215 passed, 16 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)