### PR TITLE
fix(deps): allow seqpro 0.15 (relax upper bound to <0.16)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -7713,7 +7713,7 @@ packages:
 - pypi: .
   name: genoray
   requires_dist:
-  - seqpro>=0.11,<0.15
+  - seqpro>=0.11,<0.16
   - numpy>=1.26
   - pandas>=2.2.3
   - hirola>=0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = { file = "LICENSE.txt" }
 requires-python = ">=3.10,<3.14" # blocked by pyarrow
 dependencies = [
-    "seqpro>=0.11,<0.15",
+    "seqpro>=0.11,<0.16",
     "numpy>=1.26",
     "pandas>=2.2.3",
     "hirola>=0.3.0",


### PR DESCRIPTION
## Summary
- Relax the seqpro dependency upper bound from `<0.15` to `<0.16` so genoray can co-resolve with seqpro 0.15.x.
- GenVarLoader needs `seqpro>=0.15.1` (the `IndexedArray` unbox fix for `RaggedVariants.to_packed()`/`rc_()` on sliced/reordered views); genoray's old `<0.15` pin blocked that resolution.

No code change — dependency metadata + lock only. commitizen will bump 2.9.1 → 2.9.2 (patch) on release.

## Test Plan
- [x] No code change; existing suite unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)