### PR TITLE
feat(cli): replace --skip-symbolic-alts with composable --no-symbolic / --no-breakend

### DIFF
--- a/docs/superpowers/plans/2026-06-05-svar-cli-filter-flags.md
+++ b/docs/superpowers/plans/2026-06-05-svar-cli-filter-flags.md
@@ -1,0 +1,499 @@
+# SVAR write CLI: symbolic + breakend filter flags — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single `--skip-symbolic-alts` flag on `genoray write` with two independent, composable flags `--no-symbolic` and `--no-breakend` so users can produce SVARs free of un-injectable ALT classes.
+
+**Architecture:** Two private record-level predicates in `genoray/exprs.py` mirror the existing `is_symbolic` / `is_breakend` polars exprs (anchoring cyvcf2↔polars parity). The CLI `write` command composes whichever filters the flags request into a paired `(cyvcf2 callable, polars expr)` for VCF and a single polars expr for PGEN, then hands them to `SparseVar.from_vcf` / `from_pgen` (which inherit the source filter).
+
+**Tech Stack:** Python, cyclopts (CLI), polars (filter exprs), cyvcf2 (VCF record callable), pgenlib/plink2 (PGEN), vcfixture (test fixtures), pytest, Pixi for the env.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-svar-cli-filter-flags-design.md`
+
+**Run tests with:** `pixi run pytest <path>` (single file/test). Full suite + data regen: `pixi run test`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `genoray/exprs.py` | Add `import re`; add private record-level predicates `_record_is_symbolic`, `_record_is_breakend` co-located with the exprs they mirror | Modify |
+| `genoray/_cli/__main__.py` | Replace `skip_symbolic_alts` param with `no_symbolic` + `no_breakend`; compose filters from them | Modify |
+| `tests/test_svar_filtering.py` | Rename flag in existing CLI tests; add breakend fixtures + breakend/combined tests | Modify |
+
+---
+
+## Task 1: Record-level parity predicates in `exprs.py`
+
+**Files:**
+- Modify: `genoray/exprs.py` (add `import re` near the top with the other imports; add the two helpers immediately after the `is_breakend` definition, ~line 112)
+- Test: `tests/test_svar_filtering.py`
+
+These private helpers let the VCF cyvcf2 `filter` callable mirror the `is_symbolic` / `is_breakend` polars exprs without duplicating the `_BND_PATTERN` regex in the CLI.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_svar_filtering.py`:
+
+```python
+def test_record_predicates_mirror_exprs():
+    from genoray.exprs import _record_is_breakend, _record_is_symbolic
+
+    # symbolic: any ALT starting with "<"
+    assert _record_is_symbolic(["<DEL>"]) is True
+    assert _record_is_symbolic(["A", "<INS>"]) is True
+    assert _record_is_symbolic(["A", "T"]) is False
+
+    # breakend: any ALT in mate-pair or single-breakend notation
+    assert _record_is_breakend(["G[chr1:500000["]) is True
+    assert _record_is_breakend(["]chr2:321]G"]) is True
+    assert _record_is_breakend([".TGCA"]) is True
+    assert _record_is_breakend(["TGCA."]) is True
+    assert _record_is_breakend(["A", "T"]) is False
+    # symbolic alleles are NOT breakends (distinct ALT class)
+    assert _record_is_breakend(["<DEL>"]) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar_filtering.py::test_record_predicates_mirror_exprs -v`
+Expected: FAIL with `ImportError: cannot import name '_record_is_breakend'`.
+
+- [ ] **Step 3: Add `import re` to `exprs.py`**
+
+In `genoray/exprs.py`, change the import block (currently just `import polars as pl` at line 16) to:
+
+```python
+import re
+from collections.abc import Iterable
+
+import polars as pl
+```
+
+- [ ] **Step 4: Add the two helpers after `is_breakend`**
+
+In `genoray/exprs.py`, immediately after the `is_breakend` docstring closes (the `"""` ending the block at ~line 112), insert:
+
+```python
+
+
+def _record_is_symbolic(alts: Iterable[str]) -> bool:
+    """Record-level mirror of :data:`is_symbolic` for a cyvcf2 ``Variant.ALT``.
+
+    True if any ALT allele is a symbolic allele (starts with ``<``). Used by the
+    CLI to build the cyvcf2 ``filter`` callable that must match the polars
+    ``pl_filter`` on the VCF path.
+    """
+    return any(a.startswith("<") for a in alts)
+
+
+def _record_is_breakend(alts: Iterable[str]) -> bool:
+    """Record-level mirror of :data:`is_breakend` for a cyvcf2 ``Variant.ALT``.
+
+    True if any ALT allele is a breakend (matches :data:`_BND_PATTERN`). Reuses
+    the same regex as :data:`is_breakend` so the cyvcf2 ``filter`` callable and
+    the polars ``pl_filter`` cannot drift apart.
+    """
+    return any(re.search(_BND_PATTERN, a) is not None for a in alts)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pixi run pytest tests/test_svar_filtering.py::test_record_predicates_mirror_exprs -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add genoray/exprs.py tests/test_svar_filtering.py
+git commit -m "feat(exprs): add record-level _record_is_symbolic/_record_is_breakend predicates
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Replace `skip_symbolic_alts` with `no_symbolic` + `no_breakend` in the CLI
+
+**Files:**
+- Modify: `genoray/_cli/__main__.py` (`write`, lines 45-127)
+- Test: `tests/test_svar_filtering.py` (existing `test_cli_write_skip_symbolic_*` updated in Task 3)
+
+The current `write` signature has `skip_symbolic_alts: bool = False` (line 53) and an `if skip_symbolic_alts:` branch building the VCF dual-filter (lines 102-111) plus the PGEN `filter=` (line 121). Replace all of it with composition over the two new flags.
+
+- [ ] **Step 1: Update imports and the signature**
+
+In `genoray/_cli/__main__.py`, the parameter list of `write` currently ends with:
+
+```python
+    skip_symbolic_alts: bool = False,
+) -> None:
+```
+
+Replace those lines with:
+
+```python
+    no_symbolic: Annotated[bool, Parameter(name="--no-symbolic", negative="")] = False,
+    no_breakend: Annotated[bool, Parameter(name="--no-breakend", negative="")] = False,
+) -> None:
+```
+
+(`Annotated` and `Parameter` are already imported at the top of the file.)
+
+- [ ] **Step 2: Update the docstring**
+
+In the `write` docstring, replace the `skip_symbolic_alts` parameter block (currently lines 75-81, beginning `skip_symbolic_alts` and ending `behavior.`) with:
+
+```
+    no_symbolic
+        If set, drop records whose ALT contains a symbolic allele
+        (``<DEL>``, ``<INS>``, etc.) per VCF 4.x. Applies to both VCF and PGEN
+        sources. Recommended for SV-bearing cohorts (e.g. 1kGP SNV_INDEL_SV
+        panels) to avoid emitting literal ``<DEL>`` ASCII bytes into downstream
+        haplotype buffers.
+    no_breakend
+        If set, drop records whose ALT contains a breakend (BND) in mate-pair or
+        single-breakend notation (``G[chr2:321[``, ``]chr2:321]G``, ``.TGCA``,
+        ``TGCA.``). A distinct ALT class from symbolic alleles; combine with
+        ``--no-symbolic`` to drop everything haplotype consumers cannot expand.
+```
+
+- [ ] **Step 3: Replace the filter construction**
+
+In `genoray/_cli/__main__.py`, after the `if threads is None: threads = -1` block and before `if file_type == "vcf":`, the imports line currently reads:
+
+```python
+    from genoray import PGEN, VCF, SparseVar, exprs
+    from genoray._utils import variant_file_type
+```
+
+Leave that line as-is, then locate the existing VCF branch:
+
+```python
+    if file_type == "vcf":
+        if dosages is not None and Path(dosages).exists():
+            raise ValueError(
+                "The `dosages` argument appears to be a path to an existing file, but VCF requires a FORMAT field name."
+            )
+
+        if skip_symbolic_alts:
+            # VCF needs both filters: a cyvcf2 callable applied during the
+            # genotype scan and a polars expr applied to the index; both must
+            # express the same predicate.
+            vcf = VCF(
+                source,
+                dosage_field=dosages,
+                filter=lambda rec: not any(a.startswith("<") for a in rec.ALT),
+                pl_filter=~exprs.is_symbolic,
+            )
+        else:
+            vcf = VCF(source, dosage_field=dosages)
+        SparseVar.from_vcf(
+            out, vcf, max_mem, overwrite, with_dosages=with_dosages, n_jobs=threads
+        )
+    elif file_type == "pgen":
+        pgen = PGEN(
+            source,
+            dosage_path=dosages,
+            filter=(~exprs.is_symbolic) if skip_symbolic_alts else None,
+        )
+        SparseVar.from_pgen(
+            out, pgen, max_mem, overwrite, with_dosages=with_dosages, n_jobs=threads
+        )
+    else:
+        raise ValueError(f"Unsupported file type: {source}")
+```
+
+Replace that entire block (from `if file_type == "vcf":` through the final `raise ValueError(f"Unsupported file type: {source}")`) with:
+
+```python
+    # Compose the requested ALT-class filters. Each flag contributes a polars
+    # expr (used by both VCF index and PGEN) and a record-level predicate (used
+    # by the VCF cyvcf2 genotype scan). The two representations of each flag are
+    # kept in parity via genoray.exprs.
+    pl_terms = []
+    record_preds = []
+    if no_symbolic:
+        pl_terms.append(~exprs.is_symbolic)
+        record_preds.append(exprs._record_is_symbolic)
+    if no_breakend:
+        pl_terms.append(~exprs.is_breakend)
+        record_preds.append(exprs._record_is_breakend)
+
+    if pl_terms:
+        from functools import reduce
+        from operator import and_
+
+        pl_filter = reduce(and_, pl_terms)
+
+        def record_filter(rec, _preds=tuple(record_preds)) -> bool:
+            return not any(pred(rec.ALT) for pred in _preds)
+    else:
+        pl_filter = None
+        record_filter = None
+
+    if file_type == "vcf":
+        if dosages is not None and Path(dosages).exists():
+            raise ValueError(
+                "The `dosages` argument appears to be a path to an existing file, but VCF requires a FORMAT field name."
+            )
+
+        # VCF requires both filters together (or neither): a cyvcf2 callable
+        # applied during the genotype scan and a matching polars expr applied to
+        # the index; both must express the same predicate.
+        vcf = VCF(
+            source,
+            dosage_field=dosages,
+            filter=record_filter,
+            pl_filter=pl_filter,
+        )
+        SparseVar.from_vcf(
+            out, vcf, max_mem, overwrite, with_dosages=with_dosages, n_jobs=threads
+        )
+    elif file_type == "pgen":
+        pgen = PGEN(
+            source,
+            dosage_path=dosages,
+            filter=pl_filter,
+        )
+        SparseVar.from_pgen(
+            out, pgen, max_mem, overwrite, with_dosages=with_dosages, n_jobs=threads
+        )
+    else:
+        raise ValueError(f"Unsupported file type: {source}")
+```
+
+Note: `record_filter`'s keep-predicate is `not any(...)` — a record is kept only if *none* of its ALTs match *any* requested drop-predicate, which is exactly the AND of the negated polars terms.
+
+- [ ] **Step 4: Verify the CLI imports and help still work**
+
+Run: `pixi run genoray write --help`
+Expected: help text shows `--no-symbolic` and `--no-breakend` (and NOT `--skip-symbolic-alts`, `--no-no-symbolic`, or `--no-no-breakend`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_cli/__main__.py
+git commit -m "feat(cli): replace --skip-symbolic-alts with --no-symbolic and --no-breakend
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Update existing CLI tests for the renamed flag
+
+**Files:**
+- Modify: `tests/test_svar_filtering.py` (`test_cli_write_skip_symbolic_vcf` line 178, `test_cli_write_skip_symbolic_pgen` line 189)
+
+- [ ] **Step 1: Rename the flag in both existing CLI tests**
+
+In `tests/test_svar_filtering.py`, change the call in `test_cli_write_skip_symbolic_vcf`:
+
+```python
+    cli_write(vcf_path, out, max_mem="1g", overwrite=True, skip_symbolic_alts=True)
+```
+
+to:
+
+```python
+    cli_write(vcf_path, out, max_mem="1g", overwrite=True, no_symbolic=True)
+```
+
+And the same change in `test_cli_write_skip_symbolic_pgen`:
+
+```python
+    cli_write(pgen_path, out, max_mem="1g", overwrite=True, no_symbolic=True)
+```
+
+- [ ] **Step 2: Run both tests to verify they pass**
+
+Run: `pixi run pytest tests/test_svar_filtering.py -k "cli_write_skip_symbolic" -v`
+Expected: PASS (2 passed). `test_cli_write_skip_symbolic_pgen` may be skipped if `plink2` is unavailable.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_svar_filtering.py
+git commit -m "test(cli): use no_symbolic in renamed-flag CLI tests
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Breakend fixtures + `--no-breakend` tests
+
+**Files:**
+- Modify: `tests/test_svar_filtering.py` (add `Bnd` to the vcfixture import on line 16; add fixtures + tests)
+
+The existing file imports `from vcfixture import Number, Seq, Sym, Type, VcfBuilder, VcfVersion` (line 16). `Bnd(raw: str)` builds a breakend ALT.
+
+- [ ] **Step 1: Add `Bnd` to the vcfixture import**
+
+In `tests/test_svar_filtering.py`, change line 16:
+
+```python
+from vcfixture import Number, Seq, Sym, Type, VcfBuilder, VcfVersion
+```
+
+to:
+
+```python
+from vcfixture import Bnd, Number, Seq, Sym, Type, VcfBuilder, VcfVersion
+```
+
+- [ ] **Step 2: Write the failing tests (fixtures + breakend + combined)**
+
+Append to `tests/test_svar_filtering.py`:
+
+```python
+def _bnd_vcf(tmp_path: Path) -> Path:
+    """chr1: SNV A>T@100, BND G[chr1:500000[@200, <DEL>@300, ins G>GAT@400.
+
+    One of each droppable class plus two keepers, so the three filter modes
+    (none / no_breakend / no_symbolic / both) all produce distinct counts.
+    """
+    b = (
+        VcfBuilder(
+            samples=["s1", "s2"],
+            contigs=[("chr1", 1_000_000)],
+            version=VcfVersion.V4_4,
+        )
+        .info("SVLEN")
+        .info("SVCLAIM")
+        .info("END")
+        .fmt("GT")
+    )
+    b.record("chr1", 100, ref="A", alt=[Seq("T")], gt=["0|1", "1|1"])
+    b.record("chr1", 200, ref="G", alt=[Bnd("G[chr1:500000[")], gt=["0|1", "0|0"])
+    b.record(
+        "chr1",
+        300,
+        ref="A",
+        alt=[Sym.deletion()],
+        gt=["0|0", "0|1"],
+        info={"SVLEN": [50], "SVCLAIM": ["D"], "END": [350]},
+    )
+    b.record("chr1", 400, ref="G", alt=[Seq("GAT")], gt=["1|1", "0|1"])
+    return b.write(tmp_path / "bnd.vcf.gz", bgzip=True, index=True)
+
+
+def _bnd_pgen(tmp_path: Path) -> Path:
+    """Convert the BND VCF to PGEN via plink2 (BND/symbolic carried verbatim)."""
+    if shutil.which("plink2") is None:
+        pytest.skip("plink2 not available")
+    vcf_path = _bnd_vcf(tmp_path)
+    prefix = tmp_path / "bnd"
+    subprocess.run(
+        [
+            "plink2",
+            "--vcf",
+            str(vcf_path),
+            "--make-pgen",
+            "--out",
+            str(prefix),
+            "--allow-extra-chr",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return prefix.with_suffix(".pgen")
+
+
+def test_cli_write_no_breakend_vcf(tmp_path):
+    from genoray._cli.__main__ import write as cli_write
+
+    vcf_path = _bnd_vcf(tmp_path)
+    out = tmp_path / "nobnd.svar"
+    cli_write(vcf_path, out, max_mem="1g", overwrite=True, no_breakend=True)
+    sv = SparseVar(out)
+    # BND@200 dropped; SNV@100, <DEL>@300, ins@400 kept
+    assert sv.n_variants == 3
+    assert sv.index["POS"].to_list() == [100, 300, 400]
+
+
+def test_cli_write_no_breakend_pgen(tmp_path):
+    from genoray._cli.__main__ import write as cli_write
+
+    pgen_path = _bnd_pgen(tmp_path)
+    out = tmp_path / "nobnd_pg.svar"
+    cli_write(pgen_path, out, max_mem="1g", overwrite=True, no_breakend=True)
+    sv = SparseVar(out)
+    assert sv.n_variants == 3
+    assert set(sv.index["POS"].to_list()) == {100, 300, 400}
+
+
+def test_cli_write_no_symbolic_and_no_breakend_vcf(tmp_path):
+    from genoray._cli.__main__ import write as cli_write
+
+    vcf_path = _bnd_vcf(tmp_path)
+    out = tmp_path / "both.svar"
+    cli_write(
+        vcf_path, out, max_mem="1g", overwrite=True, no_symbolic=True, no_breakend=True
+    )
+    sv = SparseVar(out)
+    # BND@200 and <DEL>@300 both dropped; only plain SNV@100 + ins@400 remain
+    assert sv.n_variants == 2
+    assert sv.index["POS"].to_list() == [100, 400]
+
+
+def test_cli_write_no_flags_keeps_all_vcf(tmp_path):
+    """Back-compat: neither flag set -> all records written."""
+    from genoray._cli.__main__ import write as cli_write
+
+    vcf_path = _bnd_vcf(tmp_path)
+    out = tmp_path / "none.svar"
+    cli_write(vcf_path, out, max_mem="1g", overwrite=True)
+    sv = SparseVar(out)
+    assert sv.n_variants == 4
+```
+
+- [ ] **Step 3: Run the new tests to verify they pass**
+
+Run: `pixi run pytest tests/test_svar_filtering.py -k "no_breakend or no_symbolic_and_no_breakend or no_flags_keeps_all" -v`
+Expected: PASS (4 passed; the `_pgen` test may be skipped if `plink2` is unavailable).
+
+- [ ] **Step 4: Run the full filtering test file**
+
+Run: `pixi run pytest tests/test_svar_filtering.py -v`
+Expected: PASS (all pass; PGEN tests may skip without `plink2`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_svar_filtering.py
+git commit -m "test(cli): add breakend + combined-flag SVAR write tests
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pixi run test`
+Expected: PASS (no failures; PGEN-dependent tests skip only if `plink2` is absent).
+
+- [ ] **Step 2: Lint/format check**
+
+Run: `pixi run -- ruff check genoray tests && pixi run -- ruff format --check genoray tests`
+Expected: no errors. If `ruff format --check` reports diffs, run `pixi run -- ruff format genoray tests` and amend the relevant commit.
+
+- [ ] **Step 3: Final flag sanity check**
+
+Run: `pixi run genoray write --help`
+Expected: `--no-symbolic` and `--no-breakend` present; no `--skip-symbolic-alts`, `--no-no-symbolic`, or `--no-no-breakend`.
+
+---
+
+## Self-Review Notes (for the author, not a step)
+
+- **Spec coverage:** §1 CLI surface → Task 2; §2 filter composition → Task 2; §3 parity helpers → Task 1; §4 tests → Tasks 3 & 4; §5 docs (write docstring) → Task 2 Step 2, SKILL.md intentionally untouched.
+- **Non-goals honored:** no `--compat-gvl`, no `--no-imprecise`, no version/CHANGELOG changes.
+- **Parity:** `_record_is_symbolic`/`_record_is_breakend` (Task 1) are the only record-level predicates the CLI (Task 2) references — names match exactly.

--- a/docs/superpowers/specs/2026-06-05-svar-cli-filter-flags-design.md
+++ b/docs/superpowers/specs/2026-06-05-svar-cli-filter-flags-design.md
@@ -1,0 +1,137 @@
+# SVAR write CLI: symbolic + breakend filter flags
+
+**Date:** 2026-06-05
+**Branch:** `feat/breakend-alts` (current)
+
+## Problem
+
+The `genoray write` CLI (VCF/PGEN → SVAR) exposes one filtering flag,
+`--skip-symbolic-alts`, which drops records carrying VCF 4.x symbolic ALT
+alleles (`<DEL>`, `<INS>`, …). Breakend (BND) ALTs — a *distinct* ALT class
+(`G[chr2:321[`, `]chr2:321]G`, `.TGCA`, `TGCA.`) that `is_symbolic` does **not**
+flag — are equally un-injectable into DNA buffers by downstream haplotype
+consumers (e.g. genvarloader), but the CLI offers no way to drop them.
+
+Users who want a gvl-ready SVAR currently cannot express "drop symbolic **and**
+breakend" through the CLI.
+
+## Goals
+
+- Drop the symbolic ALT records via a clearer flag name, `--no-symbolic`
+  (rename of `--skip-symbolic-alts`; treated as non-breaking — the flag is new
+  enough to rename freely).
+- Add `--no-breakend` to drop breakend ALT records.
+- Make the two flags independent and composable (`AND` when both are passed).
+- Preserve current behavior when neither flag is set (no filtering).
+
+## Non-goals
+
+- **No `--compat-gvl` convenience flag.** Bundling these into a single
+  "gvl-compatible" switch couples genoray to gvl's *versioned* definition of
+  compatibility (which may change). The gvl-compat recipe — "pass
+  `--no-symbolic --no-breakend`" — belongs in gvl's own docs, not in a genoray
+  flag.
+- **No `--no-imprecise` flag.** For haplotype consumers, `~is_symbolic &
+  ~is_breakend` already drops everything un-injectable, including precise
+  `<DEL>`/`<INS>`/`<DUP>` (gvl cannot expand those either). `is_imprecise`
+  serves a *different* goal (keep precise SVs, drop only un-sizable ones); users
+  who want that can use the library `filter`/`pl_filter` API with
+  `genoray.exprs.is_imprecise`. The CLI does not expose it.
+- Version bump, CHANGELOG, gvl-side documentation.
+
+## Background: how the CLI builds filters
+
+`genoray/_cli/__main__.py::write` constructs the source reader, then hands it to
+`SparseVar.from_vcf` / `from_pgen`, which inherit the source's filter.
+
+- **VCF** requires *both* a `cyvcf2` record-level callable `filter` **and** a
+  matching polars `pl_filter` — `VCF.__init__` raises if only one is supplied.
+  Both must express the same predicate so the genotype scan and the index stay
+  aligned (a divergence shifts variant indices and corrupts the sparse data).
+- **PGEN** takes a single polars `filter` expression.
+
+`genoray.exprs` already ships the polars predicates `is_symbolic` and
+`is_breakend` (the latter built on the private regex `_BND_PATTERN`).
+
+## Design
+
+### 1. CLI surface (`genoray/_cli/__main__.py`, `write`)
+
+Replace `skip_symbolic_alts: bool = False` with two independent flags:
+
+```python
+no_symbolic: Annotated[bool, Parameter(name="--no-symbolic", negative="")] = False,
+no_breakend: Annotated[bool, Parameter(name="--no-breakend", negative="")] = False,
+```
+
+- `negative=""` suppresses cyclopts' auto-generated inverse
+  (`--no-no-symbolic`), so the only spellings are `--no-symbolic` /
+  `--no-breakend`. Flag present ⇒ drop those records.
+- Both default `False` ⇒ no filtering, preserving prior behavior.
+- Exact cyclopts negation mechanics to be confirmed against the `cyclopts`
+  skill during implementation; `negative=""` is the documented way to remove the
+  auto-inverse.
+
+Update the `write` docstring: remove the `skip_symbolic_alts` entry, document
+`no_symbolic` and `no_breakend`.
+
+### 2. Filter composition
+
+Build both filter representations from whichever flags are set:
+
+- **polars side** (VCF & PGEN): collect `~exprs.is_symbolic` and/or
+  `~exprs.is_breakend` into a list; combine with `reduce(operator.and_, ...)`;
+  empty ⇒ `None`.
+- **cyvcf2 callable side** (VCF only): collect the negated record-level
+  predicates; the composed callable returns
+  `all(pred(rec.ALT) for pred in preds)`; empty ⇒ `None`.
+- **PGEN**: `filter=` the composed polars expr (or `None`).
+
+VCF is always constructed with both `filter` and `pl_filter` set (or both
+`None`), satisfying `VCF.__init__`'s paired-filter requirement.
+
+### 3. Parity helpers (`genoray/exprs.py`)
+
+The central correctness risk is the cyvcf2 record callable drifting from the
+polars expr it must mirror. Anchor parity by co-locating two **private**
+record-level predicates with the exprs they mirror:
+
+```python
+import re  # new top-level import
+
+def _record_is_symbolic(alts: Iterable[str]) -> bool:   # mirrors is_symbolic
+    return any(a.startswith("<") for a in alts)
+
+def _record_is_breakend(alts: Iterable[str]) -> bool:   # mirrors is_breakend
+    return any(re.search(_BND_PATTERN, a) is not None for a in alts)
+```
+
+The CLI imports these and negates them to form the keep-callable.
+
+*Rejected alternative:* inline both lambdas in the CLI (as the current symbolic
+lambda is). Rejected because `_BND_PATTERN` lives in `exprs.py`; inlining the
+breakend regex invites drift between the callable and the expr.
+
+### 4. Tests (`tests/test_svar_filtering.py`)
+
+- Update `test_cli_write_skip_symbolic_vcf` / `_pgen` to pass `no_symbolic=True`.
+- Add a `_breakend_vcf` fixture (a BND record via `vcfixture.Bnd` plus a plain
+  SNV) and a `_breakend_pgen` derived from it via plink2.
+- New tests: `--no-breakend` drops the BND on both the VCF and PGEN paths.
+- One combined test (`no_symbolic=True, no_breakend=True`) asserting both ALT
+  classes are dropped together.
+
+### 5. Docs / SKILL.md
+
+- Update the `write` docstring (see §1).
+- **No `skills/genoray-api/SKILL.md` change required.** SKILL.md documents the
+  Python import API, not CLI flags; the new helpers are underscore-private; and
+  `is_symbolic` / `is_breakend` semantics are unchanged.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `genoray/_cli/__main__.py` | Replace `skip_symbolic_alts` with `no_symbolic` + `no_breakend`; compose filters | Modify |
+| `genoray/exprs.py` | Add `_record_is_symbolic`, `_record_is_breakend`, `import re` | Modify |
+| `tests/test_svar_filtering.py` | Update renamed-flag tests; add breakend + combined tests | Modify |

--- a/genoray/_cli/__main__.py
+++ b/genoray/_cli/__main__.py
@@ -50,7 +50,8 @@ def write(
     overwrite: bool = False,
     dosages: str | None = None,
     threads: int | None = None,
-    skip_symbolic_alts: bool = False,
+    no_symbolic: Annotated[bool, Parameter(name="--no-symbolic", negative="")] = False,
+    no_breakend: Annotated[bool, Parameter(name="--no-breakend", negative="")] = False,
 ) -> None:
     """
     Convert a VCF or PGEN file to a SVAR file.
@@ -72,13 +73,17 @@ def write(
         If not provided, dosages will not be written.
     threads
         Number of threads to use for conversion. Defaults to the number of available CPU cores.
-    skip_symbolic_alts
-        If True, skip records whose ALT contains a symbolic allele
-        (``<DEL>``, ``<INS>``, etc.) per VCF 4.x. Applies to both VCF and
-        PGEN sources. Recommended for SV-bearing cohorts (e.g. 1kGP
-        SNV_INDEL_SV panels) to avoid emitting literal ``<DEL>`` ASCII bytes
-        into downstream haplotype buffers. Default False preserves prior
-        behavior.
+    no_symbolic
+        If set, drop records whose ALT contains a symbolic allele
+        (``<DEL>``, ``<INS>``, etc.) per VCF 4.x. Applies to both VCF and PGEN
+        sources. Recommended for SV-bearing cohorts (e.g. 1kGP SNV_INDEL_SV
+        panels) to avoid emitting literal ``<DEL>`` ASCII bytes into downstream
+        haplotype buffers.
+    no_breakend
+        If set, drop records whose ALT contains a breakend (BND) in mate-pair or
+        single-breakend notation (``G[chr2:321[``, ``]chr2:321]G``, ``.TGCA``,
+        ``TGCA.``). A distinct ALT class from symbolic alleles; combine with
+        ``--no-symbolic`` to drop everything haplotype consumers cannot expand.
     """
     from genoray import PGEN, VCF, SparseVar, exprs
     from genoray._utils import variant_file_type
@@ -93,24 +98,46 @@ def write(
     if threads is None:
         threads = -1
 
+    # Compose the requested ALT-class filters. Each flag contributes a polars
+    # expr (used by both VCF index and PGEN) and a record-level predicate (used
+    # by the VCF cyvcf2 genotype scan). The two representations of each flag are
+    # kept in parity via genoray.exprs.
+    pl_terms = []
+    record_preds = []
+    if no_symbolic:
+        pl_terms.append(~exprs.is_symbolic)
+        record_preds.append(exprs._record_is_symbolic)
+    if no_breakend:
+        pl_terms.append(~exprs.is_breakend)
+        record_preds.append(exprs._record_is_breakend)
+
+    if pl_terms:
+        from functools import reduce
+        from operator import and_
+
+        pl_filter = reduce(and_, pl_terms)
+
+        def record_filter(rec, _preds=tuple(record_preds)) -> bool:
+            return not any(pred(rec.ALT) for pred in _preds)
+    else:
+        pl_filter = None
+        record_filter = None
+
     if file_type == "vcf":
         if dosages is not None and Path(dosages).exists():
             raise ValueError(
                 "The `dosages` argument appears to be a path to an existing file, but VCF requires a FORMAT field name."
             )
 
-        if skip_symbolic_alts:
-            # VCF needs both filters: a cyvcf2 callable applied during the
-            # genotype scan and a polars expr applied to the index; both must
-            # express the same predicate.
-            vcf = VCF(
-                source,
-                dosage_field=dosages,
-                filter=lambda rec: not any(a.startswith("<") for a in rec.ALT),
-                pl_filter=~exprs.is_symbolic,
-            )
-        else:
-            vcf = VCF(source, dosage_field=dosages)
+        # VCF requires both filters together (or neither): a cyvcf2 callable
+        # applied during the genotype scan and a matching polars expr applied to
+        # the index; both must express the same predicate.
+        vcf = VCF(
+            source,
+            dosage_field=dosages,
+            filter=record_filter,
+            pl_filter=pl_filter,
+        )
         SparseVar.from_vcf(
             out, vcf, max_mem, overwrite, with_dosages=with_dosages, n_jobs=threads
         )
@@ -118,7 +145,7 @@ def write(
         pgen = PGEN(
             source,
             dosage_path=dosages,
-            filter=(~exprs.is_symbolic) if skip_symbolic_alts else None,
+            filter=pl_filter,
         )
         SparseVar.from_pgen(
             out, pgen, max_mem, overwrite, with_dosages=with_dosages, n_jobs=threads

--- a/genoray/_vcf.py
+++ b/genoray/_vcf.py
@@ -272,12 +272,7 @@ class VCF:
         progress: bool = False,
         with_gvi_index: bool = True,
     ):
-        if (filter is not None and pl_filter is None) or (
-            filter is None and pl_filter is not None
-        ):
-            raise ValueError(
-                "If a filter function is provided, a polars expression must also be provided, and vice versa."
-            )
+        self._check_filter_pair(filter, pl_filter)
 
         self.path = Path(path)
         if not self.path.exists():
@@ -307,6 +302,19 @@ class VCF:
     def _open(self) -> cyvcf2.VCF:
         return cyvcf2.VCF(self.path, samples=self._samples, lazy=True)
 
+    @staticmethod
+    def _check_filter_pair(
+        filter: Callable[[cyvcf2.Variant], bool] | None,
+        pl_filter: pl.Expr | None,
+    ) -> None:
+        """Enforce the both-or-neither invariant on a (filter, pl_filter) pair."""
+        if (filter is not None and pl_filter is None) or (
+            filter is None and pl_filter is not None
+        ):
+            raise ValueError(
+                "If a filter function is provided, a polars expression must also be provided, and vice versa."
+            )
+
     @property
     def filter(self) -> Callable[[cyvcf2.Variant], bool] | None:
         """Function to filter variants. Should return True for variants to keep."""
@@ -321,10 +329,31 @@ class VCF:
             return base.with_suffix(".gvi.zst")
 
     @filter.setter
-    def filter(self, filter: Callable[[cyvcf2.Variant], bool] | None):
-        """Changing the filter invalidates the in-memory index."""
+    def filter(
+        self,
+        value: tuple[Callable[[cyvcf2.Variant], bool] | None, pl.Expr | None] | None,
+    ):
+        """Set the record filter and its matching polars expression together.
+
+        Assign a ``(filter, pl_filter)`` pair, or ``None`` to clear both. The VCF
+        path requires both a cyvcf2 record callable (for the genotype scan) and a
+        matching polars expression (for the ``.gvi`` index); they must be set
+        together, mirroring the constructor's both-or-neither invariant. Changing
+        the filter invalidates the in-memory index.
+        """
+        if value is None:
+            filter = pl_filter = None
+        elif isinstance(value, tuple) and len(value) == 2:
+            filter, pl_filter = value
+        else:
+            raise TypeError(
+                "VCF.filter must be assigned a (filter, pl_filter) tuple or None; "
+                f"got {type(value).__name__}."
+            )
+        self._check_filter_pair(filter, pl_filter)
         self._index = None
         self._filter = filter
+        self._pl_filter = pl_filter
 
     @property
     def nbytes(self) -> int:

--- a/genoray/exprs.py
+++ b/genoray/exprs.py
@@ -84,6 +84,33 @@ For VCF, pair it with the equivalent cyvcf2 ``filter`` (both are required)::
 is filtered to match.
 """
 
+_BND_PATTERN = r"[\[\]]|^\.[A-Za-z]|[A-Za-z]\.$"
+"""Regex matching a VCF breakend (BND) ALT replacement string.
+
+Catches the paired mate forms (``t[p[``, ``t]p]``, ``]p]t``, ``[p[t`` — all
+contain ``[`` or ``]``) and the single-breakend forms (``.t`` / ``t.`` — a ``.``
+adjacent to a base). A lone ``.`` (no-ALT) does not match because a base must
+sit beside the dot."""
+
+is_breakend = (
+    pl.col("ALT").list.eval(pl.element().str.contains(_BND_PATTERN)).list.any()
+)
+"""True if any ALT allele is a breakend (BND) in mate-pair / single-breakend
+notation (e.g. :code:`G[chr2:321[`, :code:`]chr2:321]G`, :code:`.TGCA`,
+:code:`TGCA.`), per the VCF 4.x spec (§5.4).
+
+Breakends are a *distinct* ALT class from symbolic ``<...>`` alleles, so
+:data:`is_symbolic` does **not** flag them. But like symbolic alleles they are
+not expandable into nucleotides — the bracket/colon/position bytes corrupt
+personalized DNA buffers in haplotype consumers (e.g. ``genvarloader``). Their
+:func:`symbolic_ilen` value is ``null`` (so they are also :data:`is_imprecise`).
+
+To drop breakends, pass ``pl_filter=~genoray.exprs.is_breakend``. To drop *all*
+un-expandable ALTs (symbolic + breakends) for haplotype consumers, combine::
+
+    pl_filter=~genoray.exprs.is_symbolic & ~genoray.exprs.is_breakend
+"""
+
 ILEN = pl.col("ALT").list.eval(pl.element().str.len_bytes().cast(pl.Int32)) - pl.col(
     "REF"
 ).str.len_bytes().cast(pl.Int32)
@@ -99,12 +126,13 @@ def symbolic_ilen(
 ) -> pl.Expr:
     """Per-ALT corrected ILEN as ``List[Int32]``.
 
-    Non-symbolic ALTs use the literal ``len(ALT) - len(REF)``. Precise symbolic
-    ``<DEL>``/``<INS>``/``<DUP>`` use ``SVLEN`` magnitude (or ``|END - POS|`` for
-    ``<DEL>``/``<DUP>`` when ``SVLEN`` is absent): ``-|len|`` for ``<DEL>``,
-    ``+|len|`` for ``<INS>``/``<DUP>``. Everything we cannot size precisely
-    (``IMPRECISE`` flag, missing length, unsupported type such as ``<BND>``,
-    ``<CNV>``, ``<INV>``, ``<*>``) becomes ``null``.
+    Non-symbolic, non-breakend ALTs use the literal ``len(ALT) - len(REF)``.
+    Precise symbolic ``<DEL>``/``<INS>``/``<DUP>`` use ``SVLEN`` magnitude (or
+    ``|END - POS|`` for ``<DEL>``/``<DUP>`` when ``SVLEN`` is absent):
+    ``-|len|`` for ``<DEL>``, ``+|len|`` for ``<INS>``/``<DUP>``. Everything we
+    cannot size precisely (``IMPRECISE`` flag, missing length, unsupported type
+    such as ``<BND>``, ``<CNV>``, ``<INV>``, ``<*>``, and breakend mate notation
+    such as ``G[chr2:321[``) becomes ``null``.
 
     ``svlen``/``end``/``imprecise`` name scalar columns already extracted by the
     caller (per record). ``SVLEN`` magnitude is read as ``|SVLEN|`` so the VCF
@@ -131,6 +159,8 @@ def symbolic_ilen(
     )
     # Whether each ALT element is symbolic
     is_sym_list = pl.col(alt).list.eval(pl.element().str.starts_with("<"))
+    # Whether each ALT element is a breakend (BND) — un-sizable like symbolic.
+    is_bnd_list = pl.col(alt).list.eval(pl.element().str.contains(_BND_PATTERN))
 
     # Per-row scalar: sized SV length (sign-corrected), or null if un-sizable.
     # This is broadcast across all symbolic ALTs in the row.
@@ -142,6 +172,7 @@ def symbolic_ilen(
     packed = pl.struct(
         sv_type=sv_type_list,
         is_sym=is_sym_list,
+        is_bnd=is_bnd_list,
         literal=literal_list,
         del_mag=del_mag,
         ins_dup_mag=ins_dup_mag,
@@ -154,13 +185,17 @@ def _compute_ilen_row(row: dict) -> list[int | None]:
     """Compute per-ALT ILEN for a single row (called via map_elements)."""
     sv_types: list = row["sv_type"]
     is_syms: list = row["is_sym"]
+    is_bnds: list = row["is_bnd"]
     literals: list = row["literal"]
     del_mag = row["del_mag"]
     ins_dup_mag = row["ins_dup_mag"]
 
     result = []
-    for sv_type, sym, lit in zip(sv_types, is_syms, literals):
-        if not sym:
+    for sv_type, sym, bnd, lit in zip(sv_types, is_syms, is_bnds, literals):
+        if bnd:
+            # Breakends carry no expandable length — un-sizable, like symbolic SVs.
+            result.append(None)
+        elif not sym:
             result.append(lit)
         elif sv_type == "DEL":
             result.append(del_mag)

--- a/genoray/exprs.py
+++ b/genoray/exprs.py
@@ -13,6 +13,9 @@ Applicable for PGEN files and the experimental :meth:`VCF._load_index` method.
     For PGEN, all columns that existed in the underlying PVAR will be available in the index.
 """
 
+import re
+from collections.abc import Iterable
+
 import polars as pl
 
 """
@@ -110,6 +113,27 @@ un-expandable ALTs (symbolic + breakends) for haplotype consumers, combine::
 
     pl_filter=~genoray.exprs.is_symbolic & ~genoray.exprs.is_breakend
 """
+
+
+def _record_is_symbolic(alts: Iterable[str]) -> bool:
+    """Record-level mirror of :data:`is_symbolic` for a cyvcf2 ``Variant.ALT``.
+
+    True if any ALT allele is a symbolic allele (starts with ``<``). Used by the
+    CLI to build the cyvcf2 ``filter`` callable that must match the polars
+    ``pl_filter`` on the VCF path.
+    """
+    return any(a.startswith("<") for a in alts)
+
+
+def _record_is_breakend(alts: Iterable[str]) -> bool:
+    """Record-level mirror of :data:`is_breakend` for a cyvcf2 ``Variant.ALT``.
+
+    True if any ALT allele is a breakend (matches :data:`_BND_PATTERN`). Reuses
+    the same regex as :data:`is_breakend` so the cyvcf2 ``filter`` callable and
+    the polars ``pl_filter`` cannot drift apart.
+    """
+    return any(re.search(_BND_PATTERN, a) is not None for a in alts)
+
 
 ILEN = pl.col("ALT").list.eval(pl.element().str.len_bytes().cast(pl.Int32)) - pl.col(
     "REF"

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -31,7 +31,7 @@ Prefer reading these over guessing:
 - `genoray/_vcf.py` — `VCF` class: constructor, `read`, `chunk`, mode constants near the top of the class
 - `genoray/_pgen.py` — `PGEN` class: constructor, `read`, `chunk`, `read_ranges`, `chunk_ranges`, mode constants near the top of the class
 - `genoray/_svar.py` — `SparseVar`: `__init__`, `from_vcf`, `from_pgen`, `read_ranges`, `with_fields`
-- `genoray/exprs.py` — the *complete* set of pre-built filter expressions (currently 6: `is_snp`, `is_indel`, `is_biallelic`, `is_symbolic`, `is_imprecise`, `ILEN`)
+- `genoray/exprs.py` — the *complete* set of pre-built filter expressions (currently 7: `is_snp`, `is_indel`, `is_biallelic`, `is_symbolic`, `is_breakend`, `is_imprecise`, `ILEN`)
 
 When a signature, kwarg, or shape is unclear, **read the docstring in the
 source** rather than reasoning from first principles.
@@ -192,7 +192,8 @@ PGEN: pass a polars `pl.Expr` returning a boolean mask, operating on the
 - `is_indel` (True if **all** ALT alleles have ILEN != 0; rows with any `null` ILEN → False)
 - `is_biallelic`
 - `is_symbolic` (True if any ALT is a VCF 4.x symbolic allele, i.e. starts with `<`)
-- `is_imprecise` (True if any ALT's ILEN is `null` — an un-sizable symbolic allele)
+- `is_breakend` (True if any ALT is a VCF 4.x breakend in mate-pair / single-breakend notation, e.g. `G[chr2:321[`, `]chr2:321]G`, `.TGCA`, `TGCA.`. A *distinct* ALT class from symbolic alleles — `is_symbolic` does **not** flag breakends)
+- `is_imprecise` (True if any ALT's ILEN is `null` — an un-sizable symbolic allele **or** a breakend)
 - `ILEN` (a `List[Int32]` expression — one value per ALT allele, not a boolean)
 
 **`ILEN` semantics for symbolic SVs.** For precise `<DEL>`/`<INS>`/`<DUP>`,
@@ -203,8 +204,9 @@ they are parsed from the PVAR INFO string. Non-symbolic ALTs use the literal
 `len(ALT) - len(REF)`.
 
 **Un-sizable symbolic alleles carry `null` ILEN.** An allele is un-sizable when:
-the `IMPRECISE` INFO flag is set, `SVLEN`/`END` are both missing, or the symbolic
-type is unsupported (`<BND>`, `<CNV>`, `<INV>`, `<*>`/`<NON_REF>`). At NumPy
+the `IMPRECISE` INFO flag is set, `SVLEN`/`END` are both missing, the symbolic
+type is unsupported (`<BND>`, `<CNV>`, `<INV>`, `<*>`/`<NON_REF>`), or the ALT is
+a breakend in mate-pair / single-breakend notation (e.g. `G[chr2:321[`). At NumPy
 materialization, `null` ILEN is coerced to 0 (treated as a point variant).
 
 **Filtering guidance** (no new constructor kwarg — use the existing `filter`/`pl_filter` API):
@@ -225,11 +227,20 @@ materialization, `null` ILEN is coerced to 0 (treated as a point variant).
   ```
 
 - `~genoray.exprs.is_imprecise` — keeps precise symbolic SVs (correctly
-  sized/spanned) and drops only the un-sizable ones. Suitable for range/overlap
-  queries where precise SVs are queryable:
+  sized/spanned) and drops only the un-sizable ones (including breakends, which
+  are always un-sizable). Suitable for range/overlap queries where precise SVs
+  are queryable:
 
   ```python
   pgen = genoray.PGEN("file.pgen", filter=~genoray.exprs.is_imprecise)
+  ```
+
+- For haplotype consumers, drop *all* un-expandable ALTs (symbolic **and**
+  breakends) — breakends are not caught by `~is_symbolic`:
+
+  ```python
+  hap_safe = ~genoray.exprs.is_symbolic & ~genoray.exprs.is_breakend
+  pgen = genoray.PGEN("file.pgen", filter=hap_safe)
   ```
 
 For anything else, write `pl.col(...)` against the `.gvi` schema — read

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -184,6 +184,16 @@ VCF: pass a `Callable[[cyvcf2.Variant], bool]` to `filter=`. For index-based
 predicates (e.g. `is_symbolic`), also pass the matching polars `pl.Expr` to
 `pl_filter=` — VCF requires **both** when filtering via the `.gvi` index.
 
+To change a VCF's filter after construction, assign a `(filter, pl_filter)`
+tuple to the `vcf.filter` setter (or `None` to clear both); the same
+both-or-neither invariant is enforced, and the in-memory index is invalidated.
+The getter still returns just the callable.
+
+```python
+vcf.filter = (lambda rec: ..., ~genoray.exprs.is_symbolic)  # set both
+vcf.filter = None                                           # clear both
+```
+
 PGEN: pass a polars `pl.Expr` returning a boolean mask, operating on the
 `.gvi` index columns. Built-in expressions in `genoray.exprs` (the
 *complete* list):

--- a/tests/data/fixtures.py
+++ b/tests/data/fixtures.py
@@ -8,7 +8,7 @@ decoded GroundTruth oracle.
 
 from __future__ import annotations
 
-from vcfixture import Number, Seq, Sym, Type, VcfBuilder, VcfVersion
+from vcfixture import Bnd, Number, Seq, Sym, Type, VcfBuilder, VcfVersion
 
 NAN = float("nan")
 
@@ -141,7 +141,8 @@ def symbolic() -> VcfBuilder:
 
     Precise <DEL>/<INS>/<DUP> (SVLEN/SVCLAIM), then un-sizable cases:
     an IMPRECISE <DEL>, a <CNV> whose SVLEN is present but unusable because
-    the type is unsupported, and an <INV> (also unsupported / un-sizable).
+    the type is unsupported, an <INV> (also unsupported / un-sizable), and a
+    breakend (BND) in mate-pair notation (un-expandable, so un-sizable).
     VCF 4.4 so SVLEN is positive and <DEL>/<DUP> carry SVCLAIM.
 
     Record layout (0-based index):
@@ -151,6 +152,11 @@ def symbolic() -> VcfBuilder:
       3 - POS 4000: <DEL> IMPRECISE (ILEN = null)
       4 - POS 5000: <CNV> unsupported type (ILEN = null)
       5 - POS 6000: <INV> unsupported type (ILEN = null)
+      6 - POS 7000: breakend G[chr1:500000[ (ILEN = null)
+
+    The breakend uses a chr1-internal mate so no extra contig is needed. The
+    PGEN fixture (gen_from_vcf.sh) is filtered to <DEL>/<INS>/<DUP> only, so the
+    breakend never reaches PGEN — it exercises the VCF / oracle path only.
     """
     b = (
         VcfBuilder(
@@ -211,6 +217,13 @@ def symbolic() -> VcfBuilder:
         alt=[Sym.inversion()],
         gt=["0|1", "0|0"],
         info={"SVLEN": [50], "END": [6050]},
+    )
+    b.record(
+        "chr1",
+        7000,
+        ref="G",
+        alt=[Bnd("G[chr1:500000[")],
+        gt=["0|1", "0|0"],
     )
     return b
 

--- a/tests/test_svar_filtering.py
+++ b/tests/test_svar_filtering.py
@@ -175,7 +175,7 @@ def test_from_pgen_no_filter_keeps_all(tmp_path):
     assert sv.n_variants == 4
 
 
-def test_cli_write_skip_symbolic_vcf(tmp_path):
+def test_cli_write_no_symbolic_vcf(tmp_path):
     from genoray._cli.__main__ import write as cli_write
 
     vcf_path = _mixed_vcf(tmp_path)
@@ -186,7 +186,7 @@ def test_cli_write_skip_symbolic_vcf(tmp_path):
     assert sv.index["POS"].to_list() == [100, 400]
 
 
-def test_cli_write_skip_symbolic_pgen(tmp_path):
+def test_cli_write_no_symbolic_pgen(tmp_path):
     from genoray._cli.__main__ import write as cli_write
 
     pgen_path = _mixed_pgen(tmp_path)
@@ -511,6 +511,20 @@ def test_cli_write_no_symbolic_and_no_breakend_vcf(tmp_path):
     assert sv.index["POS"].to_list() == [100, 400]
 
 
+def test_cli_write_no_symbolic_and_no_breakend_pgen(tmp_path):
+    from genoray._cli.__main__ import write as cli_write
+
+    pgen_path = _bnd_pgen(tmp_path)
+    out = tmp_path / "both_pg.svar"
+    cli_write(
+        pgen_path, out, max_mem="1g", overwrite=True, no_symbolic=True, no_breakend=True
+    )
+    sv = SparseVar(out)
+    # BND@200 and <DEL>@300 both dropped; only plain SNV@100 + ins@400 remain
+    assert sv.n_variants == 2
+    assert set(sv.index["POS"].to_list()) == {100, 400}
+
+
 def test_cli_write_no_flags_keeps_all_vcf(tmp_path):
     """Back-compat: neither flag set -> all records written."""
     from genoray._cli.__main__ import write as cli_write
@@ -518,5 +532,16 @@ def test_cli_write_no_flags_keeps_all_vcf(tmp_path):
     vcf_path = _bnd_vcf(tmp_path)
     out = tmp_path / "none.svar"
     cli_write(vcf_path, out, max_mem="1g", overwrite=True)
+    sv = SparseVar(out)
+    assert sv.n_variants == 4
+
+
+def test_cli_write_no_flags_keeps_all_pgen(tmp_path):
+    """Back-compat (PGEN): neither flag set -> all records written."""
+    from genoray._cli.__main__ import write as cli_write
+
+    pgen_path = _bnd_pgen(tmp_path)
+    out = tmp_path / "none_pg.svar"
+    cli_write(pgen_path, out, max_mem="1g", overwrite=True)
     sv = SparseVar(out)
     assert sv.n_variants == 4

--- a/tests/test_svar_filtering.py
+++ b/tests/test_svar_filtering.py
@@ -396,3 +396,21 @@ def test_from_vcf_filtered_with_dosages(tmp_path):
     assert all(d > 0.0 for d in dosages_flat)
     # s1 has DS=1.9 for both haplotypes (two calls); s2 has DS=0.8 (one call)
     assert sorted(round(d, 1) for d in dosages_flat) == [0.8, 1.9, 1.9]
+
+
+def test_record_predicates_mirror_exprs():
+    from genoray.exprs import _record_is_breakend, _record_is_symbolic
+
+    # symbolic: any ALT starting with "<"
+    assert _record_is_symbolic(["<DEL>"]) is True
+    assert _record_is_symbolic(["A", "<INS>"]) is True
+    assert _record_is_symbolic(["A", "T"]) is False
+
+    # breakend: any ALT in mate-pair or single-breakend notation
+    assert _record_is_breakend(["G[chr1:500000["]) is True
+    assert _record_is_breakend(["]chr2:321]G"]) is True
+    assert _record_is_breakend([".TGCA"]) is True
+    assert _record_is_breakend(["TGCA."]) is True
+    assert _record_is_breakend(["A", "T"]) is False
+    # symbolic alleles are NOT breakends (distinct ALT class)
+    assert _record_is_breakend(["<DEL>"]) is False

--- a/tests/test_svar_filtering.py
+++ b/tests/test_svar_filtering.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import polars as pl
 import pytest
-from vcfixture import Number, Seq, Sym, Type, VcfBuilder, VcfVersion
+from vcfixture import Bnd, Number, Seq, Sym, Type, VcfBuilder, VcfVersion
 
 from genoray import PGEN, VCF, SparseVar
 from genoray import exprs as gexprs
@@ -414,3 +414,109 @@ def test_record_predicates_mirror_exprs():
     assert _record_is_breakend(["A", "T"]) is False
     # symbolic alleles are NOT breakends (distinct ALT class)
     assert _record_is_breakend(["<DEL>"]) is False
+
+
+# ---------------------------------------------------------------------------
+# Breakend filter tests
+# ---------------------------------------------------------------------------
+
+
+def _bnd_vcf(tmp_path: Path) -> Path:
+    """chr1: SNV A>T@100, BND G[chr1:500000[@200, <DEL>@300, ins G>GAT@400.
+
+    One of each droppable class plus two keepers, so the three filter modes
+    (none / no_breakend / no_symbolic / both) all produce distinct counts.
+    """
+    b = (
+        VcfBuilder(
+            samples=["s1", "s2"],
+            contigs=[("chr1", 1_000_000)],
+            version=VcfVersion.V4_4,
+        )
+        .info("SVLEN")
+        .info("SVCLAIM")
+        .info("END")
+        .fmt("GT")
+    )
+    b.record("chr1", 100, ref="A", alt=[Seq("T")], gt=["0|1", "1|1"])
+    b.record("chr1", 200, ref="G", alt=[Bnd("G[chr1:500000[")], gt=["0|1", "0|0"])
+    b.record(
+        "chr1",
+        300,
+        ref="A",
+        alt=[Sym.deletion()],
+        gt=["0|0", "0|1"],
+        info={"SVLEN": [50], "SVCLAIM": ["D"], "END": [350]},
+    )
+    b.record("chr1", 400, ref="G", alt=[Seq("GAT")], gt=["1|1", "0|1"])
+    return b.write(tmp_path / "bnd.vcf.gz", bgzip=True, index=True)
+
+
+def _bnd_pgen(tmp_path: Path) -> Path:
+    """Convert the BND VCF to PGEN via plink2 (BND/symbolic carried verbatim)."""
+    if shutil.which("plink2") is None:
+        pytest.skip("plink2 not available")
+    vcf_path = _bnd_vcf(tmp_path)
+    prefix = tmp_path / "bnd"
+    subprocess.run(
+        [
+            "plink2",
+            "--vcf",
+            str(vcf_path),
+            "--make-pgen",
+            "--out",
+            str(prefix),
+            "--allow-extra-chr",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return prefix.with_suffix(".pgen")
+
+
+def test_cli_write_no_breakend_vcf(tmp_path):
+    from genoray._cli.__main__ import write as cli_write
+
+    vcf_path = _bnd_vcf(tmp_path)
+    out = tmp_path / "nobnd.svar"
+    cli_write(vcf_path, out, max_mem="1g", overwrite=True, no_breakend=True)
+    sv = SparseVar(out)
+    # BND@200 dropped; SNV@100, <DEL>@300, ins@400 kept
+    assert sv.n_variants == 3
+    assert sv.index["POS"].to_list() == [100, 300, 400]
+
+
+def test_cli_write_no_breakend_pgen(tmp_path):
+    from genoray._cli.__main__ import write as cli_write
+
+    pgen_path = _bnd_pgen(tmp_path)
+    out = tmp_path / "nobnd_pg.svar"
+    cli_write(pgen_path, out, max_mem="1g", overwrite=True, no_breakend=True)
+    sv = SparseVar(out)
+    assert sv.n_variants == 3
+    assert set(sv.index["POS"].to_list()) == {100, 300, 400}
+
+
+def test_cli_write_no_symbolic_and_no_breakend_vcf(tmp_path):
+    from genoray._cli.__main__ import write as cli_write
+
+    vcf_path = _bnd_vcf(tmp_path)
+    out = tmp_path / "both.svar"
+    cli_write(
+        vcf_path, out, max_mem="1g", overwrite=True, no_symbolic=True, no_breakend=True
+    )
+    sv = SparseVar(out)
+    # BND@200 and <DEL>@300 both dropped; only plain SNV@100 + ins@400 remain
+    assert sv.n_variants == 2
+    assert sv.index["POS"].to_list() == [100, 400]
+
+
+def test_cli_write_no_flags_keeps_all_vcf(tmp_path):
+    """Back-compat: neither flag set -> all records written."""
+    from genoray._cli.__main__ import write as cli_write
+
+    vcf_path = _bnd_vcf(tmp_path)
+    out = tmp_path / "none.svar"
+    cli_write(vcf_path, out, max_mem="1g", overwrite=True)
+    sv = SparseVar(out)
+    assert sv.n_variants == 4

--- a/tests/test_svar_filtering.py
+++ b/tests/test_svar_filtering.py
@@ -180,7 +180,7 @@ def test_cli_write_skip_symbolic_vcf(tmp_path):
 
     vcf_path = _mixed_vcf(tmp_path)
     out = tmp_path / "cli.svar"
-    cli_write(vcf_path, out, max_mem="1g", overwrite=True, skip_symbolic_alts=True)
+    cli_write(vcf_path, out, max_mem="1g", overwrite=True, no_symbolic=True)
     sv = SparseVar(out)
     assert sv.n_variants == 2
     assert sv.index["POS"].to_list() == [100, 400]
@@ -191,7 +191,7 @@ def test_cli_write_skip_symbolic_pgen(tmp_path):
 
     pgen_path = _mixed_pgen(tmp_path)
     out = tmp_path / "cli_pg.svar"
-    cli_write(pgen_path, out, max_mem="1g", overwrite=True, skip_symbolic_alts=True)
+    cli_write(pgen_path, out, max_mem="1g", overwrite=True, no_symbolic=True)
     sv = SparseVar(out)
     assert sv.n_variants == 2
     assert set(sv.index["POS"].to_list()) == {100, 400}

--- a/tests/test_symbolic_ilen.py
+++ b/tests/test_symbolic_ilen.py
@@ -7,7 +7,7 @@ import polars as pl
 import pytest
 
 from genoray import PGEN, VCF, SparseVar, exprs
-from genoray.exprs import is_imprecise, symbolic_ilen
+from genoray.exprs import is_breakend, is_imprecise, symbolic_ilen
 from tests import _oracle
 from tests.data.fixtures import FIXTURES as _FIXTURES
 
@@ -141,14 +141,18 @@ def test_symbolic_fixture_builds_and_classifies():
 
     truth = FIXTURES["symbolic"]().truth()
     # records: 0 <DEL> precise, 1 <INS> precise, 2 <DUP> precise,
-    #          3 <DEL> IMPRECISE, 4 <CNV> (unsupported), 5 <INV> (unsupported)
-    assert len(truth.pos) == 6
+    #          3 <DEL> IMPRECISE, 4 <CNV> (unsupported), 5 <INV> (unsupported),
+    #          6 breakend (BND mate notation)
+    assert len(truth.pos) == 7
     assert truth.alts_truth[0][0].sv_type == "DEL"
     assert truth.alts_truth[1][0].sv_type == "INS"
     assert truth.alts_truth[2][0].sv_type == "DUP"
     assert truth.alts_truth[3][0].sv_type == "DEL"  # IMPRECISE <DEL>
     assert truth.alts_truth[4][0].sv_type == "CNV"  # <CNV> unsupported type
     assert truth.alts_truth[5][0].sv_type == "INV"  # <INV> unsupported type
+    # breakend: not a sequence, no symbolic sv_type
+    assert truth.alts_truth[6][0].sv_type is None
+    assert truth.alts_truth[6][0].is_sequence is False
 
 
 def test_expected_ilen_from_oracle():
@@ -162,6 +166,7 @@ def test_expected_ilen_from_oracle():
     assert exp[3] == [None]  # IMPRECISE <DEL> -> null (mirrors symbolic_ilen)
     assert exp[4] == [None]  # <CNV> unsupported
     assert exp[5] == [None]  # <INV> unsupported
+    assert exp[6] == [None]  # breakend (BND) -> null
 
 
 @pytest.fixture
@@ -192,6 +197,7 @@ def test_vcf_persisted_ilen_matches_oracle(symbolic_vcf):
     assert got[3] == exp[3] == [None]  # IMPRECISE <DEL>
     assert got[4] == exp[4] == [None]  # <CNV>
     assert got[5] == exp[5] == [None]  # <INV>
+    assert got[6] == exp[6] == [None]  # breakend (BND)
 
 
 def test_oracle_normalizes_compound_sv_type():
@@ -246,16 +252,16 @@ def test_var_ranges_handles_null_ilen(symbolic_vcf):
     # numpy array via numba ufuncs.  A null ILEN entry causes Polars to upcast
     # the column to Float64/NaN, which the numba typed ufunc cannot accept.
     # This test calls var_ranges directly so the null rows (POS=4000 IMPRECISE,
-    # POS=5000 <CNV>, and POS=6000 <INV>) are always materialised.
+    # POS=5000 <CNV>, POS=6000 <INV>, and POS=7000 breakend) are always materialised.
     from genoray._var_ranges import var_ranges
 
-    # Wide query spanning all 6 records — forces all ILEN rows through the
-    # numpy path including the three nulls.  The result covers variant indices
-    # [0, 6) — all six records are represented.
-    result = var_ranges(symbolic_vcf._c_norm, symbolic_vcf._index, "chr1", [0], [7_000])
+    # Wide query spanning all 7 records — forces all ILEN rows through the
+    # numpy path including the four nulls.  The result covers variant indices
+    # [0, 7) — all seven records are represented.
+    result = var_ranges(symbolic_vcf._c_norm, symbolic_vcf._index, "chr1", [0], [8_000])
     assert result.shape == (1, 2)
-    # All 6 variants represented: exclusive end minus start = 6
-    assert result[0, 1] - result[0, 0] == 6
+    # All 7 variants represented: exclusive end minus start = 7
+    assert result[0, 1] - result[0, 0] == 7
 
     # Narrow query overlapping only the precise <DEL> at POS=1000.
     # ILEN=-100 means the variant spans [999, 1100) in 0-based coords.
@@ -275,17 +281,17 @@ def test_var_counts_lazy_path_includes_null_ilen_variants(symbolic_vcf):
     # drops, returning 3 instead of 6.  This test exercises the LAZY path
     # (var_counts → VCF.n_vars_in_ranges → VCF.read allocation) and asserts
     # the correct count.
-    count = symbolic_vcf.n_vars_in_ranges("chr1", 0, 7_000)[0]
-    assert count == 6, (
-        f"Expected 6 variants over chr1:0-7000 (including 3 null-ILEN rows), got {count}"
+    count = symbolic_vcf.n_vars_in_ranges("chr1", 0, 8_000)[0]
+    assert count == 7, (
+        f"Expected 7 variants over chr1:0-8000 (including 4 null-ILEN rows), got {count}"
     )
 
     # Confirm this also flows through VCF.read: the allocated output array
-    # must have 6 variants on the variant axis.
-    genos = symbolic_vcf.read("chr1", 0, 7_000)
+    # must have 7 variants on the variant axis.
+    genos = symbolic_vcf.read("chr1", 0, 8_000)
     # shape is (samples, ploidy+phasing, variants) for Genos16
-    assert genos.shape[-1] == 6, (
-        f"VCF.read returned {genos.shape[-1]} variants, expected 6"
+    assert genos.shape[-1] == 7, (
+        f"VCF.read returned {genos.shape[-1]} variants, expected 7"
     )
 
 
@@ -344,7 +350,9 @@ def test_filter_parity_symbolic_vs_imprecise(tmp_path):
     base_vcf = VCF(str(path))
     base_vcf._write_gvi_index()
 
-    # ~is_symbolic drops ALL symbolic -> empty index (all 6 rows are <...> symbolic).
+    # ~is_symbolic drops the 6 <...> symbolic rows but KEEPS the breakend, which
+    # is a distinct ALT class (is_symbolic only matches `<...>`).  This is the gap
+    # the breakend row was added to lock: ~is_symbolic alone is NOT haplotype-safe.
     # The `_index` is filtered solely by `pl_filter`; the `filter` callable is an
     # inert no-op required by the VCF constructor's filter/pl_filter pairing.
     vcf_all = VCF(
@@ -353,9 +361,20 @@ def test_filter_parity_symbolic_vs_imprecise(tmp_path):
         pl_filter=~exprs.is_symbolic,
     )
     vcf_all._load_index()
-    assert vcf_all._index.height == 0
+    assert vcf_all._index.height == 1
+    assert vcf_all._index.get_column("ALT").to_list() == [["G[chr1:500000["]]
 
-    # ~is_imprecise keeps the 3 precise SVs, drops the 3 un-sizable ones.
+    # ~is_symbolic & ~is_breakend drops everything un-expandable -> empty index.
+    vcf_hap = VCF(
+        str(path),
+        filter=lambda r: True,
+        pl_filter=~exprs.is_symbolic & ~exprs.is_breakend,
+    )
+    vcf_hap._load_index()
+    assert vcf_hap._index.height == 0
+
+    # ~is_imprecise keeps the 3 precise SVs, drops the 4 un-sizable ones
+    # (IMPRECISE <DEL>, <CNV>, <INV>, and the breakend).
     # pl_filter-only requires pairing with a no-op filter callable per the VCF API.
     vcf_precise = VCF(
         str(path),
@@ -491,3 +510,92 @@ def test_property_ilen_matches_oracle():
                 )
 
     _prop()
+
+
+# ---------------------------------------------------------------------------
+# Breakend (BND) ALTs: mate-pair / single-breakend notation
+# ---------------------------------------------------------------------------
+
+
+def test_is_breakend_detects_mate_and_single_notation():
+    """is_breakend matches the VCF 4.x breakend ALT grammar (bracketed mate
+    notation and single-breakend ``.``-forms) but NOT symbolic ``<...>`` alleles
+    or plain SNP/indel sequences."""
+    df = pl.DataFrame(
+        {
+            "ALT": [
+                ["G[chr2:321["],  # paired breakend (t[p[)
+                ["]chr2:321]G"],  # paired breakend (]p]t)
+                [".TGCA"],  # single breakend, left (.t)
+                ["TGCA."],  # single breakend, right (t.)
+                ["<DEL>"],  # symbolic, NOT a breakend
+                ["A"],  # SNP
+                ["AT"],  # insertion
+                ["AT", "G[chr2:1["],  # multiallelic: any breakend -> True
+            ]
+        },
+        schema={"ALT": pl.List(pl.Utf8)},
+    )
+    out = df.with_columns(bnd=is_breakend).get_column("bnd").to_list()
+    assert out == [True, True, True, True, False, False, False, True]
+
+
+def test_symbolic_ilen_breakend_is_null():
+    """Breakend ALTs are un-expandable like symbolic SVs, so their ILEN must be
+    null — NOT the literal ``len(ALT) - len(REF)`` (which would masquerade as a
+    large insertion and slip past ``~is_imprecise``)."""
+    df = pl.DataFrame(
+        {
+            "REF": ["G", "G", "A"],
+            "ALT": [["G[chr2:321["], [".TGCA"], ["T"]],
+            "SVLEN": [None, None, None],
+            "END": [None, None, None],
+            "IMPRECISE": [False, False, False],
+            "POS": [1000, 2000, 3000],
+        },
+        schema={
+            "REF": pl.Utf8,
+            "ALT": pl.List(pl.Utf8),
+            "SVLEN": pl.Int64,
+            "END": pl.Int64,
+            "IMPRECISE": pl.Boolean,
+            "POS": pl.Int64,
+        },
+    )
+    out = df.with_columns(ILEN=symbolic_ilen()).get_column("ILEN").to_list()
+    assert out[0] == [None], f"paired breakend should be null, got {out[0]}"
+    assert out[1] == [None], f"single breakend should be null, got {out[1]}"
+    assert out[2] == [0], f"SNP should be literal 0, got {out[2]}"
+
+
+def test_vcf_breakend_ilen_null_and_filter_parity(tmp_path):
+    """End-to-end: a breakend record written to a VCF gets null ILEN through the
+    index-build path, is flagged ``is_breakend`` & ``is_imprecise`` but NOT
+    ``is_symbolic``, and is dropped by ``~is_breakend`` / ``~is_imprecise`` while
+    surviving ``~is_symbolic``."""
+    from vcfixture import Bnd, VcfBuilder, VcfVersion
+
+    b = VcfBuilder(
+        samples=["s1"],
+        contigs=[("chr1", 1_000_000), ("chr2", 1_000_000)],
+        version=VcfVersion.V4_4,
+    ).fmt("GT")
+    b.record("chr1", 1000, ref="G", alt=[Bnd("G[chr2:321[")], gt=["0|1"])
+    path = b.build().write(tmp_path / "bnd.vcf.gz", bgzip=True, index=True)
+
+    vcf = VCF(str(path))
+    vcf._write_gvi_index()
+    vcf._load_index()
+
+    assert vcf._index.get_column("ILEN").to_list() == [[None]]
+
+    df = vcf._index
+    assert df.select(is_breakend).to_series().to_list() == [True]
+    assert df.select(exprs.is_symbolic).to_series().to_list() == [False]
+    assert df.select(is_imprecise).to_series().to_list() == [True]
+
+    # ~is_symbolic keeps the breakend (it is not a <...> symbolic allele).
+    assert df.filter(~exprs.is_symbolic).height == 1
+    # ~is_breakend and ~is_imprecise both drop it.
+    assert df.filter(~is_breakend).height == 0
+    assert df.filter(~is_imprecise).height == 0

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -305,3 +305,40 @@ def test_chunk_with_length_phased_indel_in_extension():
     assert genos_phasing.shape[1] == vcf.ploidy + 1
     # and it produced at least the query's variants without crashing
     assert genos_phasing.shape[-1] > 0
+
+
+def test_filter_setter_enforces_pair_invariant():
+    import polars as pl  # noqa: F401
+
+    from genoray import exprs
+
+    vcf = VCF(ddir / "biallelic.vcf.gz")
+
+    def record_fn(v):
+        return not any(a.startswith("<") for a in v.ALT)
+
+    pl_expr = ~exprs.is_symbolic
+
+    # Setting a valid (filter, pl_filter) pair updates both and invalidates the index.
+    vcf._index = "sentinel"
+    vcf.filter = (record_fn, pl_expr)
+    assert vcf.filter is record_fn
+    assert vcf._pl_filter is pl_expr
+    assert vcf._index is None
+
+    # Assigning None clears both.
+    vcf.filter = None
+    assert vcf.filter is None
+    assert vcf._pl_filter is None
+
+    # A mismatched pair raises ValueError and leaves state untouched.
+    with pytest.raises(ValueError):
+        vcf.filter = (record_fn, None)
+    with pytest.raises(ValueError):
+        vcf.filter = (None, pl_expr)
+    assert vcf.filter is None
+    assert vcf._pl_filter is None
+
+    # A bare (non-tuple) value is rejected.
+    with pytest.raises(TypeError):
+        vcf.filter = record_fn


### PR DESCRIPTION
## Summary
- Replace the single `genoray write --skip-symbolic-alts` flag with two independent, composable flags `--no-symbolic` and `--no-breakend`, so users can drop un-injectable ALT classes (symbolic alleles like `<DEL>`, breakends like `G[chr1:500[`) independently or together.
- Add private record-level predicates `_record_is_symbolic` / `_record_is_breakend` to `genoray/exprs.py` that mirror the existing `is_symbolic` / `is_breakend` polars exprs (sharing `_BND_PATTERN`), keeping the cyvcf2 record callable and the polars index filter in parity.
- CLI composes the requested flags into a paired `(record callable, polars expr)` for the VCF path (both required, or neither) and a single polars expr for PGEN.

## Test Plan
- [x] `pixi run test` — 347 passed, 16 xfailed
- [x] `ruff check` + `ruff format --check` clean
- [x] `genoray write --help` shows `--no-symbolic` / `--no-breakend`, no `--skip-symbolic-alts` or `--no-no-*`
- [x] New tests cover no-flags / `--no-breakend` / combined `--no-symbolic --no-breakend` across VCF, plus `--no-breakend` PGEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)