### PR TITLE
fix(svar): preserve index order and fix varID column in annotate_with_gtf

### DIFF
--- a/genoray/_svar.py
+++ b/genoray/_svar.py
@@ -1457,7 +1457,11 @@ class SparseVar(Generic[_SRT]):
                 self.index = (
                     self.index.lazy()
                     .with_row_index("varID")
-                    .join(annot.lazy(), on="varID", how="left")
+                    # maintain_order="left" is required: index rows are
+                    # positionally aligned with the sparse genotype storage, so
+                    # the join must not reorder them. The default ('none') lets
+                    # polars' hash join reorder output on larger data.
+                    .join(annot.lazy(), on="varID", how="left", maintain_order="left")
                     .drop("varID")
                     .collect()
                 )
@@ -3034,6 +3038,8 @@ def _get_strand_and_codon_pos(
         )
         .group_by("var_id", maintain_order=True)
         .agg(pl.col("gene_id", "strand", "codon_pos").first())
+        # Match the column name used by _empty_annot() and the write-back join.
+        .rename({"var_id": "varID"})
     )
 
     return annot

--- a/tests/test_join_order.py
+++ b/tests/test_join_order.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for polars ``DataFrame.join`` row-order assumptions.
+
+``DataFrame.join`` / ``LazyFrame.join`` default to ``maintain_order='none'``,
+which gives NO row-order guarantee: polars' multi-threaded hash join may
+reorder the output relative to the left frame on large data, across runs, or
+across polars versions. Small test data usually *looks* ordered, hiding the
+bug. Any code that relies on the left frame's order after a join must pass
+``maintain_order='left'`` explicitly.
+
+These tests install a monkeypatch that *forces* the worst case: every join with
+``maintain_order`` left at its ``'none'`` default reverses its output rows. Code
+that correctly pins ``maintain_order='left'`` is unaffected; code that relies on
+the implicit default breaks loudly.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from genoray import SparseVar
+
+ddir = Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def reorder_unordered_joins(monkeypatch):
+    """Force every ``maintain_order='none'`` join to reverse its output rows.
+
+    This simulates polars' hash-join reordering deterministically so order
+    bugs surface on small test data instead of silently in production.
+    """
+    orig_df_join = pl.DataFrame.join
+    orig_lf_join = pl.LazyFrame.join
+
+    def _is_unordered(maintain_order) -> bool:
+        return maintain_order is None or maintain_order == "none"
+
+    def df_join(self, other, *args, maintain_order=None, **kwargs):
+        out = orig_df_join(self, other, *args, maintain_order=maintain_order, **kwargs)
+        if _is_unordered(maintain_order):
+            out = out.reverse()
+        return out
+
+    def lf_join(self, other, *args, maintain_order=None, **kwargs):
+        out = orig_lf_join(self, other, *args, maintain_order=maintain_order, **kwargs)
+        if _is_unordered(maintain_order):
+            out = out.reverse()
+        return out
+
+    monkeypatch.setattr(pl.DataFrame, "join", df_join)
+    monkeypatch.setattr(pl.LazyFrame, "join", lf_join)
+
+
+def _gtf_covering_variants() -> pl.DataFrame:
+    """A CDS GTF DataFrame overlapping every variant in the biallelic fixture.
+
+    chr1 variants -> gene G1 (+ strand); chr2 variants -> gene G2 (- strand).
+    """
+    return pl.DataFrame(
+        {
+            "feature": ["CDS", "CDS"],
+            "chrom": ["chr1", "chr2"],
+            "start": [81000, 81000],
+            "end": [82000, 82000],
+            "strand": ["+", "-"],
+            "frame": [0, 0],
+            "gene_id": ["G1", "G2"],
+            "transcript_id": ["T1", "T2"],
+            "gene_biotype": ["protein_coding", "protein_coding"],
+            "transcript_support_level": ["1", "1"],
+            "tag": ["canonical", "canonical"],
+        }
+    )
+
+
+def test_annotate_with_gtf_preserves_index_order(tmp_path, reorder_unordered_joins):
+    """``annotate_with_gtf(write_back=True)`` must not reorder ``self.index``.
+
+    The variant index rows are positionally aligned with the sparse genotype
+    storage: row ``i`` of ``self.index`` describes variant ``i``. The write-back
+    join must preserve that order, regardless of how the hash join behaves.
+    """
+    src = ddir / "biallelic.vcf.svar"
+    dst = tmp_path / "biallelic.vcf.svar"
+    shutil.copytree(src, dst)
+
+    svar = SparseVar(dst)
+    original = svar.index.select("CHROM", "POS", "REF", "ALT")
+
+    svar.annotate_with_gtf(_gtf_covering_variants(), level_filter=None, write_back=True)
+
+    after = svar.index.select("CHROM", "POS", "REF", "ALT")
+    assert after.equals(original), (
+        "annotate_with_gtf reordered the variant index; row order no longer "
+        "matches the sparse genotype storage."
+    )
+
+    # The annotation must also land on the correct contig.
+    assert (
+        svar.index.filter(pl.col("CHROM") == "chr1")["gene_id"].to_list() == ["G1"] * 3
+    )
+    assert (
+        svar.index.filter(pl.col("CHROM") == "chr2")["gene_id"].to_list() == ["G2"] * 3
+    )


### PR DESCRIPTION
## Summary

Audited all `DataFrame`/`LazyFrame.join` call sites for row-order assumptions and fixed two bugs in `SparseVar.annotate_with_gtf(write_back=True)`. Both live in the write-back path; neither was previously covered by tests.

### Bug 1 — index reordering (the join-order bug)
The write-back join lacked `maintain_order="left"`. Index rows are positionally aligned with the sparse genotype storage, so polars' hash join (default `maintain_order="none"`) could silently reorder `self.index` relative to the genotype data on larger inputs — corrupting the variant→row correspondence.

### Bug 2 — `var_id` vs `varID` column mismatch (pre-existing crash)
`_get_strand_and_codon_pos` returned a `var_id` column while `_empty_annot()`, the write-back join (`on="varID"`), and the docstring all use `varID`. This raised `ColumnNotFoundError` for **any** variant overlapping a CDS. Confirmed reproducible without the test harness, so genuinely pre-existing.

The other two joins (`_signatures.py`) already passed `maintain_order="left"` and were left unchanged.

## Test plan
- New `tests/test_join_order.py` monkeypatches `DataFrame`/`LazyFrame.join` to **reverse output rows whenever `maintain_order` is left at its `"none"` default**, deterministically reproducing hash-join reordering on small data.
- Red→green confirmed: the test first failed on the column mismatch, then on the order assertion, then passed once both fixes were in.
- Full suite: **453 passed, 2 skipped, 16 xfailed**.
- Stress run with *every* unordered join globally reversed: **452 passed** (order test deselected) — confirms no other order-dependent join in tested paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)