### PR TITLE
docs(svar-2): SVAR 2.0 roadmap and supplements

### DIFF
--- a/docs/roadmap/architecture.md
+++ b/docs/roadmap/architecture.md
@@ -1,0 +1,132 @@
+# SVAR 2.0 Software Architecture
+
+> Supplement to [`svar-2.md`](svar-2.md). Describes the conversion pipeline, the
+> abstraction seam that keeps orchestration independent of the inline encoding, the
+> query algorithm, and the Python decode path. Described in terms of **contracts**, not
+> the current scratch code — the implementation on this branch is a starting point, not
+> a spec.
+
+## Goals
+
+- **Streaming and bounded memory.** Conversion must handle larger-than-RAM inputs by
+  processing variants in chunks with backpressure between stages.
+- **Encoding-agnostic orchestration.** The pipeline must not bake in a specific inline
+  bit layout, so we can change the encoding during experimentation without touching
+  orchestration. See [the seam](#the-encoding-agnostic-seam).
+- **Per-contig independence.** Contigs convert and store independently, enabling
+  parallelism and cheap merge/split (roadmap M8).
+
+## Conversion pipeline
+
+VCF → SVAR2 is a multi-threaded, channel-connected dataflow. Each stage is a thread
+(or thread pool) communicating over bounded channels so a slow stage applies
+backpressure upstream.
+
+```
+                 bounded channels (backpressure)
+ ┌──────────┐   dense   ┌───────────┐  sparse  ┌──────────────┐
+ │  Reader  ├──────────►│ Compute / ├─────────►│   Writer(s)  │
+ │ (htslib) │   chunks  │  Encode   │ payloads │  pos / keys  │
+ └──────────┘           └─────┬─────┘          └──────────────┘
+                              │ long alleles
+                              ▼
+                        ┌───────────┐
+                        │ LUT writer│
+                        └───────────┘
+
+ ── then ──►  Phase 2: K-way merge into per-(sample, ploid) sorted streams
+```
+
+1. **Reader** — pulls variant records for one contig from the VCF/BCF (via htslib),
+   builds dense genotype chunks (variant-major), and emits them.
+2. **Compute / Encode** — normalizes variants ([`data-model.md`](data-model.md#variant-normalization)),
+   transposes dense → sparse (sample-major), and encodes each call's variant info via
+   the [encoding seam](#the-encoding-agnostic-seam). Alleles that don't fit inline are
+   pushed to the LUT.
+3. **Writers** — stream the sparse payloads (positions, keys) and the LUT buffers to
+   disk sequentially.
+4. **Phase 2 merge** — a K-way merge consolidates per-chunk outputs into the final
+   per-`(sample, ploid)` position-sorted streams and the offsets sidecar.
+
+Per-variant **routing to `var_key` / `dense` / (`pointer`)** is driven by the
+[cost model](data-model.md#dense-vs-sparse-cost-model). The MVP routes between
+`var_key` and `dense`.
+
+## The encoding-agnostic seam
+
+This is the load-bearing design constraint. Orchestration (chunking, transpose,
+routing, writing, merging) must treat the inline variant encoding as **opaque
+fixed-width bits**. Only a thin encode/decode layer knows the bit layout in
+[`data-model.md`](data-model.md#inline-variant-encoding-var_key).
+
+Contract for the encoder:
+
+- **Input:** `(ILEN, ALT bytes)` plus a handle to the LUT for spill.
+- **Output:** a fixed-width key (e.g. `u32`) — inline value or LUT pointer, with the
+  flag bit set per the layout.
+- **Constraint:** as long as the key width is unchanged, the encoding internals can be
+  swapped freely; orchestration code does not branch on the layout.
+
+A matching decoder reverses it: `key (+ LUT) → (ILEN, ALT)`. Keep these two functions
+(and their width constant) as the *only* place that knows the layout. The cost model
+and on-disk layout reference the encoding solely through `s` (bytes per variant info),
+not through any specific field positions.
+
+> If you find orchestration code branching on SNP-vs-indel bit positions, that's a
+> leak of the seam — push it back into the encode/decode layer.
+
+## On-disk layout
+
+See [`data-model.md`](data-model.md#on-disk-layout) for the full tree. Key points for
+the reader/writer:
+
+- One directory per contig; positions are sidecar arrays sorted within a contig.
+- Each contig has up to three representation subdirs (`var_key`, `pointer`, `dense`);
+  a variant lives in exactly one.
+- `meta.json` holds version (for `SparseVar2` negotiation), samples, contigs, and
+  ploidy. The per-`(contig, sample, ploid)` maximum deletion length for overlap queries
+  is stored separately in a per-contig `max_del.npy` (it is structured and potentially
+  large), not in `meta.json`.
+
+`SparseVar2` (in `genoray`, alongside the existing `SparseVar`) memory-maps these
+sidecars so genotype data stays on disk until accessed, matching the SVAR 1.0 access
+model.
+
+## Query path
+
+`(range, sample)` queries (roadmap M5) resolve overlaps, not point hits, because
+deletions span reference bases.
+
+- **Index structure:** binary search over the sorted position sidecar, starting from
+  the [left-tree static search tree](https://curiouscoding.nl/posts/static-search-tree/#left-tree)
+  for cache-friendly lookups.
+- **Overlap handling:** use the max-deletion-length bound to set the lower search
+  bound, then linear-scan to the upper bound, per the algorithm in
+  [`data-model.md`](data-model.md#overlap-queries-and-deletions).
+- **Across representations:** a query may touch variants in `var_key`, `pointer`, and
+  `dense` subdirs for the same contig; results from each must be combined in
+  position-sorted order (next section).
+
+## Python decode path
+
+Query results (roadmap M6) decode into user-facing structs/classes (exact API TBD).
+Because a single contig's variants are spread across up to three representations — each
+an independent, position-sorted source — assembling a result requires a **fast sorted
+union / merge** of multiple sorted streams.
+
+- This is the union-shaped dual of fast sorted-array **intersection**; the techniques
+  in [Doug Turnbull's "Faster intersect"](https://softwaredoug.com/blog/2024/05/05/faster-intersect)
+  (branch-light, SIMD-friendly merging of sorted integer arrays) are good inspiration
+  for the union we need.
+- The decoder reverses the [encoding seam](#the-encoding-agnostic-seam):
+  `key (+ LUT) → (ILEN, ALT)`, reconstructing the ALT against the reference and
+  position.
+
+## Open questions
+
+- **Routing granularity.** Is representation chosen strictly per variant, or can a
+  contig be forced into a single representation for simplicity in early milestones?
+- **Merge stage memory.** Bounds and chunking strategy for the Phase-2 K-way merge at
+  scale (many samples × many chunks).
+- **PGEN path (M7).** Whether the htslib reader stage is cleanly swappable for a
+  `pgenlib` FFI source behind the same chunk contract.

--- a/docs/roadmap/data-model.md
+++ b/docs/roadmap/data-model.md
@@ -1,0 +1,251 @@
+# SVAR 2.0 Data Model & Rationale
+
+> Supplement to [`svar-2.md`](svar-2.md). Describes how variants and genotypes are
+> encoded on disk and why. **Current best approximation — correctable.** The exact
+> bit layouts in particular are expected to change during the experimentation phase;
+> the architecture is built so they can (see
+> [`architecture.md`](architecture.md#the-encoding-agnostic-seam)).
+
+## VariantKey lineage
+
+We use *a form of* the [VariantKey](https://www.biorxiv.org/content/10.1101/473744v3)
+encoding, adapted for our access pattern. The original VariantKey packs
+`CHROM | POS | REF:ALT` into a single 64-bit key. We diverge in two ways:
+
+- **Position is a sidecar, not part of the key.** Variants are already partitioned by
+  contig (one directory per contig) and sorted by position, and positions are stored
+  in a parallel `positions` array. So the key does **not** carry CHROM or POS — only
+  the information needed to reconstruct the ALT allele relative to the reference.
+- **The key encodes `ILEN` + `ALT`.** Given the position and the reference genome, a
+  SNP is fully described by its 2-bit ALT base; an indel by its length change (`ILEN =
+  len(ALT) − len(REF)`) plus the inserted/changed bases.
+
+This keeps keys small enough to inline next to each call, which is the whole point of
+the `var_key` representation.
+
+## Inline variant encoding (`var_key`)
+
+The inline encoding branches into two flavors. The orchestration code treats the key
+as opaque fixed-width bits (see [`architecture.md`](architecture.md#the-encoding-agnostic-seam));
+only the encode/decode layer knows the layout below.
+
+### SNP flavor — 2 bits
+
+A SNP changes one base and `ILEN = 0`. With position and reference known, only the ALT
+base is needed:
+
+```
+2-bit ALT:  A=00  C=01  G=10  T=11
+```
+
+### Indel flavor — 32 bits
+
+Indels (and SNPs, when stored in a 32-bit stream) use a 32-bit key. The **least
+significant bit (LSB) is a flag**: `0` = inline, `1` = LUT pointer.
+
+```
+ILEN > 0 (insertion / length-increasing), inline (LSB = 0):
+
+  bit:  31              27 26                                   1   0
+        ┌─────────────────┬──────────────────────────────────────┬───┐
+        │  ILEN (5b, ≥0)  │  ALT (26b = 13 × 2-bit bases)         │ 0 │
+        └─────────────────┴──────────────────────────────────────┴───┘
+        max inline ALT length = 13 nucleotides
+
+ILEN < 0 (deletion), inline (LSB = 0):
+
+  bit:  31                                                       1   0
+        ┌──────────────────────────────────────────────────────────┬───┐
+        │  ILEN (31b, signed)                                        │ 0 │
+        └──────────────────────────────────────────────────────────┴───┘
+        (a pure deletion needs no ALT bases beyond the anchor)
+
+Either sign, LUT pointer (LSB = 1):
+
+  bit:  31                                                       1   0
+        ┌──────────────────────────────────────────────────────────┬───┐
+        │  LUT row index (31b)                                       │ 1 │
+        └──────────────────────────────────────────────────────────┴───┘
+```
+
+An ALT allele spills to the LUT when it cannot be represented inline — i.e. an
+insertion whose ALT exceeds 13 nt, or a deletion whose `ILEN` falls outside the signed
+31-bit range. Empirically this is **extremely rare** for short-read NGS, so the LUT
+stays tiny.
+
+> **Note on widths.** The SNP flavor is 2 bits and the indel flavor is 32 bits. How
+> these coexist within a single per-call stream (fixed-width vs. tagged) is an
+> [open question](#open-questions) — the cost model and the agnostic seam are written
+> in terms of *bytes per variant info* (`s`), not a single fixed width.
+
+## Long-allele lookup table (LUT)
+
+The LUT is a struct-of-arrays holding the alleles that don't fit inline:
+
+- `ILEN` — `i32` per row.
+- `ALT` — 2-bit packed DNA, concatenated.
+- `offsets` — `u32` array indexing into the packed ALT (row `i` spans
+  `offsets[i] .. offsets[i+1]`).
+
+On disk this is `long_alleles.bin` (+ its offsets). A 31-bit key references a row by
+index. Because long alleles are rare in short-read data, we do **not** do a full pass
+to pre-size the LUT — we stream and append, accepting that the LUT is small.
+
+## Dense representation (`dense`)
+
+When a variant's allele frequency is high enough (per the
+[cost model](#dense-vs-sparse-cost-model)), storing per-call data is wasteful and we
+switch to a **dense 1-bit genotype matrix**:
+
+- Shape `(sample, ploid, variant)`, **C-order** (variant is the fastest-varying axis).
+- One bit per `(sample, ploid, variant)`: present / absent.
+- The variant info itself still uses the two inline flavors (SNP 2-bit / indel 32-bit),
+  stored once per variant in a variant table alongside the matrix — not inline per call.
+
+## Dense vs. sparse cost model
+
+For each variant we pick the representation with the smallest on-disk byte cost given
+its observed number of calls. Definitions:
+
+$$
+\begin{aligned}
+n &\coloneqq \text{number of samples}, & n &\in \mathbb{Z}_{>0} \\
+p &\coloneqq \text{ploidy}, & p &\in \mathbb{Z}_{>0} \\
+x &\coloneqq \text{number of calls}, & x &\in [0,\, np] \\
+a &\coloneqq \tfrac{x}{np} \;\; \text{(allele frequency)} \\
+s &\coloneqq \text{bytes per variant info}, & s &\in \mathbb{Z}_{\ge 2}
+\end{aligned}
+$$
+
+Byte cost of each representation for one variant:
+
+$$
+\underbrace{s\,x}_{\text{VK (var\_key)}}
+\quad\lessgtr\quad
+\underbrace{s + 8x}_{\text{PT (pointer)}}
+\quad\lessgtr\quad
+\underbrace{s + \lceil np/8 \rceil}_{\text{DN (dense)}}
+$$
+
+Interpretation by regime, as allele frequency `a` (hence `x`) grows:
+
+- **VK** costs `s` bytes per call (variant info inlined `x` times) — cheapest at low `a`.
+- **PT** costs one `s`-byte table row plus a pointer per call — wins in the middle,
+  *and* when `s` is large (many INFO/FORMAT fields) so paying for the table row once
+  beats inlining it.
+- **DN** costs one `s`-byte table row plus a fixed `⌈np/8⌉`-byte bitmask independent of
+  `x` — cheapest at high `a`.
+
+> **This math is provisional and likely out of date.** For example, the `8x` term for
+> PT assumes a 64-bit pointer; it can be `4x` (32-bit) when the variant count is small
+> enough to index with `u32`. The LUT size is deliberately **ignored** here — pricing
+> it would require a full pass over all variants, and it is empirically negligible for
+> short-read data. Revisit the constants when we have measurements.
+
+## On-disk layout
+
+SVAR2 is a directory. It is split by contig; each contig directory holds up to three
+representation subdirectories, populated according to the cost model. Variants in a
+contig are partitioned across `var_key` / `pointer` / `dense` — each variant lives in
+exactly one.
+
+```
+svar2/
+├── meta.json                       # version, samples, contigs, ploidy, ...
+└── {contig}/
+    ├── max_del.npy                 # max deletion length per (sample, ploid) for this contig; bounds overlap search
+    ├── dense/
+    │   ├── long_alleles.bin        # LUT for alleles that don't fit inline
+    │   ├── positions.npy           # sidecar variant positions (sorted)
+    │   ├── alleles.npy             # inline variant keys (variant table)
+    │   ├── {field}.npy             # per-variant INFO/FORMAT fields
+    │   └── genotypes.npy           # 1-bit (sample, ploid, variant) matrix, C-order
+    ├── pointer/                    # = SVAR 1.0 representation (longer-term, M11)
+    │   ├── long_alleles.bin
+    │   ├── positions.npy
+    │   ├── alleles.npy
+    │   ├── {field}.npy
+    │   ├── pointers.npy            # u32/u64 pointers into the variant table
+    │   └── offsets.npy             # per (sample, ploid) ragged offsets into pointers
+    └── var_key/
+        ├── long_alleles.bin
+        ├── positions.npy
+        ├── alleles.npy             # inline keys, one per call (ragged)
+        ├── offsets.npy             # per (sample, ploid) ragged offsets into alleles
+        └── {field}.npy
+```
+
+`meta.json` carries the format version (so `SparseVar2` can negotiate), sample list,
+contig list, and ploidy. The per-stream maximum deletion length needed for overlap
+queries lives in a separate `max_del.npy` per contig (see below) rather than in
+`meta.json`, because it is a structured, potentially large array (e.g. 1M diploid
+samples × 20 contigs).
+
+## Variant normalization
+
+Conversion normalizes variants inline as they stream through, so the on-disk model is
+always normalized:
+
+- **Left-alignment** — shift indels to their leftmost equivalent position.
+- **Atomization** — break complex/MNV records into atomic primitives.
+- **Biallelic split** — split multi-allelic sites into separate biallelic records.
+
+This keeps `ILEN`/ALT semantics simple and makes the inline encoding well-defined.
+
+## Overlap queries and deletions
+
+A deletion spans more than one reference base, so a variant that *starts* before a
+query range can still *overlap* it. Range queries must therefore behave like region
+overlap, not point lookup.
+
+Two regions A and B overlap iff (from the VariantKey paper, §8):
+
+```
+(A_CHROM = B_CHROM) and (A_STARTPOS < B_ENDPOS) and (A_ENDPOS > B_STARTPOS)
+```
+
+Given a list `L` of sorted keys and the maximum region (deletion) length
+`L_MAX_REGION_LENGTH` over `L`, find entries overlapping a query region `R`:
+
+1. Binary search on CHROM + STARTPOS only:
+   - **Upper bound (UB):** maximal entry with `L_CHROM = R_CHROM` and `L_STARTPOS < R_ENDPOS`.
+   - **Lower bound (LB):** minimal entry `< UB` with `L_CHROM = R_CHROM` and
+     `L_STARTPOS > (R_STARTPOS − L_MAX_REGION_LENGTH)`.
+2. Linear scan between LB and UB for `L_ENDPOS > R_STARTPOS`.
+
+Consequently we **track the maximum deletion length per (contig, sample, ploid)**
+stream and store it in a per-contig `max_del.npy` (shape `(sample, ploid)`) — not in
+`meta.json`, since it is structured and potentially large (e.g. 1M diploid samples ×
+20 contigs). That bounds how far left of the query start a spanning deletion can begin,
+so the binary search stays tight. The SVAR 1.0 reader
+already does an analogous length-aware scan
+(`_find_starts_ends_with_length` in `python/genoray/_svar.py`); SVAR 2.0 generalizes it
+across the three representations.
+
+## Format constraints and non-goals
+
+SVAR2 is a **compute-oriented, derived format — not an archival format.**
+
+- **No sample appends.** You cannot add samples to an existing SVAR2 file. Adding
+  samples changes per-variant allele frequencies, which changes cost-model decisions
+  and can invalidate every LUT and variant table. Re-convert instead.
+- **Cheap merge/split by contig (M8).** Contigs are fully independent on disk, so
+  merging or splitting SVAR2 files along contig boundaries is a near-trivial file
+  operation.
+- **Cheap region subsetting (M9, non-MVP).** Subsetting by region introduces no new
+  variants and only shrinks variant tables, so it doesn't perturb the cost model.
+- **Bulk N-way merge is harder (M12).** A general merge of multiple SVAR2 files can
+  change allele frequencies and must rebuild LUTs and variant tables — deferred.
+
+## Open questions
+
+- **SNP/indel width coexistence.** How do the 2-bit SNP flavor and 32-bit indel flavor
+  share a single per-call stream? Options: a uniform 32-bit width (simplest, treats
+  every call as the indel flavor), a tagged/variable width, or separate streams. The
+  cost model is written in terms of bytes-per-variant-info `s` to stay agnostic, but
+  the wire format must pick one.
+- **Cost-model constants.** Pointer width (32 vs 64 bit) and the exact `s` per
+  representation need measurement; the current inequalities are placeholders.
+- **`s` for `var_key`.** When variant info is inlined per call, what exactly counts
+  toward `s` (key only, or key + decoded ALT bytes)? Pin this down once the wire format
+  is fixed.

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -1,0 +1,109 @@
+# SVAR 2.0 Roadmap
+
+> **Status:** active epic · **Branch:** `svar-2` · **Home:** `genoray` (new `SparseVar2` class)
+>
+> This is the entry point for the SVAR 2.0 effort. It is a living document. See
+> the supplements for detail:
+> - [`data-model.md`](data-model.md) — encodings, bit layouts, LUT, dense matrix, the dense/sparse cost model, on-disk layout, and format constraints (with rationale).
+> - [`architecture.md`](architecture.md) — conversion pipeline, the encoding-agnostic abstraction seam, query algorithm, and the Python decode path.
+>
+> Everything here is our **current best approximation**. It is version-controlled
+> and meant to be corrected as we learn. When something turns out to be wrong, fix
+> the doc in the same PR that proves it wrong.
+
+## Vision
+
+SVAR 2.0 extends the existing SparseVar format (SVAR 1.0, `python/genoray/_svar.py`)
+into a **hybrid variant store tuned for the empirical distribution of variants from
+short-read / NGS data**. SVAR 1.0 stores genotypes as sparse `u32` pointers into a
+single variant table. SVAR 2.0 adds two new ideas:
+
+1. **Inline, dense variant encoding** — most short-read variants are SNPs or small
+   indels whose ALT allele fits in a couple of bytes. Instead of paying for a pointer
+   plus a table row, we encode the variant *inline* using a compact
+   [VariantKey](https://www.biorxiv.org/content/10.1101/473744v3)-style key (see
+   [`data-model.md`](data-model.md)).
+2. **Per-variant choice of representation** — for each variant we deterministically
+   pick the cheapest representation given its allele frequency, trading inline sparse
+   storage against a dense 1-bit genotype matrix.
+
+We optimize for **short-read NGS**. Long-read data (with its long, abundant alleles)
+is explicitly **out of scope** — its variant distribution breaks the assumptions that
+make the inline encoding a win.
+
+## The hybrid at a glance
+
+Within each contig, every variant is assigned to exactly one of these representations
+by the cost model (see [`data-model.md`](data-model.md#dense-vs-sparse-cost-model)):
+
+| Representation | Code name | What it stores | Best when |
+| --- | --- | --- | --- |
+| **Inline variant key** | `var_key` | Per-call inline key (2-bit SNP ALT, or 32-bit indel key); long alleles spill to a LUT | Low allele frequency (most variants) |
+| **Pointer** | `pointer` | Sparse `u32`/`u64` pointers into a shared variant table (this is SVAR 1.0) | Variant info is large (many INFO/FORMAT fields) |
+| **Dense** | `dense` | 1-bit `(sample, ploid, variant)` matrix + variant table | High allele frequency |
+
+There are two axes here, which is the source of the "4-way" / "3-way" naming:
+
+- **Variant-info encodings — the "4-way hybrid" (MVP):** inline SNP (2-bit), inline
+  indel (32-bit), LUT pointer (long-allele spill), and dense. All four exist in the MVP
+  design.
+- **Genotype-storage representations:** `var_key` and `dense` in the MVP; adding the
+  SVAR-1.0-style `pointer` representation later makes this axis a **"3-way hybrid"**
+  (inline + pointer + dense), milestone M11.
+
+## Milestones
+
+Legend: `[ ]` not started · `[~]` in progress · `[x]` done
+
+### MVP — VCF → SVAR2
+
+- [~] **M1. VCF → SVAR2 conversion.** Streaming, chunked, multi-threaded
+  conversion producing the `var_key` representation. Builds on the existing
+  conversion pipeline on this branch. See [`architecture.md`](architecture.md#conversion-pipeline).
+- [ ] **M2. Variant normalization during conversion.** Left-alignment, atomization,
+  and biallelic splitting (split multi-allelic sites) applied inline as variants stream
+  through. See [`data-model.md`](data-model.md#variant-normalization).
+- [ ] **M3. Per-contig split + sidecar positions.** Partition the SVAR2 directory by
+  contig; keep positions as sidecar arrays. See
+  [`architecture.md`](architecture.md#on-disk-layout).
+- [ ] **M4. Dense representation + cost-model routing.** Implement the 1-bit dense
+  genotype matrix and the deterministic per-variant dense/sparse decision. See
+  [`data-model.md`](data-model.md#dense-vs-sparse-cost-model).
+- [ ] **M5. `(range, sample)` queries.** Fast overlap queries via binary search,
+  starting from the [left-tree static search tree](https://curiouscoding.nl/posts/static-search-tree/#left-tree).
+  Must handle deletions spanning the query start (see
+  [`data-model.md`](data-model.md#overlap-queries-and-deletions)).
+- [ ] **M6. Python decode.** Decode query results into user-facing structs/classes
+  (to be spec'd). Requires fast sorted **unions** to merge data from multiple
+  position-sorted sources. See [`architecture.md`](architecture.md#python-decode-path).
+
+### Beyond MVP
+
+- [ ] **M7. PGEN → SVAR2 conversion.** Likely requires FFI to C++ / `pgenlib`.
+- [ ] **M8. Merge / split by contig.** Cheap because contigs are independent on disk.
+  See [Format constraints](data-model.md#format-constraints-and-non-goals).
+- [ ] **M9. Subset by region.** Non-MVP. Doesn't affect cost-model calculations (no
+  new variants; only shrinks variant tables), so it should be cheap.
+
+### Longer term
+
+- [ ] **M10. Checkpointing / resume during conversion.**
+- [ ] **M11. 3-way hybrid.** Add the SVAR-1.0-style `pointer` representation as a
+  third co-resident option, selected by the cost model when variant info is large.
+- [ ] **M12. Bulk merge of multiple SVAR2 files.** A general N-way merge (more
+  involved than the by-contig merge of M8 because it can change the cost model and
+  must rebuild LUTs / variant tables).
+
+## Working agreement
+
+SVAR 2.0 spans many PRs. To keep the design and the code from drifting apart:
+
+**Any PR that touches the SVAR 2.0 effort MUST read and update this roadmap and the
+supplements in the same PR.** Concretely, before opening the PR:
+
+- [ ] Re-read `svar-2.md`, `data-model.md`, and `architecture.md`.
+- [ ] Update milestone checkboxes and statuses to match reality.
+- [ ] Reconcile any data-model or architecture changes with the supplements — if the
+      code now disagrees with a doc, the doc is wrong; fix it here.
+- [ ] If you discovered a new open question, add it to the relevant "Open questions"
+      section rather than leaving it in your head.


### PR DESCRIPTION
Adds the SVAR 2.0 epic roadmap and supplements under `docs/roadmap/`. Targets the `svar-2` branch — this epic does **not** merge into `main` until the roadmap is complete.

## What's here

- **`svar-2.md`** — entry point. Vision (short-read/NGS optimized; long-read out of scope), the hybrid-at-a-glance table, milestones **M1–M12** (MVP → beyond-MVP → longer-term) with checkboxes, status legend, and a **working agreement**: every PR in this epic must read and update the roadmap + supplements in the same PR.
- **`data-model.md`** — VariantKey lineage & rationale, inline **SNP (2-bit)** / **indel (32-bit)** bit-layout diagrams, the long-allele **LUT**, the **dense** 1-bit matrix, the provisional **dense/sparse cost model**, the on-disk directory layout (per-contig, 3 representation subdirs, `max_del.npy`), variant **normalization**, **overlap queries with deletions** (paper §8 + max-deletion-length tracking), and **format constraints/non-goals** (not archival; no sample appends; cheap by-contig merge/split).
- **`architecture.md`** — streaming conversion pipeline, the **encoding-agnostic seam** (orchestration treats inline keys as opaque fixed-width bits so the encoding can change during experimentation), query path, and the Python decode path.

## Notes for reviewers

- Two naming axes reconciled: **4-way** = variant-info encodings (inline SNP, inline indel, LUT pointer, dense); **3-way** = genotype-storage representations (inline + pointer + dense, the latter being SVAR 1.0, deferred to M11).
- The cost model is reproduced as given and flagged **provisional** (e.g. the pointer term assumes a 64-bit pointer; could be 32-bit).
- Open questions are captured inline rather than forced — notably how the 2-bit SNP and 32-bit indel flavors share one per-call stream.

Everything is framed as a current best approximation, version-controlled and correctable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)