### PR TITLE
test: audit & strengthen *_with_length coverage (+ VCF phasing bugfix)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-with-length-test-audit.md
+++ b/docs/superpowers/plans/2026-05-30-with-length-test-audit.md
@@ -1,0 +1,1068 @@
+# `*_with_length` Test Audit & Improvement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the coverage gaps in the `*_with_length` family (VCF/PGEN/SparseVar) with a richer indel fixture, a direct invariant-assertion helper, exact cross-backend parity (via a new private `_dense2sparse_with_length` bridge), and unit tests for the PGEN/SVAR length logic.
+
+**Architecture:** A new biallelic `indels.vcf` fixture with four isolated regions (big deletion, per-haplotype divergence, SNP-dense-after-big-deletion, deletion-near-contig-end) drives integration tests across all three backends. The per-haplotype length-accounting walk inside the SVAR numba helper is extracted into one shared njit function reused by both `_find_starts_ends_with_length` and the new `_dense2sparse_with_length`, so the dense and sparse code paths cannot drift. Parity is asserted exactly: PGEN≡VCF on dense output, and SVAR≡`_dense2sparse_with_length(dense output)`.
+
+**Tech Stack:** Python, NumPy, numba, polars, seqpro `Ragged`, cyvcf2, pgenlib, pytest, pytest-cases, Pixi. Spec: `docs/superpowers/specs/2026-05-30-with-length-test-audit-design.md`.
+
+---
+
+## Reference facts (verified against the codebase)
+
+- Run tests inside Pixi: `pixi run pytest <path>` (or `pixi run test` to also regenerate data).
+- Phantom types (`genoray/_pgen.py:40-130`): `Genos` is `(s p v)` int32; build via `Genos.parse(arr)`. `GenosPhasingDosages` is a 3-tuple. `Genos.empty(n_samples, ploidy, n_variants)`.
+- `hap_ilens(genotypes (s p v), ilens (v,)) -> (s p)` at `genoray/_utils.py:127` — sums ilens where `genos == 1`.
+- `dense2sparse(genos, var_idxs, dosages=None)` at `genoray/_svar.py:313` — `keep = genos == 1`, builds `Ragged[V_IDX_TYPE].from_offsets(data, (*lengths.shape, None), lengths_to_offsets(lengths))`.
+- Imports already in `genoray/_svar.py`: `from seqpro.rag import OFFSET_TYPE, Ragged, lengths_to_offsets` (line 30); `import numba as nb` (line 15); `from genoray._types import POS_TYPE, V_IDX_TYPE, DOSAGE_TYPE` (verify exact names in `_types.py`).
+- `_find_starts_ends_with_length` numba fn at `genoray/_svar.py:1929`, decorated `@nb.njit(parallel=False, nogil=True, cache=True)`. The inner per-haplotype walk is lines ~2001-2051.
+- SVAR method `_find_starts_ends_with_length` (`genoray/_svar.py:580`) passes `v_starts = (self.index["POS"] - 1).to_numpy()`, `ilens = self.index["ILEN"].list.first().to_numpy()`, `contig_max_idx = self._c_max_idxs[c]`.
+- `SparseVar.read_ranges_with_length` (`genoray/_svar.py:709`) returns `Ragged[V_IDX_TYPE]` with shape `(n_ranges, n_samples, ploidy, None)` and `.data` = global variant indices, `.offsets`.
+- PGEN `_chunk_ranges_with_length` (`genoray/_pgen.py:759`) yields, per range, a generator of `(data, end, var_idxs)`. `var_idxs` aligns with the variant axis of `data`.
+- PGEN `_gen_with_length` (`genoray/_pgen.py:986`) signature: `(v_chunks, q_start, q_end, read, v_starts, v_ends, ilens, contig_max_idx)`; `read: Callable[[NDArray[V_IDX_TYPE]], L]` where `L` is e.g. `Genos`; uses `isinstance(out, Genos)` to branch; doubling loop `_idx_extension *= 2` with `while (hap_lens < length).any()`.
+- VCF `_chunk_ranges_with_length` (`genoray/_vcf.py:749`) yields per range a generator of `(data, end, n_extension)`; genos dense `(s p v)` int8.
+- Coordinates: all queries 0-based half-open `[start, end)`. VCF POS is 1-based → 0-based start is `POS-1`.
+
+---
+
+## File Structure
+
+**Production**
+- `genoray/_svar.py` — add njit `_length_walk_n_keep` helper; refactor `_find_starts_ends_with_length` to call it; add `_dense2sparse_with_length`.
+
+**Test data**
+- `tests/data/indels.vcf` (new)
+- `tests/data/gen_from_vcf.sh` (add `indels` block)
+- `tests/data/gen_svar.py` (add `indels` conversions)
+- generated: `indels.vcf.gz`(+`.csi`), `indels.pgen`/`.psam`/`.pvar`(+`.gvi`), `indels.vcf.svar`, `indels.pgen.svar`
+
+**Tests**
+- `tests/_length_helpers.py` (new — invariant assertions, importable helper module; leading underscore so pytest does not collect it as a test file)
+- `tests/test_dense2sparse_with_length.py` (new — unit tests for the bridge)
+- `tests/test_parity.py` (new — cross-backend parity)
+- `tests/test_svar_internals.py` (extend — new SVAR cases)
+- `tests/test_pgen.py` (extend — `_gen_with_length` unit test + indels integration)
+- `tests/test_vcf.py` (extend — indels integration)
+- `tests/test_svar.py` (extend — `length_none` case)
+
+---
+
+## Task 1: Create the `indels.vcf` fixture and wire the generation pipeline
+
+**Files:**
+- Create: `tests/data/indels.vcf`
+- Modify: `tests/data/gen_from_vcf.sh`
+- Modify: `tests/data/gen_svar.py`
+
+- [ ] **Step 1: Write `tests/data/indels.vcf`**
+
+Four isolated regions on `chr1`, 2 phased samples, `GT:DS`. DS = count of ALT alleles. Region C's SNPs sit *after* the deletion's reference span (no spanning overlap) and are dense enough to force PGEN's multi-round extension.
+
+```
+##fileformat=VCFv4.2
+##contig=<ID=chr1>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DS,Number=1,Type=Float,Description="Dosage">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
+chr1	1000	.	GAAAAAAAAAA	G	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1011	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1013	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1015	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1017	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1019	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1021	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	2000	.	GAAAA	G	.	.	.	GT:DS	1|0:1.0	0|0:0.0
+chr1	2002	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	2004	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	2006	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3000	.	GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA	G	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+```
+
+Then append **40 SNPs** at POS `3031, 3032, …, 3070` (1bp apart), each `T	C` with `1|1:2.0	1|1:2.0`. (Generate these 40 lines programmatically when authoring the file; they are mechanical.) Region C is deliberately contrived — add a VCF comment line above POS 3000:
+`##COMMENT=Region C: -30 deletion + 40 dense SNPs, contrived to force PGEN's multi-round extension loop. Not a realistic genome.`
+
+Finally region D (deletion as the LAST variant on chr1):
+```
+chr1	5000	.	GAAAAAAAAAA	G	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+```
+
+Region intents (queries are 0-based; documented here for later tasks):
+- **A** big deletion: query `("chr1", 999, 1010)` (len 11). `-10` del carried both haps → extends across SNPs.
+- **B** per-hap: query `("chr1", 1999, 2006)` (len 7). `-4` del on sample1 hapA only → hapA extends more than hapB; sample2 not at all.
+- **C** SNP-dense: query `("chr1", 2999, 3030)` (len 31). `-30` del carried both haps → forces ≥2 PGEN extension rounds.
+- **D** clamp: query `("chr1", 4999, 5040)` (len 41). `-10` del is last variant → extension clamps, realized length < 41.
+
+- [ ] **Step 2: Add the `indels` block to `tests/data/gen_from_vcf.sh`**
+
+After the existing `unsorted` handling and before the SVAR conversion call, mirror the `biallelic` block (it uses `dosage=DS` and `--vcf-half-call r`):
+
+```bash
+indels=$ddir/indels.vcf
+
+bgzip -c "$indels" >| "$indels".gz
+bcftools index "$indels".gz
+rm -f "$indels".gz.gvi
+
+prefix="${indels%.vcf}"
+plink2 --make-pgen --vcf "$indels".gz 'dosage=DS' --out "$prefix" --vcf-half-call r
+rm -f "$prefix".log
+rm -f "$prefix".pvar.gvi
+```
+
+- [ ] **Step 3: Add `indels` conversions to `tests/data/gen_svar.py`**
+
+In `main()`, after the existing PGEN→SVAR block, add (mirroring the `biallelic` VCF and PGEN blocks):
+
+```python
+    # indels fixture (with_length edge cases)
+    ivcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+    ivcf._write_gvi_index()
+    ivcf_path = ddir / "indels.vcf.svar"
+    if ivcf_path.exists():
+        shutil.rmtree(ivcf_path)
+    max_mem = ivcf._mem_per_variant(ivcf.Genos8Dosages) * min(
+        len(ivcf.contigs), joblib.cpu_count()
+    )
+    SparseVar.from_vcf(ivcf_path, ivcf, max_mem, overwrite=True, with_dosages=True)
+    SparseVar(ivcf_path).cache_afs()
+
+    ipgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    ipgen_path = ddir / "indels.pgen.svar"
+    if ipgen_path.exists():
+        shutil.rmtree(ipgen_path)
+    assert ipgen.contigs is not None
+    max_mem = ipgen._mem_per_variant(ipgen.GenosDosages) * min(
+        len(ipgen.contigs), joblib.cpu_count()
+    )
+    SparseVar.from_pgen(ipgen_path, ipgen, max_mem, overwrite=True, with_dosages=True)
+    SparseVar(ipgen_path).cache_afs()
+```
+
+- [ ] **Step 4: Regenerate test data**
+
+Run: `cd tests/data && pixi run bash gen_from_vcf.sh`
+Expected: creates `indels.vcf.gz`, `indels.pgen`/`.psam`/`.pvar`, `indels.vcf.svar/`, `indels.pgen.svar/` with no errors.
+
+- [ ] **Step 5: Sanity-check the fixture loads and queries resolve**
+
+Run:
+```bash
+pixi run python -c "
+from pathlib import Path
+from genoray import VCF
+d = Path('tests/data')
+vcf = VCF(d/'indels.vcf.gz', dosage_field='DS')
+print('contigs', vcf.contigs)
+print('n_vars chr1', vcf.n_vars_in_ranges('chr1', 0, 10_000))
+"
+```
+Expected: `contigs` includes `chr1`; variant count is 53 (1+6 + 1+3 + 1+40 + 1).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/data/indels.vcf tests/data/gen_from_vcf.sh tests/data/gen_svar.py \
+        tests/data/indels.vcf.gz tests/data/indels.vcf.gz.csi \
+        tests/data/indels.pgen tests/data/indels.psam tests/data/indels.pvar \
+        tests/data/indels.vcf.svar tests/data/indels.pgen.svar
+git commit -m "test: add indels fixture for with_length edge cases"
+```
+
+---
+
+## Task 2: Extract shared length-walk helper and refactor `_find_starts_ends_with_length`
+
+This must be **behavior-preserving** — the existing `tests/test_svar_internals.py` regression tests guard it.
+
+**Files:**
+- Modify: `genoray/_svar.py` (add helper before line 1929; edit the numba walk ~2001-2051)
+- Test: `tests/test_svar_internals.py` (already exists — used as the guard)
+
+- [ ] **Step 1: Run the existing SVAR internals tests to confirm green baseline**
+
+Run: `pixi run pytest tests/test_svar_internals.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 2: Add the shared njit helper**
+
+Insert immediately above `@nb.njit(parallel=False, nogil=True, cache=True)` / `def _find_starts_ends_with_length` (`genoray/_svar.py:1929`):
+
+```python
+@nb.njit(nogil=True, cache=True)
+def _length_walk_n_keep(sp_genos, v_starts, ilens, start_idx, max_idx, q_start, q_end):
+    """Number of leading carried variants (from start_idx) to keep so one
+    haplotype reaches q_end - q_start in length, extending past q_end only as
+    needed. Variants strictly inside [q_start, q_end) are always kept; the
+    length budget only gates extension past q_end. Returns a count in
+    [0, max_idx - start_idx]."""
+    q_len = q_end - q_start
+    last_v_end = q_start
+    written_len = 0
+    i = -1
+    for j in range(start_idx, max_idx):
+        i = j - start_idx
+        v_idx = sp_genos[j]
+        v_start = v_starts[v_idx]
+        ilen = ilens[v_idx]
+
+        maybe_add_one = POS_TYPE(v_start >= q_start)
+        past_query = v_start >= q_end
+
+        if v_start >= q_start:
+            written_len += v_start - last_v_end
+            if past_query and written_len >= q_len:
+                i -= 1
+                break
+            written_len += max(0, ilen) + maybe_add_one
+            if past_query and written_len >= q_len:
+                break
+
+        v_end = v_start - min(0, ilen) + maybe_add_one
+        last_v_end = max(last_v_end, v_end)
+
+    return i + 1
+```
+
+- [ ] **Step 3: Replace the inner walk in `_find_starts_ends_with_length`**
+
+Replace the block from `q_start: POS_TYPE = q_starts[r]` through `out[1, r, s, p] = geno_idx + o_s + 1` (the per-`r` walk, ~lines 2001-2051) with a call to the helper:
+
+```python
+                n_keep = _length_walk_n_keep(
+                    sp_genos,
+                    v_starts,
+                    ilens,
+                    start_idx,
+                    max_idx,
+                    q_starts[r],
+                    q_ends[r],
+                )
+                out[1, r, s, p] = start_idx + o_s + n_keep
+```
+
+Keep everything above it (the `var_ranges[r,0]==var_ranges[r,1]` guard, `out[0,...] = start_idx + o_s`, and the `start_idx == max_idx` early-continue) unchanged. Equivalence check: original `end = geno_idx + o_s + 1` with `geno_idx = start_idx + i`; helper returns `n_keep = i + 1`, so `start_idx + o_s + n_keep = start_idx + i + 1 + o_s = geno_idx + o_s + 1`. The immediate-saturation `geno_idx -= 1` case maps to `i -= 1 → return 0`, giving `end = start_idx + o_s` (matches).
+
+- [ ] **Step 4: Run the regression tests to confirm behavior preserved**
+
+Run: `pixi run pytest tests/test_svar_internals.py tests/test_svar.py -v`
+Expected: PASS (all existing cases, including `test_find_starts_ends_with_length_includes_variant_at_query_edge`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_svar.py
+git commit -m "refactor: extract shared _length_walk_n_keep helper for with_length"
+```
+
+---
+
+## Task 3: Implement `_dense2sparse_with_length` with unit tests (TDD)
+
+**Files:**
+- Create: `tests/test_dense2sparse_with_length.py`
+- Modify: `genoray/_svar.py` (add `_dense2sparse_with_length` after `dense2sparse`, ~line 353)
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `tests/test_dense2sparse_with_length.py`:
+
+```python
+"""Unit tests for _dense2sparse_with_length (the dense->sparse parity bridge)."""
+
+from __future__ import annotations
+
+import numpy as np
+from seqpro.rag import OFFSET_TYPE
+
+from genoray._svar import _dense2sparse_with_length
+from genoray._types import V_IDX_TYPE
+
+
+def test_no_indels_keeps_all_carriers_within_query():
+    # 1 sample, ploidy 1, window of 3 SNPs all inside the query, all carried.
+    # genos (s p v)
+    genos = np.array([[[1, 1, 1]]], dtype=np.int8)
+    var_idxs = np.array([0, 1, 2], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 11, 12], dtype=np.int32)
+    ilens = np.array([0, 0, 0], dtype=np.int32)
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 13, v_starts, ilens)
+    # query len 3, three carried SNPs inside -> all kept
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 3], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(rag.data, np.array([0, 1, 2], dtype=V_IDX_TYPE))
+
+
+def test_deletion_forces_extension_past_query():
+    # 1 sample, ploidy 1. A -2 deletion at the query start consumes the
+    # length budget, so a variant past q_end must be kept to reach length.
+    genos = np.array([[[1, 1, 1]]], dtype=np.int8)
+    var_idxs = np.array([0, 1, 2], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 11, 20], dtype=np.int32)  # last is past q_end
+    ilens = np.array([-2, 0, 0], dtype=np.int32)        # deletion first
+    # query [10, 13): len 3. del removes 2 -> must extend past q_end.
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 13, v_starts, ilens)
+    # all three carriers kept (the post-query variant is needed)
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 3], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(rag.data, np.array([0, 1, 2], dtype=V_IDX_TYPE))
+
+
+def test_per_haplotype_independent_trim():
+    # 1 sample, ploidy 2. hapA carries a deletion (needs more), hapB does not.
+    # window vars: idx0 del, idx1 snp(in query), idx2 snp(past query)
+    genosA = [1, 1, 1]  # carries deletion + both snps
+    genosB = [0, 1, 0]  # only the in-query snp
+    genos = np.array([[genosA, genosB]], dtype=np.int8)
+    var_idxs = np.array([0, 1, 2], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 11, 20], dtype=np.int32)
+    ilens = np.array([-2, 0, 0], dtype=np.int32)
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 13, v_starts, ilens)
+    # hapA keeps all 3 carriers (0,1,2); hapB keeps its single in-query carrier (1)
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 3, 4], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(rag.data, np.array([0, 1, 2, 1], dtype=V_IDX_TYPE))
+
+
+def test_dosages_follow_genotypes():
+    genos = np.array([[[1, 1]]], dtype=np.int8)
+    var_idxs = np.array([5, 6], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 11], dtype=np.int32)
+    ilens = np.array([0, 0], dtype=np.int32)
+    dosages = np.array([[0.5, 0.9]], dtype=np.float32)  # (s v)
+    rag, drag = _dense2sparse_with_length(
+        genos, var_idxs, 10, 12, v_starts, ilens, dosages
+    )
+    np.testing.assert_array_equal(rag.data, np.array([5, 6], dtype=V_IDX_TYPE))
+    np.testing.assert_allclose(drag.data, np.array([0.5, 0.9], dtype=np.float32))
+
+
+def test_clamp_keeps_what_is_available():
+    # Window cannot reach target length (no variants past the deletion).
+    genos = np.array([[[1]]], dtype=np.int8)
+    var_idxs = np.array([0], dtype=V_IDX_TYPE)
+    v_starts = np.array([10], dtype=np.int32)
+    ilens = np.array([-5], dtype=np.int32)
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 30, v_starts, ilens)
+    # only the one carried variant is available -> kept; no error
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 1], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(rag.data, np.array([0], dtype=V_IDX_TYPE))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run pytest tests/test_dense2sparse_with_length.py -v`
+Expected: FAIL with `ImportError: cannot import name '_dense2sparse_with_length'`.
+
+- [ ] **Step 3: Implement `_dense2sparse_with_length`**
+
+Insert in `genoray/_svar.py` after the `dense2sparse` definition (after ~line 352). It walks each `(sample, haplotype)`'s carried variants with the shared `_length_walk_n_keep` helper, trims, and builds a `Ragged`:
+
+```python
+def _dense2sparse_with_length(
+    genos: NDArray[np.integer],
+    var_idxs: NDArray[V_IDX_TYPE],
+    q_start: int,
+    q_end: int,
+    v_starts: NDArray[np.int32],
+    ilens: NDArray[np.int32],
+    dosages: NDArray[DOSAGE_TYPE] | None = None,
+) -> Ragged[V_IDX_TYPE] | tuple[Ragged[V_IDX_TYPE], Ragged[DOSAGE_TYPE]]:
+    """Convert a dense ``with_length`` window (shared, over-extended across all
+    samples/haplotypes) into per-haplotype-minimal sparse output, identical to
+    ``SparseVar.read_ranges_with_length`` for the same query.
+
+    Parameters
+    ----------
+    genos
+        Dense genotypes for the window. Shape: (samples, ploidy, variants).
+    var_idxs
+        Global variant indices of the window. Shape: (variants,).
+    q_start, q_end
+        0-based, half-open original query span (before extension).
+    v_starts
+        0-based start positions of the window's variants (i.e. POS - 1).
+        Shape: (variants,).
+    ilens
+        ILEN of the window's variants (ALT - REF length). Shape: (variants,).
+    dosages
+        Optional dense dosages. Shape: (samples, variants).
+
+    Returns
+    -------
+        ``Ragged[V_IDX_TYPE]`` of shape (samples, ploidy, ~variants), or a tuple
+        with a matching ``Ragged[DOSAGE_TYPE]`` when ``dosages`` is given.
+    """
+    if genos.ndim != 3:
+        raise ValueError(
+            "Dense genotypes must have shape (samples, ploidy, variants)."
+        )
+    n_samples, ploidy, _ = genos.shape
+
+    lengths = np.empty((n_samples, ploidy), dtype=np.int64)
+    data_parts: list[NDArray[V_IDX_TYPE]] = []
+    dose_parts: list[NDArray[DOSAGE_TYPE]] = []
+
+    for s in range(n_samples):
+        for p in range(ploidy):
+            # local window indices of variants this haplotype carries (ALT)
+            carried_local = np.flatnonzero(genos[s, p] == 1).astype(V_IDX_TYPE)
+            carried_global = var_idxs[carried_local]
+            n_keep = _length_walk_n_keep(
+                carried_global,
+                v_starts,
+                ilens,
+                0,
+                len(carried_global),
+                POS_TYPE(q_start),
+                POS_TYPE(q_end),
+            )
+            kept_local = carried_local[:n_keep]
+            lengths[s, p] = n_keep
+            data_parts.append(var_idxs[kept_local])
+            if dosages is not None:
+                dose_parts.append(dosages[s, kept_local])
+
+    data = (
+        np.concatenate(data_parts)
+        if data_parts
+        else np.empty(0, dtype=V_IDX_TYPE)
+    )
+    offsets = lengths_to_offsets(lengths)
+    shape = (n_samples, ploidy, None)
+    rag = Ragged[V_IDX_TYPE].from_offsets(data, shape, offsets)
+
+    if dosages is not None:
+        dose_data = (
+            np.concatenate(dose_parts)
+            if dose_parts
+            else np.empty(0, dtype=DOSAGE_TYPE)
+        )
+        drag = Ragged[DOSAGE_TYPE].from_offsets(dose_data, shape, offsets)
+        return rag, drag
+    return rag
+```
+
+If `DOSAGE_TYPE` is not already imported in `_svar.py`, add it to the `from genoray._types import ...` line (verify the symbol name in `genoray/_types.py`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run pytest tests/test_dense2sparse_with_length.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_svar.py tests/test_dense2sparse_with_length.py
+git commit -m "feat: add private _dense2sparse_with_length bridge"
+```
+
+---
+
+## Task 4: Invariant-assertion helper module
+
+**Files:**
+- Create: `tests/_length_helpers.py`
+- Test: covered indirectly; add a tiny self-test in `tests/test_dense2sparse_with_length.py` is unnecessary — exercise via Task 5/8.
+
+- [ ] **Step 1: Write the helper module**
+
+Create `tests/_length_helpers.py`:
+
+```python
+"""Shared assertions for *_with_length tests.
+
+The feature's guarantee: each haplotype carries enough length to cover the
+original query span. Dense backends (VCF/PGEN) extend to one shared boundary
+(the worst-case haplotype reaches Q); sparse (SparseVar) extends each
+haplotype independently. ``clamped=True`` exempts cases where extension hit the
+contig end and legitimately could not reach Q.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from genoray._utils import hap_ilens
+
+
+def realized_hap_lengths(
+    genos: NDArray[np.integer], ilens: NDArray[np.int32], q_len: int
+) -> NDArray[np.int32]:
+    """Realized haplotype lengths for a dense window. genos: (s p v)."""
+    # base query length + net indel contribution carried by each haplotype
+    return q_len + hap_ilens(genos, ilens)
+
+
+def assert_dense_reaches_length(
+    genos: NDArray[np.integer],
+    ilens: NDArray[np.int32],
+    q_len: int,
+    *,
+    clamped: bool = False,
+) -> None:
+    """Dense (VCF/PGEN): the worst-case haplotype must reach q_len unless clamped."""
+    hap_lens = realized_hap_lengths(genos, ilens, q_len)
+    if clamped:
+        return
+    assert hap_lens.max() >= q_len, (
+        f"no haplotype reached query length {q_len}; max realized {hap_lens.max()}"
+    )
+
+
+def assert_sparse_reaches_length(
+    hap_lens: NDArray[np.int32], q_len: int, *, clamped: bool = False
+) -> None:
+    """Sparse (SparseVar): every haplotype must independently reach q_len."""
+    if clamped:
+        return
+    assert (hap_lens >= q_len).all(), (
+        f"some haplotype did not reach query length {q_len}: {hap_lens}"
+    )
+```
+
+- [ ] **Step 2: Verify the module imports cleanly**
+
+Run: `pixi run python -c "import tests._length_helpers as h; print(h.realized_hap_lengths)"`
+Expected: prints the function object, no error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/_length_helpers.py
+git commit -m "test: add with_length invariant assertion helpers"
+```
+
+---
+
+## Task 5: Cross-backend parity test
+
+Asserts PGEN≡VCF (dense, exact) and SVAR≡`_dense2sparse_with_length(dense)` (exact), across all four fixture regions.
+
+**Files:**
+- Create: `tests/test_parity.py`
+
+- [ ] **Step 1: Write the parity test**
+
+Create `tests/test_parity.py`:
+
+```python
+"""Cross-backend parity for *_with_length on the indels fixture.
+
+PGEN and VCF are dense/variant-major: they extend to one shared boundary, so
+their dense outputs must be identical. SparseVar extends each haplotype
+independently; its output must equal _dense2sparse_with_length applied to the
+dense window (the parity bridge).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from genoray import PGEN, VCF, SparseVar
+from genoray._svar import _dense2sparse_with_length
+
+ddir = Path(__file__).parent / "data"
+
+# (label, contig, start, end, clamped)
+REGIONS = [
+    ("A_big_deletion", "chr1", 999, 1010, False),
+    ("B_per_haplotype", "chr1", 1999, 2006, False),
+    ("C_snp_dense", "chr1", 2999, 3030, False),
+    ("D_contig_end_clamp", "chr1", 4999, 5040, True),
+]
+
+
+def _collect_pgen(pgen, contig, start, end):
+    """Concatenate a single range's chunks into one dense window + var_idxs."""
+    mode = PGEN.GenosPhasingDosages
+    # large max_mem -> few chunks; still concatenate to be safe
+    gen = pgen._chunk_ranges_with_length(contig, start, end, "1g", mode)
+    genos_parts, dose_parts, idx_parts = [], [], []
+    end_pos = None
+    for range_ in gen:
+        for chunk, e, v_idxs in range_:
+            g, p, d = chunk
+            genos_parts.append(np.asarray(g))
+            dose_parts.append(np.asarray(d))
+            idx_parts.append(np.asarray(v_idxs))
+            end_pos = e
+        break  # single range queried
+    genos = np.concatenate(genos_parts, axis=-1)
+    dosages = np.concatenate(dose_parts, axis=-1)
+    var_idxs = np.concatenate(idx_parts)
+    return genos, dosages, var_idxs, end_pos
+
+
+def _collect_vcf(vcf, contig, start, end):
+    mode = VCF.Genos16Dosages
+    vcf.phasing = True
+    max_mem = "1g"
+    gen = vcf._chunk_ranges_with_length(contig, start, end, max_mem, mode)
+    genos_parts, dose_parts = [], []
+    end_pos = None
+    for range_ in gen:
+        for chunk, e, _n_ext in range_:
+            gp, d = chunk
+            g, _p = np.array_split(gp, 2, 1)
+            genos_parts.append(np.asarray(g))
+            dose_parts.append(np.asarray(d))
+            end_pos = e
+        break
+    genos = np.concatenate(genos_parts, axis=-1)
+    dosages = np.concatenate(dose_parts, axis=-1)
+    return genos, dosages, end_pos
+
+
+@pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
+def test_pgen_equals_vcf_dense(label, contig, start, end, clamped):
+    pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    vcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+
+    pg, pd, _vidx, _pe = _collect_pgen(pgen, contig, start, end)
+    vg, vd, _ve = _collect_vcf(vcf, contig, start, end)
+
+    # same variant window for all haplotypes -> identical genos/dosages
+    np.testing.assert_array_equal(pg.astype(np.int16), vg.astype(np.int16))
+    np.testing.assert_allclose(pd, vd, rtol=1e-4, equal_nan=True)
+
+
+@pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
+def test_svar_equals_bridge(label, contig, start, end, clamped):
+    pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    svar = SparseVar(ddir / "indels.pgen.svar")
+
+    genos, dosages, var_idxs, _end = _collect_pgen(pgen, contig, start, end)
+    # global per-variant attributes for the window
+    v_starts = (svar.index["POS"] - 1).to_numpy()
+    ilens = svar.index["ILEN"].list.first().to_numpy()
+
+    bridged = _dense2sparse_with_length(
+        genos.astype(np.int8), var_idxs, start, end, v_starts, ilens, dosages
+    )
+    brag, bdrag = bridged
+
+    actual = svar.read_ranges_with_length(contig, start, end)
+    # actual shape (1 range, s, p, ~v); bridge shape (s, p, ~v)
+    np.testing.assert_array_equal(actual.data, brag.data)
+    np.testing.assert_array_equal(
+        np.asarray(actual.offsets).ravel(), np.asarray(brag.offsets).ravel()
+    )
+```
+
+Note on the SVAR offsets comparison: `read_ranges_with_length` returns shape `(1, s, p, None)` while the bridge returns `(s, p, None)`; both flatten to the same per-haplotype offsets for a single range. If the raveled offsets differ by the leading singleton range dimension, adjust the comparison to slice `actual` to its single range first (`actual[0]`).
+
+- [ ] **Step 2: Run the parity test**
+
+Run: `pixi run pytest tests/test_parity.py -v`
+Expected: PASS (8 parametrized cases). If `test_svar_equals_bridge` fails on offsets shape, apply the `actual[0]` adjustment noted above and re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_parity.py
+git commit -m "test: cross-backend parity for with_length on indels fixture"
+```
+
+---
+
+## Task 6: PGEN `_gen_with_length` unit test (fake `read`)
+
+Drives the doubling-extension loop and the contig-end clamp directly, no PGEN file.
+
+**Files:**
+- Modify: `tests/test_pgen.py` (append unit tests)
+
+- [ ] **Step 1: Write the failing/asserting unit tests**
+
+Append to `tests/test_pgen.py` (imports at top of file: ensure `from genoray._pgen import _gen_with_length, Genos` and `from genoray._types import V_IDX_TYPE, POS_TYPE`, `import numpy as np`):
+
+```python
+def _fake_read_factory(dense_genos):
+    """dense_genos: (s p V) global. Returns a read(var_idx)->Genos closure."""
+    def read(var_idx):
+        return Genos.parse(dense_genos[:, :, var_idx].astype(np.int32))
+    return read
+
+
+def test_gen_with_length_multi_round_extension():
+    # 1 sample, ploidy 1. Variant 0 is a -30 deletion (carried). Variants 1..40
+    # are SNPs 1bp apart starting just past the deletion's reference end. A
+    # single 20-variant extension cannot recover 30 bp, forcing a 2nd round.
+    n = 41
+    v_starts = np.empty(n, dtype=POS_TYPE)
+    v_starts[0] = 2999            # deletion at 0-based 2999
+    v_starts[1:] = np.arange(3030, 3030 + (n - 1), dtype=POS_TYPE)
+    ilens = np.zeros(n, dtype=np.int32)
+    ilens[0] = -30
+    v_ends = v_starts + 1
+    v_ends[0] = 2999 + 31         # REF length 31
+
+    dense = np.ones((1, 1, n), dtype=np.int32)  # all carried
+    read = _fake_read_factory(dense)
+
+    q_start, q_end = 2999, 3030   # len 31
+    # first chunk = just the deletion (the in-query variant)
+    v_chunks = [np.array([0], dtype=V_IDX_TYPE)]
+
+    out = list(
+        _gen_with_length(
+            v_chunks=v_chunks,
+            q_start=q_start,
+            q_end=q_end,
+            read=read,
+            v_starts=v_starts,
+            v_ends=v_ends,
+            ilens=ilens,
+            contig_max_idx=n - 1,
+        )
+    )
+    # extension must have pulled in well more than the first 20-variant batch
+    final_genos, _end, final_idx = out[-1]
+    assert final_idx[-1] > 20, (
+        f"multi-round extension not triggered; reached idx {final_idx[-1]}"
+    )
+
+
+def test_gen_with_length_clamps_at_contig_end():
+    # Deletion is the last variant -> extension cannot proceed, must clamp.
+    v_starts = np.array([4999], dtype=POS_TYPE)
+    v_ends = np.array([4999 + 11], dtype=POS_TYPE)
+    ilens = np.array([-10], dtype=np.int32)
+    dense = np.ones((1, 1, 1), dtype=np.int32)
+    read = _fake_read_factory(dense)
+
+    out = list(
+        _gen_with_length(
+            v_chunks=[np.array([0], dtype=V_IDX_TYPE)],
+            q_start=4999,
+            q_end=5040,
+            read=read,
+            v_starts=v_starts,
+            v_ends=v_ends,
+            ilens=ilens,
+            contig_max_idx=0,  # this IS the last variant
+        )
+    )
+    final_genos, _end, final_idx = out[-1]
+    # nothing to extend into: only the deletion variant returned
+    np.testing.assert_array_equal(final_idx, np.array([0], dtype=V_IDX_TYPE))
+```
+
+- [ ] **Step 2: Run the unit tests**
+
+Run: `pixi run pytest tests/test_pgen.py -k "gen_with_length" -v`
+Expected: PASS (2 tests). If `test_gen_with_length_multi_round_extension` does not exceed idx 20, the helper math differs from assumed — print `final_idx[-1]` and confirm the deletion/SNP geometry forces a 2nd round (increase deletion magnitude or SNP spacing), then re-run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pgen.py
+git commit -m "test: unit-test PGEN _gen_with_length multi-round + clamp"
+```
+
+---
+
+## Task 7: New SVAR internals cases (large deletion, per-haplotype, contig-end)
+
+**Files:**
+- Modify: `tests/test_svar_internals.py` (append cases)
+
+- [ ] **Step 1: Write the new cases**
+
+Append to `tests/test_svar_internals.py` (reuse existing imports `_find_starts_ends_with_length`, `np`, `OFFSET_TYPE`, `POS_TYPE`, `V_IDX_TYPE`):
+
+```python
+def test_with_length_large_deletion_extends_multiple_variants():
+    # 1 sample, ploidy 1. A -10 deletion at the query start forces extension
+    # across several downstream SNPs to recover length.
+    v_starts = np.array([999, 1010, 1012, 1014, 1016], dtype=np.int32)
+    ilens = np.array([-10, 0, 0, 0, 0], dtype=np.int32)
+    n_vars = len(v_starts)
+    genos = np.arange(n_vars, dtype=V_IDX_TYPE)          # all carried by the hap
+    geno_offsets = np.array([0, n_vars], dtype=OFFSET_TYPE)
+    sample_idxs = np.array([0], dtype=np.int64)
+
+    q_starts = np.array([999], dtype=POS_TYPE)
+    q_ends = np.array([1010], dtype=POS_TYPE)             # len 11
+    var_ranges = np.array([[0, 1]], dtype=V_IDX_TYPE)     # query covers only the deletion
+
+    out = _find_starts_ends_with_length(
+        genos, geno_offsets, q_starts, q_ends, var_ranges,
+        v_starts, ilens, sample_idxs, 1, int(v_starts[-1]) + 1,
+    )
+    start = int(out[0, 0, 0, 0])
+    end = int(out[1, 0, 0, 0])
+    assert start == 0
+    assert end > 2, f"large deletion did not extend across multiple variants: [{start},{end})"
+
+
+def test_with_length_per_haplotype_divergence():
+    # 1 sample, ploidy 2. hapA carries a deletion (needs extension); hapB does not.
+    v_starts = np.array([1999, 2002, 2004, 2006], dtype=np.int32)
+    ilens = np.array([-4, 0, 0, 0], dtype=np.int32)
+    # sparse storage is per (sample, ploidy): hapA carries all 4, hapB carries only the 3 SNPs
+    genos = np.array([0, 1, 2, 3,     1, 2, 3], dtype=V_IDX_TYPE)
+    geno_offsets = np.array([0, 4, 7], dtype=OFFSET_TYPE)  # hapA: [0,4), hapB: [4,7)
+    sample_idxs = np.array([0], dtype=np.int64)
+
+    q_starts = np.array([1999], dtype=POS_TYPE)
+    q_ends = np.array([2006], dtype=POS_TYPE)               # len 7
+    var_ranges = np.array([[0, 1]], dtype=V_IDX_TYPE)
+
+    out = _find_starts_ends_with_length(
+        genos, geno_offsets, q_starts, q_ends, var_ranges,
+        v_starts, ilens, sample_idxs, 2, int(v_starts[-1]) + 1,
+    )
+    len_hapA = int(out[1, 0, 0, 0]) - int(out[0, 0, 0, 0])
+    len_hapB = int(out[1, 0, 0, 1]) - int(out[0, 0, 0, 1])
+    assert len_hapA > len_hapB, (
+        f"haplotype carrying the deletion should extend further: A={len_hapA} B={len_hapB}"
+    )
+
+
+def test_with_length_clamps_at_contig_end():
+    # Single carried deletion is the last variant on the contig -> cannot extend.
+    v_starts = np.array([4999], dtype=np.int32)
+    ilens = np.array([-10], dtype=np.int32)
+    genos = np.array([0], dtype=V_IDX_TYPE)
+    geno_offsets = np.array([0, 1], dtype=OFFSET_TYPE)
+    sample_idxs = np.array([0], dtype=np.int64)
+
+    q_starts = np.array([4999], dtype=POS_TYPE)
+    q_ends = np.array([5040], dtype=POS_TYPE)               # len 41, unreachable
+    var_ranges = np.array([[0, 1]], dtype=V_IDX_TYPE)
+
+    out = _find_starts_ends_with_length(
+        genos, geno_offsets, q_starts, q_ends, var_ranges,
+        v_starts, ilens, sample_idxs, 1, int(v_starts[-1]) + 1,
+    )
+    start = int(out[0, 0, 0, 0])
+    end = int(out[1, 0, 0, 0])
+    assert (start, end) == (0, 1), f"clamp should keep exactly the one variant: [{start},{end})"
+```
+
+- [ ] **Step 2: Run the SVAR internals tests**
+
+Run: `pixi run pytest tests/test_svar_internals.py -v`
+Expected: PASS (3 existing + 3 new). If the per-haplotype assertion's offset arithmetic surprises you, print `out[:, 0, 0, :]` to inspect both haplotypes' `[start, end)` and adjust expectations to the documented semantics (deletion-carrying hap keeps more variants).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_svar_internals.py
+git commit -m "test: add large-deletion, per-haplotype, and clamp SVAR cases"
+```
+
+---
+
+## Task 8: Richer VCF/PGEN integration cases on the indels fixture (with invariant helper)
+
+**Files:**
+- Modify: `tests/test_vcf.py` (add an indels-driven test using the invariant helper)
+- Modify: `tests/test_pgen.py` (same)
+
+- [ ] **Step 1: Add the VCF integration test**
+
+Append to `tests/test_vcf.py` (ensure `from tests._length_helpers import assert_dense_reaches_length` and `from pathlib import Path`, `ddir` already defined in the module):
+
+```python
+import pytest as _pytest_for_indels  # if pytest not already imported, use existing import
+
+
+@_pytest_for_indels.mark.parametrize(
+    "label,start,end,clamped",
+    [
+        ("A_big_deletion", 999, 1010, False),
+        ("B_per_haplotype", 1999, 2006, False),
+        ("C_snp_dense", 2999, 3030, False),
+        ("D_contig_end_clamp", 4999, 5040, True),
+    ],
+)
+def test_indels_with_length_reaches_query_length(label, start, end, clamped):
+    vcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+    vcf.phasing = True
+    mode = VCF.Genos16Dosages
+    gen = vcf._chunk_ranges_with_length("chr1", start, end, "1g", mode)
+
+    # collect this range's dense window
+    g_parts = []
+    for range_ in gen:
+        for chunk, _e, _n in range_:
+            gp, _d = chunk
+            g, _p = np.array_split(gp, 2, 1)
+            g_parts.append(np.asarray(g))
+        break
+    genos = np.concatenate(g_parts, axis=-1)
+
+    # window ILENs from the gvi index, sliced to the returned variant window
+    ilens_all = vcf._index["ILEN"].to_numpy() if vcf._index is not None else None
+    # fall back: derive ILEN from the SVAR view to avoid index-internal coupling
+    from genoray import SparseVar
+    svar = SparseVar(ddir / "indels.vcf.svar")
+    # global ilens; the dense window starts at the first variant in [start,end)
+    # and runs contiguously, so map by genomic order via var positions.
+    # Simplest robust check: the worst-case realized length must reach q_len.
+    q_len = end - start
+    # Use only the carried-indel contribution we can see in this window:
+    # reconstruct window ilens by matching count.
+    ilens = svar.index["ILEN"].list.first().to_numpy()
+    n = genos.shape[-1]
+    # the window is the first n variants at/after the query start in index order
+    # (var_ranges are contiguous); find the start index via positions.
+    pos = (svar.index["POS"] - 1).to_numpy()
+    w_start = int(np.searchsorted(pos, start))
+    window_ilens = ilens[w_start : w_start + n].astype(np.int32)
+
+    assert_dense_reaches_length(genos, window_ilens, q_len, clamped=clamped)
+```
+
+Note: this couples the window-ILEN reconstruction to contiguous variant ordering. If `vcf._index` already exposes ILEN cleanly, prefer slicing it directly; the SVAR fallback above exists only to avoid depending on `_index` internals. Keep whichever is simpler in this codebase after inspecting `vcf._index` columns.
+
+- [ ] **Step 2: Add the PGEN integration test**
+
+Append to `tests/test_pgen.py` an analogous test. PGEN exposes `var_idxs` per chunk, so window ILENs are exact (no reconstruction):
+
+```python
+def test_indels_with_length_reaches_query_length_pgen():
+    from tests._length_helpers import assert_dense_reaches_length
+    from genoray import SparseVar
+    pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    svar = SparseVar(ddir / "indels.pgen.svar")
+    ilens_global = svar.index["ILEN"].list.first().to_numpy().astype(np.int32)
+
+    cases = [
+        (999, 1010, False),
+        (1999, 2006, False),
+        (2999, 3030, False),
+        (4999, 5040, True),
+    ]
+    mode = PGEN.GenosPhasingDosages
+    for start, end, clamped in cases:
+        gen = pgen._chunk_ranges_with_length("chr1", start, end, "1g", mode)
+        g_parts, idx_parts = [], []
+        for range_ in gen:
+            for chunk, _e, v_idxs in range_:
+                g, _p, _d = chunk
+                g_parts.append(np.asarray(g))
+                idx_parts.append(np.asarray(v_idxs))
+            break
+        genos = np.concatenate(g_parts, axis=-1)
+        var_idxs = np.concatenate(idx_parts)
+        window_ilens = ilens_global[var_idxs]
+        assert_dense_reaches_length(genos, window_ilens, end - start, clamped=clamped)
+```
+
+- [ ] **Step 3: Run both integration tests**
+
+Run: `pixi run pytest tests/test_vcf.py -k indels tests/test_pgen.py -k "indels" -v`
+Expected: PASS. If region C's worst-case does not reach length, the fixture geometry needs tuning (Task 1) — increase SNP count after POS 3070.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_vcf.py tests/test_pgen.py
+git commit -m "test: indels with_length integration with invariant assertions"
+```
+
+---
+
+## Task 9: SparseVar `length_none` case
+
+**Files:**
+- Modify: `tests/test_svar.py` (add a `length_none` case to the `length_` case group)
+
+- [ ] **Step 1: Add the case**
+
+In `tests/test_svar.py`, alongside `length_no_ext` and `length_ext` (~line 180-196), add:
+
+```python
+def length_none():
+    # Missing contig -> empty result for every haplotype.
+    cse = "chr3", 0, 1
+    shape = (1, N_SAMPLES, PLOIDY, None)
+    offsets = np.zeros((N_SAMPLES, PLOIDY + 1), OFFSET_TYPE)
+    desired = Ragged[V_IDX_TYPE].from_offsets(DATA, shape, offsets)
+    return cse, desired
+```
+
+Verify against the method: `_find_starts_ends_with_length` returns `np.full((n_ranges, len(samples), self.ploidy, 2), -1, ...)` when the contig is missing (`c is None`, `genoray/_svar.py:626-627`). Confirm how `read_ranges_with_length` reshapes that into a `Ragged` (it calls `.reshape(2, -1)`); if a missing contig yields all-equal start/end offsets (empty per haplotype), the `offsets` above (all zeros → zero-length ragged rows) is correct. If the missing-contig path produces a different offset layout, set `desired` to match the actual empty-per-haplotype `Ragged` (data length 0, monotonic offsets). Inspect by running the method once:
+
+```bash
+pixi run python -c "
+from pathlib import Path
+from genoray import SparseVar
+s = SparseVar(Path('tests/data/biallelic.vcf.svar'))
+r = s.read_ranges_with_length('chr3', 0, 1)
+print(r.shape); print(r.offsets); print(r.data)
+"
+```
+Set the expected `offsets`/`data` in `length_none` to whatever an empty result actually is, so the test asserts the real contract.
+
+- [ ] **Step 2: Run the SVAR read_ranges_with_length cases**
+
+Run: `pixi run pytest tests/test_svar.py -k read_ranges_with_length -v`
+Expected: PASS (`length_no_ext`, `length_ext`, `length_none`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_svar.py
+git commit -m "test: add missing-contig (length_none) case for SVAR with_length"
+```
+
+---
+
+## Task 10: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole suite (regenerates data)**
+
+Run: `pixi run test`
+Expected: all tests pass, including network-independent ones. If a network test fails for connectivity reasons, re-run with `pixi run pytest -m "not network"`.
+
+- [ ] **Step 2: Lint/format**
+
+Run: `pixi run ruff check genoray tests && pixi run ruff format --check genoray tests`
+Expected: clean (or run `ruff format genoray tests` and re-commit if formatting changed).
+
+- [ ] **Step 3: Confirm no public API changed**
+
+Verify `genoray/__init__.py` is unchanged and `_dense2sparse_with_length` is private (leading underscore, not exported). `skills/genoray-api/SKILL.md` requires no edit. Confirm:
+
+```bash
+git diff --stat main -- genoray/__init__.py skills/genoray-api/SKILL.md
+```
+Expected: no output (both unchanged).
+
+- [ ] **Step 4: Final commit (if formatting or stray changes)**
+
+```bash
+git add -A
+git commit -m "chore: lint/format with_length test additions"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 fixture → Task 1 (all four regions A–D wired through gen scripts). ✓
+- §2 `_dense2sparse_with_length` + shared-helper refactor → Tasks 2 & 3. ✓
+- §3 invariant helper (dense + sparse flavors) → Task 4. ✓
+- §4 parity (PGEN≡VCF exact; SVAR≡bridge) → Task 5. ✓
+- §5 unit tests: PGEN `_gen_with_length` → Task 6; SVAR internals new cases → Task 7; `_dense2sparse_with_length` units → Task 3; VCF via fixture integration → Task 8. ✓
+- §6 SVAR `length_none` → Task 9. ✓
+- Acceptance criteria 1–7 → covered by Tasks 10 (full run, lint, no-public-API) and the per-task assertions. ✓
+
+**Placeholder scan:** Fixture coordinates and Region C geometry are concrete but flagged as empirically tunable with explicit verification steps (Tasks 1/6/8) — this is honest, not a placeholder, because each carries a measured expected outcome and a tuning instruction. No "TBD"/"handle edge cases"/"write tests for the above" left.
+
+**Type/name consistency:** `_length_walk_n_keep` (Task 2) is reused with the same signature by `_dense2sparse_with_length` (Task 3) and indirectly via `_find_starts_ends_with_length`. `_dense2sparse_with_length` signature `(genos, var_idxs, q_start, q_end, v_starts, ilens, dosages=None)` is identical in Task 3 (def), Task 5 (call), and matches the spec. Invariant helpers `assert_dense_reaches_length` / `assert_sparse_reaches_length` named identically in Tasks 4 and 8. Phantom `Genos.parse` usage (Task 6) matches `genoray/_pgen.py:40-45`.
+
+**Known soft spots (verify during execution, not blockers):**
+- Region C must force ≥2 PGEN extension rounds — Task 6 unit test asserts this on synthetic data (deterministic), and Task 8 asserts the fixture reaches length; if the *fixture* doesn't trigger multi-round in the integration path, the unit test (Task 6) still covers the loop. Acceptable.
+- SVAR `length_none` exact offsets must be read off the real method (Task 9 includes the inspection command before finalizing expected values).
+- The Task 8 VCF window-ILEN reconstruction couples to contiguous variant ordering; prefer `vcf._index["ILEN"]` slicing if cleaner after inspection.

--- a/docs/superpowers/specs/2026-05-30-with-length-test-audit-design.md
+++ b/docs/superpowers/specs/2026-05-30-with-length-test-audit-design.md
@@ -1,0 +1,235 @@
+# `*_with_length` test audit & improvement — design
+
+**Date:** 2026-05-30
+**Status:** Approved, ready for implementation plan
+
+## Background
+
+The `*_with_length` family extends a query region variant-by-variant, tracking
+realized haplotype length, until each haplotype carries enough length to cover
+the original query span. Deletions (negative ILEN) shrink haplotype length and
+therefore *force* extension; insertions/SNPs do not.
+
+Three parallel implementations exist:
+
+| Backend | Core length logic | Existing tests |
+|---|---|---|
+| VCF | `_ext_genos_with_length`, `_ext_genos_dosages_with_length`, `_chunk_with_length_helper`, `_chunk_ranges_with_length` | `tests/test_vcf.py::test_chunk_with_length` (3 cases) + `tests/test_issue36.py` |
+| PGEN | `_gen_with_length` (doubling-extension loop), `_chunk_ranges_with_length` | `tests/test_pgen.py::test_chunk_with_length` (3 cases) |
+| SparseVar | `_find_starts_ends_with_length` (method + numba fn), `read_ranges_with_length` | `tests/test_svar.py::test_read_ranges_with_length` (2 cases) + `tests/test_svar_internals.py` (3 unit tests) |
+
+### Two distinct semantics (important)
+
+- **VCF & PGEN** are variant-major and return *dense* genotypes. They extend to
+  the single variant boundary at which the **worst-case** haplotype across all
+  samples reaches target length. All samples/haplotypes therefore share one
+  (over-extended) variant window. This is intrinsic to dense formats.
+- **SparseVar** is sample-major and intrinsically sparse. It extends each
+  `(sample, haplotype)` **independently** to its own minimal length, so per
+  haplotype it generally includes *fewer* variants than the shared dense window.
+
+## Problem: what the current tests miss
+
+The entire feature is exercised by `tests/data/biallelic.vcf`, which has exactly
+**3 variants per contig**: `81262 GAT>A` (the only indel — a `-2` deletion),
+`81262 G>A` (SNP), `81265 T>C` (SNP).
+
+Identified gaps:
+
+1. **One tiny deletion drives everything.** Only an ILEN `-2` deletion triggering
+   a single variant of extension. No large, compounding, or multi-variant-span
+   deletions.
+2. **PGEN's doubling-extension loop is dead in tests.** `_gen_with_length` doubles
+   `_idx_extension` and loops `while (hap_lens < length).any()` across multiple
+   read rounds. With 3 variants this multi-round path never runs.
+3. **Per-haplotype divergence untested.** A deletion on one haplotype but not the
+   other should extend the two haplotypes differently. No case isolates this.
+4. **Contig-end / clamp boundary untested.** All three clamp extension at
+   `contig_max_idx` (or cyvcf2 iterator exhaustion). The "deletion near contig
+   end, cannot reach target length, must stop short" path is never hit.
+5. **SVAR public method has no empty/missing-contig case** (`length_none`), unlike
+   VCF and PGEN.
+6. **No cross-backend parity.** The same data exists as VCF, PGEN, and SVAR; each
+   is checked against separate hand-written expectations. Nothing asserts they
+   agree.
+7. **The promised invariant is never asserted directly.** Tests check exact
+   offsets/variant-sets but never the actual guarantee: realized haplotype length
+   ≥ query length.
+
+The bright spot is `tests/test_svar_internals.py`: focused unit regression tests
+with documented bugs. VCF and PGEN length logic have no equivalent unit-level
+tests.
+
+## Scope
+
+This is primarily a **test improvement**, plus **one new private production
+function** (`_dense2sparse_with_length`) with a small shared-helper refactor that
+makes exact cross-backend parity possible.
+
+Out of scope: making any `with_length` symbol public, changing public API,
+touching `skills/genoray-api/SKILL.md` (nothing public changes).
+
+## Design
+
+### 1. New fixture — `tests/data/indels.vcf`
+
+A biallelic-only VCF (SVAR `with_length` rejects multiallelic), 2 samples,
+phased, carrying a `DS` field so it converts to PGEN and SVAR through the
+existing pipeline. Single contig, laid out as four spatially-isolated regions —
+each targeting one untested path:
+
+| Region | Construction | Exercises |
+|---|---|---|
+| **A — big deletion** | one `-10`bp deletion, then several SNPs | extension across multiple variants (not just one) |
+| **B — per-haplotype divergence** | a deletion present on hap A (`1\|0`) but not hap B (`0\|1`) | the two haplotypes extend by different amounts |
+| **C — SNP-dense after big deletion** | a `-50`bp deletion, then ~30 SNPs packed within <40bp | PGEN's doubling loop (`_idx_extension *= 2`, multi-round `while`): the first 20-variant grab spans <50bp, forcing a 2nd round |
+| **D — deletion near contig end** | a deletion close to the last variant on the contig | `contig_max_idx` clamp / iterator exhaustion: extension stops short, realized length legitimately < query length |
+
+Region C is deliberately contrived (a deletion wider than the span of 20
+downstream variants is the only way to force PGEN's multi-round loop). It must
+carry a comment in the VCF / test code stating this so it is not mistaken for a
+realistic genome.
+
+**Pipeline wiring:** add an `indels` entry to `tests/data/gen_from_vcf.sh`
+(bgzip + index + `plink2 --make-pgen ... dosage=DS`) and to
+`tests/data/gen_svar.py` (`SparseVar.from_vcf` + `SparseVar.from_pgen` +
+`cache_afs`), mirroring the existing `biallelic` handling. This produces
+`indels.vcf.gz`, `indels.pgen`/`.psam`/`.pvar`, `indels.vcf.svar`,
+`indels.pgen.svar`. Existing `biallelic`-based tests are left untouched.
+
+### 2. New production code — `_dense2sparse_with_length` (private)
+
+Lives in `genoray/_svar.py` alongside `dense2sparse`. Private (leading
+underscore), experimental — consistent with the rest of the `with_length`
+family and with `dense2sparse` itself (also internal). Not exported; genvarloader
+imports the private name, as it already does for other `with_length` methods.
+
+**Purpose:** convert dense VCF/PGEN `with_length` output (the shared,
+over-extended variant window) into per-haplotype sparse output, re-trimming each
+`(sample, haplotype)` to its own minimal length — producing output **identical
+to** `SparseVar.read_ranges_with_length` for the same query. That identity is
+what makes it a valid parity bridge.
+
+**Well-defined because:** the dense window extends until the worst-case
+haplotype (most deletions) reaches Q; every other haplotype needs ≤ that many
+variants, so each haplotype's independent minimal set is always a subset of the
+dense window. The contig-end clamp degrades gracefully (each haplotype takes
+what is available).
+
+**Signature** (mirrors `dense2sparse` plus the inputs `_gen_with_length`
+already threads):
+
+```python
+def dense2sparse_with_length(   # exposed as the private name `_dense2sparse_with_length`
+    genos,         # (s p v) dense — the with_length window
+    var_idxs,      # (v,) global variant indices of the window
+    q_start, q_end,  # query span → target length
+    v_starts,      # (v,) 0-based positions of window variants
+    ilens,         # (v,) ILEN of window variants
+    dosages=None,  # (s v) optional
+) -> Ragged[V_IDX_TYPE] | tuple[Ragged[V_IDX_TYPE], Ragged[DOSAGE_TYPE]]:
+    ...
+```
+
+(Final public-facing name is `_dense2sparse_with_length`; the body above uses a
+placeholder for readability.)
+
+**Shared-helper refactor:** the per-haplotype length-accounting walk (currently
+inlined in the numba `_find_starts_ends_with_length` at `genoray/_svar.py:1930`)
+is factored into a single shared helper that both `_find_starts_ends_with_length`
+and `_dense2sparse_with_length` call. This guarantees the dense→sparse path and
+the native sparse path cannot drift. The refactor must be behavior-preserving for
+`_find_starts_ends_with_length` (verified by the existing
+`test_svar_internals.py` regression tests still passing).
+
+### 3. Invariant helper — `tests/_length_helpers.py`
+
+A shared module with assertion helpers expressing the feature's actual
+guarantee, computed via the existing `hap_ilens` util:
+
+- **Dense (VCF/PGEN):** `max` over `(sample, haplotype)` realized length ≥ Q, and
+  the window is minimal for that worst-case haplotype (dropping the last variant
+  would push the worst case below Q) — unless extension was clamped at contig end.
+- **Sparse (SVAR):** *every* `(sample, haplotype)` realized length ≥ Q and
+  individually minimal — unless clamped.
+
+These replace brittle exact-offset assertions with the guarantee the feature
+exists to make, and are reused by the parity and case tests.
+
+### 4. Cross-backend parity test (new fixture)
+
+A single test running the same `with_length` query against all three backends:
+
+- **PGEN ≡ VCF — exact.** Both dense and variant-major, both extend to the same
+  worst-case boundary. Assert equality of genotypes, dosages, and final `end`.
+- **SVAR ≡ `_dense2sparse_with_length(<VCF/PGEN dense output>)` — exact.** The
+  bridge re-trims the dense window per haplotype; the result must equal
+  `SparseVar.read_ranges_with_length` (same `Ragged` data + offsets).
+
+Run across all four fixture regions (A–D), including the clamp region D.
+
+### 5. Unit tests (test_svar_internals.py style)
+
+- **PGEN `_gen_with_length`** — genuinely unit-testable: it takes a `read`
+  callable plus synthetic `v_starts`/`v_ends`/`ilens`. Drive it with a fake
+  `read` and synthetic arrays to assert the multi-round extension (doubling
+  loop runs ≥ 2 rounds) and the contig-end clamp directly, no file needed.
+- **SVAR `_find_starts_ends_with_length`** — extend `test_svar_internals.py`
+  with large-deletion, per-haplotype-divergence, and contig-end cases.
+- **`_dense2sparse_with_length`** — direct unit tests on synthetic dense windows,
+  including dosages and the contig-end (truncated window) case.
+- **VCF `_ext_genos_with_length`** — bound to `self._vcf(coord)`, so not cleanly
+  unit-testable; covered via the fixture (integration). Note this asymmetry in
+  the test module rather than forcing an awkward mock.
+
+### 6. SVAR public-method gap
+
+Add a `length_none` case (missing/empty contig) to
+`tests/test_svar.py::test_read_ranges_with_length`, matching the `length_none`
+cases that VCF and PGEN already have.
+
+## Files touched
+
+**Production**
+- `genoray/_svar.py` — add `_dense2sparse_with_length`; factor shared
+  length-accounting helper out of `_find_starts_ends_with_length`.
+
+**Test data**
+- `tests/data/indels.vcf` (new)
+- `tests/data/gen_from_vcf.sh` (add `indels` entry)
+- `tests/data/gen_svar.py` (add `indels` conversion)
+- generated artifacts: `indels.vcf.gz`(+`.csi`), `indels.pgen`/`.psam`/`.pvar`,
+  `indels.vcf.svar`, `indels.pgen.svar`
+
+**Tests**
+- `tests/_length_helpers.py` (new — invariant assertions)
+- `tests/test_parity.py` (new — or add to an existing module — cross-backend parity)
+- `tests/test_svar_internals.py` (new cases: large del, per-hap, contig-end;
+  `_dense2sparse_with_length` unit tests)
+- `tests/test_pgen.py` (new `_gen_with_length` unit test; richer fixture cases)
+- `tests/test_vcf.py` (richer fixture integration cases)
+- `tests/test_svar.py` (add `length_none` case)
+
+## Acceptance criteria
+
+1. `pixi run test` passes (data regeneration via `gen_from_vcf.sh` included).
+2. New fixture exercises: multi-variant extension, per-haplotype divergence,
+   PGEN multi-round doubling loop (≥ 2 rounds), and contig-end clamp.
+3. `_dense2sparse_with_length` output exactly equals
+   `SparseVar.read_ranges_with_length` across all fixture regions.
+4. PGEN `with_length` output exactly equals VCF `with_length` output across all
+   fixture regions.
+5. Invariant helper assertions hold for every backend on every region (with the
+   clamp exemption for region D).
+6. Existing `test_svar_internals.py` regression tests still pass after the
+   shared-helper refactor (behavior preserved).
+7. No public API change; `skills/genoray-api/SKILL.md` untouched.
+
+## Open considerations (non-blocking)
+
+- Whether the parity test lives in a new `tests/test_parity.py` or is appended to
+  an existing module is left to the implementation plan.
+- Exact coordinates/genotypes for the four fixture regions are to be chosen
+  during implementation so each region demonstrably triggers its target path
+  (verify region C actually forces a 2nd PGEN extension round; verify region D
+  actually clamps).

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -1926,6 +1926,41 @@ def _find_starts_ends(
     return out_offsets
 
 
+@nb.njit(nogil=True, cache=True)
+def _length_walk_n_keep(sp_genos, v_starts, ilens, start_idx, max_idx, q_start, q_end):
+    """Number of leading carried variants (from start_idx) to keep so one
+    haplotype reaches q_end - q_start in length, extending past q_end only as
+    needed. Variants strictly inside [q_start, q_end) are always kept; the
+    length budget only gates extension past q_end. Returns a count in
+    [0, max_idx - start_idx]."""
+    q_len = q_end - q_start
+    last_v_end = q_start
+    written_len = 0
+    i = -1
+    for j in range(start_idx, max_idx):
+        i = j - start_idx
+        v_idx = sp_genos[j]
+        v_start = v_starts[v_idx]
+        ilen = ilens[v_idx]
+
+        maybe_add_one = POS_TYPE(v_start >= q_start)
+        past_query = v_start >= q_end
+
+        if v_start >= q_start:
+            written_len += v_start - last_v_end
+            if past_query and written_len >= q_len:
+                i -= 1
+                break
+            written_len += max(0, ilen) + maybe_add_one
+            if past_query and written_len >= q_len:
+                break
+
+        v_end = v_start - min(0, ilen) + maybe_add_one
+        last_v_end = max(last_v_end, v_end)
+
+    return i + 1
+
+
 @nb.njit(parallel=False, nogil=True, cache=True)
 def _find_starts_ends_with_length(
     genos: NDArray[V_IDX_TYPE],
@@ -1998,57 +2033,16 @@ def _find_starts_ends_with_length(
                     out[1, r, s, p] = start_idx + o_s
                     continue
 
-                q_start: POS_TYPE = q_starts[r]
-                q_end: POS_TYPE = q_ends[r]
-                q_len: POS_TYPE = q_end - q_start
-                last_v_end: POS_TYPE = q_start
-                written_len = 0
-                # ensure geno_idx is assigned when start_idx == n_vars
-                geno_idx = start_idx
-                for geno_idx in range(start_idx, max_idx):
-                    v_idx: V_IDX_TYPE = sp_genos[geno_idx]
-                    v_start: np.int32 = v_starts[v_idx]
-                    ilen: np.int32 = ilens[v_idx]
-
-                    # only add atomized length if v_start >= ref_start
-                    maybe_add_one = POS_TYPE(v_start >= q_start)
-                    # variants strictly inside [q_start, q_end) must always be included;
-                    # length budget only governs extension past q_end
-                    past_query = v_start >= q_end
-
-                    # only variants within query can add to write length
-                    if v_start >= q_start:
-                        written_len += v_start - last_v_end
-                        if past_query and written_len >= q_len:
-                            geno_idx -= 1
-                            break
-
-                        v_write_len = (
-                            max(0, ilen)  # insertion length  # type: ignore
-                            + maybe_add_one  # maybe add atomized length
-                        )
-
-                        # right-clip insertions
-                        # Not necessary since it's inconsequential to overshoot the target length
-                        # and insertions don't affect the ref length for getting tracks.
-                        # Nevertheless, here's the code to clip a final insertion if we ever wanted to:
-                        # missing_len = target_len - cum_write_len
-                        # clip_right = max(0, v_len - missing_len)
-                        # v_len -= clip_right
-
-                        written_len += v_write_len
-                        if past_query and written_len >= q_len:
-                            break
-
-                    v_end = (
-                        v_start
-                        - min(0, ilen)  # deletion length  # type: ignore
-                        + maybe_add_one  # maybe add atomized length
-                    )
-                    last_v_end = max(last_v_end, v_end)  # type: ignore
-
-                # add o_s to make indices relative to whole array
-                out[1, r, s, p] = geno_idx + o_s + 1
+                n_keep = _length_walk_n_keep(
+                    sp_genos,
+                    v_starts,
+                    ilens,
+                    start_idx,
+                    max_idx,
+                    q_starts[r],
+                    q_ends[r],
+                )
+                out[1, r, s, p] = start_idx + o_s + n_keep
 
     unsorter = np.argsort(sorter)
     out[:] = out[:, unsorter]

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -352,6 +352,87 @@ def dense2sparse(
     return rag
 
 
+def _dense2sparse_with_length(
+    genos: NDArray[np.integer],
+    var_idxs: NDArray[V_IDX_TYPE],
+    q_start: int,
+    q_end: int,
+    v_starts: NDArray[np.int32],
+    ilens: NDArray[np.int32],
+    dosages: NDArray[DOSAGE_TYPE] | None = None,
+) -> Ragged[V_IDX_TYPE] | tuple[Ragged[V_IDX_TYPE], Ragged[DOSAGE_TYPE]]:
+    """Convert a dense ``with_length`` window (shared, over-extended across all
+    samples/haplotypes) into per-haplotype-minimal sparse output, identical to
+    ``SparseVar.read_ranges_with_length`` for the same query.
+
+    Parameters
+    ----------
+    genos
+        Dense genotypes for the window. Shape: (samples, ploidy, variants).
+    var_idxs
+        Global variant indices of the window, used only to populate the sparse
+        output. Shape: (variants,).
+    q_start, q_end
+        0-based, half-open original query span (before extension).
+    v_starts
+        0-based start positions of the window's variants (i.e. POS - 1).
+        Window-aligned: same length as the ``genos`` variant axis and
+        positionally aligned with ``var_idxs`` (NOT a global per-dataset array).
+        Shape: (variants,).
+    ilens
+        ILEN of the window's variants (ALT - REF length). Window-aligned, like
+        ``v_starts``. Shape: (variants,).
+    dosages
+        Optional dense dosages. Shape: (samples, variants).
+
+    Returns
+    -------
+        ``Ragged[V_IDX_TYPE]`` of shape (samples, ploidy, ~variants), or a tuple
+        with a matching ``Ragged[DOSAGE_TYPE]`` when ``dosages`` is given.
+    """
+    if genos.ndim != 3:
+        raise ValueError("Dense genotypes must have shape (samples, ploidy, variants).")
+    n_samples, ploidy, _ = genos.shape
+
+    lengths = np.empty((n_samples, ploidy), dtype=np.int64)
+    data_parts: list[NDArray[V_IDX_TYPE]] = []
+    dose_parts: list[NDArray[DOSAGE_TYPE]] = []
+
+    for s in range(n_samples):
+        for p in range(ploidy):
+            # local window indices of variants this haplotype carries (ALT);
+            # v_starts / ilens are window-local arrays aligned with var_idxs,
+            # so the helper must be indexed by local positions.
+            carried_local = np.flatnonzero(genos[s, p] == 1).astype(V_IDX_TYPE)
+            n_keep = _length_walk_n_keep(
+                carried_local,
+                v_starts,
+                ilens,
+                0,
+                len(carried_local),
+                POS_TYPE(q_start),
+                POS_TYPE(q_end),
+            )
+            kept_local = carried_local[:n_keep]
+            lengths[s, p] = n_keep
+            data_parts.append(var_idxs[kept_local])
+            if dosages is not None:
+                dose_parts.append(dosages[s, kept_local])
+
+    data = np.concatenate(data_parts) if data_parts else np.empty(0, dtype=V_IDX_TYPE)
+    offsets = lengths_to_offsets(lengths)
+    shape = (n_samples, ploidy, None)
+    rag = Ragged[V_IDX_TYPE].from_offsets(data, shape, offsets)
+
+    if dosages is not None:
+        dose_data = (
+            np.concatenate(dose_parts) if dose_parts else np.empty(0, dtype=DOSAGE_TYPE)
+        )
+        drag = Ragged[DOSAGE_TYPE].from_offsets(dose_data, shape, offsets)
+        return rag, drag
+    return rag
+
+
 CURRENT_VERSION = 1
 
 

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -1927,38 +1927,43 @@ def _find_starts_ends(
 
 
 @nb.njit(nogil=True, cache=True)
-def _length_walk_n_keep(sp_genos, v_starts, ilens, start_idx, max_idx, q_start, q_end):
-    """Number of leading carried variants (from start_idx) to keep so one
-    haplotype reaches q_end - q_start in length, extending past q_end only as
-    needed. Variants strictly inside [q_start, q_end) are always kept; the
-    length budget only gates extension past q_end. Returns a count in
-    [0, max_idx - start_idx]."""
+def _length_walk_n_keep(
+    sp_genos: NDArray[V_IDX_TYPE],
+    v_starts: NDArray[np.int32],
+    ilens: NDArray[np.int32],
+    start_idx: int,
+    max_idx: int,
+    q_start: POS_TYPE,
+    q_end: POS_TYPE,
+) -> int:
+    """Number of leading variants in ``sp_genos[start_idx:max_idx]`` to include
+    so one haplotype reaches ``q_end - q_start`` in length, extending past
+    ``q_end`` only as needed. Variants strictly inside ``[q_start, q_end)`` are
+    always included; the length budget only gates extension past ``q_end``.
+    Returns a count in ``[0, max_idx - start_idx]``."""
     q_len = q_end - q_start
     last_v_end = q_start
     written_len = 0
-    i = -1
     for j in range(start_idx, max_idx):
-        i = j - start_idx
         v_idx = sp_genos[j]
         v_start = v_starts[v_idx]
         ilen = ilens[v_idx]
 
         maybe_add_one = POS_TYPE(v_start >= q_start)
-        past_query = v_start >= q_end
 
         if v_start >= q_start:
+            past_query = v_start >= q_end
             written_len += v_start - last_v_end
             if past_query and written_len >= q_len:
-                i -= 1
-                break
+                return j - start_idx  # exclude this variant
             written_len += max(0, ilen) + maybe_add_one
             if past_query and written_len >= q_len:
-                break
+                return j - start_idx + 1  # include this variant
 
         v_end = v_start - min(0, ilen) + maybe_add_one
         last_v_end = max(last_v_end, v_end)
 
-    return i + 1
+    return max_idx - start_idx
 
 
 @nb.njit(parallel=False, nogil=True, cache=True)

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -390,6 +390,7 @@ def _dense2sparse_with_length(
         ``Ragged[V_IDX_TYPE]`` of shape (samples, ploidy, ~variants), or a tuple
         with a matching ``Ragged[DOSAGE_TYPE]`` when ``dosages`` is given.
     """
+    # single-range only: exactly (samples, ploidy, variants), no batch dimension
     if genos.ndim != 3:
         raise ValueError("Dense genotypes must have shape (samples, ploidy, variants).")
     n_samples, ploidy, _ = genos.shape

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -395,41 +395,36 @@ def _dense2sparse_with_length(
         raise ValueError("Dense genotypes must have shape (samples, ploidy, variants).")
     n_samples, ploidy, _ = genos.shape
 
+    v_starts = np.ascontiguousarray(v_starts, dtype=np.int32)
+    ilens = np.ascontiguousarray(ilens, dtype=np.int32)
+    var_idxs = np.ascontiguousarray(var_idxs, dtype=V_IDX_TYPE)
+
+    # Pass 1: per-haplotype kept counts (reuses the sparse path's length walk).
     lengths = np.empty((n_samples, ploidy), dtype=np.int64)
-    data_parts: list[NDArray[V_IDX_TYPE]] = []
-    dose_parts: list[NDArray[DOSAGE_TYPE]] = []
+    _dense2sparse_count(
+        genos, v_starts, ilens, POS_TYPE(q_start), POS_TYPE(q_end), lengths
+    )
 
-    for s in range(n_samples):
-        for p in range(ploidy):
-            # local window indices of variants this haplotype carries (ALT);
-            # v_starts / ilens are window-local arrays aligned with var_idxs,
-            # so the helper must be indexed by local positions.
-            carried_local = np.flatnonzero(genos[s, p] == 1).astype(V_IDX_TYPE)
-            n_keep = _length_walk_n_keep(
-                carried_local,
-                v_starts,
-                ilens,
-                0,
-                len(carried_local),
-                POS_TYPE(q_start),
-                POS_TYPE(q_end),
-            )
-            kept_local = carried_local[:n_keep]
-            lengths[s, p] = n_keep
-            data_parts.append(var_idxs[kept_local])
-            if dosages is not None:
-                dose_parts.append(dosages[s, kept_local])
-
-    data = np.concatenate(data_parts) if data_parts else np.empty(0, dtype=V_IDX_TYPE)
-    offsets = lengths_to_offsets(lengths)
+    flat_offsets = lengths_to_offsets(lengths)
+    total = int(flat_offsets[-1])
     shape = (n_samples, ploidy, None)
-    rag = Ragged[V_IDX_TYPE].from_offsets(data, shape, offsets)
 
-    if dosages is not None:
-        dose_data = (
-            np.concatenate(dose_parts) if dose_parts else np.empty(0, dtype=DOSAGE_TYPE)
-        )
-        drag = Ragged[DOSAGE_TYPE].from_offsets(dose_data, shape, offsets)
+    # Pass 2: fill the (and optionally the dosage) output in disjoint ranges.
+    out_data = np.empty(total, dtype=V_IDX_TYPE)
+    has_dose = dosages is not None
+    dose_in = (
+        np.ascontiguousarray(dosages, dtype=DOSAGE_TYPE)
+        if has_dose
+        else np.empty((0, 0), dtype=DOSAGE_TYPE)
+    )
+    out_dose = np.empty(total if has_dose else 0, dtype=DOSAGE_TYPE)
+    _dense2sparse_fill(
+        genos, var_idxs, dose_in, lengths, flat_offsets, out_data, out_dose, has_dose
+    )
+
+    rag = Ragged[V_IDX_TYPE].from_offsets(out_data, shape, flat_offsets)
+    if has_dose:
+        drag = Ragged[DOSAGE_TYPE].from_offsets(out_dose, shape, flat_offsets)
         return rag, drag
     return rag
 
@@ -2046,6 +2041,66 @@ def _length_walk_n_keep(
         last_v_end = max(last_v_end, v_end)
 
     return max_idx - start_idx
+
+
+@nb.njit(parallel=True, nogil=True, cache=True)
+def _dense2sparse_count(
+    genos: NDArray[np.integer],
+    v_starts: NDArray[np.int32],
+    ilens: NDArray[np.int32],
+    q_start: POS_TYPE,
+    q_end: POS_TYPE,
+    out_lengths: NDArray[np.int64],
+) -> None:
+    """Pass 1: per (sample, haplotype), count the carried ALT calls to keep.
+
+    Gathers each haplotype's carried (``== 1``) window-local positions in order
+    and routes them through :func:`_length_walk_n_keep` (the SAME walk the sparse
+    path uses, so the two cannot drift). Writes the kept count to ``out_lengths``.
+    """
+    n_samples, ploidy, n_var = genos.shape
+    for s in nb.prange(n_samples):
+        carriers = np.empty(n_var, dtype=V_IDX_TYPE)
+        for p in range(ploidy):
+            nc = 0
+            for v in range(n_var):
+                if genos[s, p, v] == 1:
+                    carriers[nc] = v
+                    nc += 1
+            out_lengths[s, p] = _length_walk_n_keep(
+                carriers, v_starts, ilens, 0, nc, q_start, q_end
+            )
+
+
+@nb.njit(parallel=True, nogil=True, cache=True)
+def _dense2sparse_fill(
+    genos: NDArray[np.integer],
+    var_idxs: NDArray[V_IDX_TYPE],
+    dosages: NDArray[DOSAGE_TYPE],
+    out_lengths: NDArray[np.int64],
+    flat_offsets: NDArray[OFFSET_TYPE],
+    out_data: NDArray[V_IDX_TYPE],
+    out_dose: NDArray[DOSAGE_TYPE],
+    has_dose: bool,
+) -> None:
+    """Pass 2: emit the first ``out_lengths[s, p]`` carried ALT calls per
+    haplotype into the disjoint output range ``[flat_offsets[slot], ...)``."""
+    n_samples, ploidy, n_var = genos.shape
+    for s in nb.prange(n_samples):
+        for p in range(ploidy):
+            slot = s * ploidy + p
+            n_keep = out_lengths[s, p]
+            w = flat_offsets[slot]
+            kept = 0
+            for v in range(n_var):
+                if kept >= n_keep:
+                    break
+                if genos[s, p, v] == 1:
+                    out_data[w] = var_idxs[v]
+                    if has_dose:
+                        out_dose[w] = dosages[s, v]
+                    w += 1
+                    kept += 1
 
 
 @nb.njit(parallel=False, nogil=True, cache=True)

--- a/genoray/_vcf.py
+++ b/genoray/_vcf.py
@@ -1423,7 +1423,9 @@ class VCF:
                 if v.is_indel:
                     ilen = len(v.ALT[0]) - len(v.REF)
                     dist = v.start - last_end
-                    hap_lens += dist + np.where(genos == 1, ilen, 0).squeeze(-1)
+                    hap_lens += dist + np.where(
+                        genos[:, : self.ploidy] == 1, ilen, 0
+                    ).squeeze(-1)
                     last_end = cast(int, v.end)
 
                 if i % _CHECK_LEN_EVERY_N == 0 and (hap_lens >= length).all():
@@ -1478,7 +1480,9 @@ class VCF:
                     ilen = len(v.ALT[0]) - len(v.REF)
                     dist = v.start - last_end
                     # (s p 1)
-                    hap_lens += dist + np.where(genos == 1, ilen, 0).squeeze(-1)
+                    hap_lens += dist + np.where(
+                        genos[:, : self.ploidy] == 1, ilen, 0
+                    ).squeeze(-1)
                     last_end = cast(int, v.end)
 
                 if i % _CHECK_LEN_EVERY_N == 0 and (hap_lens >= length).all():

--- a/tests/_length_helpers.py
+++ b/tests/_length_helpers.py
@@ -1,10 +1,25 @@
 """Shared assertions for *_with_length tests.
 
-The feature's guarantee: each haplotype carries enough length to cover the
-original query span. Dense backends (VCF/PGEN) extend to one shared boundary
-(the worst-case haplotype reaches Q); sparse (SparseVar) extends each
-haplotype independently. ``clamped=True`` exempts cases where extension hit the
-contig end and legitimately could not reach Q.
+The feature's guarantee (see memory ``with-length-semantics``): pick the most
+PARSIMONIOUS set of ALT calls such that the personalized haplotype, padded on the
+right with reference nucleotides, reaches the query length. Haplotype length
+counts personalized nucleotides, not reference span.
+
+Equivalent, checkable form per haplotype: let ``S`` be the selected ALT calls and
+``R = q_len - sum(ilens[S])`` the reference footprint the haplotype must cover
+(since hap_len = ref_bases_covered + sum_ilens, and we want hap_len == q_len, so
+ref_bases_covered = R). The haplotype then spans reference ``[q_start, q_start+R)``
+and is padded with plain reference where there are no ALT calls. The selection is
+correct iff:
+
+- **completeness:** every ALT call the haplotype carries with start in
+  ``[q_start, q_start + R)`` is in ``S`` (none skipped inside the footprint), and
+- **parsimony:** every selected call lies within the footprint (none included
+  past where reference padding already reaches q_len).
+
+Together these mean ``S`` is EXACTLY the carried ALT calls whose start falls in
+``[q_start, q_start + R)``. The contig-end clamp needs no special case: if no
+carried variants exist past the footprint, completeness holds trivially.
 """
 
 from __future__ import annotations
@@ -12,39 +27,54 @@ from __future__ import annotations
 import numpy as np
 from numpy.typing import NDArray
 
-from genoray._utils import hap_ilens
 
-
-def realized_hap_lengths(
-    genos: NDArray[np.integer], ilens: NDArray[np.int32], q_len: int
-) -> NDArray[np.int32]:
-    """Realized haplotype lengths for a dense window. genos: (s p v)."""
-    # base query length + net indel contribution carried by each haplotype
-    return q_len + hap_ilens(genos, ilens)
-
-
-def assert_dense_reaches_length(
-    genos: NDArray[np.integer],
-    ilens: NDArray[np.int32],
+def assert_parsimonious_with_length(
+    selected_per_hap: list[NDArray[np.integer]],
+    carried_per_hap: list[NDArray[np.integer]],
+    q_start: int,
     q_len: int,
+    v_starts: NDArray[np.integer],
+    ilens: NDArray[np.integer],
     *,
-    clamped: bool = False,
+    backend: str = "",
 ) -> None:
-    """Dense (VCF/PGEN): the worst-case haplotype must reach q_len unless clamped."""
-    hap_lens = realized_hap_lengths(genos, ilens, q_len)
-    if clamped:
-        return
-    assert hap_lens.max() >= q_len, (
-        f"no haplotype reached query length {q_len}; max realized {hap_lens.max()}"
-    )
+    """Assert each haplotype's selected ALT calls are exactly the carried calls
+    within the required reference footprint (see module docstring).
 
-
-def assert_sparse_reaches_length(
-    hap_lens: NDArray[np.int32], q_len: int, *, clamped: bool = False
-) -> None:
-    """Sparse (SparseVar): every haplotype must independently reach q_len."""
-    if clamped:
-        return
-    assert (hap_lens >= q_len).all(), (
-        f"some haplotype did not reach query length {q_len}: {hap_lens}"
-    )
+    Parameters
+    ----------
+    selected_per_hap
+        Per-haplotype arrays of GLOBAL variant indices returned by a
+        ``with_length`` read (the parsimonious selection).
+    carried_per_hap
+        Per-haplotype arrays of ALL GLOBAL variant indices the haplotype carries
+        on the contig (from a plain, non-extended read).
+    q_start, q_len
+        0-based query start and its length (``end - start``).
+    v_starts
+        GLOBAL 0-based variant start positions, indexed by variant index.
+    ilens
+        GLOBAL ILEN per variant, indexed by variant index.
+    backend
+        Optional label for assertion messages.
+    """
+    assert len(selected_per_hap) == len(carried_per_hap)
+    for h, (sel, carried) in enumerate(zip(selected_per_hap, carried_per_hap)):
+        sel = np.asarray(sel)
+        carried = np.asarray(carried)
+        # selected must be a subset of what the haplotype actually carries
+        assert set(sel.tolist()) <= set(carried.tolist()), (
+            f"[{backend}] hap {h}: selected variants not all carried"
+        )
+        sum_ilen = int(ilens[sel].sum()) if len(sel) else 0
+        footprint_end = q_start + (q_len - sum_ilen)
+        in_footprint = carried[
+            (v_starts[carried] >= q_start) & (v_starts[carried] < footprint_end)
+        ]
+        assert set(sel.tolist()) == set(in_footprint.tolist()), (
+            f"[{backend}] hap {h}: selection is not the parsimonious footprint set. "
+            f"q_start={q_start} q_len={q_len} sum_ilen={sum_ilen} "
+            f"footprint=[{q_start},{footprint_end}); "
+            f"selected={sorted(sel.tolist())} "
+            f"expected={sorted(in_footprint.tolist())}"
+        )

--- a/tests/_length_helpers.py
+++ b/tests/_length_helpers.py
@@ -1,0 +1,50 @@
+"""Shared assertions for *_with_length tests.
+
+The feature's guarantee: each haplotype carries enough length to cover the
+original query span. Dense backends (VCF/PGEN) extend to one shared boundary
+(the worst-case haplotype reaches Q); sparse (SparseVar) extends each
+haplotype independently. ``clamped=True`` exempts cases where extension hit the
+contig end and legitimately could not reach Q.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from genoray._utils import hap_ilens
+
+
+def realized_hap_lengths(
+    genos: NDArray[np.integer], ilens: NDArray[np.int32], q_len: int
+) -> NDArray[np.int32]:
+    """Realized haplotype lengths for a dense window. genos: (s p v)."""
+    # base query length + net indel contribution carried by each haplotype
+    return q_len + hap_ilens(genos, ilens)
+
+
+def assert_dense_reaches_length(
+    genos: NDArray[np.integer],
+    ilens: NDArray[np.int32],
+    q_len: int,
+    *,
+    clamped: bool = False,
+) -> None:
+    """Dense (VCF/PGEN): the worst-case haplotype must reach q_len unless clamped."""
+    hap_lens = realized_hap_lengths(genos, ilens, q_len)
+    if clamped:
+        return
+    assert hap_lens.max() >= q_len, (
+        f"no haplotype reached query length {q_len}; max realized {hap_lens.max()}"
+    )
+
+
+def assert_sparse_reaches_length(
+    hap_lens: NDArray[np.int32], q_len: int, *, clamped: bool = False
+) -> None:
+    """Sparse (SparseVar): every haplotype must independently reach q_len."""
+    if clamped:
+        return
+    assert (hap_lens >= q_len).all(), (
+        f"some haplotype did not reach query length {q_len}: {hap_lens}"
+    )

--- a/tests/data/gen_from_vcf.sh
+++ b/tests/data/gen_from_vcf.sh
@@ -8,6 +8,7 @@ ddir=$(realpath "$ddir")
 bi=$ddir/biallelic.vcf
 multi=$ddir/multiallelic.vcf
 unsorted=$ddir/three_samples_unsorted.vcf
+indels=$ddir/indels.vcf
 
 echo "Bgzipping and indexing VCF files..."
 bgzip -c "$bi" >| "$bi".gz
@@ -22,7 +23,6 @@ bgzip -c "$unsorted" >| "$unsorted".gz
 bcftools index "$unsorted".gz
 rm -f "$unsorted".gz.gvi
 
-indels=$ddir/indels.vcf
 bgzip -c "$indels" >| "$indels".gz
 bcftools index "$indels".gz
 rm -f "$indels".gz.gvi

--- a/tests/data/gen_from_vcf.sh
+++ b/tests/data/gen_from_vcf.sh
@@ -22,6 +22,11 @@ bgzip -c "$unsorted" >| "$unsorted".gz
 bcftools index "$unsorted".gz
 rm -f "$unsorted".gz.gvi
 
+indels=$ddir/indels.vcf
+bgzip -c "$indels" >| "$indels".gz
+bcftools index "$indels".gz
+rm -f "$indels".gz.gvi
+
 echo "Converting VCF to PLINK format..."
 prefix="${bi%.vcf}"
 plink2 --make-pgen --vcf "$bi".gz 'dosage=DS' --out "$prefix" --vcf-half-call r
@@ -38,6 +43,10 @@ plink2 --make-pgen vzs --vcf "$bi".gz 'dosage=DS' --out "$prefix" --vcf-half-cal
 rm -f "$prefix".log
 rm -f "$prefix".pvar.zst.gvi
 
+prefix="${indels%.vcf}"
+plink2 --make-pgen --vcf "$indels".gz 'dosage=DS' --out "$prefix" --vcf-half-call r
+rm -f "$prefix".log
+rm -f "$prefix".pvar.gvi
 
 echo "Converting VCF and PGEN to SVAR format..."
 python "$ddir"/gen_svar.py

--- a/tests/data/gen_svar.py
+++ b/tests/data/gen_svar.py
@@ -35,6 +35,29 @@ def main():
     SparseVar.from_pgen(pgen_path, pgen, max_mem, overwrite=True, with_dosages=True)
     SparseVar(pgen_path).cache_afs()
 
+    # indels fixture (with_length edge cases)
+    ivcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+    ivcf._write_gvi_index()
+    ivcf_path = ddir / "indels.vcf.svar"
+    if ivcf_path.exists():
+        shutil.rmtree(ivcf_path)
+    max_mem = ivcf._mem_per_variant(ivcf.Genos8Dosages) * min(
+        len(ivcf.contigs), joblib.cpu_count()
+    )
+    SparseVar.from_vcf(ivcf_path, ivcf, max_mem, overwrite=True, with_dosages=True)
+    SparseVar(ivcf_path).cache_afs()
+
+    ipgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    ipgen_path = ddir / "indels.pgen.svar"
+    if ipgen_path.exists():
+        shutil.rmtree(ipgen_path)
+    assert ipgen.contigs is not None
+    max_mem = ipgen._mem_per_variant(ipgen.GenosDosages) * min(
+        len(ipgen.contigs), joblib.cpu_count()
+    )
+    SparseVar.from_pgen(ipgen_path, ipgen, max_mem, overwrite=True, with_dosages=True)
+    SparseVar(ipgen_path).cache_afs()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/data/gen_svar.py
+++ b/tests/data/gen_svar.py
@@ -48,6 +48,7 @@ def main():
     SparseVar(ivcf_path).cache_afs()
 
     ipgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+
     ipgen_path = ddir / "indels.pgen.svar"
     if ipgen_path.exists():
         shutil.rmtree(ipgen_path)

--- a/tests/data/indels.vcf
+++ b/tests/data/indels.vcf
@@ -2,7 +2,7 @@
 ##contig=<ID=chr1>
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DS,Number=1,Type=Float,Description="Dosage">
-##COMMENT=Region C: -30 deletion + 40 dense SNPs, contrived to force PGENs multi-round extension loop. Not a realistic genome.
+##COMMENT=with_length edge-case fixture. Region A (POS 1000): -10 deletion + 6 SNPs (multi-variant extension). Region B (POS 2000): -4 deletion het on sample1 hapA only + 3 SNPs (per-haplotype divergence). Region C (POS 3000): -30 deletion + 40 dense SNPs, contrived to force PGENs multi-round extension loop. Region D (POS 5000): lone -10 deletion as last variant (contig-end clamp). Not a realistic genome.
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
 chr1	1000	.	GAAAAAAAAAA	G	.	.	.	GT:DS	1|1:2.0	1|1:2.0
 chr1	1011	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0

--- a/tests/data/indels.vcf
+++ b/tests/data/indels.vcf
@@ -1,0 +1,59 @@
+##fileformat=VCFv4.2
+##contig=<ID=chr1>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DS,Number=1,Type=Float,Description="Dosage">
+##COMMENT=Region C: -30 deletion + 40 dense SNPs, contrived to force PGENs multi-round extension loop. Not a realistic genome.
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
+chr1	1000	.	GAAAAAAAAAA	G	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1011	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1013	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1015	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1017	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1019	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	1021	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	2000	.	GAAAA	G	.	.	.	GT:DS	1|0:1.0	0|0:0.0
+chr1	2002	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	2004	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	2006	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3000	.	GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA	G	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3031	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3032	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3033	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3034	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3035	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3036	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3037	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3038	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3039	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3040	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3041	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3042	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3043	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3044	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3045	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3046	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3047	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3048	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3049	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3050	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3051	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3052	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3053	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3054	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3055	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3056	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3057	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3058	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3059	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3060	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3061	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3062	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3063	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3064	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3065	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3066	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3067	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3068	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3069	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	3070	.	T	C	.	.	.	GT:DS	1|1:2.0	1|1:2.0
+chr1	5000	.	GAAAAAAAAAA	G	.	.	.	GT:DS	1|1:2.0	1|1:2.0

--- a/tests/test_dense2sparse_with_length.py
+++ b/tests/test_dense2sparse_with_length.py
@@ -1,0 +1,79 @@
+"""Unit tests for _dense2sparse_with_length (the dense->sparse parity bridge)."""
+
+from __future__ import annotations
+
+import numpy as np
+from seqpro.rag import OFFSET_TYPE
+
+from genoray._svar import _dense2sparse_with_length
+from genoray._types import V_IDX_TYPE
+
+
+def test_no_indels_keeps_all_carriers_within_query():
+    # 1 sample, ploidy 1, window of 3 SNPs all inside the query, all carried.
+    genos = np.array([[[1, 1, 1]]], dtype=np.int8)
+    var_idxs = np.array([0, 1, 2], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 11, 12], dtype=np.int32)
+    ilens = np.array([0, 0, 0], dtype=np.int32)
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 13, v_starts, ilens)
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 3], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(rag.data, np.array([0, 1, 2], dtype=V_IDX_TYPE))
+
+
+def test_deletion_forces_extension_past_query():
+    # 1 sample, ploidy 1. A -2 deletion at the query start spans ref [10, 13),
+    # i.e. the whole query. To recover the lost length the walk must extend past
+    # q_end (=13) into the variants at 13 and 14. The variant at 15 is not
+    # needed. (Inputs are non-overlapping: the deletion's downstream neighbors
+    # sit at/after its reference end, not inside its deleted span.)
+    genos = np.array([[[1, 1, 1, 1]]], dtype=np.int8)
+    var_idxs = np.array([0, 1, 2, 3], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 13, 14, 15], dtype=np.int32)
+    ilens = np.array([-2, 0, 0, 0], dtype=np.int32)  # deletion first
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 13, v_starts, ilens)
+    # keeps the deletion + the two extension variants past q_end (idx 0,1,2)
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 3], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(rag.data, np.array([0, 1, 2], dtype=V_IDX_TYPE))
+
+
+def test_per_haplotype_independent_trim():
+    # 1 sample, ploidy 2. Query [10, 15) (len 5). Window: a -2 deletion at 10
+    # (spans ref [10, 13)) followed by SNPs at 13,14,15,16,17.
+    # hapA carries the deletion + all SNPs -> must extend further to recover the
+    # deleted length. hapB carries only the SNPs (no deletion) -> reaches length
+    # with far fewer variants. The two haplotypes therefore trim independently.
+    genosA = [1, 1, 1, 1, 1, 1]
+    genosB = [0, 1, 1, 1, 1, 1]
+    genos = np.array([[genosA, genosB]], dtype=np.int8)
+    var_idxs = np.array([0, 1, 2, 3, 4, 5], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 13, 14, 15, 16, 17], dtype=np.int32)
+    ilens = np.array([-2, 0, 0, 0, 0, 0], dtype=np.int32)
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 15, v_starts, ilens)
+    # hapA keeps 5 (deletion + 4 SNPs: idx 0,1,2,3,4); hapB keeps 2 (idx 1,2)
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 5, 7], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(
+        rag.data, np.array([0, 1, 2, 3, 4, 1, 2], dtype=V_IDX_TYPE)
+    )
+
+
+def test_dosages_follow_genotypes():
+    genos = np.array([[[1, 1]]], dtype=np.int8)
+    var_idxs = np.array([5, 6], dtype=V_IDX_TYPE)
+    v_starts = np.array([10, 11], dtype=np.int32)
+    ilens = np.array([0, 0], dtype=np.int32)
+    dosages = np.array([[0.5, 0.9]], dtype=np.float32)  # (s v)
+    rag, drag = _dense2sparse_with_length(
+        genos, var_idxs, 10, 12, v_starts, ilens, dosages
+    )
+    np.testing.assert_array_equal(rag.data, np.array([5, 6], dtype=V_IDX_TYPE))
+    np.testing.assert_allclose(drag.data, np.array([0.5, 0.9], dtype=np.float32))
+
+
+def test_clamp_keeps_what_is_available():
+    genos = np.array([[[1]]], dtype=np.int8)
+    var_idxs = np.array([0], dtype=V_IDX_TYPE)
+    v_starts = np.array([10], dtype=np.int32)
+    ilens = np.array([-5], dtype=np.int32)
+    rag = _dense2sparse_with_length(genos, var_idxs, 10, 30, v_starts, ilens)
+    np.testing.assert_array_equal(rag.offsets, np.array([0, 1], dtype=OFFSET_TYPE))
+    np.testing.assert_array_equal(rag.data, np.array([0], dtype=V_IDX_TYPE))

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -30,6 +30,8 @@ from genoray import PGEN, VCF, SparseVar
 from genoray._svar import _dense2sparse_with_length
 from genoray._types import V_IDX_TYPE
 
+from _length_helpers import assert_parsimonious_with_length
+
 ddir = Path(__file__).parent / "data"
 
 # (label, contig, start, end, clamped)
@@ -129,6 +131,72 @@ def test_pgen_window_bridges_to_svar(label, contig, start, end, clamped):
 
     actual = svar.read_ranges_with_length(contig, start, end)[0]
     assert _ragged_to_lists(actual) == _ragged_to_lists(brag)
+
+
+@pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
+def test_with_length_is_parsimonious(label, contig, start, end, clamped):
+    """The with_length selection (from every backend) is exactly the
+    parsimonious set of ALT calls whose start lies in the reference footprint
+    [start, start + (q_len - sum_ilen)) — i.e. enough that right-padding with
+    reference reaches the query length, and not one ALT call more. See
+    tests/_length_helpers.py for the formulation.
+    """
+    svar = SparseVar(ddir / "indels.pgen.svar")
+    v_starts_g, ilens_g = _global_attrs(svar)
+    q_len = end - start
+
+    # Full per-haplotype carried ALT calls over the whole contig (non-extended).
+    carried = [
+        np.asarray(x) for x in _ragged_to_lists(svar.read_ranges(contig, 0, 10_000)[0])
+    ]
+
+    def check(per_hap_lists, backend):
+        assert_parsimonious_with_length(
+            [np.asarray(x) for x in per_hap_lists],
+            carried,
+            start,
+            q_len,
+            v_starts_g,
+            ilens_g,
+            backend=backend,
+        )
+
+    # SparseVar: native per-haplotype selection.
+    sv = svar.read_ranges_with_length(contig, start, end)[0]
+    check(_ragged_to_lists(sv), "svar")
+
+    # PGEN: dense window -> bridge -> per-haplotype selection.
+    pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    genos, dosages, var_idxs = _collect_pgen(pgen, contig, start, end)
+    idx = var_idxs.astype(np.intp)
+    pbrag, _ = _dense2sparse_with_length(
+        genos.astype(np.int8),
+        var_idxs,
+        start,
+        end,
+        v_starts_g[idx].astype(np.int32),
+        ilens_g[idx].astype(np.int32),
+        dosages,
+    )
+    check(_ragged_to_lists(pbrag), "pgen")
+
+    # VCF: dense window -> bridge -> per-haplotype selection (indices
+    # reconstructed from the contiguous genomic-order window).
+    vcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+    vgenos, vdosages = _collect_vcf(vcf, contig, start, end)
+    n = vgenos.shape[-1]
+    w_start = int(np.searchsorted(v_starts_g, start))
+    vvar = np.arange(w_start, w_start + n, dtype=V_IDX_TYPE)
+    vbrag, _ = _dense2sparse_with_length(
+        vgenos.astype(np.int8),
+        vvar,
+        start,
+        end,
+        v_starts_g[w_start : w_start + n].astype(np.int32),
+        ilens_g[w_start : w_start + n].astype(np.int32),
+        vdosages,
+    )
+    check(_ragged_to_lists(vbrag), "vcf")
 
 
 @pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,0 +1,138 @@
+"""Cross-backend parity for *_with_length on the indels fixture.
+
+PGEN and VCF are dense/variant-major: they extend to one shared boundary, so
+their dense outputs must be identical. SparseVar extends each haplotype
+independently; its output must equal _dense2sparse_with_length applied to the
+dense window (the parity bridge).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from genoray import PGEN, VCF, SparseVar
+from genoray._svar import _dense2sparse_with_length
+
+ddir = Path(__file__).parent / "data"
+
+# (label, contig, start, end, clamped)
+REGIONS = [
+    ("A_big_deletion", "chr1", 999, 1010, False),
+    ("B_per_haplotype", "chr1", 1999, 2006, False),
+    ("C_snp_dense", "chr1", 2999, 3030, False),
+    ("D_contig_end_clamp", "chr1", 4999, 5040, True),
+]
+
+
+def _collect_pgen(pgen, contig, start, end):
+    """Concatenate a single range's chunks into one dense window + var_idxs."""
+    mode = PGEN.GenosPhasingDosages
+    gen = pgen._chunk_ranges_with_length(contig, start, end, "1g", mode)
+    genos_parts, dose_parts, idx_parts = [], [], []
+    end_pos = None
+    for range_ in gen:
+        for chunk, e, v_idxs in range_:
+            g, p, d = chunk
+            genos_parts.append(np.asarray(g))
+            dose_parts.append(np.asarray(d))
+            idx_parts.append(np.asarray(v_idxs))
+            end_pos = e
+        break  # single range queried
+    genos = np.concatenate(genos_parts, axis=-1)
+    dosages = np.concatenate(dose_parts, axis=-1)
+    var_idxs = np.concatenate(idx_parts)
+    return genos, dosages, var_idxs, end_pos
+
+
+def _collect_vcf(vcf, contig, start, end):
+    # phasing=False so genos shape is (samples, ploidy, variants) without the
+    # phasing indicator row, avoiding the (2,2) vs (2,3) broadcast error in
+    # _ext_genos_dosages_with_length when phasing=True.
+    vcf.phasing = False
+    mode = VCF.Genos16Dosages
+    gen = vcf._chunk_ranges_with_length(contig, start, end, "1g", mode)
+    genos_parts, dose_parts = [], []
+    end_pos = None
+    for range_ in gen:
+        for chunk, e, _n_ext in range_:
+            gp, d = chunk
+            # gp shape: (samples, ploidy, variants) — no phasing row when phasing=False
+            genos_parts.append(np.asarray(gp))
+            dose_parts.append(np.asarray(d))
+            end_pos = e
+        break
+    genos = np.concatenate(genos_parts, axis=-1)
+    dosages = np.concatenate(dose_parts, axis=-1)
+    return genos, dosages, end_pos
+
+
+def _ragged_to_lists(rag):
+    """Return the logical per-haplotype variant-index lists from a Ragged.
+
+    Works for both offset conventions used in this codebase:
+    - (2, n_haps) start/end pair matrix  (SparseVar.read_ranges_with_length[0])
+    - (n_haps+1,) monotonic cumsum       (_dense2sparse_with_length)
+    """
+    offsets = np.asarray(rag.offsets)
+    data = np.asarray(rag.data)
+    if offsets.ndim == 2:
+        # (2, n_haps) convention: row 0 = starts, row 1 = ends
+        return [
+            data[offsets[0, i] : offsets[1, i]].tolist()
+            for i in range(offsets.shape[1])
+        ]
+    else:
+        # (n_haps+1,) monotonic convention
+        return [
+            data[offsets[i] : offsets[i + 1]].tolist() for i in range(len(offsets) - 1)
+        ]
+
+
+@pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
+def test_pgen_equals_vcf_dense(label, contig, start, end, clamped):
+    pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    vcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+
+    pg, pd, _vidx, _pe = _collect_pgen(pgen, contig, start, end)
+    vg, vd, _ve = _collect_vcf(vcf, contig, start, end)
+
+    np.testing.assert_array_equal(pg.astype(np.int16), vg.astype(np.int16))
+    np.testing.assert_allclose(pd, vd, rtol=1e-4, equal_nan=True)
+
+
+@pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
+def test_svar_equals_bridge(label, contig, start, end, clamped):
+    pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
+    svar = SparseVar(ddir / "indels.pgen.svar")
+
+    genos, dosages, var_idxs, _end = _collect_pgen(pgen, contig, start, end)
+    # GLOBAL per-variant attributes, then slice to WINDOW-LOCAL via var_idxs
+    v_starts_global = (svar.index["POS"] - 1).to_numpy()
+    ilens_global = svar.index["ILEN"].list.first().to_numpy()
+    var_idxs_int = var_idxs.astype(np.intp)
+    v_starts_window = v_starts_global[var_idxs_int].astype(np.int32)
+    ilens_window = ilens_global[var_idxs_int].astype(np.int32)
+
+    bridged = _dense2sparse_with_length(
+        genos.astype(np.int8),
+        var_idxs,
+        start,
+        end,
+        v_starts_window,
+        ilens_window,
+        dosages,
+    )
+    brag, bdrag = bridged
+
+    actual = svar.read_ranges_with_length(contig, start, end)
+    # actual shape: (1 range, n_samples, ploidy, None); bridge shape: (n_samples, ploidy, None)
+    # Index out the single range before comparing.
+    actual_r = actual[0]
+
+    # The two Ragged objects may use different internal offset conventions
+    # ((2, n_haps) start/end pairs vs (n_haps+1,) cumsum), so compare the
+    # logical per-haplotype variant-index lists directly.
+    assert _ragged_to_lists(actual_r) == _ragged_to_lists(brag)

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,9 +1,22 @@
 """Cross-backend parity for *_with_length on the indels fixture.
 
-PGEN and VCF are dense/variant-major: they extend to one shared boundary, so
-their dense outputs must be identical. SparseVar extends each haplotype
-independently; its output must equal _dense2sparse_with_length applied to the
-dense window (the parity bridge).
+VCF and PGEN are dense/variant-major: each extends to a shared variant boundary
+sufficient for the worst-case haplotype to reach the query length. Their windows
+are NOT byte-identical to each other — the two backends use different extension
+strategies (VCF checks length every N variants per-variant; PGEN grabs doubling
+batches), so one may over-include relative to the other. Both windows are
+supersets of every haplotype's minimal set, however.
+
+SparseVar is sparse/sample-major: it extends each (sample, haplotype)
+independently to its own minimal length. The bridge ``_dense2sparse_with_length``
+trims a dense window down to that per-haplotype-minimal form. So the meaningful,
+invariant-respecting parity is:
+
+    bridge(VCF window)  == SparseVar.read_ranges_with_length
+    bridge(PGEN window) == SparseVar.read_ranges_with_length
+
+i.e. both dense backends carry the variants needed for every haplotype, and the
+bridge reconciles either one to the canonical sparse result.
 """
 
 from __future__ import annotations
@@ -15,6 +28,7 @@ import pytest
 
 from genoray import PGEN, VCF, SparseVar
 from genoray._svar import _dense2sparse_with_length
+from genoray._types import V_IDX_TYPE
 
 ddir = Path(__file__).parent / "data"
 
@@ -28,45 +42,47 @@ REGIONS = [
 
 
 def _collect_pgen(pgen, contig, start, end):
-    """Concatenate a single range's chunks into one dense window + var_idxs."""
+    """Concatenate a single range's chunks into one dense window + var_idxs.
+
+    PGEN exposes the window's global variant indices directly (3rd tuple field).
+    """
     mode = PGEN.GenosPhasingDosages
     gen = pgen._chunk_ranges_with_length(contig, start, end, "1g", mode)
     genos_parts, dose_parts, idx_parts = [], [], []
-    end_pos = None
     for range_ in gen:
-        for chunk, e, v_idxs in range_:
-            g, p, d = chunk
+        for chunk, _e, v_idxs in range_:
+            g, _p, d = chunk
             genos_parts.append(np.asarray(g))
             dose_parts.append(np.asarray(d))
             idx_parts.append(np.asarray(v_idxs))
-            end_pos = e
         break  # single range queried
     genos = np.concatenate(genos_parts, axis=-1)
     dosages = np.concatenate(dose_parts, axis=-1)
     var_idxs = np.concatenate(idx_parts)
-    return genos, dosages, var_idxs, end_pos
+    return genos, dosages, var_idxs
 
 
 def _collect_vcf(vcf, contig, start, end):
-    # phasing=False so genos shape is (samples, ploidy, variants) without the
-    # phasing indicator row, avoiding the (2,2) vs (2,3) broadcast error in
-    # _ext_genos_dosages_with_length when phasing=True.
+    """Concatenate a single range's chunks into one dense window.
+
+    phasing=False so genos is (samples, ploidy, variants) with no phasing row —
+    that's exactly the shape the bridge needs (it only inspects ALT carriers).
+    VCF does NOT expose variant indices, so the caller reconstructs them from the
+    contiguous genomic-order window (see the test).
+    """
     vcf.phasing = False
     mode = VCF.Genos16Dosages
     gen = vcf._chunk_ranges_with_length(contig, start, end, "1g", mode)
     genos_parts, dose_parts = [], []
-    end_pos = None
     for range_ in gen:
-        for chunk, e, _n_ext in range_:
+        for chunk, _e, _n_ext in range_:
             gp, d = chunk
-            # gp shape: (samples, ploidy, variants) — no phasing row when phasing=False
             genos_parts.append(np.asarray(gp))
             dose_parts.append(np.asarray(d))
-            end_pos = e
         break
     genos = np.concatenate(genos_parts, axis=-1)
     dosages = np.concatenate(dose_parts, axis=-1)
-    return genos, dosages, end_pos
+    return genos, dosages
 
 
 def _ragged_to_lists(rag):
@@ -79,60 +95,67 @@ def _ragged_to_lists(rag):
     offsets = np.asarray(rag.offsets)
     data = np.asarray(rag.data)
     if offsets.ndim == 2:
-        # (2, n_haps) convention: row 0 = starts, row 1 = ends
         return [
             data[offsets[0, i] : offsets[1, i]].tolist()
             for i in range(offsets.shape[1])
         ]
-    else:
-        # (n_haps+1,) monotonic convention
-        return [
-            data[offsets[i] : offsets[i + 1]].tolist() for i in range(len(offsets) - 1)
-        ]
+    return [data[offsets[i] : offsets[i + 1]].tolist() for i in range(len(offsets) - 1)]
+
+
+def _global_attrs(svar):
+    """Global 0-based starts and ILENs, indexed by global variant index."""
+    v_starts = (svar.index["POS"] - 1).to_numpy()
+    ilens = svar.index["ILEN"].list.first().to_numpy()
+    return v_starts, ilens
 
 
 @pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
-def test_pgen_equals_vcf_dense(label, contig, start, end, clamped):
-    pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
-    vcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
-
-    pg, pd, _vidx, _pe = _collect_pgen(pgen, contig, start, end)
-    vg, vd, _ve = _collect_vcf(vcf, contig, start, end)
-
-    np.testing.assert_array_equal(pg.astype(np.int16), vg.astype(np.int16))
-    np.testing.assert_allclose(pd, vd, rtol=1e-4, equal_nan=True)
-
-
-@pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
-def test_svar_equals_bridge(label, contig, start, end, clamped):
+def test_pgen_window_bridges_to_svar(label, contig, start, end, clamped):
     pgen = PGEN(ddir / "indels.pgen", dosage_path=ddir / "indels.pgen")
     svar = SparseVar(ddir / "indels.pgen.svar")
 
-    genos, dosages, var_idxs, _end = _collect_pgen(pgen, contig, start, end)
-    # GLOBAL per-variant attributes, then slice to WINDOW-LOCAL via var_idxs
-    v_starts_global = (svar.index["POS"] - 1).to_numpy()
-    ilens_global = svar.index["ILEN"].list.first().to_numpy()
-    var_idxs_int = var_idxs.astype(np.intp)
-    v_starts_window = v_starts_global[var_idxs_int].astype(np.int32)
-    ilens_window = ilens_global[var_idxs_int].astype(np.int32)
-
-    bridged = _dense2sparse_with_length(
+    genos, dosages, var_idxs = _collect_pgen(pgen, contig, start, end)
+    v_starts_g, ilens_g = _global_attrs(svar)
+    idx = var_idxs.astype(np.intp)
+    brag, _bdrag = _dense2sparse_with_length(
         genos.astype(np.int8),
         var_idxs,
         start,
         end,
-        v_starts_window,
-        ilens_window,
+        v_starts_g[idx].astype(np.int32),  # window-local
+        ilens_g[idx].astype(np.int32),  # window-local
         dosages,
     )
-    brag, bdrag = bridged
 
-    actual = svar.read_ranges_with_length(contig, start, end)
-    # actual shape: (1 range, n_samples, ploidy, None); bridge shape: (n_samples, ploidy, None)
-    # Index out the single range before comparing.
-    actual_r = actual[0]
+    actual = svar.read_ranges_with_length(contig, start, end)[0]
+    assert _ragged_to_lists(actual) == _ragged_to_lists(brag)
 
-    # The two Ragged objects may use different internal offset conventions
-    # ((2, n_haps) start/end pairs vs (n_haps+1,) cumsum), so compare the
-    # logical per-haplotype variant-index lists directly.
-    assert _ragged_to_lists(actual_r) == _ragged_to_lists(brag)
+
+@pytest.mark.parametrize("label,contig,start,end,clamped", REGIONS)
+def test_vcf_window_bridges_to_svar(label, contig, start, end, clamped):
+    vcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+    svar = SparseVar(ddir / "indels.vcf.svar")
+
+    genos, dosages = _collect_vcf(vcf, contig, start, end)
+    n = genos.shape[-1]
+
+    # VCF does not expose variant indices. The window is a contiguous run of
+    # variants in genomic (== global index) order starting at the first variant
+    # at/after the query start, so reconstruct the global indices by searching
+    # the (sorted) index POS.
+    v_starts_g, ilens_g = _global_attrs(svar)
+    w_start = int(np.searchsorted(v_starts_g, start))
+    var_idxs = np.arange(w_start, w_start + n, dtype=V_IDX_TYPE)
+
+    brag, _bdrag = _dense2sparse_with_length(
+        genos.astype(np.int8),
+        var_idxs,
+        start,
+        end,
+        v_starts_g[w_start : w_start + n].astype(np.int32),  # window-local
+        ilens_g[w_start : w_start + n].astype(np.int32),  # window-local
+        dosages,
+    )
+
+    actual = svar.read_ranges_with_length(contig, start, end)[0]
+    assert _ragged_to_lists(actual) == _ragged_to_lists(brag)

--- a/tests/test_pgen.py
+++ b/tests/test_pgen.py
@@ -7,7 +7,8 @@ import pytest
 from numpy.typing import ArrayLike, NDArray
 from pytest_cases import parametrize_with_cases
 
-from genoray._pgen import PGEN, POS_MAX, V_IDX_TYPE
+from genoray._pgen import PGEN, Genos, POS_MAX, V_IDX_TYPE, _gen_with_length
+from genoray._types import POS_TYPE
 
 tdir = Path(__file__).parent
 ddir = tdir / "data"
@@ -405,6 +406,81 @@ def test_pgen_nbytes_positive_after_init():
     assert pgen.nbytes > 0
     # both the index dataframe and the StartsEndsIlens cache should contribute
     assert pgen.nbytes >= pgen._index.estimated_size()
+
+
+def _fake_read_factory(dense_genos):
+    """dense_genos: (s p V) global int32 array. Returns read(var_idx)->Genos."""
+
+    def read(var_idx):
+        return Genos.parse(dense_genos[:, :, var_idx].astype(np.int32))
+
+    return read
+
+
+def test_gen_with_length_multi_round_extension():
+    # 1 sample, ploidy 2 (required by Genos predicate). Variant 0 is a -60
+    # deletion (carried on both haplotypes). Variants 1..40 are SNPs 1bp apart
+    # starting just past the deletion's reference end. The first extension batch
+    # of ~20 variants spans only ~20 bp; with a -60 deletion the haplotype
+    # length deficit is still unmet, forcing a 2nd doubling round.
+    n = 41
+    v_starts = np.empty(n, dtype=POS_TYPE)
+    v_starts[0] = 2999  # deletion at 0-based 2999
+    v_starts[1:] = np.arange(3060, 3060 + (n - 1), dtype=POS_TYPE)
+    ilens = np.zeros(n, dtype=np.int32)
+    ilens[0] = -60
+    v_ends = v_starts + 1
+    v_ends[0] = 2999 + 61  # REF length 61
+
+    # all variants carried on both haplotypes (shape: s=1, p=2, V=n)
+    dense = np.ones((1, 2, n), dtype=np.int32)
+    read = _fake_read_factory(dense)
+
+    q_start, q_end = 2999, 3060  # len 61
+    v_chunks = [np.array([0], dtype=V_IDX_TYPE)]  # query window = just the deletion
+
+    out = list(
+        _gen_with_length(
+            v_chunks=v_chunks,
+            q_start=q_start,
+            q_end=q_end,
+            read=read,
+            v_starts=v_starts,
+            v_ends=v_ends,
+            ilens=ilens,
+            contig_max_idx=n - 1,
+        )
+    )
+    final_genos, _end, final_idx = out[-1]
+    assert final_idx[-1] > 20, (
+        f"multi-round extension not triggered; reached idx {final_idx[-1]}. "
+        f"All chunks: {[(np.asarray(g).shape, int(e), fi.tolist()) for g, e, fi in out]}"
+    )
+
+
+def test_gen_with_length_clamps_at_contig_end():
+    # Deletion is the last variant -> extension cannot proceed, must clamp.
+    v_starts = np.array([4999], dtype=POS_TYPE)
+    v_ends = np.array([4999 + 11], dtype=POS_TYPE)
+    ilens = np.array([-10], dtype=np.int32)
+    # shape: s=1, p=2, V=1 (ploidy=2 required by Genos predicate)
+    dense = np.ones((1, 2, 1), dtype=np.int32)
+    read = _fake_read_factory(dense)
+
+    out = list(
+        _gen_with_length(
+            v_chunks=[np.array([0], dtype=V_IDX_TYPE)],
+            q_start=4999,
+            q_end=5040,
+            read=read,
+            v_starts=v_starts,
+            v_ends=v_ends,
+            ilens=ilens,
+            contig_max_idx=0,  # this IS the last variant
+        )
+    )
+    final_genos, _end, final_idx = out[-1]
+    np.testing.assert_array_equal(final_idx, np.array([0], dtype=V_IDX_TYPE))
 
 
 def test_pgen_nbytes_zero_after_free():

--- a/tests/test_svar.py
+++ b/tests/test_svar.py
@@ -196,6 +196,17 @@ def length_ext():
     return cse, desired
 
 
+def length_none():
+    # missing contig -> sentinel offsets (INT64_MAX) per haplotype
+    cse = "chr3", 0, 1
+    shape = (1, N_SAMPLES, PLOIDY, None)
+    sentinel = np.iinfo(OFFSET_TYPE).max
+    # (s p)
+    offsets = np.full((2, N_SAMPLES * PLOIDY), sentinel, OFFSET_TYPE)
+    desired = Ragged[V_IDX_TYPE].from_offsets(DATA, shape, offsets)
+    return cse, desired
+
+
 @parametrize_with_cases("cse, desired", cases=".", prefix="length_")
 def test_read_ranges_with_length(
     svar: SparseVar, cse: tuple[str, int, int], desired: Ragged[V_IDX_TYPE]

--- a/tests/test_svar_internals.py
+++ b/tests/test_svar_internals.py
@@ -107,3 +107,156 @@ def test_find_starts_ends_with_length_includes_variant_at_query_edge():
         f"SNP at q_end-1 was dropped due to early length-budget exit: "
         f"returned slice [{start}, {end}), expected [0, {n_vars})"
     )
+
+
+def test_with_length_large_deletion_extends_multiple_variants():
+    """A large deletion at the query start forces the walk to extend across
+    multiple downstream variants to satisfy the length budget.
+
+    Verified by running _length_walk_n_keep and _find_starts_ends_with_length
+    in a scratch session: n_keep=5, kept=5 (deletion + all 4 downstream SNPs).
+    """
+    # -10 deletion at pos 999; reference span [999, 1010).
+    # Downstream SNPs are placed at pos >= 1010 so none sit inside the
+    # deletion's deleted span on the same haplotype (avoids degenerate inputs).
+    v_starts = np.array([999, 1010, 1012, 1014, 1016], dtype=np.int32)
+    ilens = np.array([-10, 0, 0, 0, 0], dtype=np.int32)
+    n_vars = len(v_starts)
+    genos = np.arange(n_vars, dtype=V_IDX_TYPE)  # single hap carries all
+    geno_offsets = np.array([0, n_vars], dtype=OFFSET_TYPE)
+    sample_idxs = np.array([0], dtype=np.int64)
+
+    # Query covers exactly the deletion's reference span (length 11).
+    q_starts = np.array([999], dtype=POS_TYPE)
+    q_ends = np.array([1010], dtype=POS_TYPE)
+    # var_ranges covers only the deletion itself at the contig level;
+    # the length walk extends beyond it.
+    var_ranges = np.array([[0, 1]], dtype=V_IDX_TYPE)
+
+    out = _find_starts_ends_with_length(
+        genos,
+        geno_offsets,
+        q_starts,
+        q_ends,
+        var_ranges,
+        v_starts,
+        ilens,
+        sample_idxs,
+        1,
+        n_vars,
+    )
+    start = int(out[0, 0, 0, 0])
+    end = int(out[1, 0, 0, 0])
+
+    # The deletion shrinks the alternate-allele length, so the walk must pull
+    # in downstream SNPs to compensate. Observed: kept=5 (all 5 variants).
+    assert start == 0
+    assert end - start > 1, (
+        f"deletion did not force multi-variant extension: [{start}, {end})"
+    )
+
+
+def test_with_length_per_haplotype_divergence():
+    """A deletion carried by one haplotype but not the other causes the
+    deletion-carrying haplotype to keep more variants than the other.
+
+    Setup (ploidy=2, 1 sample):
+    - Global vars:
+        0: pos=100, ilen=-5 (deletion; ref span [100, 106))
+        1: pos=106, ilen=0  (SNP, at deletion's ref end -- no overlap)
+        2: pos=108, ilen=0  (SNP)
+        3: pos=110, ilen=0  (SNP, just past query end)
+        4: pos=101, ilen=0  (SNP for hapB)
+        5: pos=103, ilen=0  (SNP for hapB)
+        6: pos=109, ilen=0  (SNP for hapB)
+    - hapA (p=0) carries [0, 1, 2, 3]; hapB (p=1) carries [4, 5, 6].
+    - Query [100, 110): length 10.
+
+    Verified by scratch run:
+    - hapA kept=4 (deletion + 3 SNPs needed to cover length 10)
+    - hapB kept=3 (all 3 non-deletion SNPs)
+    hapA > hapB because the deletion reduces the alternate-allele contribution,
+    forcing the walk to extend further.
+    """
+    v_starts = np.array([100, 106, 108, 110, 101, 103, 109], dtype=np.int32)
+    ilens = np.array([-5, 0, 0, 0, 0, 0, 0], dtype=np.int32)
+    n_vars = len(v_starts)
+
+    # hapA carries global indices [0,1,2,3]; hapB carries [4,5,6].
+    # Sparse storage slots: sample 0, p=0 -> genos[0:4]; p=1 -> genos[4:7].
+    genos = np.array([0, 1, 2, 3, 4, 5, 6], dtype=V_IDX_TYPE)
+    geno_offsets = np.array([0, 4, 7], dtype=OFFSET_TYPE)
+    sample_idxs = np.array([0], dtype=np.int64)
+
+    q_starts = np.array([100], dtype=POS_TYPE)
+    q_ends = np.array([110], dtype=POS_TYPE)
+    # var_ranges spans all global variant indices so the walk can see all vars.
+    var_ranges = np.array([[0, n_vars]], dtype=V_IDX_TYPE)
+
+    out = _find_starts_ends_with_length(
+        genos,
+        geno_offsets,
+        q_starts,
+        q_ends,
+        var_ranges,
+        v_starts,
+        ilens,
+        sample_idxs,
+        2,
+        n_vars,
+    )
+    # out shape: (2, n_ranges=1, n_samples=1, ploidy=2)
+    kept_A = int(out[1, 0, 0, 0]) - int(out[0, 0, 0, 0])
+    kept_B = int(out[1, 0, 0, 1]) - int(out[0, 0, 0, 1])
+
+    # Verified observed values: hapA=4, hapB=3.
+    assert kept_A == 4, f"hapA expected 4 kept, got {kept_A}"
+    assert kept_B == 3, f"hapB expected 3 kept, got {kept_B}"
+    assert kept_A > kept_B, (
+        f"deletion hap should keep more variants than non-deletion hap; "
+        f"got hapA={kept_A}, hapB={kept_B}"
+    )
+
+
+def test_with_length_contig_end_clamp():
+    """When a lone carried deletion is the only variant on the contig and the
+    query length far exceeds what it can fill, the function returns exactly
+    that one variant and does not crash.
+
+    Verified by scratch run: n_keep=1, kept=1.
+    """
+    # Single -50 deletion at pos 1000; query [1000, 2000) length 1000 cannot
+    # be satisfied by one variant, but contig_max_idx=1 prevents extension.
+    v_starts = np.array([1000], dtype=np.int32)
+    ilens = np.array([-50], dtype=np.int32)
+    n_vars = 1
+
+    genos = np.array([0], dtype=V_IDX_TYPE)
+    geno_offsets = np.array([0, 1], dtype=OFFSET_TYPE)
+    sample_idxs = np.array([0], dtype=np.int64)
+
+    q_starts = np.array([1000], dtype=POS_TYPE)
+    q_ends = np.array([2000], dtype=POS_TYPE)
+    var_ranges = np.array([[0, 1]], dtype=V_IDX_TYPE)
+    contig_max_idx = n_vars  # exclusive upper bound; index 0 is the only valid var
+
+    out = _find_starts_ends_with_length(
+        genos,
+        geno_offsets,
+        q_starts,
+        q_ends,
+        var_ranges,
+        v_starts,
+        ilens,
+        sample_idxs,
+        1,
+        contig_max_idx,
+    )
+    start = int(out[0, 0, 0, 0])
+    end = int(out[1, 0, 0, 0])
+
+    # Despite the large query, only the one available variant is returned.
+    # Observed: kept=1.
+    assert end - start == 1, (
+        f"clamp should return exactly 1 variant; got [{start}, {end})"
+    )

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -279,3 +279,25 @@ def test_nbytes_positive_after_index_loaded():
     assert vcf.nbytes > 0
     # sanity: at least one byte per row across CHROM/POS/REF/ALT
     assert vcf.nbytes >= vcf._index.height
+
+
+def test_chunk_with_length_phased_indel_in_extension():
+    # Regression: with phasing=True, an indel in the EXTENSION region (past the
+    # query) previously crashed _ext_genos_*_with_length with a hap_lens
+    # broadcast error (shape (s, ploidy) vs (s, ploidy + phasing)). Region B of
+    # the indels fixture (query 1999-2006) extends across the -30 deletion that
+    # begins region C, exercising the indel-in-extension path.
+    vcf = VCF(ddir / "indels.vcf.gz", dosage_field="DS")
+    vcf.phasing = True
+    gen = vcf._chunk_ranges_with_length("chr1", 1999, 2006, "1g", VCF.Genos16Dosages)
+    chunks = []
+    for range_ in gen:
+        for chunk, end, n_ext in range_:
+            gp, d = chunk
+            chunks.append(gp)
+        break
+    genos_phasing = np.concatenate(chunks, axis=-1)
+    # phased Genos16 has a phasing-indicator row -> axis 1 == ploidy + 1
+    assert genos_phasing.shape[1] == vcf.ploidy + 1
+    # and it produced at least the query's variants without crashing
+    assert genos_phasing.shape[-1] > 0


### PR DESCRIPTION
## Summary
Audits and strengthens test coverage for the `*_with_length` range-extension feature (VCF / PGEN / SparseVar) and, along the way, fixes one real pre-existing bug and adds one private helper.

- **New fixture** `tests/data/indels.vcf` with four isolated regions exercising paths the prior single-deletion `biallelic` fixture never reached: a large deletion driving multi-variant extension, per-haplotype divergence, a SNP-dense region forcing PGEN's multi-round doubling loop, and a contig-end clamp.
- **Production:**
  - Extracted a shared njit helper `_length_walk_n_keep` (behavior-preserving refactor of `_find_starts_ends_with_length`) so the sparse path and the new bridge can't drift.
  - Added private `_dense2sparse_with_length` — converts a dense VCF/PGEN `with_length` window into the per-haplotype-minimal sparse form, identical to `SparseVar.read_ranges_with_length` (used by genvarloader).
  - **Bugfix** (`genoray/_vcf.py`): `_ext_genos_with_length` / `_ext_genos_dosages_with_length` crashed under `phasing=True` when an indel fell in the extension region (`hap_lens` shape `(s, ploidy)` vs `(s, ploidy+phasing)`). Fixed by slicing genos to `[:, :self.ploidy]` for the `hap_lens` update, matching the in-query path. Previously uncaught because the only existing indel sat inside the query, never the extension region.
- **Tests:** bridge unit tests; cross-backend parity asserting `bridge(VCF) == bridge(PGEN) == SparseVar` (the dense backends are NOT byte-identical — they use different extension strategies — so parity is asserted through the bridge); a correctly-formulated parsimony + reference-padding invariant; PGEN multi-round/clamp unit tests; new `_find_starts_ends_with_length` cases; a phased-indel-in-extension regression; and the SVAR missing-range `length_none` case.

### Notes
- No public API change; `_dense2sparse_with_length` is intentionally private. `skills/genoray-api/SKILL.md` unchanged.
- Design & implementation plan: `docs/superpowers/specs/2026-05-30-with-length-test-audit-design.md`, `docs/superpowers/plans/2026-05-30-with-length-test-audit.md`.

## Test Plan
- [x] `pixi run pytest -m "not network"` → 300 passed, 16 xfailed
- [x] `ruff check` / `ruff format --check` clean
- [x] New phased-indel regression fails before the VCF fix, passes after
- [ ] Reviewer: confirm the parsimony/padding semantics match intended `with_length` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)