### PR TITLE
Vectorize mutation-matrix classification + contig-scope NOT_ANNOTATED

### DIFF
--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -137,6 +137,7 @@ SENTINELS: dict[str, int] = {
     "DBS_PARTNER": -1,  # 3' half of an adjacency doublet; never counted
     "UNCLASSIFIED": -2,  # symbolic/complex/MNV>2bp/non-ACGT
     "MISSING": -3,
+    "NOT_ANNOTATED": -4,  # entry on a contig excluded from the annotation scope
 }
 
 # Internal boundary signal (NOT a public sentinel): a deletion whose deleted unit
@@ -149,7 +150,7 @@ SBS96_INDEX = {lbl: SBS96_OFFSET + i for i, lbl in enumerate(SBS96)}
 DBS78_INDEX = {lbl: DBS78_OFFSET + i for i, lbl in enumerate(DBS78)}
 ID83_INDEX = {lbl: ID83_OFFSET + i for i, lbl in enumerate(ID83)}
 
-MUTCAT_VERSION = 2
+MUTCAT_VERSION = 3
 
 _LABELS: dict[str, list[str]] = {"SBS96": SBS96, "DBS78": DBS78, "ID83": ID83}
 

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -758,19 +758,35 @@ def _utf8_flat(
     return data, offsets, not_null
 
 
-def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
+def classify_variants(
+    index: pl.DataFrame,
+    reference: Reference,
+    contigs: list[str] | None = None,
+) -> np.ndarray:
     """Return an int16 array of intrinsic mutation codes, one per row of ``index``.
 
     Vectorized: SNV->SBS-96 and native 2bp doublet->DBS-78 via numpy; indels->ID-83
     via a parallel numba kernel. ``index`` must have columns CHROM, POS (1-based),
     REF (str), ALT (List[str]; first used). POS is converted to 0-based internally.
+
+    ``contigs`` restricts annotation to the listed contigs (names must match the
+    index ``CHROM`` naming scheme exactly; the caller normalizes them). Rows on
+    contigs outside the allowlist are set to ``NOT_ANNOTATED`` and their contigs
+    are never fetched. ``None`` (default) annotates all contigs.
     """
     n = index.height
-    out = np.full(n, SENTINELS["UNCLASSIFIED"], dtype=np.int16)
+    chrom = index["CHROM"].to_numpy()
+    if contigs is None:
+        scope: set[str] | None = None
+        out = np.full(n, SENTINELS["UNCLASSIFIED"], dtype=np.int16)
+    else:
+        scope = set(map(str, contigs))
+        in_scope = np.array([str(c) in scope for c in chrom], dtype=np.bool_)
+        out = np.where(
+            in_scope, SENTINELS["UNCLASSIFIED"], SENTINELS["NOT_ANNOTATED"]
+        ).astype(np.int16)
     if n == 0:
         return out
-
-    chrom = index["CHROM"].to_numpy()
     pos0 = index["POS"].to_numpy().astype(np.int64) - 1  # 1-based -> 0-based
     ref_data, ref_off, ref_nn = _utf8_flat(index["REF"])
     alt_data, alt_off, alt_nn = _utf8_flat(index["ALT"].list.first())
@@ -788,6 +804,8 @@ def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
 
     uniq, inv = np.unique(chrom, return_inverse=True)
     for gi, c in enumerate(uniq):
+        if scope is not None and str(c) not in scope:
+            continue
         rows = np.nonzero(inv == gi)[0]
         seq = reference.contig_array(str(c))
 

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -344,6 +344,24 @@ def _sbs96_codes(
     return np.where(valid, code, _UNCL)
 
 
+def _dbs78_codes(
+    ref_b0: NDArray[np.uint8],
+    ref_b1: NDArray[np.uint8],
+    alt_b0: NDArray[np.uint8],
+    alt_b1: NDArray[np.uint8],
+) -> NDArray[np.int16]:
+    """DBS-78 codes for native 2bp doublets (context-free table lookup)."""
+    r0 = _BASE2IDX[ref_b0]
+    r1 = _BASE2IDX[ref_b1]
+    a0 = _BASE2IDX[alt_b0]
+    a1 = _BASE2IDX[alt_b1]
+    valid = (r0 >= 0) & (r1 >= 0) & (a0 >= 0) & (a1 >= 0)
+    code = _DBS_TABLE[
+        np.clip(r0, 0, 3), np.clip(r1, 0, 3), np.clip(a0, 0, 3), np.clip(a1, 0, 3)
+    ]
+    return np.where(valid, code, _UNCL)
+
+
 def _build_dbs_table() -> np.ndarray:
     """tbl[r0, r1, a0, a1] -> DBS-78 code or UNCLASSIFIED for doublets not in
     the (folded) catalogue. Bases encoded A=0,C=1,G=2,T=3."""

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -307,6 +307,42 @@ def _microhomology_len(indel: bytes, downstream: bytes, ilen: int) -> int:
 _BASE2IDX = np.full(256, -1, dtype=np.int64)
 _BASE2IDX[[ord("A"), ord("C"), ord("G"), ord("T")]] = [0, 1, 2, 3]
 
+# (ref_idx, alt_idx) -> SBS substitution index 0..5, for pyrimidine-folded refs.
+# _SBS_SUBS order: C>A, C>G, C>T, T>A, T>C, T>G  (encoding A=0,C=1,G=2,T=3)
+_SUB_LUT = np.full((4, 4), -1, dtype=np.int64)
+for _si, _sub in enumerate(_SBS_SUBS):
+    _SUB_LUT[_BASE2IDX[ord(_sub[0])], _BASE2IDX[ord(_sub[2])]] = _si
+
+_UNCL = np.int16(SENTINELS["UNCLASSIFIED"])
+
+
+def _sbs96_codes(
+    seq: NDArray[np.uint8],
+    p0: NDArray[np.int64],
+    ref_b: NDArray[np.uint8],
+    alt_b: NDArray[np.uint8],
+) -> NDArray[np.int16]:
+    """SBS-96 codes for SNVs on one contig. ``p0`` is the 0-based REF position."""
+    n = len(seq)
+    r = _BASE2IDX[ref_b]
+    a = _BASE2IDX[alt_b]
+    fpos = p0 - 1
+    tpos = p0 + 1
+    in_f = (fpos >= 0) & (fpos < n)
+    in_t = (tpos >= 0) & (tpos < n)
+    f = _BASE2IDX[seq[np.clip(fpos, 0, n - 1)]]
+    t = _BASE2IDX[seq[np.clip(tpos, 0, n - 1)]]
+    valid = (r >= 0) & (a >= 0) & (f >= 0) & (t >= 0) & (r != a) & in_f & in_t
+    purine = (r == 0) | (r == 2)  # A or G
+    rr = np.where(purine, 3 - r, r)
+    aa = np.where(purine, 3 - a, a)
+    # flanks swap and complement when folding: new 5' = comp(old 3'), new 3' = comp(old 5')
+    ff = np.where(purine, 3 - t, f)
+    tt = np.where(purine, 3 - f, t)
+    sub = _SUB_LUT[np.clip(rr, 0, 3), np.clip(aa, 0, 3)]
+    code = (sub * 16 + ff * 4 + tt).astype(np.int16)
+    return np.where(valid, code, _UNCL)
+
 
 def _build_dbs_table() -> np.ndarray:
     """tbl[r0, r1, a0, a1] -> DBS-78 code or UNCLASSIFIED for doublets not in

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -362,6 +362,156 @@ def _dbs78_codes(
     return np.where(valid, code, _UNCL)
 
 
+def _build_id83_luts() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    u = SENTINELS["UNCLASSIFIED"]
+    id1 = np.full((2, 2, 6), u, dtype=np.int16)  # [kind(Del,Ins), base(C,T), rep]
+    idr = np.full((2, 4, 6), u, dtype=np.int16)  # [kind, size_bucket(2..5), rep]
+    idm = np.full((4, 6), u, dtype=np.int16)  # [size_bucket(2..5), mh]
+    for ki, k in enumerate(("Del", "Ins")):
+        for bi, b in enumerate(("C", "T")):
+            for r in range(6):
+                id1[ki, bi, r] = ID83_INDEX[f"1:{k}:{b}:{r}"]
+        for si, s in enumerate(("2", "3", "4", "5")):
+            for r in range(6):
+                idr[ki, si, r] = ID83_INDEX[f"{s}:{k}:R:{r}"]
+    for si, (s, cap) in enumerate((("2", 1), ("3", 2), ("4", 3), ("5", 5))):
+        for m in range(1, cap + 1):
+            idm[si, m] = ID83_INDEX[f"{s}:Del:M:{m}"]
+    return id1, idr, idm
+
+
+_ID1_CODE, _IDR_CODE, _IDM_CODE = _build_id83_luts()
+_MH_CAP = np.array([1, 2, 3, 5], dtype=np.int64)  # by size bucket 2,3,4,5
+
+
+@nb.njit(parallel=True, nogil=True, cache=True)
+def _id83_kernel(
+    seq: NDArray[np.uint8],
+    p0: NDArray[np.int64],
+    ref_data: NDArray[np.uint8],
+    ref_s: NDArray[np.int64],
+    ref_len: NDArray[np.int64],
+    alt_data: NDArray[np.uint8],
+    alt_s: NDArray[np.int64],
+    alt_len: NDArray[np.int64],
+    base2idx: NDArray[np.int64],
+    id1: NDArray[np.int16],
+    idr: NDArray[np.int16],
+    idm: NDArray[np.int16],
+    mh_cap: NDArray[np.int64],
+    uncl: np.int16,
+    ref_mismatch: np.int16,
+    out: NDArray[np.int16],
+) -> None:
+    n = len(seq)
+    for k in nb.prange(len(p0)):  # type: ignore[misc]
+        rs, asz = ref_s[k], alt_s[k]
+        rl, al = ref_len[k], alt_len[k]
+        if rl == 0 or al == 0 or ref_data[rs] != alt_data[asz]:
+            out[k] = uncl
+            continue
+        is_del = rl > al
+        if is_del:
+            buf, us, ilen = ref_data, rs + 1, rl - 1
+        else:
+            buf, us, ilen = alt_data, asz + 1, al - 1
+        ok = True
+        for i in range(ilen):
+            if base2idx[buf[us + i]] < 0:
+                ok = False
+                break
+        if not ok:
+            out[k] = uncl
+            continue
+        # count tandem repeats of the unit downstream from p0+1
+        scan = p0[k] + 1
+        n_rep = 0
+        i = 0
+        while scan + i + ilen <= n:
+            match = True
+            for j in range(ilen):
+                if seq[scan + i + j] != buf[us + j]:
+                    match = False
+                    break
+            if not match:
+                break
+            n_rep += 1
+            i += ilen
+        if ilen == 1:
+            bi = base2idx[buf[us]]
+            if bi == 0 or bi == 2:  # A or G -> fold to pyrimidine partner
+                bi = 3 - bi
+            base_idx = 0 if bi == 1 else 1  # C->0, T->1
+            if is_del and n_rep == 0:
+                out[k] = ref_mismatch
+                continue
+            rep = n_rep - 1 if is_del else n_rep
+            if rep > 5:
+                rep = 5
+            out[k] = id1[0 if is_del else 1, base_idx, rep]
+            continue
+        sb = ilen if ilen < 5 else 5
+        si = sb - 2  # 0..3
+        if is_del:
+            mh = 0
+            for kk in range(1, ilen):
+                eq = True
+                for j in range(kk):
+                    if scan + j >= n or seq[scan + j] != buf[us + j]:
+                        eq = False
+                        break
+                if eq:
+                    mh = kk
+            if mh > 0 and n_rep <= 1:
+                cap = mh_cap[si]
+                m = mh if mh < cap else cap
+                out[k] = idm[si, m]
+                continue
+            if n_rep == 0:
+                out[k] = ref_mismatch
+                continue
+            rep = n_rep - 1
+        else:
+            rep = n_rep
+        if rep > 5:
+            rep = 5
+        out[k] = idr[0 if is_del else 1, si, rep]
+
+
+def _id83_codes_for_contig(
+    seq: NDArray[np.uint8],
+    p0: NDArray[np.int64],
+    ref_data: NDArray[np.uint8],
+    ref_s: NDArray[np.int64],
+    ref_len: NDArray[np.int64],
+    alt_data: NDArray[np.uint8],
+    alt_s: NDArray[np.int64],
+    alt_len: NDArray[np.int64],
+) -> NDArray[np.int16]:
+    """ID-83 codes for indels on one contig. May return ``_REF_MISMATCH``
+    entries, which the caller maps to UNCLASSIFIED with a warning."""
+    out = np.empty(len(p0), dtype=np.int16)
+    _id83_kernel(
+        np.ascontiguousarray(seq),
+        np.ascontiguousarray(p0),
+        np.ascontiguousarray(ref_data),
+        np.ascontiguousarray(ref_s),
+        np.ascontiguousarray(ref_len),
+        np.ascontiguousarray(alt_data),
+        np.ascontiguousarray(alt_s),
+        np.ascontiguousarray(alt_len),
+        _BASE2IDX,
+        _ID1_CODE,
+        _IDR_CODE,
+        _IDM_CODE,
+        _MH_CAP,
+        np.int16(SENTINELS["UNCLASSIFIED"]),
+        np.int16(_REF_MISMATCH),
+        out,
+    )
+    return out
+
+
 def _build_dbs_table() -> np.ndarray:
     """tbl[r0, r1, a0, a1] -> DBS-78 code or UNCLASSIFIED for doublets not in
     the (folded) catalogue. Bases encoded A=0,C=1,G=2,T=3."""

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 import numba as nb
 import numpy as np
 import polars as pl
+import pyarrow as pa
 from loguru import logger
 from numpy.typing import NDArray
 
@@ -679,7 +680,7 @@ def count_matrix(
     return pl.DataFrame(out)
 
 
-def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
+def _classify_variants_scalar(index: pl.DataFrame, reference: Reference) -> np.ndarray:
     """Return an int16 array of intrinsic mutation codes, one per row of ``index``.
 
     ``index`` must have columns CHROM, POS (1-based int, VCF convention), REF
@@ -731,6 +732,104 @@ def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
         examples = ", ".join(mismatch_examples)
         logger.warning(
             f"{n_mismatch}/{index.height} deletions have REF disagreeing with the "
+            f"reference genome at their position (e.g. {examples}) — wrong reference "
+            "build? These were marked UNCLASSIFIED."
+        )
+
+    return out
+
+
+def _utf8_flat(
+    s: "pl.Series",
+) -> tuple[NDArray[np.uint8], NDArray[np.int64], NDArray[np.bool_]]:
+    """Zero-copy flat byte buffer + int64 offsets + not-null mask for a Utf8 series."""
+    arr = s.rechunk().to_arrow()
+    if isinstance(arr, pa.ChunkedArray):
+        arr = arr.combine_chunks()
+    assert arr.offset == 0
+    bufs = arr.buffers()
+    offsets = np.frombuffer(bufs[1], dtype=np.int64)[: len(s) + 1]
+    data = (
+        np.frombuffer(bufs[2], dtype=np.uint8)
+        if bufs[2] is not None
+        else np.empty(0, dtype=np.uint8)
+    )
+    not_null = s.is_not_null().to_numpy()
+    return data, offsets, not_null
+
+
+def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
+    """Return an int16 array of intrinsic mutation codes, one per row of ``index``.
+
+    Vectorized: SNV->SBS-96 and native 2bp doublet->DBS-78 via numpy; indels->ID-83
+    via a parallel numba kernel. ``index`` must have columns CHROM, POS (1-based),
+    REF (str), ALT (List[str]; first used). POS is converted to 0-based internally.
+    """
+    n = index.height
+    out = np.full(n, SENTINELS["UNCLASSIFIED"], dtype=np.int16)
+    if n == 0:
+        return out
+
+    chrom = index["CHROM"].to_numpy()
+    pos0 = index["POS"].to_numpy().astype(np.int64) - 1  # 1-based -> 0-based
+    ref_data, ref_off, ref_nn = _utf8_flat(index["REF"])
+    alt_data, alt_off, alt_nn = _utf8_flat(index["ALT"].list.first())
+
+    rlen = (ref_off[1:] - ref_off[:-1]).astype(np.int64)
+    alen = (alt_off[1:] - alt_off[:-1]).astype(np.int64)
+    valid_row = ref_nn & alt_nn
+    snv_mask = valid_row & (rlen == 1) & (alen == 1)
+    dbs_mask = valid_row & (rlen == 2) & (alen == 2)
+    indel_mask = valid_row & (rlen != alen)
+
+    n_mismatch = 0
+    mismatch_examples: list[str] = []
+
+    uniq, inv = np.unique(chrom, return_inverse=True)
+    for gi, c in enumerate(uniq):
+        rows = np.nonzero(inv == gi)[0]
+        seq = reference.contig_array(str(c))
+
+        s_rows = rows[snv_mask[rows]]
+        if len(s_rows):
+            out[s_rows] = _sbs96_codes(
+                seq, pos0[s_rows], ref_data[ref_off[s_rows]], alt_data[alt_off[s_rows]]
+            )
+
+        d_rows = rows[dbs_mask[rows]]
+        if len(d_rows):
+            sr, sa = ref_off[d_rows], alt_off[d_rows]
+            out[d_rows] = _dbs78_codes(
+                ref_data[sr], ref_data[sr + 1], alt_data[sa], alt_data[sa + 1]
+            )
+
+        i_rows = rows[indel_mask[rows]]
+        if len(i_rows):
+            codes = _id83_codes_for_contig(
+                seq,
+                pos0[i_rows],
+                ref_data,
+                ref_off[i_rows],
+                rlen[i_rows],
+                alt_data,
+                alt_off[i_rows],
+                alen[i_rows],
+            )
+            mm = codes == _REF_MISMATCH
+            if mm.any():
+                mm_rows = i_rows[mm]
+                n_mismatch += int(mm.sum())
+                for ri in mm_rows[:5]:
+                    if len(mismatch_examples) < 5:
+                        mismatch_examples.append(f"{chrom[ri]}:{int(pos0[ri]) + 1}")
+                codes = codes.copy()
+                codes[mm] = SENTINELS["UNCLASSIFIED"]
+            out[i_rows] = codes
+
+    if n_mismatch:
+        examples = ", ".join(mismatch_examples)
+        logger.warning(
+            f"{n_mismatch}/{n} deletions have REF disagreeing with the "
             f"reference genome at their position (e.g. {examples}) — wrong reference "
             "build? These were marked UNCLASSIFIED."
         )

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -781,6 +781,7 @@ def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
     snv_mask = valid_row & (rlen == 1) & (alen == 1)
     dbs_mask = valid_row & (rlen == 2) & (alen == 2)
     indel_mask = valid_row & (rlen != alen)
+    n_indel = int(indel_mask.sum())
 
     n_mismatch = 0
     mismatch_examples: list[str] = []
@@ -829,7 +830,7 @@ def classify_variants(index: pl.DataFrame, reference: Reference) -> np.ndarray:
     if n_mismatch:
         examples = ", ".join(mismatch_examples)
         logger.warning(
-            f"{n_mismatch}/{n} deletions have REF disagreeing with the "
+            f"{n_mismatch}/{n_indel} deletions have REF disagreeing with the "
             f"reference genome at their position (e.g. {examples}) — wrong reference "
             "build? These were marked UNCLASSIFIED."
         )

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -624,7 +624,7 @@ def build_entry_codes(
     return out
 
 
-@nb.njit(nogil=True, cache=True)
+@nb.njit(parallel=True, nogil=True, cache=True)
 def _count_kernel(
     data_codes: NDArray[np.int16],
     offsets: NDArray[np.int64],
@@ -636,21 +636,20 @@ def _count_kernel(
 ) -> None:
     """out[sample, code] accumulator over genotype entries.
 
-    ``data_codes`` is the per-entry int16 code array (aligned to genos.data).
+    Parallelized over samples: each thread owns a disjoint row of ``out``.
     When ``per_sample`` is True, a code is counted at most once per sample.
     """
-    for slot in range(len(offsets) - 1):
-        sample = slot // ploidy
-        o_s, o_e = offsets[slot], offsets[slot + 1]
-        for j in range(o_s, o_e):
-            code = data_codes[j]
-            if code < 0 or code >= n_codes:
-                continue
-            if per_sample:
-                if out[sample, code] == 0:
+    for sample in nb.prange(n_samples):  # type: ignore[misc]
+        for slot in range(sample * ploidy, (sample + 1) * ploidy):
+            o_s, o_e = offsets[slot], offsets[slot + 1]
+            for j in range(o_s, o_e):
+                code = data_codes[j]
+                if code < 0 or code >= n_codes:
+                    continue
+                if per_sample:
                     out[sample, code] = 1
-            else:
-                out[sample, code] += 1
+                else:
+                    out[sample, code] += 1
 
 
 def count_matrix(

--- a/genoray/_mutcat.py
+++ b/genoray/_mutcat.py
@@ -532,7 +532,7 @@ _DBS_TABLE = _build_dbs_table()
 _DBS_PARTNER = SENTINELS["DBS_PARTNER"]
 
 
-@nb.njit(nogil=True, cache=True)
+@nb.njit(parallel=True, nogil=True, cache=True)
 def _entry_codes_kernel(
     data: NDArray[np.int32],
     offsets: NDArray[np.int64],
@@ -546,7 +546,7 @@ def _entry_codes_kernel(
     out: NDArray[np.int16],
     dbs_partner: np.int16,
 ):
-    for slot in range(len(offsets) - 1):
+    for slot in nb.prange(len(offsets) - 1):  # type: ignore[misc]
         o_s, o_e = offsets[slot], offsets[slot + 1]
         j = o_s
         while j < o_e:

--- a/genoray/_reference.py
+++ b/genoray/_reference.py
@@ -59,6 +59,14 @@ class Reference:
         assert self._cur_seq is not None
         return self._cur_seq
 
+    def contig_array(self, contig: str) -> NDArray[np.uint8]:
+        """Return the full contig sequence as a cached uint8 array.
+
+        Accepts ``chr``-prefixed or unprefixed names. One contig is held in
+        memory at a time (shared with :meth:`fetch`).
+        """
+        return self._load_contig(contig)
+
     def fetch(self, contig: str, start: int, end: int) -> NDArray[np.uint8]:
         """Return reference bytes for 0-based half-open ``[start, end)``.
 

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -465,6 +465,7 @@ class SparseVarMetadata(BaseModel):
     contigs: list[str]
     fields: dict[str, str] = {}  # field_name -> numpy dtype name (e.g. "float32")
     mutcat_version: int | None = None  # set when annotate_mutations has run
+    mutcat_contigs: list[str] | None = None  # normalized contigs annotated; None = all
 
 
 _SRT = TypeVar("_SRT")

--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -1473,6 +1473,7 @@ class SparseVar(Generic[_SRT]):
         self,
         reference: "Reference | str | Path",
         *,
+        contigs: "list[str] | None" = None,
         write_back: bool = True,
     ) -> None:
         """Classify every variant into SBS-96 / DBS-78 / ID-83 channels and store
@@ -1486,6 +1487,15 @@ class SparseVar(Generic[_SRT]):
         reference
             Reference genome.  A :class:`~genoray._reference.Reference` instance,
             or a path to a FASTA file (with a ``.fai`` index alongside it).
+        contigs
+            If given, only variants on these contigs are classified; entries on
+            all other contigs are marked ``NOT_ANNOTATED`` and their contigs are
+            never fetched from the reference.  Names are matched via the
+            :class:`~genoray._utils.ContigNormalizer` (so ``chr1``/``1`` both
+            work).  Requested contigs absent from the ``.svar`` index are skipped
+            with a warning.  A listed contig present in the index but absent from
+            the reference still raises (use the allowlist to exclude it instead).
+            ``None`` (default) classifies all contigs.
         write_back
             If ``True`` (default), persist ``mutcat.npy`` and update
             ``metadata.json`` on disk so that subsequent ``SparseVar(...)``
@@ -1499,8 +1509,25 @@ class SparseVar(Generic[_SRT]):
         if not isinstance(reference, Reference):
             reference = Reference.from_path(reference)
 
-        # 1. intrinsic per-variant codes
-        var_code = classify_variants(self.index, reference)
+        # 0. resolve contig scope
+        index_chroms = self.index["CHROM"].to_list()
+        if contigs is None:
+            scoped_contigs: "list[str] | None" = None
+            in_scope = np.ones(self.index.height, dtype=np.bool_)
+        else:
+            normalized = self._c_norm.norm(list(contigs))
+            unmatched = [c for c, nm in zip(contigs, normalized) if nm is None]
+            if unmatched:
+                logger.warning(
+                    f"annotate_mutations: {len(unmatched)} requested contig(s) not "
+                    f"found in the .svar index; they will be skipped: {unmatched}"
+                )
+            scope_set = {nm for nm in normalized if nm is not None}
+            scoped_contigs = sorted(scope_set)
+            in_scope = np.array([c in scope_set for c in index_chroms], dtype=np.bool_)
+
+        # 1. intrinsic per-variant codes (scoped)
+        var_code = classify_variants(self.index, reference, contigs=scoped_contigs)
 
         # 2. per-variant arrays needed by the adjacency kernel
         pos = self.index["POS"].to_numpy().astype(np.int64)
@@ -1513,6 +1540,8 @@ class SparseVar(Generic[_SRT]):
             ],
             dtype=np.bool_,
         )
+        # gate adjacency: out-of-scope variants must not be collapsed into DBS
+        is_snv &= in_scope
         # contig id per variant — equality semantics only (same contig ↔ same id)
         contig_map = {c: i for i, c in enumerate(self.contigs)}
         contig_codes = np.array(
@@ -1557,6 +1586,7 @@ class SparseVar(Generic[_SRT]):
                 meta = SparseVarMetadata.model_validate_json(f.read())
             meta.fields["mutcat"] = "int16"
             meta.mutcat_version = MUTCAT_VERSION
+            meta.mutcat_contigs = scoped_contigs
             with open(self.path / "metadata.json", "w") as f:
                 f.write(meta.model_dump_json())
 

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -35,7 +35,7 @@ Prefer reading these over guessing:
 - `genoray/_pgen.py` — `PGEN` class: constructor, `read`, `chunk`, `read_ranges`, `chunk_ranges`, mode constants near the top of the class
 - `genoray/_svar.py` — `SparseVar`: `__init__`, `from_vcf`, `from_pgen`, `read_ranges`, `with_fields`, `annotate_mutations`, `mutation_matrix`, `assign_signatures`
 - `genoray/_signatures.py` — `cosmic_signatures`, `fit_signatures`
-- `genoray/_reference.py` — `Reference`: `from_path`, `fetch`
+- `genoray/_reference.py` — `Reference`: `from_path`, `fetch`, `contig_array`
 - `genoray/exprs.py` — the *complete* set of pre-built filter expressions (currently 7: `is_snp`, `is_indel`, `is_biallelic`, `is_symbolic`, `is_breakend`, `is_imprecise`, `ILEN`)
 
 When a signature, kwarg, or shape is unclear, **read the docstring in the
@@ -288,6 +288,7 @@ Key properties:
 
 - `from_path(fasta, contigs=None)` — `fasta` is a `str | Path`; auto-calls `pysam.faidx` if the `.fai` index is missing. `contigs` filters which contigs the caller cares about (defaults to all in the FASTA).
 - `fetch(contig, start, end)` — 0-based half-open `[start, end)`. Positions outside the contig are N-padded. Returns `NDArray[np.uint8]`.
+- `contig_array(contig)` — the full contig sequence as a cached `NDArray[np.uint8]`. Shares the one-contig-in-memory cache with `fetch`. Accepts `chr`-prefixed or unprefixed names.
 - Contig-name agnostic: `"chr1"` and `"1"` both resolve correctly (`ContigNormalizer` under the hood).
 - One contig is cached in memory at a time; sequential per-contig access is efficient.
 

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -313,10 +313,19 @@ svar.annotate_mutations(ref, write_back=False) # in-memory only; not persisted
 svar.annotate_mutations("hg38.fa")             # path accepted directly
 ```
 
-Signature: `annotate_mutations(reference, *, write_back=True) -> None`
+Signature: `annotate_mutations(reference, *, contigs=None, write_back=True) -> None`
 
 - `reference` — a `genoray.Reference` instance **or** a path to a FASTA file
   (auto-wraps via `Reference.from_path`).
+- `contigs=None` — if given (a list of contig names), only variants on those
+  contigs are classified; entries on all other contigs are marked
+  `NOT_ANNOTATED` (sentinel `-4`) and their contigs are never fetched from the
+  reference. Names match via the `ContigNormalizer` (`chr1`/`1` both work).
+  Requested contigs absent from the `.svar` index are skipped with a warning; a
+  listed contig present in the index but absent from the reference raises (omit
+  it from the list to exclude it cleanly). `None` (default) classifies all
+  contigs. When `write_back=True`, the normalized scope is recorded in
+  `metadata.json` as `mutcat_contigs` (`None` = all).
 - `write_back=True` — persists `mutcat.npy` and updates `metadata.json` so
   that subsequent `SparseVar(dir, fields=["mutcat"])` opens will see the field.
   **Note:** `write_view` **never** copies `mutcat` positionally to the output
@@ -337,6 +346,7 @@ What it classifies:
 | Native 2 bp MNV in the VCF | DBS-78 |
 | MNV > 2 bp, symbolic, non-ACGT | UNCLASSIFIED |
 | Insertion / deletion | ID-83 (size, repeat-context bucketing) |
+| Variant on a contig outside `contigs=` | `NOT_ANNOTATED` (excluded from all matrices) |
 
 ### `SparseVar.mutation_matrix`
 
@@ -373,6 +383,7 @@ Signature: `mutation_matrix(kind, *, count="allele") -> pl.DataFrame`
 | `-1` | `DBS_PARTNER` — 3' half of an adjacent SNV pair; never counted |
 | `-2` | `UNCLASSIFIED` — symbolic / complex / MNV > 2 bp / non-ACGT |
 | `-3` | `MISSING` — reserved sentinel (defined in the code space but not emitted by `annotate_mutations` v1; SparseVar stores only ALT-carrying entries, so no-call slots do not appear in the ragged field) |
+| `-4` | `NOT_ANNOTATED` — entry on a contig outside the `contigs=` annotation scope; never counted |
 
 To read a previously annotated file:
 

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -13,6 +13,7 @@ from genoray._mutcat import (
     SENTINELS,
     SBS96_INDEX,
     _REF_MISMATCH,
+    _dbs78_codes,
     _sbs96_codes,
     build_entry_codes,
     classify_dbs78,
@@ -358,3 +359,24 @@ def test_sbs96_codes_match_scalar_on_random_snvs():
             five, bytes(ref_b[i : i + 1]), bytes(alt_b[i : i + 1]), three
         )
         assert got[i] == exp, (i, five, ref_b[i], alt_b[i], three)
+
+
+def test_dbs78_codes_match_scalar():
+    bases = b"ACGT"
+    ref0, ref1, alt0, alt1, exp = [], [], [], [], []
+    for r0 in bases:
+        for r1 in bases:
+            for a0 in bases:
+                for a1 in bases:
+                    ref0.append(r0)
+                    ref1.append(r1)
+                    alt0.append(a0)
+                    alt1.append(a1)
+                    exp.append(classify_dbs78(bytes([r0, r1]), bytes([a0, a1])))
+    got = _dbs78_codes(
+        np.array(ref0, np.uint8),
+        np.array(ref1, np.uint8),
+        np.array(alt0, np.uint8),
+        np.array(alt1, np.uint8),
+    )
+    assert list(got) == exp

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -27,6 +27,7 @@ from genoray._mutcat import (
     classify_sbs96,
     classify_variants,
     code_ranges,
+    count_matrix,
 )
 from genoray._reference import Reference
 
@@ -552,3 +553,23 @@ def test_entry_codes_thread_invariant():
     finally:
         nb.set_num_threads(prev)
     assert np.array_equal(a, b)
+
+
+def test_count_matrix_thread_invariant():
+    rng = np.random.default_rng(9)
+    n_samples, ploidy = 6, 2
+    per_track = 50
+    n_slots = n_samples * ploidy
+    entry_codes = rng.integers(0, 96, n_slots * per_track).astype(np.int16)
+    offsets = (np.arange(n_slots + 1) * per_track).astype(np.int64)
+    names = [f"s{i}" for i in range(n_samples)]
+
+    prev = nb.get_num_threads()
+    try:
+        nb.set_num_threads(1)
+        a = count_matrix(entry_codes, offsets, ploidy, n_samples, names, "SBS96", False)
+        nb.set_num_threads(max(2, prev))
+        b = count_matrix(entry_codes, offsets, ploidy, n_samples, names, "SBS96", False)
+    finally:
+        nb.set_num_threads(prev)
+    assert a.equals(b)

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -583,3 +583,34 @@ def test_not_annotated_sentinel_and_version():
     assert len(set(SENTINELS.values())) == len(SENTINELS)
     # on-disk semantics changed -> version bumped
     assert MUTCAT_VERSION == 3
+
+
+def test_classify_variants_contig_scope(tmp_path):
+    import pysam
+    import polars as pl
+    from genoray._reference import Reference
+    from genoray._mutcat import classify_variants, SENTINELS
+
+    # two contigs; chr2 is a valid SNV that WOULD classify if in scope
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\nACGTACGTAC\n>chr2\nACGTACGTAC\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+
+    index = pl.DataFrame(
+        {
+            "CHROM": ["chr1", "chr2"],
+            "POS": np.array([2, 2], dtype=np.int32),  # 1-based; 0-based idx 1 -> REF=C
+            "REF": ["C", "C"],
+            "ALT": [["A"], ["A"]],
+        }
+    )
+
+    # scope to chr1 only: chr2 must be NOT_ANNOTATED, chr1 must be classified
+    out = classify_variants(index, ref, contigs=["chr1"])
+    assert out[0] >= 0  # chr1 classified to a real SBS code
+    assert out[1] == SENTINELS["NOT_ANNOTATED"]
+
+    # contigs=None -> both classified (unchanged behavior)
+    out_all = classify_variants(index, ref, contigs=None)
+    assert out_all[0] >= 0 and out_all[1] >= 0

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -573,3 +573,13 @@ def test_count_matrix_thread_invariant():
     finally:
         nb.set_num_threads(prev)
     assert a.equals(b)
+
+
+def test_not_annotated_sentinel_and_version():
+    from genoray._mutcat import SENTINELS, MUTCAT_VERSION
+
+    # distinct from the existing sentinels and from MISSING (-3)
+    assert SENTINELS["NOT_ANNOTATED"] == -4
+    assert len(set(SENTINELS.values())) == len(SENTINELS)
+    # on-disk semantics changed -> version bumped
+    assert MUTCAT_VERSION == 3

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numba as nb
 import numpy as np
 import polars as pl
 
@@ -517,3 +518,37 @@ def test_classify_variants_contig_boundary(tmp_path):
     got = classify_variants(index, ref)
     exp = _classify_variants_scalar(index, ref)
     assert list(got) == list(exp) == [SENTINELS["UNCLASSIFIED"]] * 2
+
+
+def test_entry_codes_thread_invariant():
+    rng = np.random.default_rng(5)
+    n_var = 200
+    var_code = rng.integers(0, 96, n_var).astype(np.int16)
+    var_pos = np.sort(rng.integers(0, 10_000, n_var)).astype(np.int64)
+    var_contig = np.zeros(n_var, np.int32)
+    var_is_snv = np.ones(n_var, np.bool_)
+    var_ref_b = np.frombuffer(b"ACGT", np.uint8)[rng.integers(0, 4, n_var)].copy()
+    var_alt_b = np.frombuffer(b"ACGT", np.uint8)[rng.integers(0, 4, n_var)].copy()
+    # 8 tracks over the variant indices
+    data = np.tile(np.arange(n_var, dtype=np.int32), 8)
+    offsets = (np.arange(9) * n_var).astype(np.int64)
+
+    args = (
+        data,
+        offsets,
+        var_code,
+        var_pos,
+        var_contig,
+        var_is_snv,
+        var_ref_b,
+        var_alt_b,
+    )
+    prev = nb.get_num_threads()
+    try:
+        nb.set_num_threads(1)
+        a = build_entry_codes(*args)
+        nb.set_num_threads(max(2, prev))
+        b = build_entry_codes(*args)
+    finally:
+        nb.set_num_threads(prev)
+    assert np.array_equal(a, b)

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -19,6 +19,7 @@ from genoray._mutcat import (
     _dbs78_codes,
     _id83_codes_for_contig,
     _sbs96_codes,
+    _classify_variants_scalar,
     build_entry_codes,
     classify_dbs78,
     classify_id83,
@@ -449,3 +450,70 @@ def test_id83_kernel_matches_scalar_random():
     for i in range(len(refs)):
         exp = classify_id83(int(p0[i]), refs[i], alts[i], fetch)
         assert got[i] == exp, (i, refs[i], alts[i], int(p0[i]), got[i], exp)
+
+
+def _random_index_and_ref(tmp_path, rng):
+    import pysam
+
+    seq = "".join(rng.choice(list("ACGT"), size=300))
+    fa = tmp_path / "ref.fa"
+    fa.write_text(f">chr1\n{seq}\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+
+    chrom, pos, refs, alts = [], [], [], []
+    for _ in range(400):
+        p = int(rng.integers(2, len(seq) - 8))  # 0-based interior
+        kind = rng.integers(0, 4)
+        anchor = seq[p]
+        if kind == 0:  # SNV
+            alt = rng.choice([b for b in "ACGT" if b != anchor])
+            refs.append(anchor)
+            alts.append(alt)
+        elif kind == 1:  # native doublet
+            refs.append(seq[p : p + 2])
+            alts.append("".join(rng.choice(list("ACGT"), 2)))
+        elif kind == 2:  # deletion
+            size = int(rng.integers(1, 4))
+            refs.append(seq[p : p + 1 + size])
+            alts.append(anchor)
+        else:  # insertion
+            size = int(rng.integers(1, 4))
+            refs.append(anchor)
+            alts.append(anchor + "".join(rng.choice(list("ACGT"), size)))
+        chrom.append("chr1")
+        pos.append(p + 1)  # store 1-based
+
+    index = pl.DataFrame(
+        {"CHROM": chrom, "POS": pos, "REF": refs, "ALT": [[a] for a in alts]}
+    )
+    return index, ref
+
+
+def test_classify_variants_matches_scalar(tmp_path):
+    rng = np.random.default_rng(123)
+    index, ref = _random_index_and_ref(tmp_path, rng)
+    got = classify_variants(index, ref)
+    exp = _classify_variants_scalar(index, ref)
+    assert list(got) == list(exp)
+
+
+def test_classify_variants_contig_boundary(tmp_path):
+    import pysam
+
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\nACGT\n")
+    pysam.faidx(str(fa))
+    ref = Reference.from_path(fa)
+    # SNV at first and last base: no 5'/3' flank -> UNCLASSIFIED, matching scalar
+    index = pl.DataFrame(
+        {
+            "CHROM": ["chr1", "chr1"],
+            "POS": [1, 4],
+            "REF": ["A", "T"],
+            "ALT": [["C"], ["G"]],
+        }
+    )
+    got = classify_variants(index, ref)
+    exp = _classify_variants_scalar(index, ref)
+    assert list(got) == list(exp) == [SENTINELS["UNCLASSIFIED"]] * 2

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -12,8 +12,12 @@ from genoray._mutcat import (
     SBS96,
     SENTINELS,
     SBS96_INDEX,
+    _ID1_CODE,
+    _IDM_CODE,
+    _IDR_CODE,
     _REF_MISMATCH,
     _dbs78_codes,
+    _id83_codes_for_contig,
     _sbs96_codes,
     build_entry_codes,
     classify_dbs78,
@@ -380,3 +384,68 @@ def test_dbs78_codes_match_scalar():
         np.array(alt1, np.uint8),
     )
     assert list(got) == exp
+
+
+def test_id83_luts_match_index():
+    for ki, k in enumerate(("Del", "Ins")):
+        for bi, b in enumerate(("C", "T")):
+            for r in range(6):
+                assert _ID1_CODE[ki, bi, r] == ID83_INDEX[f"1:{k}:{b}:{r}"]
+        for si, s in enumerate(("2", "3", "4", "5")):
+            for r in range(6):
+                assert _IDR_CODE[ki, si, r] == ID83_INDEX[f"{s}:{k}:R:{r}"]
+    for si, s in enumerate(("2", "3", "4", "5")):
+        cap = {"2": 1, "3": 2, "4": 3, "5": 5}[s]
+        for m in range(1, cap + 1):
+            assert _IDM_CODE[si, m] == ID83_INDEX[f"{s}:Del:M:{m}"]
+
+
+def test_id83_kernel_matches_scalar_random():
+    # Build a random contig and a set of indels; compare to classify_id83.
+    rng = np.random.default_rng(7)
+    bases = b"ACGT"
+    seq = np.frombuffer(
+        bytes(np.frombuffer(bases, np.uint8)[rng.integers(0, 4, 400)]), np.uint8
+    )
+
+    def fetch(s, e, _seq=seq):
+        out = np.full(e - s, ord("N"), np.uint8)
+        a, b = max(s, 0), min(e, len(_seq))
+        if b > a:
+            out[a - s : b - s] = _seq[a:b]
+        return bytes(out)
+
+    refs, alts, p0s = [], [], []
+    for _ in range(300):
+        p = int(rng.integers(2, len(seq) - 10))
+        anchor = bytes(seq[p : p + 1])
+        size = int(rng.integers(1, 5))
+        unit = bytes(np.frombuffer(bases, np.uint8)[rng.integers(0, 4, size)])
+        if rng.random() < 0.5:  # deletion
+            refs.append(anchor + unit)
+            alts.append(anchor)
+        else:  # insertion
+            refs.append(anchor)
+            alts.append(anchor + unit)
+        p0s.append(p)
+
+    # flat buffers for the kernel
+    ref_data = np.frombuffer(b"".join(refs), np.uint8)
+    alt_data = np.frombuffer(b"".join(alts), np.uint8)
+    ref_off = np.concatenate(([0], np.cumsum([len(r) for r in refs]))).astype(np.int64)
+    alt_off = np.concatenate(([0], np.cumsum([len(a) for a in alts]))).astype(np.int64)
+    p0 = np.array(p0s, np.int64)
+
+    got = _id83_codes_for_contig(
+        seq,
+        p0,
+        ref_data,
+        ref_off[:-1],
+        (ref_off[1:] - ref_off[:-1]),
+        alt_data,
+        alt_off[:-1],
+        (alt_off[1:] - alt_off[:-1]),
+    )
+    for i in range(len(refs)):
+        exp = classify_id83(int(p0[i]), refs[i], alts[i], fetch)
+        assert got[i] == exp, (i, refs[i], alts[i], int(p0[i]), got[i], exp)

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -322,3 +322,41 @@ def test_id83_insertion_no_repeat_not_mismatch():
 
     code = classify_id83(pos=0, ref=b"C", alt=b"CG", fetch=fetch)
     assert code != _REF_MISMATCH
+
+
+from genoray._mutcat import _sbs96_codes  # noqa: E402
+
+
+def test_sbs96_arithmetic_matches_codebook():
+    # The vectorized substitution LUT + arithmetic must reproduce SBS96_INDEX
+    # for every one of the 96 labels (pyrimidine-folded form, no boundary issues).
+    from genoray._mutcat import _BASE2IDX, _SUB_LUT, _BASES, _SBS_SUBS
+
+    for sub_idx, sub in enumerate(_SBS_SUBS):
+        r_char, a_char = sub[0], sub[2]
+        r, a = _BASE2IDX[ord(r_char)], _BASE2IDX[ord(a_char)]
+        assert _SUB_LUT[r, a] == sub_idx
+        for five_idx, five in enumerate(_BASES):
+            for three_idx, three in enumerate(_BASES):
+                label = f"{five}[{sub}]{three}"
+                code = sub_idx * 16 + five_idx * 4 + three_idx
+                assert code == SBS96_INDEX[label]
+
+
+def test_sbs96_codes_match_scalar_on_random_snvs():
+    rng = np.random.default_rng(0)
+    bases = np.frombuffer(b"ACGT", np.uint8)
+    n = 500
+    seq = np.frombuffer(bytes(bases[rng.integers(0, 4, 200)]), np.uint8)
+    # interior positions only so flanks exist
+    p0 = rng.integers(1, len(seq) - 1, n).astype(np.int64)
+    ref_b = seq[p0].copy()  # ref must equal reference base is NOT required by classify,
+    alt_b = bases[rng.integers(0, 4, n)].copy()
+    got = _sbs96_codes(seq, p0, ref_b, alt_b)
+    for i in range(n):
+        five = bytes(seq[p0[i] - 1 : p0[i]])
+        three = bytes(seq[p0[i] + 1 : p0[i] + 2])
+        exp = classify_sbs96(
+            five, bytes(ref_b[i : i + 1]), bytes(alt_b[i : i + 1]), three
+        )
+        assert got[i] == exp, (i, five, ref_b[i], alt_b[i], three)

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -13,6 +13,7 @@ from genoray._mutcat import (
     SENTINELS,
     SBS96_INDEX,
     _REF_MISMATCH,
+    _sbs96_codes,
     build_entry_codes,
     classify_dbs78,
     classify_id83,
@@ -324,9 +325,6 @@ def test_id83_insertion_no_repeat_not_mismatch():
     assert code != _REF_MISMATCH
 
 
-from genoray._mutcat import _sbs96_codes  # noqa: E402
-
-
 def test_sbs96_arithmetic_matches_codebook():
     # The vectorized substitution LUT + arithmetic must reproduce SBS96_INDEX
     # for every one of the 96 labels (pyrimidine-folded form, no boundary issues).
@@ -350,7 +348,7 @@ def test_sbs96_codes_match_scalar_on_random_snvs():
     seq = np.frombuffer(bytes(bases[rng.integers(0, 4, 200)]), np.uint8)
     # interior positions only so flanks exist
     p0 = rng.integers(1, len(seq) - 1, n).astype(np.int64)
-    ref_b = seq[p0].copy()  # ref must equal reference base is NOT required by classify,
+    ref_b = seq[p0].copy()  # use the actual reference base as REF
     alt_b = bases[rng.integers(0, 4, n)].copy()
     got = _sbs96_codes(seq, p0, ref_b, alt_b)
     for i in range(n):

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pysam
 import pytest
 
@@ -41,3 +42,21 @@ def test_fetch_right_oob_pads_with_N(tiny_fasta):
     # chr1 has 10 bases; positions 8,9 = "AC", then 2 N pads
     seq = ref.fetch("chr1", 8, 12)
     assert bytes(seq) == b"ACNN"
+
+
+def _write_fasta(path, seq, contig="chr1"):
+    path.write_text(f">{contig}\n{seq}\n")
+    pysam.faidx(str(path))
+
+
+def test_contig_array_matches_fetch(tmp_path):
+    fa = tmp_path / "ref.fa"
+    _write_fasta(fa, "ACGTACGTAC")
+    ref = Reference.from_path(fa)
+    arr = ref.contig_array("chr1")
+    assert isinstance(arr, np.ndarray) and arr.dtype == np.uint8
+    assert bytes(arr) == b"ACGTACGTAC"
+    # equals fetch over the full span
+    assert bytes(ref.fetch("chr1", 0, 10)) == bytes(arr)
+    # chr-prefix normalization still works
+    assert bytes(ref.contig_array("1")) == b"ACGTACGTAC"

--- a/tests/test_svar_mutations.py
+++ b/tests/test_svar_mutations.py
@@ -480,3 +480,17 @@ def test_classify_variants_snv_context_uses_pos_minus_one(tmp_path):
     three = seq[p0 + 1].encode()
     expected = classify_sbs96(five, b"G", b"A", three)
     assert int(codes[0]) == expected
+
+
+def test_metadata_has_mutcat_contigs_default():
+    from genoray._svar import SparseVarMetadata
+
+    m = SparseVarMetadata(samples=["s0"], ploidy=1, contigs=["chr1"])
+    assert m.mutcat_contigs is None
+    # round-trips through JSON
+    m2 = SparseVarMetadata.model_validate_json(
+        SparseVarMetadata(
+            samples=["s0"], ploidy=1, contigs=["chr1"], mutcat_contigs=["chr1"]
+        ).model_dump_json()
+    )
+    assert m2.mutcat_contigs == ["chr1"]

--- a/tests/test_svar_mutations.py
+++ b/tests/test_svar_mutations.py
@@ -427,6 +427,34 @@ def test_issue59_deletion_no_longer_crashes(tmp_path):
     assert len(id83_codes) == 1
 
 
+def test_mutation_matrix_thread_invariant(tmp_path):
+    import numba as nb
+
+    # Inline the same construction used by the annotated_svar fixture.
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\nACGTACGTAC\n")
+    pysam.faidx(str(fa))
+    svar_dir = tmp_path / "tiny.svar"
+    _build_tiny_svar(svar_dir)
+    ref = Reference.from_path(fa)
+
+    prev = nb.get_num_threads()
+    try:
+        nb.set_num_threads(1)
+        svar = SparseVar(svar_dir)
+        svar.annotate_mutations(ref, write_back=True)
+        a = SparseVar(svar_dir, fields=["mutcat"]).mutation_matrix("SBS96")
+
+        nb.set_num_threads(max(2, prev))
+        svar2 = SparseVar(svar_dir)
+        svar2.annotate_mutations(ref, write_back=True)
+        b = SparseVar(svar_dir, fields=["mutcat"]).mutation_matrix("SBS96")
+    finally:
+        nb.set_num_threads(prev)
+
+    assert a.equals(b), "mutation_matrix('SBS96') differs between 1 and >=2 threads"
+
+
 def test_classify_variants_snv_context_uses_pos_minus_one(tmp_path):
     import polars as pl
 

--- a/tests/test_svar_mutations.py
+++ b/tests/test_svar_mutations.py
@@ -494,3 +494,171 @@ def test_metadata_has_mutcat_contigs_default():
         ).model_dump_json()
     )
     assert m2.mutcat_contigs == ["chr1"]
+
+
+# ---------------------------------------------------------------------------
+# contig-scope tests (Task 4)
+# ---------------------------------------------------------------------------
+
+
+def _build_two_contig_svar(path):
+    """chr1 has the 3-SNV tiny layout; chr2 carries one adjacent SNV pair.
+
+    Variants (1-based POS): chr1@2, chr1@3, chr1@9, chr2@2, chr2@3.
+    chr2@2 and chr2@3 are adjacent SNVs on sample 0's single haplotype.
+    """
+    from genoray._svar import SparseVarMetadata, _write_genos
+    from seqpro.rag import Ragged
+
+    path.mkdir(parents=True)
+    index = pl.DataFrame(
+        {
+            "CHROM": ["chr1", "chr1", "chr1", "chr2", "chr2"],
+            "POS": np.array([2, 3, 9, 2, 3], dtype=np.int32),
+            "REF": ["C", "G", "A", "C", "G"],
+            "ALT": [["A"], ["T"], ["C"], ["A"], ["T"]],
+            "ILEN": pl.Series([[0]] * 5, dtype=pl.List(pl.Int32)),
+        }
+    )
+    index.write_ipc(path / "index.arrow")
+    # sample 0 carries chr1@2, chr1@3 (var 0,1) and chr2@2, chr2@3 (var 3,4);
+    # sample 1 carries chr1@9 (var 2). ploidy 1 -> 2 tracks.
+    data = np.array([0, 1, 3, 4, 2], dtype=np.int32)
+    offsets = np.array([0, 4, 5], dtype=np.int64)  # n_samples*ploidy + 1 = 3
+    genos = Ragged.from_offsets(data, (2, 1, None), offsets)
+    _write_genos(path, genos)
+    with open(path / "metadata.json", "w") as f:
+        f.write(
+            SparseVarMetadata(
+                version=1, samples=["s0", "s1"], ploidy=1, contigs=["chr1", "chr2"]
+            ).model_dump_json()
+        )
+
+
+def _two_contig_ref(tmp_path):
+    fa = tmp_path / "ref.fa"
+    fa.write_text(">chr1\nACGTACGTAC\n>chr2\nACGTACGTAC\n")
+    pysam.faidx(str(fa))
+    return Reference.from_path(fa)
+
+
+def test_annotate_scope_marks_excluded_not_annotated(tmp_path):
+    from genoray._mutcat import SENTINELS
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(
+        _two_contig_ref(tmp_path), contigs=["chr1"], write_back=True
+    )
+
+    mut = svar.fields["mutcat"]
+    # data order matches genos: [chr1@2, chr1@3, chr2@2, chr2@3, chr1@9]
+    flat = mut.data
+    assert flat[2] == SENTINELS["NOT_ANNOTATED"]
+    assert flat[3] == SENTINELS["NOT_ANNOTATED"]
+    # chr1 entries are NOT NOT_ANNOTATED (classified or DBS)
+    assert flat[0] != SENTINELS["NOT_ANNOTATED"]
+
+
+def test_annotate_scope_excludes_from_matrix(tmp_path):
+    """A scoped run's SBS96 matrix equals an all-contig run on a chr1-only svar."""
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(
+        _two_contig_ref(tmp_path), contigs=["chr1"], write_back=False
+    )
+    sbs = svar.mutation_matrix("SBS96", count="allele")
+    # chr2's SNVs contribute nothing; totals come only from chr1 isolated SNV(s)
+    assert sbs.height == 96
+    # chr1@9 (sample 1) is an isolated SNV -> exactly one SBS event total
+    total = sum(sbs[c].sum() for c in ["s0", "s1"])
+    assert total == 1  # chr1@2,@3 collapse to DBS (not SBS); chr2 excluded
+
+
+def test_annotate_scope_normalizes_contig_names(tmp_path):
+    """Allowlist given without 'chr' prefix still matches a chr-prefixed index."""
+    from genoray._mutcat import SENTINELS
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    # index uses 'chr1'/'chr2'; pass '1' -> should match chr1
+    svar.annotate_mutations(_two_contig_ref(tmp_path), contigs=["1"], write_back=False)
+    flat = svar.fields["mutcat"].data
+    assert flat[2] == SENTINELS["NOT_ANNOTATED"]  # chr2 excluded
+    assert flat[0] != SENTINELS["NOT_ANNOTATED"]  # chr1 annotated
+
+
+def test_annotate_scope_warns_on_unmatched_contig(tmp_path):
+    # loguru bypasses stdlib logging so caplog doesn't work; use a loguru sink instead.
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    messages = []
+    sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        svar.annotate_mutations(
+            _two_contig_ref(tmp_path), contigs=["chr1", "chrZ"], write_back=False
+        )
+    finally:
+        logger.remove(sink_id)
+    assert any("chrZ" in m for m in messages), messages
+
+
+def test_annotate_scope_adjacent_oos_snvs_not_dbs(tmp_path):
+    """chr2's adjacent SNV pair, when out of scope, is NOT collapsed to DBS."""
+    from genoray._mutcat import SENTINELS
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(
+        _two_contig_ref(tmp_path), contigs=["chr1"], write_back=False
+    )
+    flat = svar.fields["mutcat"].data
+    # both chr2 entries are NOT_ANNOTATED; neither is a DBS code or DBS_PARTNER
+    assert flat[2] == SENTINELS["NOT_ANNOTATED"]
+    assert flat[3] == SENTINELS["NOT_ANNOTATED"]
+    assert flat[3] != SENTINELS["DBS_PARTNER"]
+
+
+def test_annotate_scope_persists_mutcat_contigs(tmp_path):
+    from genoray._svar import SparseVarMetadata
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(
+        _two_contig_ref(tmp_path), contigs=["chr1"], write_back=True
+    )
+    with open(d / "metadata.json", "rb") as f:
+        meta = SparseVarMetadata.model_validate_json(f.read())
+    assert meta.mutcat_contigs == ["chr1"]
+    assert meta.mutcat_version == 3
+
+
+def test_annotate_no_scope_persists_none(tmp_path):
+    from genoray._svar import SparseVarMetadata
+
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    svar.annotate_mutations(_two_contig_ref(tmp_path), write_back=True)
+    with open(d / "metadata.json", "rb") as f:
+        meta = SparseVarMetadata.model_validate_json(f.read())
+    assert meta.mutcat_contigs is None
+
+
+def test_annotate_inscope_contig_absent_from_reference_raises(tmp_path):
+    """Listing a contig present in the index but absent from the reference raises."""
+    d = tmp_path / "two.svar"
+    _build_two_contig_svar(d)
+    svar = SparseVar(d)
+    # reference has only chr1; chr2 is in scope but unfetchable
+    fa = tmp_path / "ref1.fa"
+    fa.write_text(">chr1\nACGTACGTAC\n")
+    pysam.faidx(str(fa))
+    with pytest.raises(Exception):
+        svar.annotate_mutations(Reference.from_path(fa), contigs=["chr1", "chr2"])


### PR DESCRIPTION
## Summary

This branch bundles **two related features** on top of `main` (`223a4e8`):

### 1. Vectorize SBS/DBS/INDEL matrix classification (commits `18cae08`–`3db6989`)
Replaces the per-variant Python loop in `classify_variants` with vectorized NumPy + a parallel numba kernel, with results **identical to the original scalar implementation** (preserved as `_classify_variants_scalar`, used as the test oracle):
- `Reference.contig_array` — exposes the cached full-contig uint8 array for vectorized flank/downstream lookups.
- `_sbs96_codes` (SNV→SBS-96) and `_dbs78_codes` (native doublet→DBS-78) — pure-NumPy fancy-index passes.
- `_id83_kernel` / `_id83_codes_for_contig` — `@nb.njit(parallel=True)` ID-83 indel kernel reading the contig array directly, with LUTs derived from `ID83_INDEX`.
- New vectorized `classify_variants` dispatching by variant type, grouped by contig, with REF-mismatch → UNCLASSIFIED warning.
- `_entry_codes_kernel` parallelized over tracks; `_count_kernel` parallelized over samples (race-free; disjoint output rows).

### 2. Contig-scope `NOT_ANNOTATED` in `annotate_mutations` (commits `eb8772f`–`405d417`, ref #62)
- `NOT_ANNOTATED` sentinel + `MUTCAT_VERSION` bump to 3.
- Contig allowlist in `classify_variants`; `mutcat_contigs` in `SparseVarMetadata`; `contigs=` scope in `annotate_mutations`.

## Test Plan
- [x] `pixi run pytest tests/test_mutcat.py tests/test_svar_mutations.py tests/test_reference.py` → 65 passed
- [x] Differential tests: vectorized `classify_variants` == scalar oracle (random ACGT SNV/DBS/indel mixes + contig boundaries)
- [x] SigProfiler calibration test passes in the `sigprofiler` pixi env (vectorized == scalar == SigProfiler ground truth)
- [x] Thread-invariance: unit-level (`_entry_codes_kernel`, `_count_kernel`) and end-to-end (`mutation_matrix`) determinism across thread counts
- [x] `skills/genoray-api/SKILL.md` updated for the new public `Reference.contig_array`

🤖 Generated with [Claude Code](https://claude.com/claude-code)