### PR TITLE
fix(utils): treat mitochondrial aliases M/MT/chrM/chrMT as equivalent (#61)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-annotate-mutations-contig-scope.md
+++ b/docs/superpowers/plans/2026-06-13-annotate-mutations-contig-scope.md
@@ -1,0 +1,616 @@
+# Contig-scoped `annotate_mutations` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `SparseVar.annotate_mutations` annotate a caller-selected subset of contigs, marking entries on excluded contigs with a distinct `NOT_ANNOTATED` sentinel and persisting the scope in metadata — so scoped analyses no longer crash on contigs absent from the reference.
+
+**Architecture:** Contig scoping integrates with the vectorized `classify_variants` per-contig loop on the `vectorize-mutation-matrices` branch. `classify_variants` gains a `contigs` allowlist; out-of-scope rows initialize to `NOT_ANNOTATED` and their contigs are never fetched. `annotate_mutations` normalizes the allowlist via `ContigNormalizer`, warns on unmatched entries, gates the SNV adjacency mask to in-scope variants, threads the allowlist down, and records the normalized scope in `SparseVarMetadata.mutcat_contigs`. `MUTCAT_VERSION` bumps to 3.
+
+**Tech Stack:** Python, NumPy, Polars, pydantic (`BaseModel`), loguru, pysam (test fixtures), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-annotate-mutations-contig-scope-design.md`
+
+**Branch:** Implement on a branch off `vectorize-mutation-matrices` (its vectorized `classify_variants` at `genoray/_mutcat.py:760` and `annotate_mutations` at `genoray/_svar.py:1471` are the integration targets). The `.claude/worktrees/vectorize-mutation-matrices/` worktree holds that branch.
+
+**Environment:** all commands run inside Pixi — prefix with `pixi run`.
+
+---
+
+## File Structure
+
+- `genoray/_mutcat.py` — Modify: add `NOT_ANNOTATED` to `SENTINELS` (`:135`); bump `MUTCAT_VERSION` to 3 (`:152`); add `contigs` param + scoping to `classify_variants` (`:760`).
+- `genoray/_svar.py` — Modify: add `mutcat_contigs` to `SparseVarMetadata` (`:461`); add `contigs` param + scope logic to `annotate_mutations` (`:1471`).
+- `skills/genoray-api/SKILL.md` — Modify: document `contigs=`, `NOT_ANNOTATED`, `mutcat_contigs`.
+- `tests/test_svar_mutations.py` — Modify: scoping, normalization, warning, raise, adjacency-suppression, metadata round-trip tests.
+- `tests/test_mutcat.py` — Modify: `classify_variants(contigs=...)` unit test.
+
+---
+
+## Task 1: Add `NOT_ANNOTATED` sentinel and bump `MUTCAT_VERSION`
+
+This task is independent and committed first. `NOT_ANNOTATED` is negative, so the existing `code < 0` guard in `_count_kernel` already excludes it from counts — no counting change.
+
+**Files:**
+- Modify: `genoray/_mutcat.py:135` (SENTINELS) and `genoray/_mutcat.py:152` (MUTCAT_VERSION)
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_mutcat.py`:
+
+```python
+def test_not_annotated_sentinel_and_version():
+    from genoray._mutcat import SENTINELS, MUTCAT_VERSION
+
+    # distinct from the existing sentinels and from MISSING (-3)
+    assert SENTINELS["NOT_ANNOTATED"] == -4
+    assert len(set(SENTINELS.values())) == len(SENTINELS)
+    # on-disk semantics changed -> version bumped
+    assert MUTCAT_VERSION == 3
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_not_annotated_sentinel_and_version -v`
+Expected: FAIL — `KeyError: 'NOT_ANNOTATED'` (and/or `MUTCAT_VERSION == 2`).
+
+- [ ] **Step 3: Implement**
+
+In `genoray/_mutcat.py`, extend `SENTINELS` (`:135`):
+
+```python
+SENTINELS: dict[str, int] = {
+    "DBS_PARTNER": -1,  # 3' half of an adjacency doublet; never counted
+    "UNCLASSIFIED": -2,  # symbolic/complex/MNV>2bp/non-ACGT
+    "MISSING": -3,
+    "NOT_ANNOTATED": -4,  # entry on a contig excluded from the annotation scope
+}
+```
+
+Bump the version (`:152`):
+
+```python
+MUTCAT_VERSION = 3
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_not_annotated_sentinel_and_version -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "feat(mutcat): add NOT_ANNOTATED sentinel and bump MUTCAT_VERSION to 3"
+```
+
+---
+
+## Task 2: Add `contigs` allowlist to `classify_variants`
+
+`contigs` is a list of contig names **already matching the index `CHROM` naming scheme** (the caller — `annotate_mutations` — normalizes them; see Task 4), or `None` for all. Out-of-scope rows initialize to `NOT_ANNOTATED`; in-scope rows initialize to `UNCLASSIFIED` (so an in-scope-but-unclassifiable variant stays `UNCLASSIFIED`). The per-contig loop skips contigs not in the allowlist, so excluded contigs are never fetched. An in-scope contig absent from the reference still raises via `reference.contig_array` — unchanged.
+
+**Files:**
+- Modify: `genoray/_mutcat.py:760` (`classify_variants`)
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_mutcat.py` (mirrors the existing reference/index test setup in this file — a small FASTA + a Polars index with `CHROM/POS/REF/ALT`):
+
+```python
+def test_classify_variants_contig_scope(tmp_path):
+    import pysam
+    import polars as pl
+    from genoray._reference import Reference
+    from genoray._mutcat import classify_variants, SENTINELS
+
+    # two contigs; chr2 is a valid SNV that WOULD classify if in scope
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\nACGTACGTAC\n>chr2\nACGTACGTAC\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+
+    index = pl.DataFrame(
+        {
+            "CHROM": ["chr1", "chr2"],
+            "POS": np.array([2, 2], dtype=np.int32),  # 1-based; 0-based idx 1 -> REF=C
+            "REF": ["C", "C"],
+            "ALT": [["A"], ["A"]],
+        }
+    )
+
+    # scope to chr1 only: chr2 must be NOT_ANNOTATED, chr1 must be classified
+    out = classify_variants(index, ref, contigs=["chr1"])
+    assert out[0] >= 0  # chr1 classified to a real SBS code
+    assert out[1] == SENTINELS["NOT_ANNOTATED"]
+
+    # contigs=None -> both classified (unchanged behavior)
+    out_all = classify_variants(index, ref, contigs=None)
+    assert out_all[0] >= 0 and out_all[1] >= 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_classify_variants_contig_scope -v`
+Expected: FAIL — `classify_variants()` got an unexpected keyword argument `contigs`.
+
+- [ ] **Step 3: Implement**
+
+In `genoray/_mutcat.py`, change the `classify_variants` signature and the `out`-initialization / loop guard. Replace the signature and the top of the body (`:760-770`):
+
+```python
+def classify_variants(
+    index: pl.DataFrame,
+    reference: Reference,
+    contigs: list[str] | None = None,
+) -> np.ndarray:
+    """Return an int16 array of intrinsic mutation codes, one per row of ``index``.
+
+    Vectorized: SNV->SBS-96 and native 2bp doublet->DBS-78 via numpy; indels->ID-83
+    via a parallel numba kernel. ``index`` must have columns CHROM, POS (1-based),
+    REF (str), ALT (List[str]; first used). POS is converted to 0-based internally.
+
+    ``contigs`` restricts annotation to the listed contigs (names must match the
+    index ``CHROM`` naming scheme exactly; the caller normalizes them). Rows on
+    contigs outside the allowlist are set to ``NOT_ANNOTATED`` and their contigs
+    are never fetched. ``None`` (default) annotates all contigs.
+    """
+    n = index.height
+    chrom = index["CHROM"].to_numpy()
+    if contigs is None:
+        scope: set[str] | None = None
+        out = np.full(n, SENTINELS["UNCLASSIFIED"], dtype=np.int16)
+    else:
+        scope = set(map(str, contigs))
+        in_scope = np.array([str(c) in scope for c in chrom], dtype=np.bool_)
+        out = np.where(
+            in_scope, SENTINELS["UNCLASSIFIED"], SENTINELS["NOT_ANNOTATED"]
+        ).astype(np.int16)
+    if n == 0:
+        return out
+```
+
+Then delete the now-duplicated `chrom = index["CHROM"].to_numpy()` line that previously sat after the `if n == 0` block (`:772`), and add a skip guard as the first line inside the `for gi, c in enumerate(uniq):` loop (before `rows = ...`, `:789-790`):
+
+```python
+    for gi, c in enumerate(uniq):
+        if scope is not None and str(c) not in scope:
+            continue
+        rows = np.nonzero(inv == gi)[0]
+        seq = reference.contig_array(str(c))
+```
+
+(Everything from `s_rows = ...` onward, and the mismatch warning block, is unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_classify_variants_contig_scope -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full mutcat suite to confirm no regression**
+
+Run: `pixi run pytest tests/test_mutcat.py tests/test_mutcat_calibration.py -q`
+Expected: PASS (the `contigs=None` path is byte-for-byte the prior behavior, so the differential/oracle tests still pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "feat(mutcat): contig allowlist in classify_variants -> NOT_ANNOTATED"
+```
+
+---
+
+## Task 3: Add `mutcat_contigs` to `SparseVarMetadata`
+
+Backward-compatible: new field has a default, so all existing construction sites keep working.
+
+**Files:**
+- Modify: `genoray/_svar.py:461` (`SparseVarMetadata`)
+- Test: `tests/test_svar_mutations.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_svar_mutations.py`:
+
+```python
+def test_metadata_has_mutcat_contigs_default():
+    from genoray._svar import SparseVarMetadata
+
+    m = SparseVarMetadata(samples=["s0"], ploidy=1, contigs=["chr1"])
+    assert m.mutcat_contigs is None
+    # round-trips through JSON
+    m2 = SparseVarMetadata.model_validate_json(
+        SparseVarMetadata(
+            samples=["s0"], ploidy=1, contigs=["chr1"], mutcat_contigs=["chr1"]
+        ).model_dump_json()
+    )
+    assert m2.mutcat_contigs == ["chr1"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar_mutations.py::test_metadata_has_mutcat_contigs_default -v`
+Expected: FAIL — `mutcat_contigs` is an unexpected/unknown field.
+
+- [ ] **Step 3: Implement**
+
+In `genoray/_svar.py`, extend `SparseVarMetadata` (`:461`):
+
+```python
+class SparseVarMetadata(BaseModel):
+    version: int | None = None
+    samples: list[str]
+    ploidy: int
+    contigs: list[str]
+    fields: dict[str, str] = {}  # field_name -> numpy dtype name (e.g. "float32")
+    mutcat_version: int | None = None  # set when annotate_mutations has run
+    mutcat_contigs: list[str] | None = None  # normalized contigs annotated; None = all
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest tests/test_svar_mutations.py::test_metadata_has_mutcat_contigs_default -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_svar.py tests/test_svar_mutations.py
+git commit -m "feat(svar): add mutcat_contigs to SparseVarMetadata"
+```
+
+---
+
+## Task 4: Add `contigs` to `annotate_mutations` (scope, warn, gate, persist)
+
+Normalize the allowlist via `self._c_norm`, warn on entries matching no index contig, compute the per-variant in-scope mask, gate `is_snv` to in-scope (so out-of-scope adjacent SNVs are not DBS-collapsed), thread the normalized allowlist to `classify_variants`, and persist `mutcat_contigs`.
+
+**Files:**
+- Modify: `genoray/_svar.py:1471` (`annotate_mutations`)
+- Test: `tests/test_svar_mutations.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_svar_mutations.py`. These reuse the existing `_build_tiny_svar` helper (2 samples, ploidy 1, 3 SNVs on `chr1` at 1-based POS 2,3,9; sample 0 carries the adjacent pair → DBS).
+
+```python
+def _build_two_contig_svar(path):
+    """chr1 has the 3-SNV tiny layout; chr2 carries one adjacent SNV pair.
+
+    Variants (1-based POS): chr1@2, chr1@3, chr1@9, chr2@2, chr2@3.
+    chr2@2 and chr2@3 are adjacent SNVs on sample 0's single haplotype.
+    """
+    from genoray._svar import SparseVarMetadata, _write_genos
+    from seqpro.rag import Ragged
+
+    path.mkdir(parents=True)
+    index = pl.DataFrame(
+        {
+            "CHROM": ["chr1", "chr1", "chr1", "chr2", "chr2"],
+            "POS": np.array([2, 3, 9, 2, 3], dtype=np.int32),
+            "REF": ["C", "G", "A", "C", "G"],
+            "ALT": [["A"], ["T"], ["C"], ["A"], ["T"]],
+            "ILEN": pl.Series([[0]] * 5, dtype=pl.List(pl.Int32)),
+        }
+    )
+    index.write_ipc(path / "index.arrow")
+    # sample 0 carries chr1@2, chr1@3 (var 0,1) and chr2@2, chr2@3 (var 3,4);
+    # sample 1 carries chr1@9 (var 2). ploidy 1 -> 2 tracks.
+    data = np.array([0, 1, 3, 4, 2], dtype=np.int32)
+    offsets = np.array([0, 4, 5], dtype=np.int64)  # n_samples*ploidy + 1 = 3
+    genos = Ragged.from_offsets(data, (2, 1, None), offsets)
+    _write_genos(path, genos)
+    with open(path / "metadata.json", "w") as f:
+        f.write(
+            SparseVarMetadata(
+                version=1, samples=["s0", "s1"], ploidy=1, contigs=["chr1", "chr2"]
+            ).model_dump_json()
+        )
+
+
+def _two_contig_ref(tmp_path):
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\nACGTACGTAC\n>chr2\nACGTACGTAC\n")
+    pysam.faidx(str(fa))
+    return Reference.from_path(fa)
+
+
+def test_annotate_scope_marks_excluded_not_annotated(tmp_path):
+    from genoray._mutcat import SENTINELS
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(_two_contig_ref(tmp_path), contigs=["chr1"], write_back=True)
+
+    mut = svar.fields["mutcat"]
+    # entries on chr2 (sample 0's last two entries: vars 3,4) must be NOT_ANNOTATED
+    flat = mut.data
+    # data order matches genos: [chr1@2, chr1@3, chr2@2, chr2@3, chr1@9]
+    assert flat[2] == SENTINELS["NOT_ANNOTATED"]
+    assert flat[3] == SENTINELS["NOT_ANNOTATED"]
+    # chr1 entries are NOT NOT_ANNOTATED (classified or DBS)
+    assert flat[0] != SENTINELS["NOT_ANNOTATED"]
+
+
+def test_annotate_scope_excludes_from_matrix(tmp_path):
+    """A scoped run's SBS96 matrix equals an all-contig run on a chr1-only svar."""
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(_two_contig_ref(tmp_path), contigs=["chr1"], write_back=False)
+    sbs = svar.mutation_matrix("SBS96", count="allele")
+    # chr2's SNVs contribute nothing; totals come only from chr1 isolated SNV(s)
+    assert sbs.height == 96
+    # chr1@9 (sample 1) is an isolated SNV -> exactly one SBS event total
+    total = sum(sbs[c].sum() for c in ["s0", "s1"])
+    assert total == 1  # chr1@2,@3 collapse to DBS (not SBS); chr2 excluded
+
+
+def test_annotate_scope_normalizes_contig_names(tmp_path):
+    """Allowlist given without 'chr' prefix still matches a chr-prefixed index."""
+    from genoray._mutcat import SENTINELS
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    # index uses 'chr1'/'chr2'; pass '1' -> should match chr1
+    svar.annotate_mutations(_two_contig_ref(tmp_path), contigs=["1"], write_back=False)
+    flat = svar.fields["mutcat"].data
+    assert flat[2] == SENTINELS["NOT_ANNOTATED"]  # chr2 excluded
+    assert flat[0] != SENTINELS["NOT_ANNOTATED"]  # chr1 annotated
+
+
+def test_annotate_scope_warns_on_unmatched_contig(tmp_path, capsys):
+    # loguru writes to stderr by default; capsys captures it (caplog does not,
+    # since loguru bypasses stdlib logging) — matches the repo's #59 convention.
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(
+        _two_contig_ref(tmp_path), contigs=["chr1", "chrZ"], write_back=False
+    )
+    assert "chrZ" in capsys.readouterr().err
+
+
+def test_annotate_scope_adjacent_oos_snvs_not_dbs(tmp_path):
+    """chr2's adjacent SNV pair, when out of scope, is NOT collapsed to DBS."""
+    from genoray._mutcat import SENTINELS
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(_two_contig_ref(tmp_path), contigs=["chr1"], write_back=False)
+    flat = svar.fields["mutcat"].data
+    # both chr2 entries are NOT_ANNOTATED; neither is a DBS code or DBS_PARTNER
+    assert flat[2] == SENTINELS["NOT_ANNOTATED"]
+    assert flat[3] == SENTINELS["NOT_ANNOTATED"]
+    assert flat[3] != SENTINELS["DBS_PARTNER"]
+
+
+def test_annotate_scope_persists_mutcat_contigs(tmp_path):
+    from genoray._svar import SparseVarMetadata
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(_two_contig_ref(tmp_path), contigs=["chr1"], write_back=True)
+    with open(d / "metadata.json", "rb") as f:
+        meta = SparseVarMetadata.model_validate_json(f.read())
+    assert meta.mutcat_contigs == ["chr1"]
+    assert meta.mutcat_version == 3
+
+
+def test_annotate_no_scope_persists_none(tmp_path):
+    from genoray._svar import SparseVarMetadata
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(_two_contig_ref(tmp_path), write_back=True)
+    with open(d / "metadata.json", "rb") as f:
+        meta = SparseVarMetadata.model_validate_json(f.read())
+    assert meta.mutcat_contigs is None
+
+
+def test_annotate_inscope_contig_absent_from_reference_raises(tmp_path):
+    """Listing a contig present in the index but absent from the reference raises."""
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    # reference has only chr1; chr2 is in scope but unfetchable
+    fa = tmp_path / "ref1.fa"
+    fa.write_text(">chr1\nACGTACGTAC\n")
+    pysam.faidx(str(fa))
+    with pytest.raises(Exception):
+        svar.annotate_mutations(Reference.from_path(fa), contigs=["chr1", "chr2"])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run pytest tests/test_svar_mutations.py -k "scope or persists" -v`
+Expected: FAIL — `annotate_mutations()` got an unexpected keyword argument `contigs`.
+
+- [ ] **Step 3: Implement**
+
+In `genoray/_svar.py`, replace the `annotate_mutations` signature and body up through the `is_snv`/`classify_variants` section (`:1471-1534`). Add the `contigs` parameter, the scope resolution, the `classify_variants` call with `contigs=`, and the `is_snv` gate:
+
+```python
+    def annotate_mutations(
+        self,
+        reference: "Reference | str | Path",
+        *,
+        contigs: list[str] | None = None,
+        write_back: bool = True,
+    ) -> None:
+        """Classify every variant into SBS-96 / DBS-78 / ID-83 channels and store
+        a per-genotype-entry ``mutcat`` field (int16, enum-encoded).
+
+        Adjacent SNVs carried on the same haplotype are combined into DBS; the
+        5' entry receives the DBS code and the 3' entry a ``DBS_PARTNER`` sentinel.
+
+        Parameters
+        ----------
+        reference
+            Reference genome.  A :class:`~genoray._reference.Reference` instance,
+            or a path to a FASTA file (with a ``.fai`` index alongside it).
+        contigs
+            If given, only variants on these contigs are classified; entries on
+            all other contigs are marked ``NOT_ANNOTATED`` and their contigs are
+            never fetched from the reference.  Names are matched via the
+            :class:`~genoray._utils.ContigNormalizer` (so ``chr1``/``1`` both
+            work).  Requested contigs absent from the ``.svar`` index are skipped
+            with a warning.  A listed contig present in the index but absent from
+            the reference still raises (use the allowlist to exclude it instead).
+            ``None`` (default) classifies all contigs.
+        write_back
+            If ``True`` (default), persist ``mutcat.npy`` and update
+            ``metadata.json`` on disk so that subsequent ``SparseVar(...)``
+            opens will see the field.  If ``False``, the ``mutcat`` field lives
+            only in memory (``self.fields["mutcat"]``) and is NOT written to
+            disk — reopening the file will not find it.  Note: the
+            ``metadata.json`` update is not safe against concurrent writers;
+            single-writer access is expected (consistent with
+            ``annotate_with_gtf``).
+        """
+        if not isinstance(reference, Reference):
+            reference = Reference.from_path(reference)
+
+        # 0. resolve contig scope
+        index_chroms = self.index["CHROM"].to_list()
+        if contigs is None:
+            scoped_contigs: list[str] | None = None
+            in_scope = np.ones(self.index.height, dtype=np.bool_)
+        else:
+            normalized = self._c_norm.norm(list(contigs))
+            unmatched = [c for c, nm in zip(contigs, normalized) if nm is None]
+            if unmatched:
+                logger.warning(
+                    f"annotate_mutations: {len(unmatched)} requested contig(s) not "
+                    f"found in the .svar index; they will be skipped: {unmatched}"
+                )
+            scope_set = {nm for nm in normalized if nm is not None}
+            scoped_contigs = sorted(scope_set)
+            in_scope = np.array([c in scope_set for c in index_chroms], dtype=np.bool_)
+
+        # 1. intrinsic per-variant codes (scoped)
+        var_code = classify_variants(self.index, reference, contigs=scoped_contigs)
+
+        # 2. per-variant arrays needed by the adjacency kernel
+        pos = self.index["POS"].to_numpy().astype(np.int64)
+        ref0 = self.index["REF"].to_list()
+        alt0 = self.index["ALT"].list.first().to_list()
+        is_snv = np.array(
+            [
+                r is not None and a is not None and len(r) == 1 and len(a) == 1
+                for r, a in zip(ref0, alt0)
+            ],
+            dtype=np.bool_,
+        )
+        # out-of-scope variants must not participate in DBS adjacency, so their
+        # NOT_ANNOTATED code broadcasts unchanged to every entry.
+        is_snv &= in_scope
+```
+
+The remainder of the method — the `contig_map`/`contig_codes`/`ref_b`/`alt_b` arrays, `build_entry_codes`, the in-memory field registration, and the `write_back` block — stays as-is, except add the `mutcat_contigs` line in the `write_back` metadata update (after `meta.mutcat_version = MUTCAT_VERSION`):
+
+```python
+            meta.fields["mutcat"] = "int16"
+            meta.mutcat_version = MUTCAT_VERSION
+            meta.mutcat_contigs = scoped_contigs
+            with open(self.path / "metadata.json", "w") as f:
+                f.write(meta.model_dump_json())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run pytest tests/test_svar_mutations.py -k "scope or persists" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full svar-mutations + mutcat suites**
+
+Run: `pixi run pytest tests/test_svar_mutations.py tests/test_mutcat.py tests/test_mutcat_calibration.py -q`
+Expected: PASS (existing tests unaffected; `contigs=None` is the prior path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add genoray/_svar.py tests/test_svar_mutations.py
+git commit -m "feat(svar): contig scope + NOT_ANNOTATED + mutcat_contigs in annotate_mutations (#62)"
+```
+
+---
+
+## Task 5: Update the public API skill doc
+
+Per `CLAUDE.md`, the same PR must update `skills/genoray-api/SKILL.md` for the new public surface: the `contigs=` kwarg, the `NOT_ANNOTATED` sentinel, and `mutcat_contigs`.
+
+**Files:**
+- Modify: `skills/genoray-api/SKILL.md` (the `annotate_mutations` section, around `:304-338`)
+
+- [ ] **Step 1: Update the signature and parameter docs**
+
+Change the signature line to:
+
+```
+Signature: `annotate_mutations(reference, *, contigs=None, write_back=True) -> None`
+```
+
+Add a bullet describing `contigs` (place it before the `write_back=True` bullet):
+
+```markdown
+- `contigs=None` — if given (a list of contig names), only variants on those
+  contigs are classified; entries on all other contigs are marked
+  `NOT_ANNOTATED` (sentinel `-4`) and their contigs are never fetched from the
+  reference. Names match via the `ContigNormalizer` (`chr1`/`1` both work).
+  Requested contigs absent from the `.svar` index are skipped with a warning; a
+  listed contig present in the index but absent from the reference raises (omit
+  it from the list to exclude it cleanly). `None` (default) classifies all
+  contigs. When `write_back=True`, the normalized scope is recorded in
+  `metadata.json` as `mutcat_contigs` (`None` = all).
+```
+
+- [ ] **Step 2: Document the new sentinel in the classification table**
+
+In the "What it classifies" table, add a row:
+
+```markdown
+| Variant on a contig outside `contigs=` | `NOT_ANNOTATED` (excluded from all matrices) |
+```
+
+- [ ] **Step 3: Verify there are no other stale references**
+
+Run: `grep -n "annotate_mutations" skills/genoray-api/SKILL.md`
+Expected: every shown signature/usage reflects the `contigs=` kwarg (the examples that omit it still work, since it defaults to `None`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/genoray-api/SKILL.md
+git commit -m "docs(skill): document contigs= scope and NOT_ANNOTATED in annotate_mutations"
+```
+
+---
+
+## Task 6: Full-suite regression check
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `pixi run pytest -m "not network" -q`
+Expected: PASS — no regressions across the repo.
+
+- [ ] **Step 2: Lint/format**
+
+Run: `pixi run ruff check genoray tests && pixi run ruff format --check genoray tests`
+Expected: clean (run `ruff format genoray tests` first if needed, then re-stage/commit).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §1 sentinel → Task 1; §2 `classify_variants(contigs=)` → Task 2; §3 `annotate_mutations` scope/gate/persist → Task 4; §4 metadata + version → Tasks 1 & 3; §6 SKILL.md → Task 5; testing §7 → Tasks 2 & 4. §5 (#61 relationship) is a no-code decision (no auto-skip mode) — honored by `contigs=None` keeping the raise-on-absent path (test in Task 4).
+- **Type consistency:** `contigs: list[str] | None` is identical across `classify_variants` and `annotate_mutations`; `scoped_contigs` (normalized, index-scheme names or `None`) is what both `classify_variants` receives and `mutcat_contigs` stores; the `in_scope` bool mask gates `is_snv`. `NOT_ANNOTATED = -4` used consistently.
+- **Naming authority:** `annotate_mutations` normalizes via `self._c_norm` and passes already-index-scheme names to `classify_variants`, which does pure set membership (no second normalization, no double warning).

--- a/docs/superpowers/plans/2026-06-13-mito-contig-aliasing.md
+++ b/docs/superpowers/plans/2026-06-13-mito-contig-aliasing.md
@@ -1,0 +1,132 @@
+# Mitochondrial Contig Aliasing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ContigNormalizer` treat the four mitochondrial contig spellings `{M, MT, chrM, chrMT}` as mutually equivalent, so an Ensembl-named `MT` variant resolves against a UCSC-named `chrM` reference instead of crashing.
+
+**Architecture:** Add a module-level `_MITO_ALIASES` tuple and, in `ContigNormalizer.__init__`, detect the reference's mito contig and merge a `{alias: mito_contig}` map into the existing `contig_map`. All downstream structures (`remapper`, `_c2dup`, `dup2i`) derive from `contig_map`, so `norm()` and `c_idxs()` pick up the aliases automatically.
+
+**Tech Stack:** Python, `pytest`, `pytest_cases`, run via `pixi run pytest`.
+
+Reference spec: `docs/superpowers/specs/2026-06-13-mito-contig-aliasing-design.md`
+
+---
+
+### Task 1: Mito aliasing in `ContigNormalizer`
+
+**Files:**
+- Modify: `genoray/_utils.py:16-33` (add `_MITO_ALIASES`, update `contig_map`, fix docstring at line 21)
+- Test: `tests/test_utils.py:38-49` (add `contig_*` cases consumed by existing `test_normalize_contig_name`)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_utils.py`, add these three case functions after `contig_no_match` (around line 42). They follow the existing `contig_*` / `parametrize_with_cases` pattern and need no new test function:
+
+```python
+def contig_mito_mt_to_chrm():
+    unnormed = "MT"
+    source = ContigNormalizer(["chr1", "chrM"])
+    desired = "chrM"
+    return unnormed, source, desired
+
+
+def contig_mito_chrmt_to_chrm():
+    unnormed = "chrMT"
+    source = ContigNormalizer(["chr1", "chrM"])
+    desired = "chrM"
+    return unnormed, source, desired
+
+
+def contig_mito_chrm_to_mt():
+    unnormed = "chrM"
+    source = ContigNormalizer(["1", "MT"])
+    desired = "MT"
+    return unnormed, source, desired
+
+
+def contig_mito_absent():
+    unnormed = "MT"
+    source = ContigNormalizer(["chr1", "chr2"])
+    desired = None
+    return unnormed, source, desired
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run pytest tests/test_utils.py::test_normalize_contig_name -v`
+Expected: the three mito-resolving cases FAIL (`assert None == 'chrM'` / `'MT'`); `contig_mito_absent` PASSES (already `None`).
+
+- [ ] **Step 3: Add `_MITO_ALIASES` constant**
+
+In `genoray/_utils.py`, add after line 16 (`DTYPE = TypeVar(...)`):
+
+```python
+_MITO_ALIASES = ("M", "MT", "chrM", "chrMT")
+```
+
+- [ ] **Step 4: Update `contig_map` and the docstring**
+
+In `genoray/_utils.py`, replace the docstring note (line 21) and the `contig_map` construction (lines 29-33).
+
+Change the docstring line 21 from:
+
+```python
+    Note: this does not handle the special case of equivalence between M and MT.
+```
+
+to:
+
+```python
+    Mitochondrial aliases {M, MT, chrM, chrMT} are treated as mutually equivalent and
+    resolve to whichever spelling the reference actually contains.
+```
+
+Replace the `contig_map` assignment:
+
+```python
+        self.contig_map = (
+            {f"{c[3:]}": c for c in contigs if c.startswith("chr")}
+            | {f"chr{c}": c for c in contigs if not c.startswith("chr")}
+            | {c: c for c in contigs}
+        )
+```
+
+with:
+
+```python
+        mito = next((c for c in self.contigs if c in _MITO_ALIASES), None)
+        mito_map = {a: mito for a in _MITO_ALIASES} if mito is not None else {}
+        self.contig_map = (
+            {f"{c[3:]}": c for c in contigs if c.startswith("chr")}
+            | {f"chr{c}": c for c in contigs if not c.startswith("chr")}
+            | {c: c for c in contigs}
+            | mito_map
+        )
+```
+
+Note: `self.contigs` is already assigned on line 28 before this block, so `next(...)` over it is safe.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pixi run pytest tests/test_utils.py::test_normalize_contig_name -v`
+Expected: all cases PASS, including the three mito-resolving cases and `contig_mito_absent`.
+
+- [ ] **Step 6: Run the full utils test file to check for regressions**
+
+Run: `pixi run pytest tests/test_utils.py -v`
+Expected: all PASS (existing `chr`-prefix cases unaffected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add genoray/_utils.py tests/test_utils.py
+git commit -m "fix(utils): treat mitochondrial aliases M/MT/chrM/chrMT as equivalent (#61)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Mito aliasing (Task 1, Steps 3-4), behavior table incl. symmetric MT case + no-mito fallback (Step 1 cases), degenerate multi-mito → `next()` first-in-order (Step 4 code), docstring fix (Step 4). No graceful-skip work — out of scope per spec.
+- **Public API:** None changed (`_utils.py` is internal); no `SKILL.md` update needed, per spec.
+- **Placeholders:** None — all code and commands are concrete.

--- a/docs/superpowers/plans/2026-06-13-vectorize-mutation-matrices.md
+++ b/docs/superpowers/plans/2026-06-13-vectorize-mutation-matrices.md
@@ -1,0 +1,967 @@
+# Vectorize SBS/DBS/INDEL Matrix Classification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-variant Python loop in `classify_variants` with vectorized numpy (SNV/DBS) plus one parallel numba kernel (indels), and parallelize the entry-code and count kernels, with results identical to the current implementation on all common ACGT SBS/DBS/ID cases.
+
+**Architecture:** Hybrid. SNV→SBS-96 and native-doublet→DBS-78 become pure-numpy fancy-index passes; the indel→ID-83 repeat/microhomology scan becomes a single `nb.njit(parallel=True)` kernel reading a per-contig reference array. The existing `_entry_codes_kernel` and `_count_kernel` gain `prange`. The current scalar classifiers are retained as the test oracle.
+
+**Tech Stack:** Python, NumPy, numba (`prange`, `parallel=True`), Polars + PyArrow (zero-copy REF/ALT byte buffers), pysam (`Reference`), pytest. All commands run under Pixi: prefix with `pixi run`.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-vectorize-mutation-matrices-design.md`
+
+---
+
+## Key facts (read before starting)
+
+- `genoray/_mutcat.py` holds the codebooks, scalar classifiers, kernels, and `classify_variants`. `genoray/_reference.py` holds `Reference`.
+- `classify_variants(index, reference)` (`_mutcat.py:478`) takes a `pl.DataFrame` with columns `CHROM` (str), `POS` (1-based int), `REF` (str), `ALT` (List[str]; first used) and returns `int16[index.height]`. **POS is 1-based; the function converts to 0-based internally (`p = POS - 1`).**
+- Base encoding used throughout: `A=0, C=1, G=2, T=3`. Complement under this encoding is `3 - x` (A↔T, C↔G). Purine refs are `A` and `G` (encoded `0` and `2`).
+- `SBS96 = [f"{five}[{sub}]{three}" for sub in _SBS_SUBS for five in _BASES for three in _BASES]` with `_SBS_SUBS = ["C>A","C>G","C>T","T>A","T>C","T>G"]` and `_BASES = ["A","C","G","T"]`. So the code for a folded SNV is `sub_idx*16 + five_idx*4 + three_idx`.
+- `_DBS_TABLE` (`_mutcat.py:326`) is a `(4,4,4,4)` int16 array `[r0,r1,a0,a1] -> code | UNCLASSIFIED`, already built from the scalar `classify_dbs78`.
+- `_BASE2IDX` (`_mutcat.py:307`) is a 256-entry int64 LUT: `A/C/G/T -> 0/1/2/3`, else `-1`.
+- Sentinels: `SENTINELS["UNCLASSIFIED"] = -2`, `SENTINELS["DBS_PARTNER"] = -1`; `_REF_MISMATCH = -99` (internal).
+- Polars `Series.to_arrow()` yields a `pyarrow.LargeStringArray` (int64 offsets). `arr.buffers()` is `[validity, offsets(int64), data(uint8)]`. PyArrow ≥21 is a hard dependency.
+- numba thread count is controlled at runtime by `numba.set_num_threads(n)` and `numba.get_num_threads()`. Use these in determinism tests.
+- Tests live in `tests/`, import private helpers directly, and run via `pixi run pytest tests/<file> -v`.
+- Commit convention: Conventional Commits (`feat:`, `test:`, `perf:`, `refactor:`, `docs:`).
+
+---
+
+## File structure
+
+- **Modify** `genoray/_reference.py` — add `Reference.contig_array`.
+- **Modify** `genoray/_mutcat.py` — add `_SUB_LUT`; `_sbs96_codes`; `_dbs78_codes`; `_build_id83_luts` + module-level `_ID1_CODE/_IDR_CODE/_IDM_CODE`; `_id83_kernel`; `_utf8_flat`; rename the current `classify_variants` body to `_classify_variants_scalar` (oracle) and write a new vectorized `classify_variants`; add `parallel=True`/`prange` to `_entry_codes_kernel` and `_count_kernel`.
+- **Modify** `tests/test_mutcat.py` — codebook-arithmetic, per-classifier differential, kernel-vs-scalar, full differential, boundary, determinism tests.
+- **Modify** `tests/test_svar_mutations.py` — parallel-determinism regression for `mutation_matrix`.
+
+---
+
+## Task 1: Add `Reference.contig_array`
+
+Expose the already-cached full-contig uint8 array so the vectorized paths can gather flanks and the indel kernel can scan downstream, without per-variant `fetch()` calls.
+
+**Files:**
+- Modify: `genoray/_reference.py`
+- Test: `tests/test_reference.py` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_reference.py`:
+
+```python
+import numpy as np
+import pysam
+
+from genoray._reference import Reference
+
+
+def _write_fasta(path, seq, contig="chr1"):
+    path.write_text(f">{contig}\n{seq}\n")
+    pysam.faidx(str(path))
+
+
+def test_contig_array_matches_fetch(tmp_path):
+    fa = tmp_path / "ref.fa"
+    _write_fasta(fa, "ACGTACGTAC")
+    ref = Reference.from_path(fa)
+    arr = ref.contig_array("chr1")
+    assert isinstance(arr, np.ndarray) and arr.dtype == np.uint8
+    assert bytes(arr) == b"ACGTACGTAC"
+    # equals fetch over the full span
+    assert bytes(ref.fetch("chr1", 0, 10)) == bytes(arr)
+    # chr-prefix normalization still works
+    assert bytes(ref.contig_array("1")) == b"ACGTACGTAC"
+```
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `pixi run pytest tests/test_reference.py::test_contig_array_matches_fetch -v`
+Expected: FAIL — `AttributeError: 'Reference' object has no attribute 'contig_array'`.
+
+- [ ] **Step 3: Implement `contig_array`**
+
+In `genoray/_reference.py`, add this method to `Reference` (after `_load_contig`, before `fetch`):
+
+```python
+    def contig_array(self, contig: str) -> NDArray[np.uint8]:
+        """Return the full contig sequence as a cached uint8 array.
+
+        Accepts ``chr``-prefixed or unprefixed names. One contig is held in
+        memory at a time (shared with :meth:`fetch`).
+        """
+        return self._load_contig(contig)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pixi run pytest tests/test_reference.py::test_contig_array_matches_fetch -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_reference.py tests/test_reference.py
+git commit -m "feat(reference): expose cached contig_array for vectorized lookups"
+```
+
+---
+
+## Task 2: Vectorized SBS-96 classifier `_sbs96_codes`
+
+Compute SBS-96 codes for a batch of SNVs on one contig with pure numpy, and prove the arithmetic matches the codebook order.
+
+**Files:**
+- Modify: `genoray/_mutcat.py`
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_mutcat.py`:
+
+```python
+from genoray._mutcat import _sbs96_codes, classify_sbs96  # noqa: E402
+
+
+def test_sbs96_arithmetic_matches_codebook():
+    # The vectorized substitution LUT + arithmetic must reproduce SBS96_INDEX
+    # for every one of the 96 labels (pyrimidine-folded form, no boundary issues).
+    from genoray._mutcat import _BASE2IDX, _SUB_LUT, _BASES, _SBS_SUBS
+
+    for sub_idx, sub in enumerate(_SBS_SUBS):
+        r_char, a_char = sub[0], sub[2]
+        r, a = _BASE2IDX[ord(r_char)], _BASE2IDX[ord(a_char)]
+        assert _SUB_LUT[r, a] == sub_idx
+        for five_idx, five in enumerate(_BASES):
+            for three_idx, three in enumerate(_BASES):
+                label = f"{five}[{sub}]{three}"
+                code = sub_idx * 16 + five_idx * 4 + three_idx
+                assert code == SBS96_INDEX[label]
+
+
+def test_sbs96_codes_match_scalar_on_random_snvs():
+    rng = np.random.default_rng(0)
+    bases = np.frombuffer(b"ACGT", np.uint8)
+    n = 500
+    seq = np.frombuffer(bytes(bases[rng.integers(0, 4, 200)]), np.uint8)
+    # interior positions only so flanks exist
+    p0 = rng.integers(1, len(seq) - 1, n).astype(np.int64)
+    ref_b = seq[p0].copy()  # ref must equal reference base is NOT required by classify,
+    alt_b = bases[rng.integers(0, 4, n)].copy()
+    got = _sbs96_codes(seq, p0, ref_b, alt_b)
+    for i in range(n):
+        five = bytes(seq[p0[i] - 1 : p0[i]])
+        three = bytes(seq[p0[i] + 1 : p0[i] + 2])
+        exp = classify_sbs96(five, bytes(ref_b[i : i + 1]), bytes(alt_b[i : i + 1]), three)
+        assert got[i] == exp, (i, five, ref_b[i], alt_b[i], three)
+```
+
+- [ ] **Step 2: Run them to verify failure**
+
+Run: `pixi run pytest tests/test_mutcat.py -k sbs96_ -v`
+Expected: FAIL — `ImportError: cannot import name '_sbs96_codes'` (and `_SUB_LUT`).
+
+- [ ] **Step 3: Implement `_SUB_LUT` and `_sbs96_codes`**
+
+In `genoray/_mutcat.py`, after the `_BASE2IDX` definition (`:307-308`), add:
+
+```python
+# (ref_idx, alt_idx) -> SBS substitution index 0..5, for pyrimidine-folded refs.
+# _SBS_SUBS order: C>A, C>G, C>T, T>A, T>C, T>G  (encoding A=0,C=1,G=2,T=3)
+_SUB_LUT = np.full((4, 4), -1, dtype=np.int64)
+for _si, _sub in enumerate(_SBS_SUBS):
+    _SUB_LUT[_BASE2IDX[ord(_sub[0])], _BASE2IDX[ord(_sub[2])]] = _si
+
+_UNCL = np.int16(SENTINELS["UNCLASSIFIED"])
+
+
+def _sbs96_codes(
+    seq: NDArray[np.uint8],
+    p0: NDArray[np.int64],
+    ref_b: NDArray[np.uint8],
+    alt_b: NDArray[np.uint8],
+) -> NDArray[np.int16]:
+    """SBS-96 codes for SNVs on one contig. ``p0`` is the 0-based REF position."""
+    n = len(seq)
+    r = _BASE2IDX[ref_b]
+    a = _BASE2IDX[alt_b]
+    fpos = p0 - 1
+    tpos = p0 + 1
+    in_f = (fpos >= 0) & (fpos < n)
+    in_t = (tpos >= 0) & (tpos < n)
+    f = _BASE2IDX[seq[np.clip(fpos, 0, n - 1)]]
+    t = _BASE2IDX[seq[np.clip(tpos, 0, n - 1)]]
+    valid = (r >= 0) & (a >= 0) & (f >= 0) & (t >= 0) & (r != a) & in_f & in_t
+    purine = (r == 0) | (r == 2)  # A or G
+    rr = np.where(purine, 3 - r, r)
+    aa = np.where(purine, 3 - a, a)
+    # flanks swap and complement when folding: new 5' = comp(old 3'), new 3' = comp(old 5')
+    ff = np.where(purine, 3 - t, f)
+    tt = np.where(purine, 3 - f, t)
+    sub = _SUB_LUT[np.clip(rr, 0, 3), np.clip(aa, 0, 3)]
+    code = (sub * 16 + ff * 4 + tt).astype(np.int16)
+    return np.where(valid, code, _UNCL)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pixi run pytest tests/test_mutcat.py -k sbs96_ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "feat(mutcat): vectorized SBS-96 batch classifier"
+```
+
+---
+
+## Task 3: Vectorized DBS-78 classifier `_dbs78_codes`
+
+**Files:**
+- Modify: `genoray/_mutcat.py`
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_mutcat.py`:
+
+```python
+from genoray._mutcat import _dbs78_codes  # noqa: E402
+
+
+def test_dbs78_codes_match_scalar():
+    bases = b"ACGT"
+    ref0, ref1, alt0, alt1, exp = [], [], [], [], []
+    for r0 in bases:
+        for r1 in bases:
+            for a0 in bases:
+                for a1 in bases:
+                    ref0.append(r0); ref1.append(r1)
+                    alt0.append(a0); alt1.append(a1)
+                    exp.append(
+                        classify_dbs78(bytes([r0, r1]), bytes([a0, a1]))
+                    )
+    got = _dbs78_codes(
+        np.array(ref0, np.uint8), np.array(ref1, np.uint8),
+        np.array(alt0, np.uint8), np.array(alt1, np.uint8),
+    )
+    assert list(got) == exp
+```
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_dbs78_codes_match_scalar -v`
+Expected: FAIL — `ImportError: cannot import name '_dbs78_codes'`.
+
+- [ ] **Step 3: Implement `_dbs78_codes`**
+
+In `genoray/_mutcat.py`, after `_sbs96_codes`, add:
+
+```python
+def _dbs78_codes(
+    ref_b0: NDArray[np.uint8],
+    ref_b1: NDArray[np.uint8],
+    alt_b0: NDArray[np.uint8],
+    alt_b1: NDArray[np.uint8],
+) -> NDArray[np.int16]:
+    """DBS-78 codes for native 2bp doublets (context-free table lookup)."""
+    r0 = _BASE2IDX[ref_b0]
+    r1 = _BASE2IDX[ref_b1]
+    a0 = _BASE2IDX[alt_b0]
+    a1 = _BASE2IDX[alt_b1]
+    valid = (r0 >= 0) & (r1 >= 0) & (a0 >= 0) & (a1 >= 0)
+    code = _DBS_TABLE[
+        np.clip(r0, 0, 3), np.clip(r1, 0, 3), np.clip(a0, 0, 3), np.clip(a1, 0, 3)
+    ]
+    return np.where(valid, code, _UNCL)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_dbs78_codes_match_scalar -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "feat(mutcat): vectorized DBS-78 batch classifier"
+```
+
+---
+
+## Task 4: ID-83 lookup arrays + parallel numba kernel
+
+Replace `classify_id83`'s Python window scan with a `prange` kernel that reads the contig array directly. Code labels are mapped to int16 codes via arrays derived once from `ID83_INDEX`.
+
+**Files:**
+- Modify: `genoray/_mutcat.py`
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_mutcat.py`:
+
+```python
+from genoray._mutcat import (  # noqa: E402
+    _ID1_CODE,
+    _IDM_CODE,
+    _IDR_CODE,
+    _id83_codes_for_contig,
+)
+
+
+def test_id83_luts_match_index():
+    for ki, k in enumerate(("Del", "Ins")):
+        for bi, b in enumerate(("C", "T")):
+            for r in range(6):
+                assert _ID1_CODE[ki, bi, r] == ID83_INDEX[f"1:{k}:{b}:{r}"]
+        for si, s in enumerate(("2", "3", "4", "5")):
+            for r in range(6):
+                assert _IDR_CODE[ki, si, r] == ID83_INDEX[f"{s}:{k}:R:{r}"]
+    for si, s in enumerate(("2", "3", "4", "5")):
+        cap = {"2": 1, "3": 2, "4": 3, "5": 5}[s]
+        for m in range(1, cap + 1):
+            assert _IDM_CODE[si, m] == ID83_INDEX[f"{s}:Del:M:{m}"]
+
+
+def test_id83_kernel_matches_scalar_random():
+    # Build a random contig and a set of indels; compare to classify_id83.
+    rng = np.random.default_rng(7)
+    bases = b"ACGT"
+    seq = np.frombuffer(
+        bytes(np.frombuffer(bases, np.uint8)[rng.integers(0, 4, 400)]), np.uint8
+    )
+
+    def fetch(s, e, _seq=seq):
+        out = np.full(e - s, ord("N"), np.uint8)
+        a, b = max(s, 0), min(e, len(_seq))
+        if b > a:
+            out[a - s : b - s] = _seq[a:b]
+        return bytes(out)
+
+    refs, alts, p0s = [], [], []
+    for _ in range(300):
+        p = int(rng.integers(2, len(seq) - 10))
+        anchor = bytes(seq[p : p + 1])
+        size = int(rng.integers(1, 5))
+        unit = bytes(np.frombuffer(bases, np.uint8)[rng.integers(0, 4, size)])
+        if rng.random() < 0.5:  # deletion
+            refs.append(anchor + unit); alts.append(anchor)
+        else:  # insertion
+            refs.append(anchor); alts.append(anchor + unit)
+        p0s.append(p)
+
+    # flat buffers for the kernel
+    ref_data = np.frombuffer(b"".join(refs), np.uint8)
+    alt_data = np.frombuffer(b"".join(alts), np.uint8)
+    ref_off = np.concatenate(([0], np.cumsum([len(r) for r in refs]))).astype(np.int64)
+    alt_off = np.concatenate(([0], np.cumsum([len(a) for a in alts]))).astype(np.int64)
+    p0 = np.array(p0s, np.int64)
+
+    got = _id83_codes_for_contig(
+        seq, p0, ref_data, ref_off[:-1], (ref_off[1:] - ref_off[:-1]),
+        alt_data, alt_off[:-1], (alt_off[1:] - alt_off[:-1]),
+    )
+    for i in range(len(refs)):
+        exp = classify_id83(int(p0[i]), refs[i], alts[i], fetch)
+        assert got[i] == exp, (i, refs[i], alts[i], int(p0[i]), got[i], exp)
+```
+
+- [ ] **Step 2: Run them to verify failure**
+
+Run: `pixi run pytest tests/test_mutcat.py -k id83 -v`
+Expected: FAIL — `ImportError: cannot import name '_ID1_CODE'`.
+
+- [ ] **Step 3: Implement the LUTs, kernel, and Python wrapper**
+
+In `genoray/_mutcat.py`, after `_dbs78_codes`, add:
+
+```python
+def _build_id83_luts() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    u = SENTINELS["UNCLASSIFIED"]
+    id1 = np.full((2, 2, 6), u, dtype=np.int16)  # [kind(Del,Ins), base(C,T), rep]
+    idr = np.full((2, 4, 6), u, dtype=np.int16)  # [kind, size_bucket(2..5), rep]
+    idm = np.full((4, 6), u, dtype=np.int16)  # [size_bucket(2..5), mh]
+    for ki, k in enumerate(("Del", "Ins")):
+        for bi, b in enumerate(("C", "T")):
+            for r in range(6):
+                id1[ki, bi, r] = ID83_INDEX[f"1:{k}:{b}:{r}"]
+        for si, s in enumerate(("2", "3", "4", "5")):
+            for r in range(6):
+                idr[ki, si, r] = ID83_INDEX[f"{s}:{k}:R:{r}"]
+    for si, (s, cap) in enumerate((("2", 1), ("3", 2), ("4", 3), ("5", 5))):
+        for m in range(1, cap + 1):
+            idm[si, m] = ID83_INDEX[f"{s}:Del:M:{m}"]
+    return id1, idr, idm
+
+
+_ID1_CODE, _IDR_CODE, _IDM_CODE = _build_id83_luts()
+_MH_CAP = np.array([1, 2, 3, 5], dtype=np.int64)  # by size bucket 2,3,4,5
+
+
+@nb.njit(parallel=True, nogil=True, cache=True)
+def _id83_kernel(
+    seq: NDArray[np.uint8],
+    p0: NDArray[np.int64],
+    ref_data: NDArray[np.uint8],
+    ref_s: NDArray[np.int64],
+    ref_len: NDArray[np.int64],
+    alt_data: NDArray[np.uint8],
+    alt_s: NDArray[np.int64],
+    alt_len: NDArray[np.int64],
+    base2idx: NDArray[np.int64],
+    id1: NDArray[np.int16],
+    idr: NDArray[np.int16],
+    idm: NDArray[np.int16],
+    mh_cap: NDArray[np.int64],
+    uncl: np.int16,
+    ref_mismatch: np.int16,
+    out: NDArray[np.int16],
+) -> None:
+    n = len(seq)
+    for k in nb.prange(len(p0)):
+        rs, asz = ref_s[k], alt_s[k]
+        rl, al = ref_len[k], alt_len[k]
+        if rl == 0 or al == 0 or ref_data[rs] != alt_data[asz]:
+            out[k] = uncl
+            continue
+        is_del = rl > al
+        if is_del:
+            buf, us, ilen = ref_data, rs + 1, rl - 1
+        else:
+            buf, us, ilen = alt_data, asz + 1, al - 1
+        ok = True
+        for i in range(ilen):
+            if base2idx[buf[us + i]] < 0:
+                ok = False
+                break
+        if not ok:
+            out[k] = uncl
+            continue
+        # count tandem repeats of the unit downstream from p0+1
+        scan = p0[k] + 1
+        n_rep = 0
+        i = 0
+        while scan + i + ilen <= n:
+            match = True
+            for j in range(ilen):
+                if seq[scan + i + j] != buf[us + j]:
+                    match = False
+                    break
+            if not match:
+                break
+            n_rep += 1
+            i += ilen
+        if ilen == 1:
+            bi = base2idx[buf[us]]
+            if bi == 0 or bi == 2:  # A or G -> fold to pyrimidine partner
+                bi = 3 - bi
+            base_idx = 0 if bi == 1 else 1  # C->0, T->1
+            if is_del and n_rep == 0:
+                out[k] = ref_mismatch
+                continue
+            rep = n_rep - 1 if is_del else n_rep
+            if rep > 5:
+                rep = 5
+            out[k] = id1[0 if is_del else 1, base_idx, rep]
+            continue
+        sb = ilen if ilen < 5 else 5
+        si = sb - 2  # 0..3
+        if is_del:
+            mh = 0
+            for kk in range(1, ilen):
+                eq = True
+                for j in range(kk):
+                    if scan + j >= n or seq[scan + j] != buf[us + j]:
+                        eq = False
+                        break
+                if eq:
+                    mh = kk
+            if mh > 0 and n_rep <= 1:
+                cap = mh_cap[si]
+                m = mh if mh < cap else cap
+                out[k] = idm[si, m]
+                continue
+            if n_rep == 0:
+                out[k] = ref_mismatch
+                continue
+            rep = n_rep - 1
+        else:
+            rep = n_rep
+        if rep > 5:
+            rep = 5
+        out[k] = idr[0 if is_del else 1, si, rep]
+
+
+def _id83_codes_for_contig(
+    seq: NDArray[np.uint8],
+    p0: NDArray[np.int64],
+    ref_data: NDArray[np.uint8],
+    ref_s: NDArray[np.int64],
+    ref_len: NDArray[np.int64],
+    alt_data: NDArray[np.uint8],
+    alt_s: NDArray[np.int64],
+    alt_len: NDArray[np.int64],
+) -> NDArray[np.int16]:
+    """ID-83 codes for indels on one contig. May return ``_REF_MISMATCH``
+    entries, which the caller maps to UNCLASSIFIED with a warning."""
+    out = np.empty(len(p0), dtype=np.int16)
+    _id83_kernel(
+        np.ascontiguousarray(seq),
+        np.ascontiguousarray(p0),
+        np.ascontiguousarray(ref_data),
+        np.ascontiguousarray(ref_s),
+        np.ascontiguousarray(ref_len),
+        np.ascontiguousarray(alt_data),
+        np.ascontiguousarray(alt_s),
+        np.ascontiguousarray(alt_len),
+        _BASE2IDX,
+        _ID1_CODE,
+        _IDR_CODE,
+        _IDM_CODE,
+        _MH_CAP,
+        np.int16(SENTINELS["UNCLASSIFIED"]),
+        np.int16(_REF_MISMATCH),
+        out,
+    )
+    return out
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pixi run pytest tests/test_mutcat.py -k id83 -v`
+Expected: PASS (the kernel compiles on first call; allow a few seconds).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "feat(mutcat): parallel numba ID-83 indel kernel + derived LUTs"
+```
+
+---
+
+## Task 5: Rewrite `classify_variants` (vectorized), keep scalar oracle
+
+Rename the current implementation to `_classify_variants_scalar` (the test oracle), then write the new vectorized `classify_variants` that dispatches by variant type and groups by contig.
+
+**Files:**
+- Modify: `genoray/_mutcat.py`
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Rename the current implementation to the oracle**
+
+In `genoray/_mutcat.py`, rename the existing `def classify_variants(` (`:478`) to `def _classify_variants_scalar(` — keep its body byte-for-byte identical. This preserves the exact current behavior as a reference for differential tests.
+
+- [ ] **Step 2: Write the failing differential + boundary tests**
+
+Append to `tests/test_mutcat.py`:
+
+```python
+from genoray._mutcat import _classify_variants_scalar  # noqa: E402
+
+
+def _random_index_and_ref(tmp_path, rng):
+    import pysam
+
+    seq = "".join(rng.choice(list("ACGT"), size=300))
+    fa = tmp_path / "ref.fa"
+    fa.write_text(f">chr1\n{seq}\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+
+    chrom, pos, refs, alts = [], [], [], []
+    for _ in range(400):
+        p = int(rng.integers(2, len(seq) - 8))  # 0-based interior
+        kind = rng.integers(0, 4)
+        anchor = seq[p]
+        if kind == 0:  # SNV
+            alt = rng.choice([b for b in "ACGT" if b != anchor])
+            refs.append(anchor); alts.append(alt)
+        elif kind == 1:  # native doublet
+            refs.append(seq[p : p + 2])
+            alts.append("".join(rng.choice(list("ACGT"), 2)))
+        elif kind == 2:  # deletion
+            size = int(rng.integers(1, 4))
+            refs.append(seq[p : p + 1 + size]); alts.append(anchor)
+        else:  # insertion
+            size = int(rng.integers(1, 4))
+            refs.append(anchor)
+            alts.append(anchor + "".join(rng.choice(list("ACGT"), size)))
+        chrom.append("chr1"); pos.append(p + 1)  # store 1-based
+
+    index = pl.DataFrame(
+        {"CHROM": chrom, "POS": pos, "REF": refs, "ALT": [[a] for a in alts]}
+    )
+    return index, ref
+
+
+def test_classify_variants_matches_scalar(tmp_path):
+    rng = np.random.default_rng(123)
+    index, ref = _random_index_and_ref(tmp_path, rng)
+    got = classify_variants(index, ref)
+    exp = _classify_variants_scalar(index, ref)
+    assert list(got) == list(exp)
+
+
+def test_classify_variants_contig_boundary(tmp_path):
+    import pysam
+
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\nACGT\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+    # SNV at first and last base: no 5'/3' flank -> UNCLASSIFIED, matching scalar
+    index = pl.DataFrame(
+        {"CHROM": ["chr1", "chr1"], "POS": [1, 4], "REF": ["A", "T"],
+         "ALT": [["C"], ["G"]]}
+    )
+    got = classify_variants(index, ref)
+    exp = _classify_variants_scalar(index, ref)
+    assert list(got) == list(exp) == [SENTINELS["UNCLASSIFIED"]] * 2
+```
+
+- [ ] **Step 3: Run them to verify failure**
+
+Run: `pixi run pytest tests/test_mutcat.py -k classify_variants -v`
+Expected: FAIL — `classify_variants` still points at the old (now renamed) name, so import of `classify_variants` fails (`ImportError`), or the differential test errors. Confirm it fails before implementing.
+
+- [ ] **Step 4: Implement `_utf8_flat` and the vectorized `classify_variants`**
+
+In `genoray/_mutcat.py`, add `import pyarrow as pa` near the top imports, then add (placing `classify_variants` where the old one was):
+
+```python
+def _utf8_flat(s: "pl.Series") -> tuple[NDArray[np.uint8], NDArray[np.int64], NDArray[np.bool_]]:
+    """Zero-copy flat byte buffer + int64 offsets + not-null mask for a Utf8 series."""
+    arr = s.rechunk().to_arrow()
+    if isinstance(arr, pa.ChunkedArray):
+        arr = arr.combine_chunks()
+    assert arr.offset == 0
+    bufs = arr.buffers()
+    offsets = np.frombuffer(bufs[1], dtype=np.int64)[: len(s) + 1]
+    data = (
+        np.frombuffer(bufs[2], dtype=np.uint8)
+        if bufs[2] is not None
+        else np.empty(0, dtype=np.uint8)
+    )
+    not_null = s.is_not_null().to_numpy()
+    return data, offsets, not_null
+
+
+def classify_variants(index: "pl.DataFrame", reference: Reference) -> np.ndarray:
+    """Return an int16 array of intrinsic mutation codes, one per row of ``index``.
+
+    Vectorized: SNV->SBS-96 and native 2bp doublet->DBS-78 via numpy; indels->ID-83
+    via a parallel numba kernel. ``index`` must have columns CHROM, POS (1-based),
+    REF (str), ALT (List[str]; first used). POS is converted to 0-based internally.
+    """
+    n = index.height
+    out = np.full(n, SENTINELS["UNCLASSIFIED"], dtype=np.int16)
+    if n == 0:
+        return out
+
+    chrom = index["CHROM"].to_numpy()
+    pos0 = index["POS"].to_numpy().astype(np.int64) - 1  # 1-based -> 0-based
+    ref_data, ref_off, ref_nn = _utf8_flat(index["REF"])
+    alt_data, alt_off, alt_nn = _utf8_flat(index["ALT"].list.first())
+
+    rlen = (ref_off[1:] - ref_off[:-1]).astype(np.int64)
+    alen = (alt_off[1:] - alt_off[:-1]).astype(np.int64)
+    valid_row = ref_nn & alt_nn
+    snv_mask = valid_row & (rlen == 1) & (alen == 1)
+    dbs_mask = valid_row & (rlen == 2) & (alen == 2)
+    indel_mask = valid_row & (rlen != alen)
+
+    n_mismatch = 0
+    mismatch_examples: list[str] = []
+
+    uniq, inv = np.unique(chrom, return_inverse=True)
+    for gi, c in enumerate(uniq):
+        rows = np.nonzero(inv == gi)[0]
+        seq = reference.contig_array(str(c))
+
+        s_rows = rows[snv_mask[rows]]
+        if len(s_rows):
+            out[s_rows] = _sbs96_codes(
+                seq, pos0[s_rows], ref_data[ref_off[s_rows]], alt_data[alt_off[s_rows]]
+            )
+
+        d_rows = rows[dbs_mask[rows]]
+        if len(d_rows):
+            sr, sa = ref_off[d_rows], alt_off[d_rows]
+            out[d_rows] = _dbs78_codes(
+                ref_data[sr], ref_data[sr + 1], alt_data[sa], alt_data[sa + 1]
+            )
+
+        i_rows = rows[indel_mask[rows]]
+        if len(i_rows):
+            codes = _id83_codes_for_contig(
+                seq, pos0[i_rows],
+                ref_data, ref_off[i_rows], rlen[i_rows],
+                alt_data, alt_off[i_rows], alen[i_rows],
+            )
+            mm = codes == _REF_MISMATCH
+            if mm.any():
+                mm_rows = i_rows[mm]
+                n_mismatch += int(mm.sum())
+                for ri in mm_rows[:5]:
+                    if len(mismatch_examples) < 5:
+                        mismatch_examples.append(f"{chrom[ri]}:{int(pos0[ri]) + 1}")
+                codes = codes.copy()
+                codes[mm] = SENTINELS["UNCLASSIFIED"]
+            out[i_rows] = codes
+
+    if n_mismatch:
+        examples = ", ".join(mismatch_examples)
+        logger.warning(
+            f"{n_mismatch}/{n} deletions have REF disagreeing with the "
+            f"reference genome at their position (e.g. {examples}) — wrong reference "
+            "build? These were marked UNCLASSIFIED."
+        )
+
+    return out
+```
+
+- [ ] **Step 5: Run the differential and boundary tests**
+
+Run: `pixi run pytest tests/test_mutcat.py -k classify_variants -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full mutcat + calibration suite (no regressions)**
+
+Run: `pixi run pytest tests/test_mutcat.py tests/test_mutcat_calibration.py -v`
+Expected: PASS (existing calibration test still matches SigProfiler).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "perf(mutcat): vectorize classify_variants (SNV/DBS numpy, indel kernel)"
+```
+
+---
+
+## Task 6: Parallelize `_entry_codes_kernel`
+
+Each track writes only its own `[o_s, o_e)` slice, so the slot loop is race-free under `prange`.
+
+**Files:**
+- Modify: `genoray/_mutcat.py`
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing determinism test**
+
+Append to `tests/test_mutcat.py`:
+
+```python
+import numba as nb  # noqa: E402
+
+
+def test_entry_codes_thread_invariant():
+    rng = np.random.default_rng(5)
+    n_var = 200
+    var_code = rng.integers(0, 96, n_var).astype(np.int16)
+    var_pos = np.sort(rng.integers(0, 10_000, n_var)).astype(np.int64)
+    var_contig = np.zeros(n_var, np.int32)
+    var_is_snv = np.ones(n_var, np.bool_)
+    var_ref_b = np.frombuffer(b"ACGT", np.uint8)[rng.integers(0, 4, n_var)].copy()
+    var_alt_b = np.frombuffer(b"ACGT", np.uint8)[rng.integers(0, 4, n_var)].copy()
+    # 8 tracks over the variant indices
+    data = np.tile(np.arange(n_var, dtype=np.int32), 8)
+    offsets = (np.arange(9) * n_var).astype(np.int64)
+
+    args = (data, offsets, var_code, var_pos, var_contig, var_is_snv,
+            var_ref_b, var_alt_b)
+    prev = nb.get_num_threads()
+    try:
+        nb.set_num_threads(1)
+        a = build_entry_codes(*args)
+        nb.set_num_threads(max(2, prev))
+        b = build_entry_codes(*args)
+    finally:
+        nb.set_num_threads(prev)
+    assert np.array_equal(a, b)
+```
+
+- [ ] **Step 2: Run it to verify it passes single-threaded but with current serial kernel**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_entry_codes_thread_invariant -v`
+Expected: PASS even now (kernel is serial). This test is a guard for Step 3; keep it.
+
+- [ ] **Step 3: Add `prange` parallelism to `_entry_codes_kernel`**
+
+In `genoray/_mutcat.py`, change the decorator on `_entry_codes_kernel` (`:330`) from
+`@nb.njit(nogil=True, cache=True)` to `@nb.njit(parallel=True, nogil=True, cache=True)`,
+and change the outer loop
+`for slot in range(len(offsets) - 1):` to
+`for slot in nb.prange(len(offsets) - 1):`.
+Leave the inner `while j < o_e:` body unchanged.
+
+- [ ] **Step 4: Run the determinism test (now parallel)**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_entry_codes_thread_invariant -v`
+Expected: PASS — output identical across thread counts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "perf(mutcat): parallelize entry-code kernel over tracks"
+```
+
+---
+
+## Task 7: Parallelize `_count_kernel` over samples
+
+`prange` over slots would race when `ploidy > 1` (two slots share one sample row). Parallelize over **samples** so each thread owns a disjoint accumulator row.
+
+**Files:**
+- Modify: `genoray/_mutcat.py`
+- Test: `tests/test_mutcat.py`
+
+- [ ] **Step 1: Write the failing determinism test**
+
+Append to `tests/test_mutcat.py`:
+
+```python
+def test_count_matrix_thread_invariant():
+    rng = np.random.default_rng(9)
+    n_samples, ploidy = 6, 2
+    per_track = 50
+    n_slots = n_samples * ploidy
+    entry_codes = rng.integers(0, 96, n_slots * per_track).astype(np.int16)
+    offsets = (np.arange(n_slots + 1) * per_track).astype(np.int64)
+    names = [f"s{i}" for i in range(n_samples)]
+
+    from genoray._mutcat import count_matrix
+
+    prev = nb.get_num_threads()
+    try:
+        nb.set_num_threads(1)
+        a = count_matrix(entry_codes, offsets, ploidy, n_samples, names, "SBS96", False)
+        nb.set_num_threads(max(2, prev))
+        b = count_matrix(entry_codes, offsets, ploidy, n_samples, names, "SBS96", False)
+    finally:
+        nb.set_num_threads(prev)
+    assert a.equals(b)
+```
+
+- [ ] **Step 2: Run it to verify it passes with the current serial kernel**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_count_matrix_thread_invariant -v`
+Expected: PASS now (serial). Guard for Step 3.
+
+- [ ] **Step 3: Rewrite `_count_kernel` to parallelize over samples**
+
+In `genoray/_mutcat.py`, replace the `_count_kernel` body (`:422-448`) with:
+
+```python
+@nb.njit(parallel=True, nogil=True, cache=True)
+def _count_kernel(
+    data_codes: NDArray[np.int16],
+    offsets: NDArray[np.int64],
+    ploidy: np.int64,
+    n_samples: np.int64,
+    n_codes: np.int64,
+    per_sample: np.bool_,
+    out: NDArray[np.int64],
+) -> None:
+    """out[sample, code] accumulator over genotype entries.
+
+    Parallelized over samples: each thread owns a disjoint row of ``out``.
+    When ``per_sample`` is True, a code is counted at most once per sample.
+    """
+    for sample in nb.prange(n_samples):
+        for slot in range(sample * ploidy, (sample + 1) * ploidy):
+            o_s, o_e = offsets[slot], offsets[slot + 1]
+            for j in range(o_s, o_e):
+                code = data_codes[j]
+                if code < 0 or code >= n_codes:
+                    continue
+                if per_sample:
+                    out[sample, code] = 1
+                else:
+                    out[sample, code] += 1
+```
+
+- [ ] **Step 4: Run the determinism test (now parallel)**
+
+Run: `pixi run pytest tests/test_mutcat.py::test_count_matrix_thread_invariant -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add genoray/_mutcat.py tests/test_mutcat.py
+git commit -m "perf(mutcat): parallelize count kernel over samples"
+```
+
+---
+
+## Task 8: End-to-end determinism regression + full suite
+
+Confirm the whole `annotate_mutations` → `mutation_matrix` path is thread-count invariant and that nothing regressed.
+
+**Files:**
+- Test: `tests/test_svar_mutations.py`
+
+- [ ] **Step 1: Write the end-to-end determinism test**
+
+Add to `tests/test_svar_mutations.py` (reuse the file's existing fixtures for building an annotated `.svar`; mirror the construction used by the other tests there). The assertion:
+
+```python
+def test_mutation_matrix_thread_invariant(tmp_path):
+    import numba as nb
+
+    svar, ref = _build_annotated_svar(tmp_path)  # use this file's existing helper/fixture
+    prev = nb.get_num_threads()
+    try:
+        nb.set_num_threads(1)
+        svar.annotate_mutations(ref)
+        a = svar.mutation_matrix("SBS96")
+        nb.set_num_threads(max(2, prev))
+        svar.annotate_mutations(ref)
+        b = svar.mutation_matrix("SBS96")
+    finally:
+        nb.set_num_threads(prev)
+    assert a.equals(b)
+```
+
+If no shared helper exists in `tests/test_svar_mutations.py`, inline the same `.svar`-building steps already used by the nearest existing test in that file (do not invent a new fixture API).
+
+- [ ] **Step 2: Run it**
+
+Run: `pixi run pytest tests/test_svar_mutations.py::test_mutation_matrix_thread_invariant -v`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full affected suite**
+
+Run: `pixi run pytest tests/test_mutcat.py tests/test_mutcat_calibration.py tests/test_svar_mutations.py tests/test_reference.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Lint/format**
+
+Run: `pixi run ruff check genoray tests && pixi run ruff format genoray tests`
+Expected: clean (format may rewrite; re-stage if so).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_svar_mutations.py
+git commit -m "test(mutcat): end-to-end thread-invariance for mutation_matrix"
+```
+
+- [ ] **Step 6 (optional): Ad-hoc timing sanity check**
+
+On a large real `.svar`, time `annotate_mutations` before/after (compare against the `git` tag prior to Task 5). No committed benchmark; this is a manual confidence check only. Record the speedup in the PR description.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** SNV (Task 2), DBS (Task 3), ID-83 kernel (Task 4), per-contig vectorized dispatch + REF-mismatch warning + boundary handling (Task 5), `Reference.contig_array` (Task 1), entry-code parallelism (Task 6), count parallelism over samples (Task 7), oracle-based differential + codebook-arithmetic + determinism tests (Tasks 2–8). No public API or code-space change → no SKILL.md edit (matches spec).
+- **Oracle:** the current `classify_variants` is preserved verbatim as `_classify_variants_scalar`; the vectorized version is asserted equal to it on random ACGT mixes and at contig boundaries.
+- **Type consistency:** the kernel wrapper `_id83_codes_for_contig` takes `(seq, p0, ref_data, ref_s, ref_len, alt_data, alt_s, alt_len)`; both the Task-4 test and the Task-5 caller pass that exact tuple. `_sbs96_codes(seq, p0, ref_b, alt_b)` and `_dbs78_codes(ref_b0, ref_b1, alt_b0, alt_b1)` signatures match their call sites. LUT names `_ID1_CODE/_IDR_CODE/_IDM_CODE` and `_SUB_LUT` are consistent across definition, tests, and callers.

--- a/docs/superpowers/specs/2026-06-13-annotate-mutations-contig-scope-design.md
+++ b/docs/superpowers/specs/2026-06-13-annotate-mutations-contig-scope-design.md
@@ -1,0 +1,234 @@
+# Contig-scoped `annotate_mutations`: select contigs + a distinct NOT_ANNOTATED sentinel
+
+**Date:** 2026-06-13
+**Issue:** [#62](https://github.com/d-laub/genoray/issues/62)
+**Status:** Approved design (pending spec review)
+**Branches off:** `vectorize-mutation-matrices` (integrates with its per-contig
+`classify_variants` loop). Complements [#61](https://github.com/d-laub/genoray/issues/61).
+
+## Problem
+
+`SparseVar.annotate_mutations` classifies **every** variant in the index,
+all-or-nothing, and aborts the whole pass if any contig is absent from the
+reference. Real analyses are usually scoped to a contig subset — e.g. the 24
+nuclear contigs (`chr1..chr22, chrX, chrY`) — and want to deliberately leave
+mitochondrial, pseudoautosomal (`PAR1`/`PAR2`), and decoy/alt contigs out,
+without crashing and without conflating "not annotated" with "couldn't be
+classified."
+
+Concretely: a genome-wide SBS96 run on a 16,007-tumor `.svar` dies on
+`ValueError: Contig 'MT' not found in reference GRCh38.fa.` The `.svar` also
+carries `PAR1` (300,353 rows) and `PAR2` (39,747 rows), which no standard FASTA
+has a sequence for — so [#61](https://github.com/d-laub/genoray/issues/61)'s
+`MT`↔`chrM` naming fix alone cannot unblock them. An allowlist scoping the run
+to the nuclear contigs is the only clean fix.
+
+Two asks:
+
+1. **Let callers select which contigs to annotate.** Only listed contigs are
+   classified; entries on excluded contigs are marked with a dedicated sentinel
+   rather than triggering a reference fetch.
+2. **A distinct "not annotated" category + write-back metadata.** `UNCLASSIFIED`
+   means "we tried and it isn't a classifiable substitution" — semantically
+   different from "we chose not to annotate this contig." Use a separate
+   sentinel, and persist the annotation scope so a later open knows the `mutcat`
+   field is contig-scoped.
+
+## Design decisions
+
+### 1. New sentinel `NOT_ANNOTATED = -4`
+
+Add to `SENTINELS` in `genoray/_mutcat.py`:
+
+```python
+SENTINELS: dict[str, int] = {
+    "DBS_PARTNER": -1,    # 3' half of an adjacency doublet; never counted
+    "UNCLASSIFIED": -2,   # symbolic/complex/MNV>2bp/non-ACGT/ref-mismatch
+    "MISSING": -3,
+    "NOT_ANNOTATED": -4,  # entry on a contig excluded from the annotation scope
+}
+```
+
+The issue suggested `-3`, but `-3` is already `MISSING`; `-4` is the next free
+slot. Semantics: "entry on a contig deliberately left out of scope," distinct
+from `UNCLASSIFIED` ("tried, not a classifiable substitution"). Because it is
+negative, `NOT_ANNOTATED` is already excluded from every `mutation_matrix`
+count by the existing `code < 0` guard in `_count_kernel`
+(`genoray/_mutcat.py`) — no counting change is needed.
+
+### 2. `classify_variants(index, reference, contigs=None)`
+
+New keyword-or-positional parameter `contigs: list[str] | None = None`
+(`None` = all contigs, current behavior).
+
+In the vectorize branch, `classify_variants` already loops per contig:
+
+```python
+for contig in contigs present in the index:
+    seq  = reference.contig_array(contig)
+    rows = where(contig_code == contig)
+    ...
+```
+
+Contig scoping integrates at this seam:
+
+- Normalize the allowlist through the index's `ContigNormalizer` (so `chr1`/`1`
+  both match the index's naming scheme), producing the set of in-scope contig
+  ids and a per-row in-scope mask.
+- **Initialize `out`** to `NOT_ANNOTATED` for out-of-scope rows and
+  `UNCLASSIFIED` for in-scope rows. (In-scope but unclassifiable variants thus
+  stay `UNCLASSIFIED`; out-of-scope rows that are never visited stay
+  `NOT_ANNOTATED`.)
+- The per-contig loop iterates **only contigs in the allowlist**, so excluded
+  contigs are never fetched.
+- When `contigs is None`, behavior is identical to today: `out` initializes to
+  `UNCLASSIFIED` everywhere and all contigs are visited.
+
+**Bad allowlist entry** — a listed contig that, after normalization, matches no
+contig in the index (e.g. a typo `chr23`): emit **one aggregated loguru
+warning** naming the unmatched entries, then proceed annotating the contigs that
+did match. (Chosen over fail-fast: surfaces typos without aborting a long run.)
+
+**In-scope contig absent from the reference FASTA** — a listed contig present in
+the index but with no reference sequence (e.g. explicitly listing `MT` against a
+reference that lacks it): `reference.contig_array()` **raises** as today. You
+explicitly asked to annotate it, so a missing reference sequence is a real
+error. The documented way to avoid the crash is to not list the contig.
+
+### 3. `annotate_mutations(reference, *, contigs=None, write_back=True)`
+
+- Threads `contigs` through to `classify_variants`.
+- Computes the per-variant in-scope mask (same `ContigNormalizer`-based logic)
+  and applies `is_snv &= in_scope` before calling `build_entry_codes`. This is
+  required for correctness: the DBS adjacency override in `_entry_codes_kernel`
+  (`genoray/_mutcat.py:351`) fires only when both the variant and its neighbor
+  are `var_is_snv`. Without the mask, two adjacent **out-of-scope** SNVs would be
+  collapsed into a DBS code (and a `DBS_PARTNER`), overwriting their
+  `NOT_ANNOTATED` codes. Masking `is_snv` to in-scope leaves out-of-scope
+  variants as plain non-SNV broadcasts, so their `NOT_ANNOTATED` `var_code`
+  propagates unchanged to every entry.
+- On `write_back=True`, records the **normalized** annotated contig names in
+  metadata (see below).
+
+### 4. Metadata + version bump
+
+`SparseVarMetadata` (`genoray/_svar.py:461`) gains:
+
+```python
+mutcat_contigs: list[str] | None = None  # normalized contigs annotated; None = all
+```
+
+Backward-compatible (new field has a default; every existing construction site
+keeps working). When `annotate_mutations` writes back, it sets
+`mutcat_contigs` to the normalized list of contigs actually annotated, or `None`
+when `contigs is None`. A later `SparseVar(...)` open can then tell which
+contigs are `NOT_ANNOTATED` versus genuinely processed.
+
+Bump `MUTCAT_VERSION` from `2` to `3` (`genoray/_mutcat.py:151`): the on-disk
+`mutcat` semantics changed (new `NOT_ANNOTATED` sentinel + contig scoping).
+Reopening a `mutcat_version=2` file with `fields=["mutcat"]` triggers the
+existing staleness warning in `SparseVar.__init__`.
+
+### 5. Relationship to #61
+
+This spec resolves the underlying need behind #61's optional "skip/mark
+contigs absent from the reference" nicety — but via the **explicit allowlist**,
+not a separate auto-skip mode:
+
+- The allowlist is the sanctioned, intentional way to avoid the abort: scope to
+  the nuclear contigs and `MT`/`PAR1`/`PAR2` become `NOT_ANNOTATED`, never
+  fetched, no crash.
+- `contigs=None` stays **raise-on-absent**, consistent with the in-scope rule in
+  §2 ("if you asked for it and it's missing, that's a real error"). Adding an
+  auto-skip mode would contradict that principle and add a second behavior.
+- #61 proper remains narrowly the `chrM`↔`MT` **naming** fix (so a contig whose
+  sequence exists under another name resolves), which is a genuinely different
+  bug.
+
+### 6. Public API docs (required)
+
+Per `CLAUDE.md`, this PR updates `skills/genoray-api/SKILL.md`:
+
+- `annotate_mutations` signature gains `contigs=None`; document the allowlist
+  semantics, `ContigNormalizer` matching, the bad-entry warning, and the
+  in-scope-absent-from-reference raise.
+- Add the `NOT_ANNOTATED` sentinel to the sentinel/category documentation and
+  note that out-of-scope entries are excluded from `mutation_matrix` counts.
+- Document `mutcat_contigs` in the persisted-metadata description.
+
+## Architecture and data flow
+
+```
+annotate_mutations(reference, contigs=CONTIGS):
+    normalize CONTIGS via index ContigNormalizer -> in_scope contig set
+    warn about CONTIGS entries that match no index contig
+    var_code = classify_variants(index, reference, contigs=CONTIGS)
+        # out-of-scope rows -> NOT_ANNOTATED
+        # in-scope rows     -> SBS/DBS/ID code or UNCLASSIFIED
+        # raises if an in-scope contig is absent from the reference
+    is_snv = per-variant SNV mask & in_scope        # gate DBS adjacency
+    entry_codes = build_entry_codes(..., var_code, ..., is_snv, ...)
+    register in-memory field
+    if write_back:
+        memmap mutcat.npy <- entry_codes
+        metadata.fields["mutcat"] = "int16"
+        metadata.mutcat_version   = MUTCAT_VERSION   # 3
+        metadata.mutcat_contigs   = normalized list (or None)
+```
+
+`build_entry_codes`, `_entry_codes_kernel`, `count_matrix`, and `_count_kernel`
+are **unchanged** — out-of-scope handling lives entirely in `classify_variants`
+(code selection) and the `is_snv &= in_scope` gate (adjacency suppression).
+
+## Testing
+
+Extend `tests/test_svar_mutations.py` (and `tests/test_mutcat.py` for the
+`classify_variants` level where convenient):
+
+1. **Subset annotation** — `contigs=` listing a subset: variants on listed
+   contigs get real codes; entries on excluded contigs are `NOT_ANNOTATED`
+   (value `-4`), **not** `UNCLASSIFIED`; `mutation_matrix` counts are identical
+   to a run on a `.svar` that physically lacked the excluded contigs.
+2. **Normalization** — an allowlist given as `chr1` matches an index stored as
+   `1` (and vice versa).
+3. **Bad allowlist entry** — listing a contig absent from the index logs a
+   warning and the run still annotates the matching contigs.
+4. **In-scope contig absent from reference** — listing a contig that exists in
+   the index but not the reference raises (regression guard for the documented
+   behavior).
+5. **Adjacency suppression** — two adjacent out-of-scope SNVs are **not**
+   DBS-collapsed; both entries remain `NOT_ANNOTATED`.
+6. **Metadata round-trip** — `mutcat_contigs` persists and reloads;
+   `contigs=None` stores `None`.
+7. **Staleness** — a `mutcat_version=2` file reopened with `fields=["mutcat"]`
+   warns (existing mechanism, new version number).
+
+No reference-genome-free codebook changes; the existing oracle/differential
+tests in the vectorize branch are unaffected because `contigs=None` preserves
+element-for-element behavior.
+
+## Scope
+
+**In scope:** `contigs=` parameter on `annotate_mutations` and
+`classify_variants`; `NOT_ANNOTATED` sentinel; `mutcat_contigs` metadata;
+`MUTCAT_VERSION` bump to 3; `is_snv` adjacency gate; `SKILL.md` update; tests.
+
+**Out of scope:** auto-skip mode for `contigs=None` (see §5); the `chrM`↔`MT`
+naming fix (#61); `write_view` propagation of a scoped `mutcat`
+(`write_view` already never copies `mutcat` positionally); any change to the
+int16 code space, `build_entry_codes`, or the counting kernels.
+
+## Files
+
+- **Modify** `genoray/_mutcat.py` — add `NOT_ANNOTATED` to `SENTINELS`; bump
+  `MUTCAT_VERSION` to 3; add `contigs` param to `classify_variants` with
+  allowlist normalization, scoped per-contig loop, out-of-scope `NOT_ANNOTATED`
+  initialization, and the bad-entry warning.
+- **Modify** `genoray/_svar.py` — add `mutcat_contigs` to `SparseVarMetadata`;
+  add `contigs` param to `annotate_mutations`, compute the in-scope mask, gate
+  `is_snv`, thread `contigs` to `classify_variants`, and persist
+  `mutcat_contigs` on write-back.
+- **Modify** `skills/genoray-api/SKILL.md` — document `contigs=`,
+  `NOT_ANNOTATED`, and `mutcat_contigs`.
+- **Modify** `tests/test_svar_mutations.py` (and `tests/test_mutcat.py` as
+  needed) — the tests above.

--- a/docs/superpowers/specs/2026-06-13-mito-contig-aliasing-design.md
+++ b/docs/superpowers/specs/2026-06-13-mito-contig-aliasing-design.md
@@ -1,0 +1,98 @@
+# Mitochondrial contig aliasing in `ContigNormalizer`
+
+Fixes [#61](https://github.com/d-laub/genoray/issues/61).
+
+## Problem
+
+`ContigNormalizer` bridges the `chr`-prefix difference (`chr1` ↔ `1`) but does not
+treat all mitochondrial contig aliases as equivalent. The mito genome appears under
+several names in the wild — `MT` (Ensembl/GRCh38), `chrM` (UCSC), `M`, and `chrMT`.
+
+The existing `chr`-prefix logic already makes `M ↔ chrM` work (stripping `chr` from
+`chrM` yields `M`), but `MT` and `chrMT` resolve to `None`. Against a UCSC-named
+reference (`chrM`), an Ensembl-named `.svar` source (`MT`) crashes partway through
+annotation:
+
+```
+File ".../genoray/_mutcat.py", line 505, in classify_variants
+    five = reference.fetch(c, p - 1, p).tobytes()
+File ".../genoray/_reference.py", line 54, in _load_contig
+    raise ValueError(f"Contig {contig!r} not found in reference GRCh38.fa.")
+ValueError: Contig 'MT' not found in reference GRCh38.fa.
+```
+
+This is a common GRCh38 mix: GDC/Ensembl variant sources + a UCSC-named FASTA.
+
+## Fix
+
+Extend `ContigNormalizer.__init__` so the four spellings `{M, MT, chrM, chrMT}` are
+mutually equivalent. After building the existing `contig_map`, detect whether the
+reference contains a mito contig and, if so, map all four spellings to it.
+
+```python
+# module level
+_MITO_ALIASES = ("M", "MT", "chrM", "chrMT")
+
+# in __init__, merged AFTER the existing three dicts
+mito = next((c for c in self.contigs if c in _MITO_ALIASES), None)
+mito_map = {a: mito for a in _MITO_ALIASES} if mito is not None else {}
+self.contig_map = (
+    {f"{c[3:]}": c for c in contigs if c.startswith("chr")}
+    | {f"chr{c}": c for c in contigs if not c.startswith("chr")}
+    | {c: c for c in contigs}
+    | mito_map
+)
+```
+
+### Why this is sufficient
+
+`remapper`, the `HashTable` (`_c2dup`), and `dup2i` are all derived from
+`contig_map`. Adding entries there flows through to both `norm()` and `c_idxs()`
+automatically. No changes are needed in `_reference.py`, `_svar.py`, `_pgen.py`, or
+`_vcf.py`.
+
+### Behavior
+
+Reference contains `chrM`:
+
+| query   | current | desired |
+|---------|---------|---------|
+| `MT`    | `None`  | `chrM`  |
+| `chrMT` | `None`  | `chrM`  |
+| `M`     | `chrM`  | `chrM`  |
+| `chrM`  | `chrM`  | `chrM`  |
+
+Symmetric when the reference uses `MT` (all four → `MT`). If the reference has no
+mito contig, nothing changes — all four still resolve to `None`.
+
+### Degenerate input
+
+If a reference somehow contains more than one mito spelling, the aliases bind to the
+first one in contig order (`next(...)`). Deterministic and harmless.
+
+## Scope
+
+- **Exact spellings only.** Matching is against the literal set `{M, MT, chrM, chrMT}`,
+  mirroring the case-sensitive `chr`-prefix handling already in place. Lowercase
+  variants (`m`, `chrm`) are not handled.
+- **Out of scope:** coordinate-system differences, pseudo-contigs (`PAR1`/`PAR2`), and
+  the optional graceful-skip / `UNCLASSIFIED` handling for genuinely-absent contigs
+  (left for a separate issue).
+
+## Testing
+
+Add cases to `tests/test_utils.py` following the existing `pytest_cases`
+`contig_*` pattern consumed by `test_normalize_contig_name`:
+
+- `ContigNormalizer(["chr1", "chrM"])`: `MT`, `chrMT`, `M`, `chrM` → all `chrM`.
+- `ContigNormalizer(["1", "MT"])`: `M`, `chrM`, `chrMT`, `MT` → all `MT`.
+- No-mito reference (`["chr1", "chr2"]`): `MT` → `None`.
+
+Also update the stale docstring note at `_utils.py:21` which currently states the
+M/MT equivalence is not handled.
+
+## Documentation
+
+No public-API surface changes (`ContigNormalizer` is internal, `_utils.py`). No
+`skills/genoray-api/SKILL.md` update required. The fix only relaxes contig-name
+matching, which is already documented behavior.

--- a/docs/superpowers/specs/2026-06-13-vectorize-mutation-matrices-design.md
+++ b/docs/superpowers/specs/2026-06-13-vectorize-mutation-matrices-design.md
@@ -1,0 +1,227 @@
+# Vectorize / numba-ify SBS-96 / DBS-78 / ID-83 classification on SparseVar
+
+**Date:** 2026-06-13
+**Status:** Approved (pending spec review)
+
+## Goal
+
+Make `SparseVar.annotate_mutations` and `SparseVar.mutation_matrix` as fast as
+possible on huge files by removing the per-variant Python loop in
+`classify_variants` and parallelizing the existing entry-code and counting
+kernels. The mutation-classification *results* must match the current
+implementation on all common SBS/DBS/ID cases; rare/degenerate inputs
+(non-ACGT, MNV > 2 bp, symbolic) continue to map to `UNCLASSIFIED` as today.
+
+This is a performance refactor. The public surface — `annotate_mutations`,
+`mutation_matrix`, the int16 code space, the sentinels, and `classify_variants`'
+signature and return type — is unchanged, so `skills/genoray-api/SKILL.md`
+needs no API update.
+
+## Current state and bottleneck
+
+The pipeline behind `mutation_matrix` has three stages (`genoray/_mutcat.py`):
+
+1. `classify_variants(index, reference)` (`:478`) — a **pure-Python `for` loop
+   over every variant row**. Per variant it encodes REF/ALT strings, makes 1–2
+   `reference.fetch()` calls (SNV) or a window fetch (indel), and classifies via
+   string-formatting + dict lookups (`classify_sbs96` / `classify_dbs78` /
+   `classify_id83`). Scales with the number of variants.
+2. `build_entry_codes(...)` (`:392`) — broadcasts per-variant codes to per-entry
+   codes and applies the DBS adjacency override. Already `nb.njit`, single-thread.
+3. `count_matrix(...)` (`:451`) — per-sample accumulation into a
+   `(n_samples, N_CODES)` matrix. Already `nb.njit`, single-thread.
+
+Stage 1 is the dominant per-variant cost. Stages 2–3 scale with total sparse
+*entries* (samples × variants-per-sample), which dominate on many-sample files;
+they are already numba but single-threaded.
+
+All three stages are in scope.
+
+## Design decisions
+
+- **Approach: hybrid.** Vectorize the dominant context-free / fancy-index cases
+  (SNV → SBS-96, native 2 bp doublet → DBS-78) in plain numpy; isolate the one
+  genuinely sequential case (indel repeat/microhomology scan → ID-83) in a single
+  parallel numba kernel. Add `prange` to stages 2 and 3.
+- **Multi-threaded.** Numba kernels use `parallel=True` + `prange`. (No
+  thread-count knob in v1; callers control concurrency via `NUMBA_NUM_THREADS`.)
+- **Correctness contract:** element-for-element equal to the current
+  `classify_variants` on ACGT inputs across SNV/DBS/indel. The existing scalar
+  `classify_sbs96` / `classify_dbs78` / `classify_id83` are **retained as the
+  test oracle**, not deleted.
+- **Single-sourced codebooks:** all label→code mappings (SBS-96 arithmetic,
+  ID-83 lookup arrays) are derived once from the existing `SBS96` /
+  `ID83_INDEX` / `_DBS_TABLE` definitions and asserted equal in tests, so there
+  is no second hand-maintained copy of the codebook order.
+
+## Architecture and data flow
+
+`classify_variants(index, reference)` keeps its signature and return type
+(`int16[n_variants]`) and is reimplemented as:
+
+```
+classify_variants(index, reference):
+    pos        = index["POS"].to_numpy().astype(int32)   # 1-based (VCF)
+    ref_buf, ref_off = flat uint8 buffer + int32 offsets for REF
+    alt_buf, alt_off = flat uint8 buffer + int32 offsets for ALT.list.first()
+    contig_code = per-row contig id (equality semantics only)
+
+    rlen = ref_off[1:] - ref_off[:-1]
+    alen = alt_off[1:] - alt_off[:-1]
+    snv_mask   = (rlen == 1) & (alen == 1)
+    dbs_mask   = (rlen == 2) & (alen == 2)
+    indel_mask = (rlen != alen)          # anchored check inside the kernel
+
+    out = full(n_variants, UNCLASSIFIED, int16)
+    for contig in contigs present in the index:
+        seq = reference.contig_array(contig)             # uint8, loaded once
+        rows = where(contig_code == contig)
+        out[snv  rows] = _sbs96_vec(seq, pos, ref_buf/off, alt_buf/off)
+        out[dbs  rows] = _dbs78_vec(ref_buf/off, alt_buf/off)
+        out[indel rows] = _id83_kernel(seq, pos, ref_buf/off, alt_buf/off)
+    # REF-mismatch handling (deletions with n_rep == 0):
+    #   kernel returns _REF_MISMATCH sentinel; collect those rows, emit the
+    #   same aggregated loguru warning with chrom:pos examples, set UNCLASSIFIED
+    return out
+```
+
+REF/ALT are extracted as one flat `uint8` buffer + `int32` offsets via a
+vectorized Polars/numpy path (no per-row Python string list). The three masks
+are mutually exclusive; unmatched rows stay `UNCLASSIFIED` (MNV > 2 bp,
+symbolic, non-ACGT — same as today).
+
+`build_entry_codes` and `count_matrix` keep their interfaces; only their kernels
+change (stages 2–3 below).
+
+### Stage 1a — SNV → SBS-96 (vectorized numpy)
+
+For the SNV-masked rows on a contig, in one vectorized pass:
+
+```
+p     = pos[snv] - 1                       # 1-based → 0-based, int32
+ref_b = REF first byte ; alt_b = ALT first byte
+five  = seq[clip(p-1)] ; three = seq[clip(p+1)]   # gather; OOB → invalid
+r,a,f,t = BASE2IDX[ref_b], BASE2IDX[alt_b], BASE2IDX[five], BASE2IDX[three]
+valid = (r>=0)&(a>=0)&(f>=0)&(t>=0)&(r!=a) & in-bounds(p-1) & in-bounds(p+1)
+purine = (r in {A,G}) → r,a = comp(r),comp(a); f,t = comp(t),comp(f)   # vectorized
+sub_idx = SUB_LUT[r,a]                      # 4x4 → 0..5
+code    = sub_idx*16 + f*4 + t              # COSMIC order: sub outer, 5' next, 3' inner
+out[snv] = where(valid, code, UNCLASSIFIED)
+```
+
+- `BASE2IDX`: 256-entry LUT, `A/C/G/T → 0/1/2/3`, else `-1`.
+- `comp(x) = 3 - x` (A↔T, C↔G under the 0–3 encoding = exact complement).
+- `SUB_LUT`, the complement map, and the base LUT are module-level constants.
+- Contig-boundary variants (first/last base) → OOB flank → `valid=False` →
+  `UNCLASSIFIED`, matching today's `N`-padded fetch (`N ∉ _COMP`).
+- A test asserts `sub_idx*16 + f*4 + t == SBS96_INDEX[label]` for all 96 labels.
+
+### Stage 1b — DBS-78 native doublet (vectorized table lookup)
+
+Reuses the existing `_DBS_TABLE[r0,r1,a0,a1]` (built at import from the scalar
+`classify_dbs78`, inheriting fold/revcomp correctness). For `dbs_mask` rows:
+
+```
+r0,r1 = BASE2IDX[ref_byte0], BASE2IDX[ref_byte1]
+a0,a1 = BASE2IDX[alt_byte0], BASE2IDX[alt_byte1]
+valid = all >= 0
+out[dbs] = where(valid, _DBS_TABLE[r0,r1,a0,a1], UNCLASSIFIED)
+```
+
+Context-free; no sequence needed. Non-catalogue doublets already return
+`UNCLASSIFIED` from the table; `where` only guards LUT bounds for non-ACGT bytes.
+
+### Stage 1c — ID-83 indel kernel (numba, parallel)
+
+`@nb.njit(parallel=True, nogil=True, cache=True)`, `prange` over the indel subset
+on one contig. Inputs: the contig `seq` (uint8), `pos0` (0-based anchor), REF/ALT
+flat `uint8` buffers + `int32` offsets for the indel rows, and three precomputed
+code-lookup arrays derived once from `ID83_INDEX`:
+
+- `id1_code[kind, base, rep]` — 1 bp channel (kind∈{Del=0,Ins=1}, base∈{C=0,T=1}, rep 0–5)
+- `idR_code[kind, size_bucket, rep]` — ≥2 bp repeat channel (size bucket 2,3,4,5+)
+- `idM_code[size_bucket, mh]` — microhomology deletions
+
+Per indel the kernel reproduces `classify_id83` exactly:
+
+- Re-check anchor `ref[0]==alt[0]`; if not → `UNCLASSIFIED`.
+- `is_del = rlen > alen`; indel unit = `ref[1:]` (del) or `alt[1:]` (ins); validate
+  ACGT (else `UNCLASSIFIED`).
+- Count tandem repeats of the unit by scanning `seq` downstream from `p+1`;
+  reads past contig end simply stop matching (equivalent to today's `N`-padding).
+- For deletions, compute microhomology length (partial prefix match, capped per
+  size bucket).
+- 1 bp: purine→pyrimidine base fold; `is_del and n_rep==0` → `_REF_MISMATCH`;
+  else `rep = repeat_bucket(n_rep-1 if del else n_rep)`; `code = id1_code[...]`.
+- ≥2 bp: if `is_del` and `mh>0` and `n_rep<=1` → `idM_code[...]`; else
+  `is_del and n_rep==0` → `_REF_MISMATCH`; else `idR_code[...]`.
+
+After the kernel, Python collects rows equal to `_REF_MISMATCH`, emits the
+**same aggregated warning** (count + up to 5 `chrom:pos` examples) and sets them
+to `UNCLASSIFIED`. UX is unchanged from the current implementation.
+
+### Stage 2 — `build_entry_codes` parallelism
+
+Add `parallel=True` and `prange` over tracks (the `slot` loop). Each track writes
+only its own `[o_s, o_e)` range of `out`, so there are no write races. The DBS
+adjacency logic within a track is unchanged.
+
+### Stage 3 — `count_matrix` parallelism
+
+Parallelize over **samples** (not slots): each thread owns disjoint rows of the
+`(n_samples, N_CODES)` accumulator, so no atomics and no false sharing on the
+sample axis. A sample's slots are the contiguous `ploidy` slots
+`[sample*ploidy, (sample+1)*ploidy)`. Both `allele` and `sample` (presence) modes
+stay in the one kernel.
+
+## Reference access change
+
+Add `Reference.contig_array(contig) -> NDArray[uint8]` that returns the cached
+full-contig array (it already builds `_cur_seq` in `_load_contig`; this exposes
+it, preserving the one-contig-in-memory cache and `ContigNormalizer` behavior).
+The vectorized SNV gather and the ID-83 kernel read this array directly instead
+of per-variant `fetch()` calls. `fetch()` is retained for other callers and as
+the scalar oracle's backend.
+
+## Testing
+
+Oracle-based, exploiting the "common cases must match" contract:
+
+1. **Codebook arithmetic** — assert the SBS-96 arithmetic code equals
+   `SBS96_INDEX[label]` for all 96 labels, and the ID-83 lookup arrays equal
+   `ID83_INDEX` for every channel. No reference genome needed.
+2. **Differential / property tests** — synthetic reference + randomized
+   SNV/DBS/indel variants; assert the new `classify_variants` output equals the
+   old scalar path element-for-element on ACGT inputs. Extend
+   `tests/test_mutcat.py` and `tests/test_mutcat_calibration.py`; the scalar
+   `classify_sbs96/dbs78/id83` remain as the oracle.
+3. **Regression** — existing `tests/test_svar_mutations.py` (incl. the #59 POS
+   off-by-one and the deletion REF-mismatch warning) must pass unchanged; add a
+   contig-boundary variant case (first/last base of a contig).
+4. **Parallelism determinism** — results identical with `NUMBA_NUM_THREADS=1`
+   vs many, so threading cannot reorder or corrupt counts.
+
+No formal benchmark gate (consistent with repo convention — no existing perf
+harness). The plan includes an optional ad-hoc timing script on a large `.svar`
+to confirm the speedup.
+
+## Scope
+
+**In scope:** vectorize SNV/DBS classification, numba indel kernel, parallelize
+entry-code and count kernels, `Reference.contig_array`, oracle-based tests.
+
+**Out of scope:** changing the public API or code space; new context sizes
+(SBS-192/384, DBS-186); runs of ≥3 adjacent SNVs (still individual SBS, handled
+by the unchanged `build_entry_codes` adjacency logic); a thread-count API knob;
+a committed benchmark harness.
+
+## Files
+
+- **Modify** `genoray/_mutcat.py` — reimplement `classify_variants`; add
+  `_sbs96_vec`, `_dbs78_vec`, the ID-83 numba kernel and its derived lookup
+  arrays; add `parallel=True`/`prange` to `_entry_codes_kernel` and
+  `_count_kernel`. Keep scalar `classify_*` as oracle.
+- **Modify** `genoray/_reference.py` — add `contig_array`.
+- **Modify** `tests/test_mutcat.py`, `tests/test_mutcat_calibration.py`,
+  `tests/test_svar_mutations.py` — codebook, differential, regression,
+  determinism tests.

--- a/genoray/_utils.py
+++ b/genoray/_utils.py
@@ -15,10 +15,13 @@ from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 DTYPE = TypeVar("DTYPE", bound=np.generic)
 
+_MITO_ALIASES = ("M", "MT", "chrM", "chrMT")
+
 
 class ContigNormalizer:
     """Normalizes contig name(s) to match alternative naming schemes. For example, "chr1" to "1" or "1" to "chr1".
-    Note: this does not handle the special case of equivalence between M and MT.
+    Mitochondrial aliases {M, MT, chrM, chrMT} are treated as mutually equivalent and
+    resolve to whichever spelling the reference actually contains.
     """
 
     contigs: list[str]
@@ -26,10 +29,13 @@ class ContigNormalizer:
 
     def __init__(self, contigs: Iterable[str]):
         self.contigs = list(contigs)
+        mito = next((c for c in self.contigs if c in _MITO_ALIASES), None)
+        mito_map = {a: mito for a in _MITO_ALIASES} if mito is not None else {}
         self.contig_map = (
             {f"{c[3:]}": c for c in contigs if c.startswith("chr")}
             | {f"chr{c}": c for c in contigs if not c.startswith("chr")}
             | {c: c for c in contigs}
+            | mito_map
         )
         self.remapper = {k: self.contigs.index(c) for k, c in self.contig_map.items()}
         keys = np.array(list(self.remapper.keys()))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,34 @@ def contig_no_match():
     return unnormed, source, desired
 
 
+def contig_mito_mt_to_chrm():
+    unnormed = "MT"
+    source = ContigNormalizer(["chr1", "chrM"])
+    desired = "chrM"
+    return unnormed, source, desired
+
+
+def contig_mito_chrmt_to_chrm():
+    unnormed = "chrMT"
+    source = ContigNormalizer(["chr1", "chrM"])
+    desired = "chrM"
+    return unnormed, source, desired
+
+
+def contig_mito_chrm_to_mt():
+    unnormed = "chrM"
+    source = ContigNormalizer(["1", "MT"])
+    desired = "MT"
+    return unnormed, source, desired
+
+
+def contig_mito_absent():
+    unnormed = "MT"
+    source = ContigNormalizer(["chr1", "chr2"])
+    desired = None
+    return unnormed, source, desired
+
+
 def contig_list():
     unnormed = ["chr1", "1", "chr3"]
     source = ContigNormalizer(["chr1", "chr2"])


### PR DESCRIPTION
## Summary
- `ContigNormalizer` now treats the four mitochondrial contig spellings `{M, MT, chrM, chrMT}` as mutually equivalent, resolving any of them to whichever spelling the reference actually contains.
- Fixes the hard crash in `classify_variants`/`annotate_mutations` when an Ensembl-named `MT` variant is queried against a UCSC-named `chrM` reference (a common GRCh38 mix).
- Implementation is a single `mito_map` merged into `contig_map` in `ContigNormalizer.__init__`; `norm()` and `c_idxs()` pick it up automatically since both derive from `contig_map`.

Closes #61.

## Test Plan
- [x] `pixi run pytest tests/test_utils.py` — 4 new `contig_mito_*` cases (MT→chrM, chrMT→chrM, symmetric chrM→MT, and no-mito→None) pass alongside existing chr-prefix cases (39 passed)
- [x] `pixi run pytest tests/test_reference.py` passes (no regressions)

## Scope
Naming equivalence only. Exact spellings (case-sensitive), matching existing chr-prefix handling. Coordinate differences, pseudo-contigs (`PAR1`/`PAR2`), lowercase spellings, and the optional graceful-skip/`UNCLASSIFIED` feature are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)