### PR TITLE
fix(svar): correct 1-based POS off-by-one in annotate_mutations (#59)

### DIFF
--- a/docs/superpowers/plans/2026-06-12-annotate-mutations-pos-offby-one.md
+++ b/docs/superpowers/plans/2026-06-12-annotate-mutations-pos-offby-one.md
@@ -1,0 +1,458 @@
+# Fix `annotate_mutations` 1-based POS off-by-one (#59) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 1-based→0-based POS off-by-one in `SparseVar.annotate_mutations` so SBS-96/DBS-78/ID-83 catalogues are computed at the correct reference position, add a defensive guard that turns the `KeyError: '<size>:Del:R:-1'` crash into a graceful UNCLASSIFIED + aggregated "wrong reference" warning, and invalidate stale persisted catalogues.
+
+**Architecture:** `classify_variants` (`genoray/_mutcat.py`) becomes the single boundary between genoray's 1-based index convention and 0-based `reference.fetch`, converting `p = POS - 1`. A module-private `_REF_MISMATCH` sentinel returned by `classify_id83` signals a deletion whose deleted unit is absent in the reference; `classify_variants` maps it to UNCLASSIFIED, counts occurrences, and emits one aggregated loguru warning. `MUTCAT_VERSION` bumps to 2 so previously-persisted `mutcat.npy` is detected as stale on load.
+
+**Tech Stack:** Python, NumPy, Polars, loguru, pysam (test fixtures), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-annotate-mutations-pos-offby-one-design.md`
+
+**Environment:** all commands run inside Pixi: prefix with `pixi run`.
+
+---
+
+## File Structure
+
+- `genoray/_mutcat.py` — Modify: add `loguru` import; add `_REF_MISMATCH` constant; bump `MUTCAT_VERSION`; guard the two deletion repeat-bucket branches in `classify_id83`; convert POS and aggregate the mismatch warning in `classify_variants`.
+- `genoray/_svar.py` — Modify: add a staleness warning in `SparseVar.__init__` when a loaded `mutcat` field's `mutcat_version` is older than `MUTCAT_VERSION`.
+- `tests/test_mutcat.py` — Modify: add guard/`_REF_MISMATCH` unit tests for `classify_id83`.
+- `tests/test_svar_mutations.py` — Modify: add the issue regression test (deletion no longer crashes) and the SNV-context correctness test.
+- `tests/test_mutcat_calibration.py` — Modify: remove the manual `- 1` POS conversion (line ~294).
+
+---
+
+## Task 1: Bump `MUTCAT_VERSION` and add staleness warning on load
+
+This task is independent of the off-by-one fix and is committed first.
+
+**Files:**
+- Modify: `genoray/_mutcat.py:145`
+- Modify: `genoray/_svar.py` (in `SparseVar.__init__`, after `self.fields = {...}` block at `:573-576`)
+- Test: `tests/test_svar_mutations.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_svar_mutations.py`. This builds an `.svar`, annotates it (writes `mutcat.npy` + `mutcat_version`), then rewrites `metadata.json` with an artificially old `mutcat_version=0` and asserts reopening with `fields=["mutcat"]` logs a staleness warning.
+
+```python
+def test_mutcat_staleness_warning(tmp_path, capsys):
+    import json
+    from loguru import logger
+    import genoray
+    from genoray import SparseVar
+    from genoray._reference import Reference
+
+    # --- build a tiny reference + single-SNV VCF ---
+    import pysam
+    seq = "ACGTACGTACGTACGT"
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\n" + seq + "\n")
+    pysam.faidx(str(fa))
+
+    vcf = tmp_path / "t.vcf"
+    h = pysam.VariantHeader()
+    h.add_line("##contig=<ID=chr1,length=16>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="GT">')
+    h.add_sample("S1")
+    with pysam.VariantFile(str(vcf), "w", header=h) as vf:
+        r = h.new_record(contig="chr1", start=4, alleles=("A", "C"))  # 1-based POS=5
+        r.samples["S1"]["GT"] = (0, 1)
+        vf.write(r)
+    pysam.tabix_index(str(vcf), preset="vcf", force=True)
+
+    svp = tmp_path / "sv.svar"
+    genoray.SparseVar.from_vcf(svp, genoray.VCF(str(vcf) + ".gz"), max_mem="1g", overwrite=True)
+    sv = SparseVar(svp)
+    sv.annotate_mutations(Reference.from_path(fa), write_back=True)
+
+    # corrupt the persisted version to look stale
+    meta_path = svp / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["mutcat_version"] = 0
+    meta_path.write_text(json.dumps(meta))
+
+    # capture loguru output
+    messages = []
+    sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        SparseVar(svp, fields=["mutcat"])
+    finally:
+        logger.remove(sink_id)
+
+    assert any("older version" in m for m in messages), messages
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar_mutations.py::test_mutcat_staleness_warning -v`
+Expected: FAIL — no warning emitted (assertion error on `messages`).
+
+- [ ] **Step 3: Bump `MUTCAT_VERSION`**
+
+In `genoray/_mutcat.py:145`:
+
+```python
+MUTCAT_VERSION = 2
+```
+
+- [ ] **Step 4: Add the staleness warning in `SparseVar.__init__`**
+
+In `genoray/_svar.py`, immediately after the `self.fields = {...}` dict comprehension (currently `:573-576`), add:
+
+```python
+        if (
+            "mutcat" in (fields or [])
+            and metadata.mutcat_version is not None
+            and metadata.mutcat_version < MUTCAT_VERSION
+        ):
+            logger.warning(
+                "mutcat field was computed with an older version "
+                f"(v{metadata.mutcat_version} < v{MUTCAT_VERSION}); "
+                "recompute via annotate_mutations()."
+            )
+```
+
+`MUTCAT_VERSION` and `logger` are already imported in `genoray/_svar.py` (`:33` and the loguru import).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pixi run pytest tests/test_svar_mutations.py::test_mutcat_staleness_warning -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add genoray/_mutcat.py genoray/_svar.py tests/test_svar_mutations.py
+git commit -m "fix(svar): bump MUTCAT_VERSION and warn on stale persisted mutcat"
+```
+
+---
+
+## Task 2: Defensive guard in `classify_id83` for deletion REF/reference mismatch
+
+Add `_REF_MISMATCH` and guard both deletion repeat-bucket branches so a deletion whose deleted unit is absent at `scan_start` returns the sentinel instead of underflowing into `_repeat_bucket(-1)` → `KeyError`.
+
+**Files:**
+- Modify: `genoray/_mutcat.py` (add `loguru` import near top `:8-13`; add `_REF_MISMATCH` constant near `:138`; edit `classify_id83` branches at `:273` and `:283`)
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_mutcat.py`. `classify_id83` takes `(pos, ref, alt, fetch)` where `fetch(start, end)` returns reference bytes. A deletion of `"GG"` whose downstream reference is all `"A"` (deleted unit absent at `scan_start`) must return `_REF_MISMATCH`. Mirror the existing `_ref_fn` helper pattern (`tests/test_mutcat.py:103`).
+
+```python
+from genoray._mutcat import _REF_MISMATCH  # add to existing import block
+
+
+def test_id83_2bp_deletion_ref_absent_returns_mismatch():
+    # REF="CGG" -> ALT="C": deleted unit "GG". Downstream reference is "AAAA..."
+    # so the deleted unit is NOT present at scan_start -> REF/reference mismatch.
+    downstream = b"A" * 20
+
+    def fetch(s: int, e: int) -> bytes:
+        return downstream[: e - s]
+
+    assert classify_id83(pos=0, ref=b"CGG", alt=b"C", fetch=fetch) == _REF_MISMATCH
+
+
+def test_id83_1bp_deletion_ref_absent_returns_mismatch():
+    # REF="CG" -> ALT="C": deleted unit "G". Downstream reference is "AAAA..."
+    downstream = b"A" * 20
+
+    def fetch(s: int, e: int) -> bytes:
+        return downstream[: e - s]
+
+    assert classify_id83(pos=0, ref=b"CG", alt=b"C", fetch=fetch) == _REF_MISMATCH
+
+
+def test_id83_2bp_deletion_ref_present_classifies():
+    # Deleted unit "GG" IS present once downstream -> valid R:0 channel, not mismatch.
+    downstream = b"GG" + b"A" * 18
+
+    def fetch(s: int, e: int) -> bytes:
+        return downstream[: e - s]
+
+    code = classify_id83(pos=0, ref=b"CGG", alt=b"C", fetch=fetch)
+    assert code != _REF_MISMATCH
+    assert code == ID83_INDEX["2:Del:R:0"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run pytest tests/test_mutcat.py -k "ref_absent or ref_present" -v`
+Expected: FAIL — `ImportError: cannot import name '_REF_MISMATCH'` (the two mismatch tests would otherwise raise `KeyError: '...:Del:R:-1'`).
+
+- [ ] **Step 3: Add `loguru` import**
+
+In `genoray/_mutcat.py`, with the other imports (after `import polars as pl` at `:10`), add:
+
+```python
+from loguru import logger
+```
+
+- [ ] **Step 4: Add the `_REF_MISMATCH` sentinel**
+
+In `genoray/_mutcat.py`, immediately after the `SENTINELS` dict (`:134-138`), add:
+
+```python
+# Internal boundary signal (NOT a public sentinel): a deletion whose deleted unit
+# is absent in the reference at scan_start, i.e. REF disagrees with the reference
+# genome. classify_variants maps this to UNCLASSIFIED and aggregates a warning.
+_REF_MISMATCH = -99
+```
+
+- [ ] **Step 5: Guard both deletion repeat-bucket branches in `classify_id83`**
+
+In `genoray/_mutcat.py`, change the 1 bp branch (`:273-274`):
+
+```python
+    if ilen == 1:
+        base = indel.decode()
+        # fold purine to pyrimidine for the 1bp channel
+        if base in ("A", "G"):
+            base = chr(_comp(ord(base)))
+        if is_del and n_rep == 0:
+            return _REF_MISMATCH
+        rep = _repeat_bucket(n_rep - 1 if is_del else n_rep)
+        return ID83_INDEX[f"1:{kind}:{base}:{rep}"]
+```
+
+And the ≥2 bp branch (`:283-284`):
+
+```python
+    if is_del and n_rep == 0:
+        return _REF_MISMATCH
+    rep = _repeat_bucket(n_rep - 1 if is_del else n_rep)
+    return ID83_INDEX[f"{size}:{kind}:R:{rep}"]
+```
+
+(Insertions keep `n_rep` without `-1`, so they never underflow and are untouched.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pixi run pytest tests/test_mutcat.py -k "ref_absent or ref_present" -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "fix(mutcat): guard deletion repeat bucket against REF/reference mismatch"
+```
+
+---
+
+## Task 3: Convert POS in `classify_variants` + aggregate mismatch warning
+
+Make `classify_variants` the single source of truth: index POS is 1-based, convert to 0-based for `reference.fetch`. Translate `_REF_MISMATCH` to UNCLASSIFIED, count occurrences, emit one aggregated warning.
+
+**Files:**
+- Modify: `genoray/_mutcat.py` (`classify_variants`, `:468-504`)
+- Modify: `tests/test_mutcat_calibration.py:294`
+- Test: `tests/test_svar_mutations.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_svar_mutations.py`.
+
+Test A is the issue's exact reproducer — the deletion must no longer crash and must classify as a valid ID-83 channel. Test B confirms the SNV trinucleotide context is read at `POS-1`.
+
+```python
+def test_issue59_deletion_no_longer_crashes(tmp_path):
+    import pysam
+    import genoray
+    from genoray import SparseVar
+    from genoray._reference import Reference
+    from genoray._mutcat import ID83_OFFSET, N_CODES
+
+    seq = "ACGTTGCAACGTTGCAAGGCCTTAGCATCGTACGATCGTTAGCCATGACTGACATGCATGC"
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\n" + seq + "\n")
+    pysam.faidx(str(fa))
+
+    anchor0 = 19
+    REF, ALT = seq[anchor0:anchor0 + 6], seq[anchor0]  # "CCTTAG" -> "C", 5bp del
+
+    vcf = tmp_path / "t.vcf"
+    h = pysam.VariantHeader()
+    h.add_line("##contig=<ID=chr1,length=60>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="GT">')
+    h.add_sample("S1")
+    with pysam.VariantFile(str(vcf), "w", header=h) as vf:
+        r = h.new_record(contig="chr1", start=anchor0, alleles=(REF, ALT))
+        r.samples["S1"]["GT"] = (0, 1)
+        vf.write(r)
+    pysam.tabix_index(str(vcf), preset="vcf", force=True)
+
+    svp = tmp_path / "sv.svar"
+    genoray.SparseVar.from_vcf(svp, genoray.VCF(str(vcf) + ".gz"), max_mem="1g", overwrite=True)
+    sv = SparseVar(svp)
+    assert sv.index["POS"].to_list() == [20]  # 1-based preserved
+
+    sv.annotate_mutations(Reference.from_path(fa), write_back=False)  # must NOT raise
+    codes = sv.fields["mutcat"].data
+    # the deletion entry must be a valid ID-83 code, not UNCLASSIFIED/mismatch
+    id83_codes = [c for c in codes if ID83_OFFSET <= c < N_CODES]
+    assert len(id83_codes) >= 1
+
+
+def test_classify_variants_snv_context_uses_pos_minus_one(tmp_path):
+    import polars as pl
+    from genoray._mutcat import classify_variants, classify_sbs96
+    from genoray._reference import Reference
+    import pysam
+
+    # Reference where the base at 0-based index differs left vs right of the variant,
+    # so a +1 shift would pick a different trinucleotide context.
+    seq = "AACGTTGCA"
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\n" + seq + "\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+
+    # Variant at 1-based POS=4 => 0-based index 3, REF = seq[3] = "G".
+    p0 = 3
+    assert seq[p0] == "G"
+    index = pl.DataFrame({"CHROM": ["chr1"], "POS": [p0 + 1], "REF": ["G"], "ALT": [["A"]]})
+    codes = classify_variants(index, ref)
+
+    five = seq[p0 - 1].encode()
+    three = seq[p0 + 1].encode()
+    expected = classify_sbs96(five, b"G", b"A", three)
+    assert int(codes[0]) == expected
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run pytest tests/test_svar_mutations.py -k "issue59 or snv_context_uses_pos" -v`
+Expected: FAIL — `test_issue59...` raises `KeyError: '5:Del:R:-1'`; `test_classify_variants_snv_context...` asserts wrong code (context shifted +1).
+
+- [ ] **Step 3: Convert POS and aggregate the warning in `classify_variants`**
+
+In `genoray/_mutcat.py`, edit `classify_variants` (`:468-504`). Update the docstring and add the conversion + mismatch aggregation:
+
+```python
+def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
+    """Return an int16 array of intrinsic mutation codes, one per row of ``index``.
+
+    ``index`` must have columns CHROM, POS (1-based int, VCF convention), REF
+    (str), ALT (List[str]; first ALT used). POS is converted to a 0-based
+    reference coordinate internally. Reference context is fetched per contig.
+    """
+    chrom = index["CHROM"].to_numpy()
+    pos = index["POS"].to_numpy().astype(np.int64)
+    ref = index["REF"].to_list()
+    alt0 = index["ALT"].list.first().to_list()
+
+    out = np.full(index.height, SENTINELS["UNCLASSIFIED"], dtype=np.int16)
+
+    n_mismatch = 0
+    mismatch_examples: list[str] = []
+
+    for i in range(index.height):
+        r = ref[i]
+        a = alt0[i]
+        if a is None or r is None:
+            continue
+        rb, ab = r.encode(), a.encode()
+        c = str(chrom[i])
+        p = int(pos[i]) - 1  # index POS is 1-based (VCF); reference.fetch is 0-based
+
+        if len(rb) == 1 and len(ab) == 1:  # SNV
+            five = reference.fetch(c, p - 1, p).tobytes()
+            three = reference.fetch(c, p + 1, p + 2).tobytes()
+            out[i] = classify_sbs96(five, rb, ab, three)
+        elif len(rb) == 2 and len(ab) == 2:  # native MNV doublet
+            out[i] = classify_dbs78(rb, ab)
+        elif len(rb) != len(ab):  # indel
+            _c = c  # capture per-iteration contig for closure
+
+            def _fetch(s: int, e: int, _c: str = _c) -> bytes:
+                return reference.fetch(_c, s, e).tobytes()
+
+            code = classify_id83(p, rb, ab, _fetch)
+            if code == _REF_MISMATCH:
+                n_mismatch += 1
+                if len(mismatch_examples) < 5:
+                    mismatch_examples.append(f"{c}:{int(pos[i])}")
+                out[i] = SENTINELS["UNCLASSIFIED"]
+            else:
+                out[i] = code
+
+    if n_mismatch:
+        examples = ", ".join(mismatch_examples)
+        logger.warning(
+            f"{n_mismatch}/{index.height} deletions have REF disagreeing with the "
+            f"reference genome at their position (e.g. {examples}) — wrong reference "
+            "build? These were marked UNCLASSIFIED."
+        )
+
+    return out
+```
+
+- [ ] **Step 4: Update the calibration test**
+
+In `tests/test_mutcat_calibration.py:294`, change the POS column so it no longer pre-converts (the conversion now happens inside `classify_variants`):
+
+```python
+            "POS": [v[1] for v in VCF_LINES],  # 1-based; classify_variants converts
+```
+
+Also update the comment on the preceding line (`:290`) if it states POS must be 0-based:
+
+```python
+    # VCF_LINES has 1-based POS; classify_variants now converts to 0-based internally.
+```
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `pixi run pytest tests/test_svar_mutations.py -k "issue59 or snv_context_uses_pos" -v`
+Expected: PASS
+
+- [ ] **Step 6: Run the full mutcat + svar test suites to check for regressions**
+
+Run: `pixi run pytest tests/test_mutcat.py tests/test_svar_mutations.py -v`
+Expected: PASS (all). If `tests/test_mutcat_calibration.py` runs locally (requires SigProfilerMatrixGenerator), also run `pixi run pytest tests/test_mutcat_calibration.py -v` and expect PASS; otherwise it is skipped.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat_calibration.py tests/test_svar_mutations.py
+git commit -m "fix(svar): convert 1-based POS to 0-based in classify_variants (#59)"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `pixi run pytest -m "not network" -q`
+Expected: PASS (no failures, no errors). The previously-crashing `KeyError: '5:Del:R:-1'` path is gone.
+
+- [ ] **Step 2: Confirm no public API / SKILL.md drift**
+
+The fix changes no public name and aligns code with the already-documented convention at `skills/genoray-api/SKILL.md:188` (`svar.index.POS` is 1-based). Confirm no SKILL.md edit is needed:
+
+Run: `grep -n "0-based\|1-based" skills/genoray-api/SKILL.md`
+Expected: existing lines already state POS is 1-based; no change required.
+
+- [ ] **Step 3: Final commit (if any stray changes)**
+
+```bash
+git status
+# if clean, nothing to do
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Change 1 (POS conversion) → Task 3. Change 2 (guard + aggregated warning) → Tasks 2 & 3. Change 3 (MUTCAT_VERSION bump + staleness warning) → Task 1. All four spec test items covered: regression (Task 3 A), SNV context (Task 3 B), guard+warning (Task 2 + Task 3 aggregation), calibration update (Task 3 Step 4).
+- **Type consistency:** `_REF_MISMATCH = -99` defined in Task 2, imported/consumed in Task 2 tests and Task 3. `MUTCAT_VERSION` bumped in Task 1, consumed in `_svar.py` (already imported). `classify_id83(pos, ref, alt, fetch)` signature unchanged.
+- **Known limitation:** wrong-reference SNV-context corruption remains silent (per spec, out of scope).

--- a/docs/superpowers/specs/2026-06-12-annotate-mutations-pos-offby-one-design.md
+++ b/docs/superpowers/specs/2026-06-12-annotate-mutations-pos-offby-one-design.md
@@ -1,0 +1,137 @@
+# Fix `annotate_mutations` 1-based POS off-by-one (issue #59)
+
+**Date:** 2026-06-12
+**Issue:** [#59](https://github.com/d-laub/genoray/issues/59)
+**Status:** Approved design
+
+## Problem
+
+`SparseVar.annotate_mutations` passes the variant index to `classify_variants`
+without converting `POS` from 1-based to 0-based. `SparseVar.index.POS` is stored
+**1-based** (preserved from the source VCF, and documented as such in
+`skills/genoray-api/SKILL.md:188`), but `classify_variants` uses `POS` directly as
+a 0-based reference coordinate. Every variant's reference context is therefore
+fetched one base to the right.
+
+Two consequences:
+
+1. **Silent corruption:** SNV trinucleotide context and indel repeat context are
+   computed at the wrong position, so `mutation_matrix("SBS96")` / `assign_signatures`
+   return a systematically shifted spectrum rather than erroring.
+2. **Crash:** for a deletion whose deleted unit is not tandem-repeated immediately
+   downstream, the off-by-one makes the repeat scan return `n_rep == 0`, so
+   `classify_id83` computes `_repeat_bucket(n_rep - 1) = _repeat_bucket(-1) = -1` and
+   raises `KeyError: '<size>:Del:R:-1'` (valid buckets are `R:0`..`R:5`).
+
+### Root cause (confirmed)
+
+`classify_variants` (`genoray/_mutcat.py:468`) is the only place `POS` is used as an
+absolute coordinate — the SNV trinucleotide fetch (`:491-492`) and the ID-83
+downstream repeat scan in `classify_id83` (`scan_start = pos + 1`, `:254`). Its two
+callers disagree on convention:
+
+- `annotate_mutations` passes the 1-based `self.index` (`genoray/_svar.py:1491`).
+- `tests/test_mutcat_calibration.py:294` pre-subtracts 1 before calling.
+
+The adjacency kernel `_entry_codes_kernel` (`genoray/_mutcat.py:321`) uses only
+*relative* POS deltas (`var_pos[w] - var_pos[v] == 1`), so DBS detection is
+unaffected by the convention.
+
+## Design decisions
+
+- **Single source of truth:** genoray's index `POS` is 1-based everywhere.
+  `classify_variants` is the boundary to 0-based reference coordinates and performs
+  the conversion. (Confirmed with user.)
+- **Guard behavior:** a deletion with `n_rep == 0` indicates `REF` disagrees with the
+  reference genome (a serious "wrong reference" condition). Return `UNCLASSIFIED` and
+  emit a single aggregated warning rather than fabricating a plausible-but-wrong
+  classification. (Confirmed with user.)
+- **No public API change.** `classify_variants` is private (`_mutcat`). The fix makes
+  behavior match the already-documented `SKILL.md` convention, so no SKILL.md update
+  is required.
+
+## Changes
+
+### Change 1 — convert POS in `classify_variants` (the single source of truth)
+
+In `classify_variants` (`genoray/_mutcat.py`, around `:488`):
+
+```python
+p = int(pos[i]) - 1   # index POS is 1-based (VCF convention); reference.fetch is 0-based
+```
+
+- Update the docstring (`:471`) from *"POS (0-based int)"* to
+  *"POS (1-based, VCF convention)"*.
+- Remove the manual `- 1` conversion in `tests/test_mutcat_calibration.py:294`
+  (it would otherwise double-subtract).
+
+This single change corrects both the SNV trinucleotide context and the indel repeat
+scan, because both derive their reference coordinates from `p`.
+
+### Change 2 — defensive guard + aggregated wrong-reference warning
+
+After Change 1, a correctly-anchored deletion always has `n_rep >= 1`: the deleted
+unit `REF[1:]` is by definition present in the reference at `scan_start = pos + 1`
+when `REF` matches the reference. Therefore `n_rep == 0` for a deletion is equivalent
+to `REF` disagreeing with the reference genome.
+
+- In `classify_id83` (`genoray/_mutcat.py:234`): when `is_del and n_rep == 0`, return a
+  module-private sentinel `_REF_MISMATCH` instead of evaluating `_repeat_bucket(n_rep - 1)`.
+  This covers both the 1 bp deletion branch (`:273`) and the ≥2 bp deletion branch
+  (`:283`). `_REF_MISMATCH` is **not** added to the public `SENTINELS` dict; it is an
+  internal boundary signal whose value must not collide with any valid code or existing
+  sentinel (e.g. `-99`).
+- In `classify_variants` (`genoray/_mutcat.py:468`): translate `_REF_MISMATCH` to
+  `SENTINELS["UNCLASSIFIED"]` in the output array and increment a counter. After the
+  loop, if the counter is > 0, emit a single `loguru` warning summarizing the count and
+  a few example `CHROM:POS` locations, e.g.:
+
+  > `{n}/{total} deletions have REF disagreeing with the reference genome at their position (e.g. chr1:100, chr2:55) — wrong reference build?`
+
+  Aggregation (one warning, not one-per-variant) is required to avoid log-flooding on
+  genome-wide data (the issue was found on a ≈348M-variant `.svar`).
+
+This requires adding `from loguru import logger` to `genoray/_mutcat.py`.
+
+**Known limitation (intentionally out of scope):** a wrong reference still silently
+corrupts SNV trinucleotide context (consequence #1). The deletion mismatch is the only
+signal available for free from the existing repeat scan; a general per-variant
+`REF[0]` vs `reference[p]` check is deferred (YAGNI).
+
+### Change 3 — invalidate stale persisted catalogues
+
+Existing `.svar` files carry a `mutcat.npy` computed under the buggy code; those values
+are wrong. Bump `MUTCAT_VERSION` from `1` to `2` (`genoray/_mutcat.py:145`) so a stored
+`mutcat_version` no longer matches the current version.
+
+Inspect the `mutcat` load path in `SparseVar.__init__` and add a staleness warning when
+a loaded file's `mutcat_version` is present and less than `MUTCAT_VERSION`:
+
+> `mutcat field was computed with an older version (v{old} < v{current}); recompute via annotate_mutations()`
+
+If no load-time version comparison currently exists, add the comparison at the point
+where the `mutcat` field is registered/opened.
+
+## Tests
+
+Add to `tests/test_svar_mutations.py` and `tests/test_mutcat.py` as appropriate:
+
+1. **Regression (off-by-one crash):** the issue's minimal reproducer — a 5 bp deletion
+   at 1-based POS=20 in a non-repetitive sequence — runs `annotate_mutations(ref,
+   write_back=False)` without raising `KeyError` and produces a valid ID-83 code
+   (`5:Del:R:0`).
+2. **SNV context correctness:** a SNV whose true trinucleotide context (at `POS-1`)
+   differs from the +1-shifted context; assert the resulting SBS-96 code matches the
+   `POS-1` context, not the shifted one.
+3. **Guard + warning:** drive `classify_id83` (and/or `classify_variants`) with a `REF`
+   whose deleted unit is absent at `scan_start` (a deliberate REF/reference mismatch);
+   assert the result is `UNCLASSIFIED` and that the aggregated warning is emitted
+   (capture via a loguru sink / `caplog`).
+4. **Calibration test update:** remove the `- 1` at `tests/test_mutcat_calibration.py:294`
+   so it relies on the new in-function conversion.
+
+## Out of scope
+
+- General per-variant `REF` vs reference verification for SNVs/insertions.
+- Any change to the public `genoray` API surface or `SKILL.md` (the fix aligns code
+  with existing documentation).

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -137,6 +137,11 @@ SENTINELS: dict[str, int] = {
     "MISSING": -3,
 }
 
+# Internal boundary signal (NOT a public sentinel): a deletion whose deleted unit
+# is absent in the reference at scan_start, i.e. REF disagrees with the reference
+# genome. classify_variants maps this to UNCLASSIFIED and aggregates a warning.
+_REF_MISMATCH = -99
+
 # index -> label, for building DataFrames
 SBS96_INDEX = {lbl: SBS96_OFFSET + i for i, lbl in enumerate(SBS96)}
 DBS78_INDEX = {lbl: DBS78_OFFSET + i for i, lbl in enumerate(DBS78)}
@@ -270,6 +275,8 @@ def classify_id83(
         # fold purine to pyrimidine for the 1bp channel
         if base in ("A", "G"):
             base = chr(_comp(ord(base)))
+        if is_del and n_rep == 0:
+            return _REF_MISMATCH
         rep = _repeat_bucket(n_rep - 1 if is_del else n_rep)
         return ID83_INDEX[f"1:{kind}:{base}:{rep}"]
 
@@ -280,6 +287,8 @@ def classify_id83(
         if mh > 0 and n_rep <= 1:
             mh_cap = {2: 1, 3: 2, 4: 3}.get(ilen, 5)
             return ID83_INDEX[f"{size}:Del:M:{min(mh, mh_cap)}"]
+    if is_del and n_rep == 0:
+        return _REF_MISMATCH
     rep = _repeat_bucket(n_rep - 1 if is_del else n_rep)
     return ID83_INDEX[f"{size}:{kind}:R:{rep}"]
 

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -142,7 +142,7 @@ SBS96_INDEX = {lbl: SBS96_OFFSET + i for i, lbl in enumerate(SBS96)}
 DBS78_INDEX = {lbl: DBS78_OFFSET + i for i, lbl in enumerate(DBS78)}
 ID83_INDEX = {lbl: ID83_OFFSET + i for i, lbl in enumerate(ID83)}
 
-MUTCAT_VERSION = 1
+MUTCAT_VERSION = 2
 
 _LABELS: dict[str, list[str]] = {"SBS96": SBS96, "DBS78": DBS78, "ID83": ID83}
 

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 import numba as nb
 import numpy as np
 import polars as pl
+from loguru import logger
 from numpy.typing import NDArray
 
 from ._reference import Reference
@@ -477,8 +478,9 @@ def count_matrix(
 def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
     """Return an int16 array of intrinsic mutation codes, one per row of ``index``.
 
-    ``index`` must have columns CHROM, POS (0-based int), REF (str), ALT
-    (List[str]; first ALT used). Reference context is fetched per contig.
+    ``index`` must have columns CHROM, POS (1-based int, VCF convention), REF
+    (str), ALT (List[str]; first ALT used). POS is converted to a 0-based
+    reference coordinate internally. Reference context is fetched per contig.
     """
     chrom = index["CHROM"].to_numpy()
     pos = index["POS"].to_numpy().astype(np.int64)
@@ -487,6 +489,9 @@ def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
 
     out = np.full(index.height, SENTINELS["UNCLASSIFIED"], dtype=np.int16)
 
+    n_mismatch = 0
+    mismatch_examples: list[str] = []
+
     for i in range(index.height):
         r = ref[i]
         a = alt0[i]
@@ -494,7 +499,7 @@ def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
             continue
         rb, ab = r.encode(), a.encode()
         c = str(chrom[i])
-        p = int(pos[i])
+        p = int(pos[i]) - 1  # index POS is 1-based (VCF); reference.fetch is 0-based
 
         if len(rb) == 1 and len(ab) == 1:  # SNV
             five = reference.fetch(c, p - 1, p).tobytes()
@@ -508,6 +513,22 @@ def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
             def _fetch(s: int, e: int, _c: str = _c) -> bytes:
                 return reference.fetch(_c, s, e).tobytes()
 
-            out[i] = classify_id83(p, rb, ab, _fetch)
+            code = classify_id83(p, rb, ab, _fetch)
+            if code == _REF_MISMATCH:
+                n_mismatch += 1
+                if len(mismatch_examples) < 5:
+                    mismatch_examples.append(f"{c}:{int(pos[i])}")
+                out[i] = SENTINELS["UNCLASSIFIED"]
+            else:
+                out[i] = code
         # else: MNV>2bp or symbolic -> stays UNCLASSIFIED
+
+    if n_mismatch:
+        examples = ", ".join(mismatch_examples)
+        logger.warning(
+            f"{n_mismatch}/{index.height} deletions have REF disagreeing with the "
+            f"reference genome at their position (e.g. {examples}) — wrong reference "
+            "build? These were marked UNCLASSIFIED."
+        )
+
     return out

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -574,6 +574,17 @@ class SparseVar(Generic[_SRT]):
             name: _open_fmt(name, self.available_fields[name], path, shape, "r")
             for name in (fields or [])
         }
+        if (
+            "mutcat" in (fields or [])
+            # None: svar predates mutcat versioning; no warning (treat as pre-v1).
+            and metadata.mutcat_version is not None
+            and metadata.mutcat_version < MUTCAT_VERSION
+        ):
+            logger.warning(
+                "mutcat field was computed with an older version "
+                f"(v{metadata.mutcat_version} < v{MUTCAT_VERSION}); "
+                "recompute via annotate_mutations()."
+            )
         logger.info("Loading genoray index")
         self.index = self._load_index(attrs)
         self._is_biallelic = (self.index["ALT"].list.len() == 1).all()

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -12,6 +12,7 @@ from genoray._mutcat import (
     SBS96,
     SENTINELS,
     SBS96_INDEX,
+    _REF_MISMATCH,
     build_entry_codes,
     classify_dbs78,
     classify_id83,
@@ -274,3 +275,50 @@ def test_build_entry_codes_no_pair_across_tracks():
     )
     # Neither entry should be promoted to a DBS or marked DBS_PARTNER
     assert codes.tolist() == [10, 11]
+
+
+def test_id83_2bp_deletion_ref_absent_returns_mismatch():
+    # REF="CGG" -> ALT="C": deleted unit "GG". Downstream reference is "AAAA..."
+    # so the deleted unit is NOT present at scan_start -> REF/reference mismatch.
+    downstream = b"A" * 20
+
+    def fetch(s: int, e: int) -> bytes:
+        return downstream[: e - s]
+
+    assert classify_id83(pos=0, ref=b"CGG", alt=b"C", fetch=fetch) == _REF_MISMATCH
+
+
+def test_id83_1bp_deletion_ref_absent_returns_mismatch():
+    # REF="CG" -> ALT="C": deleted unit "G". Downstream reference is "AAAA..."
+    downstream = b"A" * 20
+
+    def fetch(s: int, e: int) -> bytes:
+        return downstream[: e - s]
+
+    assert classify_id83(pos=0, ref=b"CG", alt=b"C", fetch=fetch) == _REF_MISMATCH
+
+
+def test_id83_2bp_deletion_ref_present_classifies():
+    # n_rep=2 means the MH guard (n_rep <= 1) doesn't fire, so this falls through
+    # to the repeat branch -> 2:Del:R:1, confirming the guard doesn't reject a
+    # legitimately repeated deleted unit.
+    downstream = b"GG" * 2 + b"A" * 16
+
+    def fetch(s: int, e: int) -> bytes:
+        return downstream[: e - s]
+
+    code = classify_id83(pos=0, ref=b"CGG", alt=b"C", fetch=fetch)
+    assert code != _REF_MISMATCH
+    assert code == ID83_INDEX["2:Del:R:1"]
+
+
+def test_id83_insertion_no_repeat_not_mismatch():
+    # An insertion with no downstream repeat must NOT trigger the deletion-only
+    # _REF_MISMATCH guard (guards are gated on is_del).
+    downstream = b"A" * 20
+
+    def fetch(s: int, e: int) -> bytes:
+        return downstream[: e - s]
+
+    code = classify_id83(pos=0, ref=b"C", alt=b"CG", fetch=fetch)
+    assert code != _REF_MISMATCH

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -152,7 +152,7 @@ def test_classify_variants_mixed(tmp_path):
     index = pl.DataFrame(
         {
             "CHROM": ["chr1", "chr1"],
-            "POS": [1, 2],  # 0-based
+            "POS": [2, 3],  # 1-based (VCF convention); classify_variants converts
             "REF": ["C", "G"],
             "ALT": [["A"], ["GT"]],  # SNV ; insertion
         }

--- a/tests/test_mutcat_calibration.py
+++ b/tests/test_mutcat_calibration.py
@@ -287,11 +287,11 @@ def test_sigprofiler_calibration(tmp_path: Path) -> None:
     _write_plain_fasta(fa_path)
     ref = Reference.from_path(fa_path)
 
-    # VCF_LINES has 1-based POS; genoray classify_variants expects 0-based POS.
+    # VCF_LINES has 1-based POS; classify_variants converts internally.
     geno_index = pl.DataFrame(
         {
             "CHROM": [v[0] for v in VCF_LINES],
-            "POS": [v[1] - 1 for v in VCF_LINES],  # convert 1-based -> 0-based
+            "POS": [v[1] for v in VCF_LINES],  # 1-based; classify_variants converts
             "REF": [v[2] for v in VCF_LINES],
             "ALT": [[v[3]] for v in VCF_LINES],
         }

--- a/tests/test_svar_mutations.py
+++ b/tests/test_svar_mutations.py
@@ -33,13 +33,15 @@ def _build_tiny_svar(path):
     from seqpro.rag import Ragged
 
     path.mkdir(parents=True)
-    # 3 variants on chr1 at POS 1,2,8 (0-based); all SNVs
+    # 3 variants on chr1 at 1-based POS 2,3,9 (VCF convention); all SNVs
+    # Reference chr1: A C G T A C G T A C (0-based 0..9)
+    # POS=2 -> 0-based 1 -> REF=C; POS=3 -> 0-based 2 -> REF=G; POS=9 -> 0-based 8 -> REF=A
     # Note: _load_index adds 'index' as a row-index column; the on-disk file
     # must NOT include it.
     index = pl.DataFrame(
         {
             "CHROM": ["chr1", "chr1", "chr1"],
-            "POS": np.array([1, 2, 8], dtype=np.int32),
+            "POS": np.array([2, 3, 9], dtype=np.int32),
             "REF": ["C", "G", "A"],
             "ALT": [["A"], ["T"], ["C"]],
             "ILEN": pl.Series([[0], [0], [0]], dtype=pl.List(pl.Int32)),
@@ -118,7 +120,7 @@ def annotated_svar_ploidy2(tmp_path):
 def _build_ploidy2_svar(path):
     """Write a minimal SVAR with 2 samples, ploidy 2.
 
-    One variant: chr1 POS=7 (0-based), A>C (isolated SNV -> SBS).
+    One variant: chr1 POS=8 (1-based), T>C (isolated SNV -> SBS).
     Sample 0 is HOMOZYGOUS: hap0=[0], hap1=[0].
     Sample 1 is REF: hap0=[], hap1=[].
     offsets length = n_samples*ploidy + 1 = 2*2 + 1 = 5.
@@ -129,13 +131,13 @@ def _build_ploidy2_svar(path):
 
     path.mkdir(parents=True)
     # Reference chr1: A C G T A C G T A C (0-based indices)
-    # POS=7 -> ref base T, but we use an A context:
-    # Let's place the SNV at POS=7 (T>C) — flanks at 6=G and 8=A.
+    # 1-based POS=8 -> 0-based index 7 -> ref base T
+    # Flanks: 0-based 6=G (5') and 8=A (3').
     # Pyrimidine ref T -> label: G[T>C]A
     index = pl.DataFrame(
         {
             "CHROM": ["chr1"],
-            "POS": np.array([7], dtype=np.int32),
+            "POS": np.array([8], dtype=np.int32),
             "REF": ["T"],
             "ALT": [["C"]],
             "ILEN": pl.Series([[0]], dtype=pl.List(pl.Int32)),
@@ -298,8 +300,8 @@ def test_write_view_recompute_breaks_dbs_when_partner_dropped(annotated_svar, tm
     """write_view with reference= RECOMPUTES mutcat; dropping the DBS 3' partner
     reclassifies the surviving 5' SNV as SBS rather than leaving a stale DBS code.
 
-    Variant layout (0-based POS): s0 carries POS=1 (DBS 5') and POS=2 (DBS 3').
-    Region [1, 2) keeps POS=1 only — the partner at POS=2 is excluded.
+    Variant layout (1-based POS): s0 carries POS=2 (DBS 5') and POS=3 (DBS 3').
+    Region [1, 2) keeps POS=2 only — the partner at POS=3 is excluded.
     After recompute, the isolated SNV must count as SBS96=1, DBS78=0.
     A positional copy of the old mutcat would wrongly leave DBS78=1, SBS96=0.
     """
@@ -387,3 +389,66 @@ def test_assign_signatures_with_explicit_reference(annotated_svar):
     assert set(act["Sample"].to_list()).issubset(set(svar.available_samples))
     # activities are nonnegative
     assert (act.select(["SBS_A", "SBS_B"]).to_numpy() >= 0).all()
+
+
+def test_issue59_deletion_no_longer_crashes(tmp_path):
+    from genoray._mutcat import ID83_OFFSET, N_CODES
+
+    seq = "ACGTTGCAACGTTGCAAGGCCTTAGCATCGTACGATCGTTAGCCATGACTGACATGCATGC"
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\n" + seq + "\n")
+    pysam.faidx(str(fa))
+
+    anchor0 = 19
+    REF, ALT = seq[anchor0 : anchor0 + 6], seq[anchor0]  # "CCTTAG" -> "C", 5bp del
+
+    vcf = tmp_path / "t.vcf"
+    h = pysam.VariantHeader()
+    h.add_line("##contig=<ID=chr1,length=60>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="GT">')
+    h.add_sample("S1")
+    with pysam.VariantFile(str(vcf), "w", header=h) as vf:
+        r = h.new_record(contig="chr1", start=anchor0, alleles=(REF, ALT))
+        r.samples["S1"]["GT"] = (0, 1)
+        vf.write(r)
+    pysam.tabix_index(str(vcf), preset="vcf", force=True)
+
+    svp = tmp_path / "sv.svar"
+    genoray.SparseVar.from_vcf(
+        svp, genoray.VCF(str(vcf) + ".gz"), max_mem="1g", overwrite=True
+    )
+    sv = SparseVar(svp)
+    assert sv.index["POS"].to_list() == [20]  # 1-based preserved
+
+    sv.annotate_mutations(Reference.from_path(fa), write_back=False)  # must NOT raise
+    codes = sv.fields["mutcat"].data
+    # the deletion entry must be a valid ID-83 code, not UNCLASSIFIED/mismatch
+    id83_codes = [c for c in codes if ID83_OFFSET <= c < N_CODES]
+    assert len(id83_codes) == 1
+
+
+def test_classify_variants_snv_context_uses_pos_minus_one(tmp_path):
+    import polars as pl
+
+    from genoray._mutcat import classify_sbs96, classify_variants
+
+    # Reference where the base at 0-based index differs left vs right of the variant,
+    # so a +1 shift would pick a different trinucleotide context.
+    seq = "AACGTTGCA"
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\n" + seq + "\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+
+    # Variant at 1-based POS=4 => 0-based index 3, REF = seq[3] = "G".
+    p0 = 3
+    assert seq[p0] == "G"
+    index = pl.DataFrame(
+        {"CHROM": ["chr1"], "POS": [p0 + 1], "REF": ["G"], "ALT": [["A"]]}
+    )
+    codes = classify_variants(index, ref)
+
+    five = seq[p0 - 1].encode()
+    three = seq[p0 + 1].encode()
+    expected = classify_sbs96(five, b"G", b"A", three)
+    assert int(codes[0]) == expected

--- a/tests/test_svar_mutations.py
+++ b/tests/test_svar_mutations.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import polars as pl
 import pysam
 import pytest
+from loguru import logger
 
 import genoray
 from genoray import SparseVar
@@ -206,6 +209,49 @@ def test_write_view_mutcat_explicit_without_reference_raises(annotated_svar, tmp
             fields=["mutcat"],
             # reference=None (default) — should raise
         )
+
+
+def test_mutcat_staleness_warning(tmp_path):
+    # --- build a tiny reference + single-SNV VCF ---
+
+    seq = "ACGTACGTACGTACGT"
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\n" + seq + "\n")
+    pysam.faidx(str(fa))
+
+    vcf = tmp_path / "t.vcf"
+    h = pysam.VariantHeader()
+    h.add_line("##contig=<ID=chr1,length=16>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="GT">')
+    h.add_sample("S1")
+    with pysam.VariantFile(str(vcf), "w", header=h) as vf:
+        r = h.new_record(contig="chr1", start=4, alleles=("A", "C"))  # 1-based POS=5
+        r.samples["S1"]["GT"] = (0, 1)
+        vf.write(r)
+    pysam.tabix_index(str(vcf), preset="vcf", force=True)
+
+    svp = tmp_path / "sv.svar"
+    genoray.SparseVar.from_vcf(
+        svp, genoray.VCF(str(vcf) + ".gz"), max_mem="1g", overwrite=True
+    )
+    sv = SparseVar(svp)
+    sv.annotate_mutations(Reference.from_path(fa), write_back=True)
+
+    # corrupt the persisted version to look stale
+    meta_path = svp / "metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta["mutcat_version"] = 0
+    meta_path.write_text(json.dumps(meta))
+
+    # capture loguru output
+    messages = []
+    sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        SparseVar(svp, fields=["mutcat"])
+    finally:
+        logger.remove(sink_id)
+
+    assert any("older version" in m for m in messages), messages
 
 
 def test_write_view_recomputes_mutcat_with_reference(annotated_svar, tmp_path):


### PR DESCRIPTION
## Summary

Fixes the 1-based→0-based POS off-by-one in `SparseVar.annotate_mutations` (issue #59), so SBS-96/DBS-78/ID-83 catalogues are computed at the correct reference position.

- **`classify_variants` is now the single conversion boundary** between genoray's 1-based index convention and `Reference.fetch`'s 0-based coordinates (`p = POS - 1`). This corrects the trinucleotide SNV context (was shifted +1) and fixes deletion classification.
- **Graceful handling of REF/reference mismatch:** a new module-private `_REF_MISMATCH` sentinel, returned by `classify_id83` when a deletion's deleted unit is absent at scan_start, is mapped to `UNCLASSIFIED` and aggregated into a single loguru warning — replacing the previous `KeyError: '<size>:Del:R:-1'` crash.
- **Stale-catalogue detection:** `MUTCAT_VERSION` bumped 1→2; `SparseVar.__init__` warns when a persisted `mutcat` field was computed with an older version.

No public API names changed; the fix aligns code with the already-documented convention (`svar.index.POS` is 1-based, per `skills/genoray-api/SKILL.md`).

## Test Plan

- [x] `test_issue59_deletion_no_longer_crashes` — the issue's exact reproducer (5bp deletion) no longer crashes and classifies as a valid ID-83 code
- [x] `test_classify_variants_snv_context_uses_pos_minus_one` — SNV trinucleotide context is read at POS-1
- [x] `classify_id83` guard unit tests (`_REF_MISMATCH` for ref-absent deletions; insertions/repeated-units unaffected)
- [x] `test_mutcat_staleness_warning` — stale persisted `mutcat` triggers a warning
- [x] Full suite: `pixi run pytest -m "not network" -q` → 426 passed, 2 skipped, 16 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)