### PR TITLE
fix(types): add pyrefly hook and resolve strict type errors

### DIFF
--- a/.github/workflows/prek.yaml
+++ b/.github/workflows/prek.yaml
@@ -6,4 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # The pyrefly hook runs `pixi run typecheck`, so pixi (and the default
+      # environment that provides pyrefly) must be available to prek-action.
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.68.1
+          environments: default
       - uses: j178/prek-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
     stages: [commit-msg]
 - repo: local
   hooks:
+  - id: pyrefly
+    name: Type-check with pyrefly
+    entry: pixi run typecheck
+    language: system
+    types: [python]
+    pass_filenames: false
   - id: pixi lock
     name: Lock pixi environment
     entry: pixi lock

--- a/genoray/_cli/__main__.py
+++ b/genoray/_cli/__main__.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from importlib.metadata import version
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Callable, Literal
 
+import polars as pl
 from cyclopts import App, Parameter
 
 app = App(
@@ -102,8 +103,8 @@ def write(
     # expr (used by both VCF index and PGEN) and a record-level predicate (used
     # by the VCF cyvcf2 genotype scan). The two representations of each flag are
     # kept in parity via genoray.exprs.
-    pl_terms = []
-    record_preds = []
+    pl_terms: list[pl.Expr] = []
+    record_preds: list[Callable[[list[str]], bool]] = []
     if no_symbolic:
         pl_terms.append(~exprs.is_symbolic)
         record_preds.append(exprs._record_is_symbolic)
@@ -117,7 +118,10 @@ def write(
 
         pl_filter = reduce(and_, pl_terms)
 
-        def record_filter(rec, _preds=tuple(record_preds)) -> bool:
+        def record_filter(
+            rec: Any,
+            _preds: tuple[Callable[[list[str]], bool], ...] = tuple(record_preds),
+        ) -> bool:
             return not any(pred(rec.ALT) for pred in _preds)
     else:
         pl_filter = None

--- a/genoray/_pgen.py
+++ b/genoray/_pgen.py
@@ -16,7 +16,7 @@ from more_itertools import mark_ends, windowed
 from numpy.typing import ArrayLike, NDArray
 from phantom import Phantom
 from seqpro.rag import OFFSET_TYPE
-from typing_extensions import Self, assert_never
+from typing_extensions import Self, assert_never, override
 from zstandard import ZstdDecompressor
 
 from ._types import POS_MAX, POS_TYPE
@@ -71,7 +71,7 @@ class Phasing(NDArray[np.bool_], Phantom, predicate=_is_phasing):
         return cls.parse(np.empty((n_samples, n_variants), dtype=cls._dtype))
 
 
-def _is_genos_phasing(obj) -> TypeGuard[GenosPhasing]:
+def _is_genos_phasing(obj: object) -> TypeGuard[GenosPhasing]:
     return (
         isinstance(obj, tuple)
         and len(obj) == 2
@@ -93,7 +93,7 @@ class GenosPhasing(tuple[Genos, Phasing], Phantom, predicate=_is_genos_phasing):
         )
 
 
-def _is_genos_dosages(obj) -> TypeGuard[GenosDosages]:
+def _is_genos_dosages(obj: object) -> TypeGuard[GenosDosages]:
     return (
         isinstance(obj, tuple)
         and len(obj) == 2
@@ -115,7 +115,7 @@ class GenosDosages(tuple[Genos, Dosages], Phantom, predicate=_is_genos_dosages):
         )
 
 
-def _is_genos_phasing_dosages(obj) -> TypeGuard[GenosPhasingDosages]:
+def _is_genos_phasing_dosages(obj: object) -> TypeGuard[GenosPhasingDosages]:
     return (
         isinstance(obj, tuple)
         and len(obj) == 3
@@ -290,7 +290,7 @@ class PGEN:
                 + self._sei.ilens.nbytes
                 + self._sei.alt.estimated_size()
             )
-        return n
+        return int(n)
 
     @property
     def filter(self) -> pl.Expr | None:
@@ -493,7 +493,7 @@ class PGEN:
         elif issubclass(mode, GenosPhasingDosages):
             out = self._read_genos_phasing_dosages(var_idxs)
         else:
-            assert_never(mode)
+            assert_never(mode)  # type: ignore[bad-argument-type]
 
         return cast(T, out)
 
@@ -571,7 +571,7 @@ class PGEN:
             elif issubclass(mode, GenosPhasingDosages):
                 _out = self._read_genos_phasing_dosages(var_idx)
             else:
-                assert_never(mode)
+                assert_never(mode)  # type: ignore[bad-argument-type]
 
             yield mode.parse(_out)
 
@@ -648,7 +648,7 @@ class PGEN:
         elif issubclass(mode, GenosPhasingDosages):
             out = self._read_genos_phasing_dosages(var_idxs)
         else:
-            assert_never(mode)
+            assert_never(mode)  # type: ignore[bad-argument-type]
 
         return cast(T, out), offsets
 
@@ -752,7 +752,7 @@ class PGEN:
             elif issubclass(mode, GenosPhasingDosages):
                 read = self._read_genos_phasing_dosages
             else:
-                assert_never(mode)
+                assert_never(mode)  # type: ignore[bad-argument-type]
 
             yield (cast(T, read(var_idx)) for var_idx in v_chunks)
 
@@ -882,7 +882,7 @@ class PGEN:
         elif issubclass(mode, GenosPhasingDosages):
             read = self._read_genos_phasing_dosages
         else:
-            assert_never(mode)
+            assert_never(mode)  # type: ignore[bad-argument-type]
 
         read = cast(Callable[[NDArray[np.uint32]], L], read)
 
@@ -931,7 +931,7 @@ class PGEN:
             mem += self.n_samples * mode._dtypes[1]().itemsize
             mem += self.n_samples * mode._dtypes[2]().itemsize
         else:
-            assert_never(mode)
+            assert_never(mode)  # type: ignore[bad-argument-type]
 
         if isinstance(self._s_unsorter, np.ndarray):
             mem *= 2  # have to make a copy to sort by samples
@@ -1074,7 +1074,7 @@ def _gen_with_length(
             )
 
         var_idx = np.arange(var_idx[0], last_idx + 1, dtype=V_IDX_TYPE)
-        yield (
+        yield (  # type: ignore[invalid-yield]
             out,  # type: ignore
             last_end,
             var_idx,
@@ -1294,6 +1294,7 @@ class ZstdFile(TextIOWrapper):
         self.reader = ZstdDecompressor().stream_reader(open(path, "rb"))
         super().__init__(self.reader, newline="\n", encoding="utf-8")
 
+    @override
     def __exit__(
         self,
         exc_type: type[BaseException] | None,

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -4,11 +4,11 @@ import copy
 import re
 import shutil
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Generic, Literal, TypeVar, cast, overload
+from typing import Any, Generic, Literal, TypeVar, cast, overload
 
 import awkward as ak
 import joblib
@@ -168,7 +168,7 @@ def _normalize_samples(
     and deduping by first occurrence. Raises ValueError on unknown samples."""
     if isinstance(samples, str):
         candidates: list[str] = [samples]
-    elif isinstance(samples, PathLike) or hasattr(samples, "__fspath__"):
+    elif isinstance(samples, PathLike):
         candidates = Path(samples).read_text().splitlines()
         candidates = [s for s in candidates if s.strip()]
     else:
@@ -491,7 +491,7 @@ class SparseVar(Generic[_SRT]):
         held by this reader. Only the polars variant index counts; `genos`
         and `fields` are memory-mapped and excluded.
         """
-        return self.index.estimated_size()
+        return int(self.index.estimated_size())
 
     @overload
     def __init__(
@@ -1035,6 +1035,7 @@ class SparseVar(Generic[_SRT]):
         with TemporaryDirectory() as contig_dir:
             contig_dir = Path(contig_dir)
 
+            assert pgen._index is not None
             keep_by_contig = {
                 chrom: np.asarray(idxs, dtype=np.uint32)
                 for chrom, idxs in (
@@ -1044,7 +1045,7 @@ class SparseVar(Generic[_SRT]):
                 )
             }
 
-            tasks = []
+            tasks: list[Any] = []
             for c in contigs:
                 keep_idxs = keep_by_contig.get(c)
                 if keep_idxs is None or len(keep_idxs) == 0:
@@ -1264,7 +1265,7 @@ class SparseVar(Generic[_SRT]):
         return self.index.drop("index")
 
     def _load_genos(self):
-        def memmap2array(layout: Content, **kwargs):
+        def memmap2array(layout: Content, **kwargs: Any):
             if isinstance(layout, NumpyArray):
                 data = layout.data
                 if isinstance(data, np.memmap):
@@ -1275,7 +1276,7 @@ class SparseVar(Generic[_SRT]):
 
     def write_view(
         self,
-        regions: str | tuple[str, int, int] | Path,
+        regions: str | tuple[str, int, int] | Path | pl.DataFrame,
         samples: str | Sequence[str] | Path,
         output: str | Path,
         fields: Sequence[str] | None = None,
@@ -1478,7 +1479,12 @@ class SparseVar(Generic[_SRT]):
 
 
 @nb.njit(nogil=True, cache=True)
-def _nb_af_helper(afs, v_idxs, offsets, max_count):
+def _nb_af_helper(
+    afs: NDArray[np.float32],
+    v_idxs: NDArray[np.int32],
+    offsets: NDArray[np.int64],
+    max_count: int,
+):
     for i in range(len(offsets) - 1):
         o_s, o_e = offsets[i], offsets[i + 1]
         v_slice = v_idxs[o_s:o_e]
@@ -1488,13 +1494,18 @@ def _nb_af_helper(afs, v_idxs, offsets, max_count):
 
 @nb.njit(parallel=True, nogil=True, cache=True)
 def _nb_count_kept(
-    src_data, src_offsets, src_sample_idxs, ploidy, kept_var_idxs, out_lengths
+    src_data: NDArray[np.int32],
+    src_offsets: NDArray[np.int64],
+    src_sample_idxs: NDArray[np.int64],
+    ploidy: int,
+    kept_var_idxs: NDArray[np.int32],
+    out_lengths: NDArray[np.int64],
 ):
     """Pass 1: count, per output (sample, ploidy) slot, how many source variant
     indices fall in `kept_var_idxs`."""
     n_out = src_sample_idxs.shape[0]
     n_kept = kept_var_idxs.shape[0]
-    for i in nb.prange(n_out):
+    for i in nb.prange(n_out):  # type: ignore[not-iterable]
         s = src_sample_idxs[i]
         for p in range(ploidy):
             src_slot = s * ploidy + p
@@ -1511,14 +1522,19 @@ def _nb_count_kept(
 
 @nb.njit(parallel=True, nogil=True, cache=True)
 def _nb_count_mac_per_kept(
-    src_data, src_offsets, src_sample_idxs, ploidy, kept_var_idxs, mac_out
+    src_data: NDArray[np.int32],
+    src_offsets: NDArray[np.int64],
+    src_sample_idxs: NDArray[np.int64],
+    ploidy: int,
+    kept_var_idxs: NDArray[np.int32],
+    mac_out: NDArray[np.int64],
 ):
     """Count, per kept variant, the number of non-ref entries across (sample, ploidy)
     in the output. Outer prange is over kept variants so each writes its own slot —
     no atomics needed."""
     n_kept = kept_var_idxs.shape[0]
     n_samples = src_sample_idxs.shape[0]
-    for k in nb.prange(n_kept):
+    for k in nb.prange(n_kept):  # type: ignore[not-iterable]
         v = kept_var_idxs[k]
         count = 0
         for i in range(n_samples):
@@ -1535,18 +1551,18 @@ def _nb_count_mac_per_kept(
 
 @nb.njit(parallel=True, nogil=True, cache=True)
 def _nb_write_var_idxs(
-    src_data,
-    src_offsets,
-    src_sample_idxs,
-    ploidy,
-    kept_var_idxs,
-    new_offsets,
-    out_var_idxs,
+    src_data: NDArray[np.int32],
+    src_offsets: NDArray[np.int64],
+    src_sample_idxs: NDArray[np.int64],
+    ploidy: int,
+    kept_var_idxs: NDArray[np.int32],
+    new_offsets: NDArray[np.int64],
+    out_var_idxs: NDArray[np.int32],
 ):
     """Pass 2: write remapped variant indices."""
     n_out = src_sample_idxs.shape[0]
     n_kept = kept_var_idxs.shape[0]
-    for i in nb.prange(n_out):
+    for i in nb.prange(n_out):  # type: ignore[not-iterable]
         s = src_sample_idxs[i]
         for p in range(ploidy):
             src_slot = s * ploidy + p
@@ -1564,19 +1580,19 @@ def _nb_write_var_idxs(
 
 @nb.njit(parallel=True, nogil=True, cache=True)
 def _nb_write_field(
-    src_field,
-    src_data,
-    src_offsets,
-    src_sample_idxs,
-    ploidy,
-    kept_var_idxs,
-    new_offsets,
-    out_field,
+    src_field: NDArray[Any],
+    src_data: NDArray[np.int32],
+    src_offsets: NDArray[np.int64],
+    src_sample_idxs: NDArray[np.int64],
+    ploidy: int,
+    kept_var_idxs: NDArray[np.int32],
+    new_offsets: NDArray[np.int64],
+    out_field: NDArray[Any],
 ):
     """Pass 2 (field variant): writes src_field values at filter-kept positions."""
     n_out = src_sample_idxs.shape[0]
     n_kept = kept_var_idxs.shape[0]
-    for i in nb.prange(n_out):
+    for i in nb.prange(n_out):  # type: ignore[not-iterable]
         s = src_sample_idxs[i]
         for p in range(ploidy):
             src_slot = s * ploidy + p
@@ -1630,8 +1646,8 @@ def _process_contig_vcf(
     contig: str,
     chunk_dir: Path,
     chunk_idx: int,
-    cyvcf2_filter=None,
-    pl_filter=None,
+    cyvcf2_filter: Callable[..., bool] | None = None,
+    pl_filter: pl.Expr | None = None,
 ) -> tuple[int, int]:
     vcf = VCF(
         path,
@@ -1770,7 +1786,7 @@ def _open_fmt(
     offsets = np.memmap(path / "offsets.npy", dtype=np.int64, mode=mode)
 
     sp_genos = Ragged.from_offsets(data, shape, offsets)
-    return sp_genos
+    return sp_genos  # type: ignore[bad-return]
 
 
 def _write_genos(path: Path, sp_genos: Ragged[V_IDX_TYPE]):
@@ -1938,7 +1954,7 @@ def _copy_chunk_helper(
     n_samples: int,
     ploidy: int,
 ):
-    for s in nb.prange(n_samples):
+    for s in nb.prange(n_samples):  # type: ignore[not-iterable]
         for p in range(ploidy):
             sp = s * ploidy + p
 
@@ -1963,7 +1979,7 @@ def _copy_chunk_dosages_helper(
     n_samples: int,
     ploidy: int,
 ):
-    for s in nb.prange(n_samples):
+    for s in nb.prange(n_samples):  # type: ignore[not-iterable]
         for p in range(ploidy):
             sp = s * ploidy + p
 
@@ -2015,8 +2031,8 @@ def _find_starts_ends(
     sorter = np.argsort(var_ranges[:, 0])
     var_ranges = var_ranges[sorter]
 
-    for s in nb.prange(n_samples):
-        for p in nb.prange(ploidy):
+    for s in nb.prange(n_samples):  # type: ignore[not-iterable]
+        for p in nb.prange(ploidy):  # type: ignore[not-iterable]
             s_idx = sample_idxs[s]
             sp = s_idx * ploidy + p
             o_s, o_e = geno_offsets[sp], geno_offsets[sp + 1]
@@ -2068,7 +2084,7 @@ def _length_walk_n_keep(
                 return j - start_idx + 1  # include this variant
 
         v_end = v_start - min(0, ilen) + maybe_add_one
-        last_v_end = max(last_v_end, v_end)
+        last_v_end = max(last_v_end, v_end)  # type: ignore[bad-specialization]
 
     return max_idx - start_idx
 
@@ -2089,7 +2105,7 @@ def _dense2sparse_count(
     path uses, so the two cannot drift). Writes the kept count to ``out_lengths``.
     """
     n_samples, ploidy, n_var = genos.shape
-    for s in nb.prange(n_samples):
+    for s in nb.prange(n_samples):  # type: ignore[not-iterable]
         carriers = np.empty(n_var, dtype=V_IDX_TYPE)
         for p in range(ploidy):
             nc = 0
@@ -2116,7 +2132,7 @@ def _dense2sparse_fill(
     """Pass 2: emit the first ``out_lengths[s, p]`` carried ALT calls per
     haplotype into the disjoint output range ``[flat_offsets[slot], ...)``."""
     n_samples, ploidy, n_var = genos.shape
-    for s in nb.prange(n_samples):
+    for s in nb.prange(n_samples):  # type: ignore[not-iterable]
         for p in range(ploidy):
             slot = s * ploidy + p
             n_keep = out_lengths[s, p]
@@ -2181,8 +2197,8 @@ def _find_starts_ends_with_length(
     sorter = np.argsort(var_ranges[:, 0])
     var_ranges = var_ranges[sorter]
 
-    for s in nb.prange(n_samples):
-        for p in nb.prange(ploidy):
+    for s in nb.prange(n_samples):  # type: ignore[not-iterable]
+        for p in nb.prange(ploidy):  # type: ignore[not-iterable]
             s_idx = sample_idxs[s]
             sp = s_idx * ploidy + p
             o_s, o_e = geno_offsets[sp], geno_offsets[sp + 1]
@@ -2209,8 +2225,8 @@ def _find_starts_ends_with_length(
                     sp_genos,
                     v_starts,
                     ilens,
-                    start_idx,
-                    max_idx,
+                    int(start_idx),
+                    int(max_idx),
                     q_starts[r],
                     q_ends[r],
                 )

--- a/genoray/_vcf.py
+++ b/genoray/_vcf.py
@@ -131,7 +131,7 @@ class Genos8Dosages(tuple[Genos8, Dosages], Phantom, predicate=_is_genos8_dosage
         )
 
 
-def _is_genos16_dosages(obj) -> TypeGuard[tuple[Genos8, Dosages]]:
+def _is_genos16_dosages(obj: object) -> TypeGuard[tuple[Genos8, Dosages]]:
     """Check if the object is a tuple of genotypes and dosages.
 
     Parameters
@@ -291,7 +291,7 @@ class VCF:
         self.contigs = natsorted(vcf.seqnames)
         self._c_norm = ContigNormalizer(vcf.seqnames)
         avail = np.asarray(self.available_samples)
-        self._s2i = HashTable(max=len(avail) * 2, dtype=avail.dtype)
+        self._s2i = HashTable(max=len(avail) * 2, dtype=avail.dtype)  # type: ignore[bad-argument-type]
         self._s2i.add(avail)
 
         self.set_samples(None)
@@ -370,7 +370,7 @@ class VCF:
         """
         if self._index is None:
             return 0
-        return self._index.estimated_size()
+        return int(self._index.estimated_size())
 
     @property
     def current_samples(self) -> list[str]:
@@ -646,7 +646,7 @@ class VCF:
                     vcf, data, self.dosage_field, mode=mode
                 )
             else:
-                assert_never(mode)
+                assert_never(mode)  # type: ignore[bad-argument-type]
 
             out = cast(T, data)
         else:
@@ -659,7 +659,7 @@ class VCF:
                 assert self.dosage_field is not None
                 self._fill_genos_and_dosages(vcf, out, self.dosage_field)
             else:
-                assert_never(mode)
+                assert_never(mode)  # type: ignore[bad-argument-type]
 
         return out
 
@@ -776,11 +776,11 @@ class VCF:
                 buffer.append(gt_buffer)
             if ds_buffer is not None:
                 ds_buffer = ds_buffer[..., :i]
-                buffer.append(ds_buffer)
+                buffer.append(ds_buffer)  # type: ignore[bad-argument-type]
             buffer = tuple(buffer)
 
             if len(buffer) == 1:
-                yield buffer[0]
+                yield buffer[0]  # type: ignore[invalid-yield]
             else:
                 yield buffer  # type: ignore
 
@@ -926,7 +926,7 @@ class VCF:
                 )
                 hap_lens += hap_ilens(out[0][:, : self.ploidy], ilens)
             else:
-                assert_never(mode)
+                assert_never(mode)  # type: ignore[bad-argument-type]
 
             if not is_last:
                 yield cast(L, out), last_end, 0
@@ -948,7 +948,7 @@ class VCF:
                     last_end,
                 )
             else:
-                assert_never(mode)
+                assert_never(mode)  # type: ignore[bad-argument-type]
 
             if len(ls_ext) > 0:
                 if issubclass(mode, (Genos8, Genos16)):
@@ -1283,7 +1283,7 @@ class VCF:
             assert mode is not None
             assert ilens is None, "caller should not provide ilens if out is None"
 
-            out_ls = []
+            out_ls: list[NDArray[np.int16]] = []
 
             for i, v in enumerate(vcf):
                 if self.phasing:
@@ -1346,7 +1346,7 @@ class VCF:
             vcf = filter(self._filter, vcf)
 
         if out is None:
-            out_ls = []
+            out_ls: list[NDArray[np.float32]] = []
             for v in vcf:
                 d = v.format(dosage_field)
                 if d is None:
@@ -1418,8 +1418,8 @@ class VCF:
             assert mode is not None
             assert ilens is None, "caller should not provide ilens if out is None"
 
-            geno_ls = []
-            dosage_ls = []
+            geno_ls: list[NDArray[np.int16]] = []
+            dosage_ls: list[NDArray[np.float32]] = []
             for i, v in enumerate(vcf):
                 if self.phasing:
                     # (s p+1) np.int16
@@ -1530,7 +1530,7 @@ class VCF:
             mem += self.n_samples * ploidy * mode._gdtype().itemsize
             mem += self.n_samples * np.float32().itemsize
         else:
-            assert_never(mode)
+            assert_never(mode)  # type: ignore[bad-argument-type]
 
         return mem
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -73,6 +73,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.3.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py310h139afa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.19-h3c07f61_3_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310h4f33d48_0.conda
@@ -319,6 +320,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.3.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py310haea493c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-h1b19095_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py310hf0664f0_2.conda
@@ -480,6 +482,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.3.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hfb55c3c_0.conda
@@ -798,6 +801,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.3.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py312hb3ab3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
@@ -949,6 +953,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.3.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py310h139afa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.19-h3c07f61_3_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310h4f33d48_0.conda
@@ -1195,6 +1200,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.3.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py310haea493c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-h1b19095_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py310hf0664f0_2.conda
@@ -1354,6 +1360,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.3.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py311haee01d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.14-hd63d673_3_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h2315fbb_0.conda
@@ -1600,6 +1607,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.3.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py311he363849_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.15-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py311hc290fe0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py311h745ac33_2.conda
@@ -1757,6 +1765,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.3.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hfb55c3c_0.conda
@@ -2009,6 +2018,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.3.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py312hb3ab3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
@@ -2164,6 +2174,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.3.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313h54dd161_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.11-hc97d973_101_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py313h3dea7bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hfb55c3c_0.conda
@@ -2417,6 +2428,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.3.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py313h6688731_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py313h65a2061_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
@@ -2572,6 +2584,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prek-0.3.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py310h139afa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.19-h3c07f61_3_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310h4f33d48_0.conda
@@ -2819,6 +2832,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prek-0.3.11-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py310haea493c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-h1b19095_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py310hb46c203_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py310hf0664f0_2.conda
@@ -4166,6 +4180,19 @@ packages:
   - pkg:pypi/psutil?source=compressed-mapping
   size: 228663
   timestamp: 1769678153829
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
+  sha256: 225d491c94a6962b92377154b33b424cb0cc30aa2fe0b433c6c110d05da7283d
+  md5: 132a1bc9d31e17d6e12d7188ca7ddfb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 10962615
+  timestamp: 1778629320799
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.19-h3c07f61_3_cpython.conda
   build_number: 3
   sha256: 2d8b5566d82c3872f057661e056d696f2f77a17ee5a36d9ae6ec43052c4d1c51
@@ -7246,6 +7273,18 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 242596
   timestamp: 1769678288893
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
+  sha256: 34dd964342267b5d93674eefe37055b8915943de60d43b4e36a08b9642319f46
+  md5: b0b2e5d34dba70dfad3955a59e611b46
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 10330096
+  timestamp: 1778629356792
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.20-h1b19095_0_cpython.conda
   sha256: f0f6fcbb6cfdee5a6b9c03b5b94d2bbe737f3b17a618006c7685cc48992ae667
   md5: 55ec25b0d09379eb11c32dbe09ee28c4

--- a/pixi.toml
+++ b/pixi.toml
@@ -18,6 +18,7 @@ bcftools = "*"
 commitizen = "*"
 prek = "*"
 ruff = "*"
+pyrefly = "*"
 memray = ">=1.12.0,<2"
 pytest = "*"
 pytest-cases = "*"
@@ -40,6 +41,7 @@ vcfixture = ">=0.6.0,<0.7"
 [tasks]
 gen = "sh tests/data/gen_from_vcf.sh"
 test = { cmd = "pytest tests", depends-on = "gen" }
+typecheck = "pyrefly check genoray"
 prek-install = "prek install -t pre-commit -t pre-push -t commit-msg"
 bump-dry = "cz bump --dry-run"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,3 +56,14 @@ markers = ["network: requires network access (deselect with '-m not network')"]
 [tool.basedpyright]
 enableTypeIgnoreComments = true
 reportMissingTypeArgument = false
+
+[tool.pyrefly]
+preset = "strict"
+project-includes = ["genoray"]
+# pgenlib is a compiled extension with no type stubs; treat it as untyped.
+replace-imports-with-any = ["pgenlib"]
+
+[tool.pyrefly.errors]
+# Mostly numpy-scalar noise (np.integer -> np.integer[Any]) and the Phantom
+# NDArray subclasses, which can't be cleanly parametrized. Keep the rest of strict.
+implicit-any-type-argument = false


### PR DESCRIPTION
## Summary

- Adds a local **pre-commit hook** running pyrefly via pixi (`typecheck` task + `pyrefly` dependency).
- Configures `[tool.pyrefly]`: **strict** preset, `pgenlib` treated as untyped (compiled extension, no stubs), and `implicit-any-type-argument` disabled — that category was almost entirely numpy-scalar noise (`np.integer` → `np.integer[Any]`) plus the Phantom `NDArray` subclasses, which can't be cleanly parametrized without fighting the phantom-types design. The rest of strict stays enforced.
- Resolves **all** reported errors across `_vcf`, `_pgen`, `_svar`, `_cli`.

## How errors were handled

**Real fixes (behavior-preserving):**
- `int(...)` casts where polars `estimated_size()` (`int | float`) was returned as a declared `int`.
- `assert ... is not None` guards for narrowing.
- `int(...)` casts on numpy scalars passed to `int`-typed params.
- Annotated numba `@njit` kernel params with concrete `NDArray[dtype]`/`int` types matched to call sites.
- Typed empty containers, TypeGuard predicate params (`obj: object`), and added `@override` (`typing_extensions`, py3.10-safe).
- Widened `SparseVar.write_view(regions=...)` to accept `pl.DataFrame` — the annotation was narrower than its own docstring and `_normalize_regions`.

**Targeted per-line ignores (genuine tool limitations only):**
- numba `nb.prange` `not-iterable`.
- phantom-type `assert_never` exhaustiveness (pyrefly can't treat phantom subclasses as a closed set).
- a couple of generic-variance cases.

## Verification
- `pyrefly check genoray` → **0 errors**
- `ruff check` / `ruff format --check` → clean
- `pytest tests -m "not network"` → **350 passed, 16 xfailed**
- Hook passes via `prek run pyrefly`

No runtime or public-API behavior changes; SKILL.md needs no update (the `write_view` widening only matches the existing docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)