### PR TITLE
fix: filtered PGEN var_idxs returns positional indices into _index (#69)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-filtered-pgen-var-idxs.md
+++ b/docs/superpowers/plans/2026-06-24-filtered-pgen-var-idxs.md
@@ -1,0 +1,292 @@
+# Filtered-PGEN `var_idxs()` Coordinate-Space Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `PGEN.var_idxs()` return indices that are consistent with the reader's own filtered `_index`, fixing the out-of-bounds / mis-alignment bug in issue #69.
+
+**Architecture:** The single shared `_var_ranges.var_indices()` helper currently returns the `"index"` column, which holds *physical* (pre-filter, file-global) PVAR row ids. After a filter compacts `_index`, those ids no longer index `_index`. We change `var_indices()` to return *positional* row numbers over the filtered table. PGEN's internal read paths still need physical ids for pgenlib random access, so they go through a new private `_var_idxs_phys()` helper that maps positional → physical via the (still physical) `_index["index"]` column. The public `var_idxs()` returns positional. VCF needs no code change (its `_var_idxs` is private and never gathers `_index`); it gets consistency for free and is covered by a regression test.
+
+**Tech Stack:** Python, polars, numpy, pgenlib, cyvcf2, pytest / pytest-cases, vcfixture (test oracle), plink2 (test-data generation).
+
+## Global Constraints
+
+- Coordinate convention: ranges are 0-based, half-open `[start, end)`. Missing genotypes are `-1`. (Unchanged by this work.)
+- `var_idxs()` is a **public** name (reachable via `import genoray` without underscore); its docstring MUST be updated when its contract changes (CLAUDE.md rule). `skills/genoray-api/SKILL.md` must be updated *if* it documents `var_idxs` or its coordinate space.
+- Commits follow Conventional Commits (`fix:`, `test:`, `docs:`).
+- With **no** filter, positional == physical — existing unfiltered behavior and the existing `tests/test_pgen.py::test_var_idxs` MUST remain green.
+- `_index["index"]` stays = physical (do NOT rename it): `_svar.py` (`from_pgen`) and `_c_max_idxs` depend on it.
+
+---
+
+### Task 1: Core fix — `var_indices()` positional + `_var_idxs_phys()` remap + PGEN regression test
+
+**Files:**
+- Modify: `genoray/_var_ranges.py:123-148` (`var_indices`)
+- Modify: `genoray/_pgen.py` — add `_var_idxs_phys` helper (after `var_idxs`, ~line 443); switch 5 internal call sites at `:479`, `:546`, `:633`, `:718`, `:853`; update `var_idxs` docstring (`:433-437`)
+- Test: `tests/test_pgen.py` (add `test_filtered_var_idxs_consistent_with_index`)
+- Verify (likely no-op): `skills/genoray-api/SKILL.md`
+
+**Interfaces:**
+- Consumes: `genoray.exprs.is_snp` (filter expr); `tests._oracle`; `tests.data.fixtures.FIXTURES["biallelic"]`; existing committed fixtures `tests/data/biallelic.pgen` (+ `.pvar`).
+- Produces:
+  - `var_indices(idx_dtype, c_norm, var_table, contig, starts, ends) -> (NDArray positional, NDArray offsets)` — return values are now positional row indices into `var_table`.
+  - `PGEN.var_idxs(contig, starts, ends) -> (NDArray positional, NDArray offsets)` — positional into `self._index`.
+  - `PGEN._var_idxs_phys(contig, starts, ends) -> (NDArray physical, NDArray offsets)` — physical PVAR row ids for pgenlib.
+
+**Background facts (the `biallelic` fixture):**
+Records in physical/file order — chr1: (0) `81262 GAT>A`, (1) `81262 G>A`, (2) `81265 T>C`; chr2: (3) `81262 GAT>A`, (4) `81262 G>A`, (5) `81265 T>C`. `exprs.is_snp` (ILEN==0) drops the two `GAT>A` indels (physical 0 and 3). Filtered `_index`: physical `[1,2,4,5]` ↔ positional `[0,1,2,3]`, height 4. A `chr2` query selects positional `[2,3]` (physical `[4,5]`). Pre-fix, `var_idxs("chr2", …)` returns `[4,5]` whose max (5) ≥ height (4) → `_index[[4,5]]` is out of bounds.
+
+- [ ] **Step 1: Write the failing PGEN regression test**
+
+Add to `tests/test_pgen.py` (imports `from genoray import exprs` at top with the other imports if not present; `PGEN`, `Genos`, `POS_MAX` are already imported; `_BIALLELIC`, `ddir` already defined):
+
+```python
+def test_filtered_var_idxs_consistent_with_index():
+    """Regression for #69: filtered PGEN var_idxs must index its own _index.
+
+    `is_snp` drops the interior GAT>A indels (physical rows 0 and 3), so for a
+    filtered reader physical != positional. var_idxs() must return positional
+    indices into the (filtered) _index, and reads must still return the correct
+    (physical) genotypes.
+    """
+    from genoray import exprs
+
+    g_filt = PGEN(ddir / "biallelic.pgen", filter=exprs.is_snp)
+    g_full = PGEN(ddir / "biallelic.pgen")
+
+    # Filter drops physical rows 0 and 3 -> 4 rows remain.
+    assert g_filt._index.height == 4
+
+    # chr2 query: positional [2, 3] (NOT physical [4, 5]).
+    vi, offsets = g_filt.var_idxs("chr2", 0, POS_MAX)
+    assert int(vi.max()) < g_filt._index.height          # #69: in-bounds
+    assert np.array_equal(vi, np.array([2, 3], dtype=vi.dtype))
+    assert np.array_equal(offsets, np.array([0, 2], dtype=offsets.dtype))
+
+    # _index[var_idxs] selects the kept chr2 SNPs (POS 81262, 81265).
+    assert g_filt._index[vi]["POS"].to_list() == [81262, 81265]
+
+    # Read correctness: a filtered chr1 read returns exactly the same genotypes
+    # as the corresponding (physical) variants from an unfiltered read. chr1's
+    # SNPs are physical rows [1, 2] -> within the full chr1 read those are the
+    # 2nd and 3rd variants on the variant axis.
+    filt = g_filt.read("chr1", 0, POS_MAX, mode=Genos)        # (s, p, 2)
+    full = g_full.read("chr1", 0, POS_MAX, mode=Genos)        # (s, p, 3)
+    assert filt.shape[-1] == 2
+    assert np.array_equal(filt, full[..., [1, 2]])
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pixi run pytest tests/test_pgen.py::test_filtered_var_idxs_consistent_with_index -v`
+Expected: FAIL — `var_idxs("chr2", …)` returns physical `[4, 5]`, so `int(vi.max()) < 4` is False (and/or `g_filt._index[vi]` raises out-of-bounds).
+
+- [ ] **Step 3: Change `var_indices()` to return positional indices**
+
+In `genoray/_var_ranges.py`, replace the `var_table = (...)` block (currently `:123-133`) with a version that assigns a positional row index over the full filtered table *before* the `CHROM` filter and selects it as `"index"`:
+
+```python
+    var_table = (
+        var_table.lazy()
+        .with_row_index("__pos")
+        .filter(pl.col("CHROM") == c)
+        .select(
+            pl.col("__pos").cast(np_to_pl_dtype(idx_dtype)).alias("index"),
+            chrom=pl.col("CHROM").cast(pl.Utf8),
+            start=pl.col("POS") - 1,
+            end=pl.col("POS")
+            - pl.col("ILEN").list.first().clip(upper_bound=0).fill_null(0),
+        )
+    )
+```
+
+Rationale: `with_row_index("__pos")` numbers rows `0..N-1` over the entire (already user-filtered) `var_table`, which is exactly the positional space of `_index`. The downstream join/rename/`join["index"]` code is unchanged because we alias the selected column back to `"index"`. The original physical `"index"` column is simply not selected.
+
+- [ ] **Step 4: Add the `_var_idxs_phys` helper to `PGEN`**
+
+In `genoray/_pgen.py`, immediately after the `var_idxs` method (after `:442`), add:
+
+```python
+    def _var_idxs_phys(
+        self,
+        contig: str,
+        starts: ArrayLike = 0,
+        ends: ArrayLike = POS_MAX,
+    ) -> tuple[NDArray[V_IDX_TYPE], NDArray[OFFSET_TYPE]]:
+        """Internal: like :meth:`var_idxs`, but maps the positional indices to
+        physical (file-global) PVAR row ids for pgenlib random access. The
+        ``_index["index"]`` column holds physical ids; ``var_idxs`` returns
+        positions into ``_index`` (issue #69), so reads remap here.
+        """
+        pos, offsets = self.var_idxs(contig, starts, ends)
+        assert self._index is not None
+        phys = self._index["index"].to_numpy()[pos].astype(V_IDX_TYPE)
+        return phys, offsets
+```
+
+(`OFFSET_TYPE`, `ArrayLike`, `NDArray`, `V_IDX_TYPE`, `POS_MAX` are already imported in this module — `var_idxs` uses all of them.)
+
+- [ ] **Step 5: Point the 5 internal read sites at `_var_idxs_phys`**
+
+In `genoray/_pgen.py`, change `self.var_idxs(` to `self._var_idxs_phys(` at exactly these call sites (the public `var_idxs` definition at `:416` and its docstring are NOT touched here):
+
+- `:479` `var_idxs, _ = self.var_idxs(c, start, end)` (in `read`)
+- `:546` `var_idxs, _ = self.var_idxs(c, start, end)` (in `chunk`)
+- `:633` `var_idxs, offsets = self.var_idxs(c, starts, ends)` (in `read_ranges`)
+- `:718` `var_idxs, offsets = self.var_idxs(c, starts, ends)` (in `chunk_ranges`)
+- `:853` `var_idxs, offsets = self.var_idxs(c, starts, ends)` (in `_chunk_ranges_with_length`)
+
+Each becomes, e.g.: `var_idxs, offsets = self._var_idxs_phys(c, starts, ends)`. Leave the surrounding code unchanged — every downstream use (`_read_*`, `_sei`-indexing in `_gen_with_length`, `_c_max_idxs`, returned chunk idxs) keeps operating in physical space exactly as before.
+
+- [ ] **Step 6: Update the public `var_idxs` docstring**
+
+In `genoray/_pgen.py`, in the `var_idxs` Returns section (`:433-437`), replace the first return-value description so it states the coordinate space:
+
+```python
+        Returns
+        -------
+            Shape: (tot_variants). Variant indices for the given ranges, as
+            0-based **positions into this reader's (filtered) ``_index``** — i.e.
+            ``reader._index[var_idxs]`` is always valid. With no filter these
+            equal the physical PVAR row order.
+
+            Shape: (ranges+1). Offsets to get variant indices for each range.
+```
+
+- [ ] **Step 7: Run the new test to verify it passes**
+
+Run: `pixi run pytest tests/test_pgen.py::test_filtered_var_idxs_consistent_with_index -v`
+Expected: PASS.
+
+- [ ] **Step 8: Run the existing PGEN suite to confirm no regressions**
+
+Run: `pixi run pytest tests/test_pgen.py tests/test_parity.py -q`
+Expected: PASS (including the unchanged `test_var_idxs` — with no filter, positional == physical).
+
+- [ ] **Step 9: Run the svar suite (shares `_index["index"]` semantics)**
+
+Run: `pixi run pytest tests/test_svar.py tests/test_svar_filtering.py tests/test_svar_from_subset.py -q`
+Expected: PASS — `_svar.py` reads `_index["index"]` (still physical) and never calls `var_idxs()`, so it is unaffected.
+
+- [ ] **Step 10: Verify `skills/genoray-api/SKILL.md`**
+
+Run: `grep -n "var_idxs" skills/genoray-api/SKILL.md`
+Expected: no matches. `var_idxs` is not documented in the skill, so no SKILL.md edit is required (the docstring in Step 6 is the public-facing contract). If the grep *does* return matches, update those lines to state that `var_idxs` returns positional indices into the reader's filtered `_index`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add genoray/_var_ranges.py genoray/_pgen.py tests/test_pgen.py
+git commit -m "fix: filtered PGEN var_idxs returns positional indices into _index (#69)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: VCF regression guard
+
+**Files:**
+- Test: `tests/test_vcf.py` (add `test_filtered_var_idxs_consistent_with_index`)
+
+**Interfaces:**
+- Consumes: `VCF`; `genoray.exprs.is_snp`; committed fixture `tests/data/biallelic.vcf.gz`; `POS_MAX` (import from `genoray._vcf`).
+
+**Why no VCF code change:** `VCF._var_idxs` is private and never used to gather `_index`; reads stream by genomic position via cyvcf2 and apply the per-record `filter` in `_fill_genos`, counting via `var_counts`. The shared `var_indices()` change (Task 1) makes `_var_idxs` positional too — this test guards that consistency and proves filtered reads are correct. The `_var_idxs` in-bounds assertion below would have FAILED before Task 1 (it returned physical `[4,5]` into a height-4 index); it passes after.
+
+- [ ] **Step 1: Write the VCF regression test**
+
+Add to `tests/test_vcf.py` (`VCF` and `_BIALLELIC`/`ddir` are already imported/defined; add `POS_MAX` to the `from genoray._vcf import ...` line):
+
+```python
+def test_filtered_var_idxs_consistent_with_index():
+    """Regression guard for #69 on the VCF backend.
+
+    VCF._var_idxs is private and never gathers _index, but it shares
+    var_indices() with PGEN, so it must also return positional indices. Filtered
+    reads must return the same genotypes as the matching unfiltered variants.
+    """
+    from genoray import exprs
+
+    # is_snp as a (cyvcf2 record callable, pl.Expr) pair (VCF requires both).
+    record_is_snp = lambda rec: len(rec.REF) == 1 and all(len(a) == 1 for a in rec.ALT)
+
+    v_filt = VCF(
+        ddir / "biallelic.vcf.gz",
+        filter=record_is_snp,
+        pl_filter=exprs.is_snp,
+    )
+    v_filt._write_gvi_index()
+    v_filt._load_index()
+    v_full = VCF(ddir / "biallelic.vcf.gz")
+
+    assert v_filt._index.height == 4
+
+    # _var_idxs is positional and in-bounds (pre-#69 it returned physical [4,5]).
+    vi, _ = v_filt._var_idxs("chr2", 0, POS_MAX)
+    assert int(vi.max()) < v_filt._index.height
+    assert np.array_equal(vi, np.array([2, 3], dtype=vi.dtype))
+    assert v_filt._index[vi]["POS"].to_list() == [81262, 81265]
+
+    # Filtered chr1 read == the SNP variants (physical [1, 2]) of the full read.
+    filt = v_filt.read("chr1", 0, POS_MAX, mode=VCF.Genos16)
+    full = v_full.read("chr1", 0, POS_MAX, mode=VCF.Genos16)
+    assert filt.shape[-1] == 2
+    assert np.array_equal(filt, full[..., [1, 2]])
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `pixi run pytest tests/test_vcf.py::test_filtered_var_idxs_consistent_with_index -v`
+Expected: PASS (Task 1 already made `_var_idxs` positional; VCF read was already filter-correct).
+
+- [ ] **Step 3: Run the full VCF suite**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_vcf.py
+git commit -m "test: guard filtered VCF var_idxs consistency (#69)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full suite + issue cross-reference
+
+**Files:** none (verification + bookkeeping).
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `pixi run test`
+Expected: PASS (this also regenerates test data via `gen_from_vcf.sh`; the committed fixtures are unchanged by this work).
+
+- [ ] **Step 2: If `pixi run test` is too slow locally, run the targeted set**
+
+Run: `pixi run pytest -m "not network" -q`
+Expected: PASS.
+
+- [ ] **Step 3 (optional, if pushing a PR): note the fix on the issue**
+
+When the branch is pushed and a PR opened, reference `Fixes #69` in the PR body so the issue closes on merge. (Do not push or open the PR unless the user asks.)
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Spec §"Chosen approach" / §1 (`var_indices` positional) → Task 1 Step 3. ✔
+- Spec §2 (PGEN positional→physical remap at read boundary) → Task 1 Steps 4-5 (`_var_idxs_phys` + 5 sites; spec said "four" entry points — corrected to the 5 actual internal call sites, including `_chunk_ranges_with_length`, which also feeds physical-indexed `_sei`/`_c_max_idxs`). ✔
+- Spec §3 (VCF verify-only) → Task 2. ✔
+- Spec §4 (docstring mandatory; SKILL.md only if referenced) → Task 1 Steps 6 & 10. ✔
+- Spec §Testing (in-bounds, index-alignment, read-correctness; VCF read + in-bounds) → Task 1 Step 1 / Task 2 Step 1. Read-correctness uses filtered-vs-unfiltered-slice comparison (stronger and not sensitive to half-call/phase oracle decoding) plus POS alignment via the index. ✔
+- Spec §"Unchanged" (unfiltered `test_var_idxs` stays green) → Task 1 Step 8. ✔
+- Spec §Out of scope (gvl guard; no new fixtures) → respected; reuses committed `biallelic` fixtures. ✔
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to". Every code step shows full code. ✔
+
+**3. Type consistency:** `var_indices` returns `(NDArray, NDArray offsets)`; `var_idxs` returns positional `(NDArray[V_IDX_TYPE], NDArray[OFFSET_TYPE])`; `_var_idxs_phys` returns physical with the same signature; all 5 call sites unpack `(idxs, offsets)`. `_index["index"]` referenced consistently as physical throughout. ✔

--- a/docs/superpowers/specs/2026-06-23-filtered-pgen-var-idxs-coordinate-space-design.md
+++ b/docs/superpowers/specs/2026-06-23-filtered-pgen-var-idxs-coordinate-space-design.md
@@ -1,0 +1,146 @@
+# Fix #69 — Consistent coordinate space for filtered PGEN `var_idxs()`
+
+**Date:** 2026-06-23
+**Issue:** [#69](https://github.com/d-laub/genoray/issues/69)
+**Status:** Approved design, pending implementation
+
+## Problem
+
+For a **filtered** `PGEN`, `var_idxs()` returns variant indices in the
+**unfiltered / physical** (file-global) coordinate space, while `_index` is the
+**filtered / compacted** table. The two no longer share an index space, so a
+consumer that does `_index[var_idx]` (or indexes any array aligned to `_index`
+with values from `var_idxs()`) goes out of bounds or reads the wrong row.
+
+This silently breaks downstream consumers. GenVarLoader's `gvl.write()` hit it as
+an `IndexError` when reading a filtered PGEN.
+
+### Root cause
+
+In `_var_ranges.var_indices()` the returned indices come from the `"index"`
+column of the variant table. That column is assigned by
+`pl.scan_ipc(..., row_index_name="index")` **before** the user filter is applied
+(`_pgen._load_index`, `_vcf._load_index`). After `index.filter(filter)` the table
+is compacted to N rows, but the `"index"` column still holds the original
+physical/global row ids (max can exceed N-1). So `var_idxs()` returns physical
+ids while `_index` has N positional rows.
+
+### Why the physical ids are load-bearing (constraint on the fix)
+
+The physical ids are **not** simply wrong to compute — they are required
+internally:
+
+- `PGEN._read_genos` / `_read_dosages` / `_read_genos_phasing` / etc. pass
+  `var_idxs` straight to pgenlib's `read_alleles_list` / `read_dosages_list`,
+  which address the underlying `.pgen` by **physical file row id**
+  (`genoray/_pgen.py:945`).
+- `_svar.py` `from_pgen` reads `pgen._index["index"]` as the physical id array
+  (`phys`) for pgenlib random access (`genoray/_svar.py:1192`, comment at
+  1219-1221). It does **not** call `var_idxs()`.
+
+So the fix must keep a physical mapping available internally while making the
+**public** `var_idxs()` contract consistent with `_index`.
+
+## Chosen approach (issue Option 1)
+
+`var_idxs()` returns **positional** indices into the reader's own (filtered)
+`_index` — the least-surprising contract: "indices from a reader index that
+reader's own `_index`."
+
+Crucially, because polars `_index[idx_array]` gathers **by row position**, the
+`"index"` column does **not** need to be renamed or recomputed. We keep
+`"index"` = physical (so `_svar.py` and `_c_max_idxs` are untouched) and change
+only what `var_indices()` returns.
+
+### Rejected alternatives
+
+- **Option 2** (keep `_index` as the full/unfiltered table, expose a mask):
+  large blast radius — much internal code assumes `_index` is already filtered
+  (sample reads, contig offsets, chunking).
+- **Option 3** (keep `var_idxs()` physical, add an explicit physical→filtered
+  mapping helper): least invasive but leaves the footgun — `_index[var_idxs]`
+  stays wrong unless the caller knows to map first.
+
+## Changes
+
+### 1. `genoray/_var_ranges.py` — `var_indices()` returns positional indices
+
+Assign a fresh row index over the **full** (already-filtered) `var_table`
+*before* the `CHROM == c` filter, and return that positional column instead of
+`pl.col("index")`. The positional index is over the entire filtered `_index`, so
+it correctly gathers `_index` rows across all contigs.
+
+Order guarantee: `_index` is built by `scan_ipc` in file order then filtered
+(stable), so positional `k` ↔ the k-th kept variant in file order, and
+`_index["index"][k]` is its physical id.
+
+This function is shared by `PGEN.var_idxs` and `VCF._var_idxs`; both become
+positional from this one change (see §3).
+
+### 2. `genoray/_pgen.py` — map positional → physical at the read boundary
+
+In each of the four read entry points — `read`, `chunk`, `read_ranges`,
+`chunk_ranges` — after `var_idxs, ... = self.var_idxs(...)`, compute:
+
+```python
+phys = self._index["index"].to_numpy()[var_idxs]
+```
+
+and pass `phys` into the `_read_*` helpers. The `_read_*` helper signatures keep
+their existing "physical indices" meaning (no change there). Returned `offsets`
+are unchanged. For `chunk` / `chunk_ranges`, map before chunk-splitting
+(positional→physical is elementwise, so splitting either array is equivalent).
+
+**Invariant:** with no filter, positional == physical, so unfiltered reads and
+the existing `test_var_idxs` are unchanged.
+
+### 3. `genoray/_vcf.py` — no code change (verify only)
+
+VCF is structurally immune to the original bug: `_var_idxs` is **private** and
+unused in the read path; reads stream by position via cyvcf2, apply the
+per-record `_filter` in `_fill_genos`, and count via `var_counts`. The shared
+`var_indices()` change makes `_var_idxs` positional too — a free consistency
+win, asserted by a test.
+
+### 4. Public API docs
+
+- Update the `PGEN.var_idxs` docstring: indices are 0-based **positions into the
+  reader's filtered `_index`**, not file-global ids.
+- `skills/genoray-api/SKILL.md` does not currently document `var_idxs` or its
+  coordinate space; update it only if the implementation decides to surface this
+  name. The docstring change is mandatory regardless (per CLAUDE.md public-name
+  rule).
+
+## Testing (TDD — tests written first, must fail before the fix)
+
+Reuse the existing `biallelic` fixture + `exprs.is_snp`, which drops the interior
+`GAT→A` indels at **physical rows 0 and 3** (one per contig), making physical ≠
+positional. The vcfixture `GroundTruth` oracle (`tests/_oracle.py`) supplies
+expected values.
+
+### `tests/test_pgen.py` — filtered PGEN
+
+1. **In-bounds (direct #69 assertion):** for a chr2 query,
+   `var_idxs().max() < g._index.height` (pre-fix returns physical `[4, 5]` into a
+   4-row `_index`).
+2. **Index alignment:** `g._index[var_idxs]["POS"]` matches the oracle's kept
+   variants.
+3. **Read correctness:** `read()` / `read_ranges()` genotypes equal
+   `_oracle.genos(truth, physical_idx)` for the kept variants — proves the
+   positional→physical remap is correct, not merely in-bounds.
+
+### `tests/test_vcf.py` — filtered VCF
+
+- Filtered `read()` returns oracle-correct genotypes.
+- `_var_idxs` values are in-bounds positional (`< _index.height`).
+
+### Unchanged
+
+- Existing unfiltered `test_var_idxs` stays green (positional == physical).
+
+## Out of scope
+
+- gvl-side guard (separate repo; cross-ref gvl PR #241). This spec fixes the root
+  cause in genoray only.
+- Adding new fixture data or a mixed SNP/SV fixture (the existing `biallelic`
+  fixture + `is_snp` is sufficient to reproduce physical ≠ positional).

--- a/genoray/_pgen.py
+++ b/genoray/_pgen.py
@@ -432,7 +432,10 @@ class PGEN:
 
         Returns
         -------
-            Shape: (tot_variants). Variant indices for the given ranges.
+            Shape: (tot_variants). Variant indices for the given ranges, as
+            0-based **positions into this reader's (filtered) ``_index``** — i.e.
+            ``reader._index[var_idxs]`` is always valid. With no filter these
+            equal the physical PVAR row order.
 
             Shape: (ranges+1). Offsets to get variant indices for each range.
         """
@@ -440,6 +443,22 @@ class PGEN:
             self._init_index()
             assert self._c_norm is not None and self._index is not None
         return var_indices(V_IDX_TYPE, self._c_norm, self._index, contig, starts, ends)
+
+    def _var_idxs_phys(
+        self,
+        contig: str,
+        starts: ArrayLike = 0,
+        ends: ArrayLike = POS_MAX,
+    ) -> tuple[NDArray[V_IDX_TYPE], NDArray[OFFSET_TYPE]]:
+        """Internal: like :meth:`var_idxs`, but maps the positional indices to
+        physical (file-global) PVAR row ids for pgenlib random access. The
+        ``_index["index"]`` column holds physical ids; ``var_idxs`` returns
+        positions into ``_index`` (issue #69), so reads remap here.
+        """
+        pos, offsets = self.var_idxs(contig, starts, ends)
+        assert self._index is not None
+        phys = self._index["index"].to_numpy()[pos].astype(V_IDX_TYPE)
+        return phys, offsets
 
     def read(
         self,
@@ -476,7 +495,7 @@ class PGEN:
         if c is None:
             return mode.empty(self.n_samples, self.ploidy, 0)
 
-        var_idxs, _ = self.var_idxs(c, start, end)
+        var_idxs, _ = self._var_idxs_phys(c, start, end)
         n_variants = len(var_idxs)
 
         if n_variants == 0:
@@ -543,7 +562,7 @@ class PGEN:
             yield mode.empty(self.n_samples, self.ploidy, 0)
             return
 
-        var_idxs, _ = self.var_idxs(c, start, end)
+        var_idxs, _ = self._var_idxs_phys(c, start, end)
         n_variants = len(var_idxs)
         if n_variants == 0:
             yield mode.empty(self.n_samples, self.ploidy, 0)
@@ -630,7 +649,7 @@ class PGEN:
                 n_ranges + 1, OFFSET_TYPE
             )
 
-        var_idxs, offsets = self.var_idxs(c, starts, ends)
+        var_idxs, offsets = self._var_idxs_phys(c, starts, ends)
         n_variants = len(var_idxs)
         if n_variants == 0:
             return mode.empty(self.n_samples, self.ploidy, 0), np.zeros(
@@ -715,7 +734,7 @@ class PGEN:
 
         ends = np.atleast_1d(np.asarray(ends, POS_TYPE))
 
-        var_idxs, offsets = self.var_idxs(c, starts, ends)
+        var_idxs, offsets = self._var_idxs_phys(c, starts, ends)
         vars_per_range = np.diff(offsets)
         tot_variants = len(var_idxs)
         if tot_variants == 0:
@@ -850,7 +869,7 @@ class PGEN:
 
         ends = np.atleast_1d(np.asarray(ends, POS_TYPE))
 
-        var_idxs, offsets = self.var_idxs(c, starts, ends)
+        var_idxs, offsets = self._var_idxs_phys(c, starts, ends)
         tot_variants = len(var_idxs)
         if tot_variants == 0:
             for e in ends:

--- a/genoray/_var_ranges.py
+++ b/genoray/_var_ranges.py
@@ -122,9 +122,10 @@ def var_indices(
 
     var_table = (
         var_table.lazy()
+        .with_row_index("__pos")
         .filter(pl.col("CHROM") == c)
         .select(
-            pl.col("index").cast(np_to_pl_dtype(idx_dtype)),
+            pl.col("__pos").cast(np_to_pl_dtype(idx_dtype)).alias("index"),
             chrom=pl.col("CHROM").cast(pl.Utf8),
             start=pl.col("POS") - 1,
             end=pl.col("POS")

--- a/tests/test_pgen.py
+++ b/tests/test_pgen.py
@@ -492,3 +492,38 @@ def test_pgen_nbytes_zero_after_free():
     assert pgen._index is None
     assert pgen._sei is None
     assert pgen.nbytes == 0
+
+
+def test_filtered_var_idxs_consistent_with_index():
+    """Regression for #69: filtered PGEN var_idxs must index its own _index.
+
+    `is_snp` drops the interior GAT>A indels (physical rows 0 and 3), so for a
+    filtered reader physical != positional. var_idxs() must return positional
+    indices into the (filtered) _index, and reads must still return the correct
+    (physical) genotypes.
+    """
+    from genoray import exprs
+
+    g_filt = PGEN(ddir / "biallelic.pgen", filter=exprs.is_snp)
+    g_full = PGEN(ddir / "biallelic.pgen")
+
+    # Filter drops physical rows 0 and 3 -> 4 rows remain.
+    assert g_filt._index.height == 4
+
+    # chr2 query: positional [2, 3] (NOT physical [4, 5]).
+    vi, offsets = g_filt.var_idxs("chr2", 0, POS_MAX)
+    assert int(vi.max()) < g_filt._index.height  # #69: in-bounds
+    assert np.array_equal(vi, np.array([2, 3], dtype=vi.dtype))
+    assert np.array_equal(offsets, np.array([0, 2], dtype=offsets.dtype))
+
+    # _index[var_idxs] selects the kept chr2 SNPs (POS 81262, 81265).
+    assert g_filt._index[vi]["POS"].to_list() == [81262, 81265]
+
+    # Read correctness: a filtered chr1 read returns exactly the same genotypes
+    # as the corresponding (physical) variants from an unfiltered read. chr1's
+    # SNPs are physical rows [1, 2] -> within the full chr1 read those are the
+    # 2nd and 3rd variants on the variant axis.
+    filt = g_filt.read("chr1", 0, POS_MAX, mode=Genos)  # (s, p, 2)
+    full = g_full.read("chr1", 0, POS_MAX, mode=Genos)  # (s, p, 3)
+    assert filt.shape[-1] == 2
+    assert np.array_equal(filt, full[..., [1, 2]])

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.typing import ArrayLike, NDArray
 from pytest_cases import fixture, parametrize_with_cases
 
-from genoray._vcf import VCF
+from genoray._vcf import POS_MAX, VCF
 from tests import _oracle
 from tests.data.fixtures import FIXTURES
 
@@ -346,3 +346,40 @@ def test_filter_setter_enforces_pair_invariant():
     # A bare (non-tuple) value is rejected.
     with pytest.raises(TypeError):
         vcf.filter = record_fn
+
+
+def test_filtered_var_idxs_consistent_with_index():
+    """Regression guard for #69 on the VCF backend.
+
+    VCF._var_idxs is private and never gathers _index, but it shares
+    var_indices() with PGEN, so it must also return positional indices. Filtered
+    reads must return the same genotypes as the matching unfiltered variants.
+    """
+    from genoray import exprs
+
+    # is_snp as a (cyvcf2 record callable, pl.Expr) pair (VCF requires both).
+    def record_is_snp(rec):
+        return len(rec.REF) == 1 and all(len(a) == 1 for a in rec.ALT)
+
+    v_filt = VCF(
+        ddir / "biallelic.vcf.gz",
+        filter=record_is_snp,
+        pl_filter=exprs.is_snp,
+    )
+    v_filt._write_gvi_index()
+    v_filt._load_index()
+    v_full = VCF(ddir / "biallelic.vcf.gz")
+
+    assert v_filt._index.height == 4
+
+    # _var_idxs is positional and in-bounds (pre-#69 it returned physical [4,5]).
+    vi, _ = v_filt._var_idxs("chr2", 0, POS_MAX)
+    assert int(vi.max()) < v_filt._index.height
+    assert np.array_equal(vi, np.array([2, 3], dtype=vi.dtype))
+    assert v_filt._index[vi]["POS"].to_list() == [81262, 81265]
+
+    # Filtered chr1 read == the SNP variants (physical [1, 2]) of the full read.
+    filt = v_filt.read("chr1", 0, POS_MAX, mode=VCF.Genos16)
+    full = v_full.read("chr1", 0, POS_MAX, mode=VCF.Genos16)
+    assert filt.shape[-1] == 2
+    assert np.array_equal(filt, full[..., [1, 2]])


### PR DESCRIPTION
## Summary

Fixes #69. Filtered PGEN `var_idxs()` previously returned **physical** (pre-filter, file-global) PVAR row ids. After a filter compacts `_index`, those ids no longer index the filtered table, so `reader._index[var_idxs]` could go out of bounds / mis-align.

This makes the shared `_var_ranges.var_indices()` return **positional** row indices over the filtered table. PGEN's internal pgenlib reads still need physical ids for random access, so they now go through a new private `PGEN._var_idxs_phys()` that remaps positional → physical via the (still physical) `_index["index"]` column. The public `var_idxs()` returns positional. With **no** filter, positional == physical, so unfiltered behavior is unchanged.

VCF needs no code change (`_var_idxs` is private and never gathers `_index`); it shares `var_indices()` and gets consistency for free, guarded by a regression test.

## Changes

- **`fix:`** `genoray/_var_ranges.py` — `var_indices()` assigns a positional row index over the filtered table (via `with_row_index` before the `CHROM` filter) and returns it as `"index"`.
- **`fix:`** `genoray/_pgen.py` — new `_var_idxs_phys()` helper; 5 internal read sites (`read`, `chunk`, `read_ranges`, `chunk_ranges`, `_chunk_ranges_with_length`) switched to it; public `var_idxs` docstring updated to state the positional contract.
- **`test:`** PGEN + VCF regression tests asserting in-bounds, exact positional values, `_index[vi]` POS alignment, and filtered-vs-unfiltered genotype equality.

`_index["index"]` stays physical (unchanged) — `_svar.py` (`from_pgen`) and `_c_max_idxs` depend on it.

## Testing

Full suite green: `458 passed, 2 skipped, 16 xfailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
