### PR TITLE
feat(svar-2): M2 — variant normalization (split + atomize)

### DIFF
--- a/docs/roadmap/data-model.md
+++ b/docs/roadmap/data-model.md
@@ -235,11 +235,18 @@ sub-streams span exactly one base, so they need no leftward overlap extension.
 Conversion normalizes variants inline as they stream through, so the on-disk model is
 always normalized:
 
-- **Left-alignment** — shift indels to their leftmost equivalent position.
-- **Atomization** — break complex/MNV records into atomic primitives.
-- **Biallelic split** — split multi-allelic sites into separate biallelic records.
+- **Atomization (M2)** — break complex/MNV records into atomic primitives (SNP /
+  anchored INS / anchored DEL), mirroring bcftools `_atomize_allele`.
+- **Biallelic split (M2)** — split multi-allelic sites into separate biallelic records,
+  remapping genotypes by original ALT index.
+- **Left-alignment (M2b, deferred)** — shift indels to their leftmost equivalent
+  position. Deferred because it is the only step requiring a reference genome.
 
 This keeps `ILEN`/ALT semantics simple and makes the inline encoding well-defined.
+Because atomization spreads atom positions rightward (and, once M2b lands,
+left-alignment shifts them leftward), the reader emits atoms through a position-keyed
+reorder buffer so each per-`(sample, ploid)` stream stays position-sorted for the
+interleaving merge.
 
 ## Overlap queries and deletions
 

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -72,14 +72,21 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   `var_key` stream is now split into 2-bit `snp/` and 32-bit `indel/`
   sub-streams per [`data-model.md`](data-model.md#on-disk-layout); the SNP stream
   is 2-bit-packed post-merge and carries no LUT.
-- [ ] **M2. Variant normalization during conversion.** Left-alignment, atomization,
-  and biallelic splitting (split multi-allelic sites) applied inline as variants stream
-  through. See [`data-model.md`](data-model.md#variant-normalization).
-  *Not started — currently an input precondition.* The reader asserts normalized input
-  and panics on multi-allelic or complex records; the inline encoder bakes in the
-  atomized invariant `ref_len = 1` (it stores `ILEN = alt_len − 1` and decodes
-  `alt_len = ILEN + 1`). M2 is what will let conversion accept un-normalized VCFs
-  directly.
+- [~] **M2. Variant normalization during conversion.** Atomization and biallelic
+  splitting (split multi-allelic sites) applied inline as variants stream through. See
+  [`data-model.md`](data-model.md#variant-normalization). *Shipped:* the reader accepts
+  un-normalized VCFs — a pure `normalize.rs` decomposes each record into atomic
+  biallelic primitives (SNP / anchored INS / anchored DEL) mirroring bcftools
+  `_atomize_allele`, and a position-keyed reorder buffer preserves the merge's
+  sorted-position invariant across chunk boundaries. Genotypes are remapped by comparing
+  each haplotype's integer allele index to the atom's source ALT index. The former
+  "input must be normalized" asserts are gone; symbolic/breakend ALTs are rejected and
+  `*`/`.` alleles are skipped.
+- [ ] **M2b. Left-alignment during conversion.** Shift indels to their leftmost
+  equivalent position. Deferred from M2 because it is the only normalization step that
+  needs a reference genome (FASTA/faidx) and a new required conversion argument, and it
+  widens the reorder-buffer bound (leftward shifts). See
+  [`data-model.md`](data-model.md#variant-normalization).
 - [~] **M3. Per-contig split + sidecar positions.** Partition the SVAR2 directory by
   contig; keep positions as sidecar arrays. See
   [`architecture.md`](architecture.md#on-disk-layout).

--- a/docs/superpowers/plans/2026-07-02-svar2-m2-normalization.md
+++ b/docs/superpowers/plans/2026-07-02-svar2-m2-normalization.md
@@ -1,0 +1,929 @@
+# SVAR 2.0 M2 — Variant normalization (split + atomize) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept un-normalized VCFs during SVAR2 conversion by decomposing multi-allelic / MNP / complex records into atomized biallelic primitives inline as they stream through the reader.
+
+**Architecture:** A new pure `normalize.rs` module turns one VCF record into a list of atomic `Atom`s (SNP / anchored INS / anchored DEL), mirroring bcftools `_atomize_allele`. The reader is restructured around a position-keyed min-heap reorder buffer so atomization (which spreads atom positions rightward) still emits globally position-sorted `DenseChunk`s, preserving the invariant the interleaving merge depends on. Genotypes are remapped by comparing each haplotype's integer allele index to the atom's source ALT index. The encode seam, executor, and merge are untouched.
+
+**Tech Stack:** Rust 2024, rust-htslib (BCF/VCF), proptest, tempfile. Left-alignment (the only reference-genome-dependent piece) is explicitly deferred to a follow-up (M2b).
+
+## Global Constraints
+
+- Every emitted `Atom` MUST be one of exactly three encoder-valid shapes: SNP (`ref_len==1, alt_len==1, ilen==0`); anchored INS (`ref_len==1, alt_len>=2, ilen>0`, `alt.len()==ilen+1`); anchored DEL (`ref_len>=2, alt_len==1, ilen<0`). The encode seam (`rvk.rs`, `streams.rs`) is NOT modified.
+- No change to the Python API signature `run_conversion_pipeline`, the on-disk layout, or `meta.json`.
+- `*` (spanning-deletion) and `.` (no-ALT) alleles are skipped (no atom). Symbolic/breakend alleles (`<...>`, containing `[` or `]`) are rejected.
+- No left-alignment. Consequently every atom's `pos >= its source record's start pos`; the reorder buffer relies on this.
+- Run the Rust test suite with: `pixi run -e lint cargo test --no-default-features`. (Default features enable pyo3 `extension-module`, which doesn't link libpython for test binaries; the `lint` env provides rust + libclang + the htslib build deps.)
+- Match existing code style; keep files focused. `normalize.rs` owns all atomization logic — no SNP/indel branching leaks into the reader beyond genotype presence.
+
+---
+
+### Task 1: `normalize.rs` — pure atomization core
+
+**Files:**
+- Create: `src/normalize.rs`
+- Modify: `src/lib.rs` (add `pub mod normalize;`)
+- Test: in-source `#[cfg(test)]` in `src/normalize.rs`
+
+**Interfaces:**
+- Consumes: nothing (pure module).
+- Produces:
+  - `genoray_core::normalize::Atom { pub pos: u32, pub ilen: i32, pub alt: Vec<u8>, pub source_alt_index: u16 }`
+  - `genoray_core::normalize::NormalizeError` (thiserror enum; variant `SymbolicAllele { pos: u32, alt: String }`)
+  - `pub fn atomize_record(pos: u32, ref_allele: &[u8], alts: &[&[u8]], out: &mut Vec<Atom>) -> Result<(), NormalizeError>`
+
+- [ ] **Step 1: Add the module declaration**
+
+In `src/lib.rs`, add alongside the other `pub mod` lines (keep alphabetical grouping near `pub mod nrvk;`):
+
+```rust
+pub mod normalize;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/normalize.rs` with ONLY the test module first (the types/fn don't exist yet, so it won't compile — that's the "fail"):
+
+```rust
+//! Variant normalization: biallelic split + atomization (no left-alignment; roadmap M2).
+//! Pure functions over (pos, REF, ALTs) → atomic biallelic primitives. This is the only
+//! module that knows atomization rules; the encode seam downstream stays sealed.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn atoms(pos: u32, r: &[u8], alts: &[&[u8]]) -> Vec<Atom> {
+        let mut out = Vec::new();
+        atomize_record(pos, r, alts, &mut out).unwrap();
+        out
+    }
+
+    fn atom(pos: u32, ilen: i32, alt: &[u8], src: u16) -> Atom {
+        Atom { pos, ilen, alt: alt.to_vec(), source_alt_index: src }
+    }
+
+    #[test]
+    fn snp_passthrough() {
+        assert_eq!(atoms(100, b"A", &[b"C"]), vec![atom(100, 0, b"C", 1)]);
+    }
+
+    #[test]
+    fn biallelic_split_tags_source_index() {
+        // A>C,G → two independent SNPs carrying source indices 1 and 2.
+        assert_eq!(
+            atoms(100, b"A", &[b"C", b"G"]),
+            vec![atom(100, 0, b"C", 1), atom(100, 0, b"G", 2)]
+        );
+    }
+
+    #[test]
+    fn mnp_becomes_per_position_snps() {
+        // AC>GT → A>G@100, C>T@101 (both differ).
+        assert_eq!(
+            atoms(100, b"AC", &[b"GT"]),
+            vec![atom(100, 0, b"G", 1), atom(101, 0, b"T", 1)]
+        );
+    }
+
+    #[test]
+    fn mnp_skips_matching_bases() {
+        // ACA>ATA → only the middle base changes.
+        assert_eq!(atoms(100, b"ACA", &[b"ATA"]), vec![atom(101, 0, b"T", 1)]);
+    }
+
+    #[test]
+    fn simple_insertion_anchored() {
+        // A>AT → anchored INS, ilen=+1, full alt stored.
+        assert_eq!(atoms(100, b"A", &[b"AT"]), vec![atom(100, 1, b"AT", 1)]);
+    }
+
+    #[test]
+    fn simple_deletion_anchored() {
+        // ATG>A → pure DEL, ilen=-2, alt = anchor base.
+        assert_eq!(atoms(100, b"ATG", &[b"A"]), vec![atom(100, -2, b"A", 1)]);
+    }
+
+    #[test]
+    fn shared_suffix_is_trimmed() {
+        // ATG>CG shares suffix G → AT>C: anchor substitutes (A→C), so split into
+        // SNV(A>C)@100 plus a clean DEL(anchor=ref base A, delete T)@100.
+        assert_eq!(
+            atoms(100, b"ATG", &[b"CG"]),
+            vec![atom(100, 0, b"C", 1), atom(100, -1, b"A", 1)]
+        );
+    }
+
+    #[test]
+    fn complex_snv_plus_insertion() {
+        // GCG>GTGA (the bcftools abuf.c example): interior SNV C>T@101, then an
+        // anchored INS G>GA@102.
+        assert_eq!(
+            atoms(100, b"GCG", &[b"GTGA"]),
+            vec![atom(101, 0, b"T", 1), atom(102, 1, b"GA", 1)]
+        );
+    }
+
+    #[test]
+    fn star_and_missing_alleles_skipped() {
+        assert_eq!(atoms(100, b"A", &[b"*"]), vec![]);
+        assert_eq!(atoms(100, b"A", &[b"."]), vec![]);
+        // still processes the real ALT alongside a skipped one
+        assert_eq!(atoms(100, b"A", &[b"*", b"C"]), vec![atom(100, 0, b"C", 2)]);
+    }
+
+    #[test]
+    fn symbolic_allele_errors() {
+        let mut out = Vec::new();
+        assert!(matches!(
+            atomize_record(100, b"A", &[b"<DEL>"], &mut out),
+            Err(NormalizeError::SymbolicAllele { .. })
+        ));
+        assert!(matches!(
+            atomize_record(100, b"A", &[b"A[chr2:321[".as_slice()], &mut out),
+            Err(NormalizeError::SymbolicAllele { .. })
+        ));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2000))]
+
+        // Every atom is encoder-valid and starts within the record's reference span.
+        #[test]
+        fn atoms_are_encoder_valid(
+            pos in 0u32..1_000_000,
+            r in proptest::collection::vec(prop_oneof![Just(b'A'), Just(b'C'), Just(b'G'), Just(b'T')], 1..12),
+            a in proptest::collection::vec(prop_oneof![Just(b'A'), Just(b'C'), Just(b'G'), Just(b'T')], 1..12),
+        ) {
+            let mut out = Vec::new();
+            let ref_bytes: Vec<u8> = r;
+            let alt_bytes: Vec<u8> = a;
+            atomize_record(pos, &ref_bytes, &[alt_bytes.as_slice()], &mut out).unwrap();
+            for at in &out {
+                let alt_len = at.alt.len() as i32;
+                let valid = (at.ilen == 0 && alt_len == 1)
+                    || (at.ilen > 0 && alt_len == at.ilen + 1)  // INS: ref_len 1
+                    || (at.ilen < 0 && alt_len == 1);           // DEL: alt_len 1
+                prop_assert!(valid, "atom not encoder-valid: {:?}", at);
+                prop_assert!(at.pos >= pos, "atom before record start");
+                prop_assert!(at.pos < pos + ref_bytes.len() as u32, "atom past reference span");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pixi run -e lint cargo test --no-default-features normalize`
+Expected: FAIL — compile error, `cannot find type Atom` / `atomize_record` not found.
+
+- [ ] **Step 4: Write the implementation**
+
+Prepend to `src/normalize.rs` (above the `#[cfg(test)]` module, below the top doc comment):
+
+```rust
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum NormalizeError {
+    #[error("symbolic/breakend ALT '{alt}' at pos {pos} is out of scope (short-read only)")]
+    SymbolicAllele { pos: u32, alt: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Atom {
+    /// 0-based start position of the atom.
+    pub pos: u32,
+    /// len(alt) - len(ref): 0 = SNP, > 0 = INS, < 0 = DEL.
+    pub ilen: i32,
+    /// SNP: the single ALT base. INS: anchor + inserted bases. DEL: the anchor base.
+    pub alt: Vec<u8>,
+    /// 1-based index into the record's original ALTs, for genotype remapping.
+    pub source_alt_index: u16,
+}
+
+/// Decompose one VCF record into atomic biallelic primitives, appended to `out`.
+/// `alts` are the ALT alleles only (REF excluded). `*` / `.` alleles are skipped;
+/// symbolic/breakend alleles return an error.
+pub fn atomize_record(
+    pos: u32,
+    ref_allele: &[u8],
+    alts: &[&[u8]],
+    out: &mut Vec<Atom>,
+) -> Result<(), NormalizeError> {
+    for (j, &alt) in alts.iter().enumerate() {
+        let src = (j + 1) as u16;
+        if alt == b"*" || alt == b"." {
+            continue;
+        }
+        if is_symbolic(alt) {
+            return Err(NormalizeError::SymbolicAllele {
+                pos,
+                alt: String::from_utf8_lossy(alt).into_owned(),
+            });
+        }
+        atomize_biallelic(pos, ref_allele, alt, src, out);
+    }
+    Ok(())
+}
+
+#[inline]
+fn is_symbolic(alt: &[u8]) -> bool {
+    alt.first() == Some(&b'<') || alt.contains(&b'[') || alt.contains(&b']')
+}
+
+/// Decompose a single REF/ALT pair. Mirrors bcftools `_atomize_allele`: trim the
+/// shared suffix, emit a SNV per interior mismatch, and attach any length change as a
+/// single left-anchored indel at the last aligned index. The one deviation is the
+/// substituted-deletion-anchor case (see below), forced by the pure-DEL encoding.
+fn atomize_biallelic(pos: u32, ref_allele: &[u8], alt: &[u8], src: u16, out: &mut Vec<Atom>) {
+    // 1. Trim shared suffix, keeping >= 1 base on each side.
+    let mut rlen = ref_allele.len();
+    let mut alen = alt.len();
+    while rlen > 1 && alen > 1 && ref_allele[rlen - 1] == alt[alen - 1] {
+        rlen -= 1;
+        alen -= 1;
+    }
+    let r = &ref_allele[..rlen];
+    let a = &alt[..alen];
+
+    let n = rlen.min(alen);
+    let k = n - 1; // last aligned index; the indel (if any) anchors here
+
+    // 2. Interior aligned positions [0, k): one SNV per mismatch.
+    for i in 0..k {
+        if r[i] != a[i] {
+            out.push(Atom { pos: pos + i as u32, ilen: 0, alt: vec![a[i]], source_alt_index: src });
+        }
+    }
+
+    // 3. Boundary at k.
+    let apos = pos + k as u32;
+    if rlen == alen {
+        // Pure substitution tail.
+        if r[k] != a[k] {
+            out.push(Atom { pos: apos, ilen: 0, alt: vec![a[k]], source_alt_index: src });
+        }
+    } else if alen > rlen {
+        // Insertion anchored at k. ref[k..] is a single base; alt[k..] carries the
+        // (possibly substituted) anchor + inserted bases — the full alt is stored, so a
+        // substituted anchor is faithfully represented.
+        let ins_alt = a[k..alen].to_vec();
+        let ilen = ins_alt.len() as i32 - 1; // ref_len == 1
+        out.push(Atom { pos: apos, ilen, alt: ins_alt, source_alt_index: src });
+    } else {
+        // Deletion anchored at k. alt[k..] is a single base.
+        let del_ref_len = (rlen - k) as i32; // >= 2
+        let ilen = 1 - del_ref_len; // alt_len(1) - ref_len
+        if r[k] == a[k] {
+            // Clean anchor → pure DEL (alt = the anchor base).
+            out.push(Atom { pos: apos, ilen, alt: vec![a[k]], source_alt_index: src });
+        } else {
+            // Substituted anchor: the pure-DEL encoding reconstructs the anchor from
+            // the reference, so it cannot carry a substitution. Split into a SNV plus a
+            // clean DEL whose anchor is the unchanged reference base.
+            out.push(Atom { pos: apos, ilen: 0, alt: vec![a[k]], source_alt_index: src });
+            out.push(Atom { pos: apos, ilen, alt: vec![r[k]], source_alt_index: src });
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pixi run -e lint cargo test --no-default-features normalize`
+Expected: PASS (all unit tests + the proptest).
+
+- [ ] **Step 6: Lint**
+
+Run: `pixi run -e lint cargo clippy --no-default-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/normalize.rs src/lib.rs
+git commit -m "feat(svar-2): normalize.rs — biallelic split + atomization core"
+```
+
+---
+
+### Task 2: Extract shared test harness; drop obsolete negative e2e tests
+
+**Files:**
+- Create: `tests/common/mod.rs`
+- Modify: `tests/test_e2e.rs`
+- Test: `tests/test_e2e.rs` (still passes with existing positive coverage)
+
+**Interfaces:**
+- Consumes: `genoray_core::process_chromosome`, `genoray_core::vcf_reader::VcfChunkReader`.
+- Produces (in `tests/common/mod.rs`, `pub`):
+  - `struct SynthRecord<'a> { pub pos: i64, pub ref_allele: &'a [u8], pub alts: Vec<&'a [u8]>, pub gt: Vec<i32> }`
+  - `fn build_bcf_with_index(bcf_path: &Path, chrom: &str, chrom_len: u64, samples: &[&str], records: &[SynthRecord])`
+  - `fn read_u32_bin(path: &Path) -> Vec<u32>`
+  - `fn read_offsets_npy(path: &Path) -> Vec<u64>`
+
+- [ ] **Step 1: Create the shared harness module**
+
+Create `tests/common/mod.rs` by moving the harness out of `tests/test_e2e.rs` and making the items `pub`:
+
+```rust
+// Shared synthetic-BCF harness for the e2e / atomization integration tests.
+use rust_htslib::bcf::record::GenotypeAllele;
+use rust_htslib::bcf::{Format, Header, Writer};
+use std::path::Path;
+
+// One synthetic VCF record: position, ref allele, list of alt alleles, and a flat
+// genotype vector laid out as [s0_p0, s0_p1, s1_p0, s1_p1, ...] holding allele indices
+// (0 = ref, 1 = first alt, ...). Use a negative value for a missing allele.
+pub struct SynthRecord<'a> {
+    pub pos: i64,
+    pub ref_allele: &'a [u8],
+    pub alts: Vec<&'a [u8]>,
+    pub gt: Vec<i32>,
+}
+
+pub fn build_bcf_with_index(
+    bcf_path: &Path,
+    chrom: &str,
+    chrom_len: u64,
+    samples: &[&str],
+    records: &[SynthRecord],
+) {
+    let mut header = Header::new();
+    let contig = format!("##contig=<ID={},length={}>", chrom, chrom_len);
+    header.push_record(contig.as_bytes());
+    header.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+    for s in samples {
+        header.push_sample(s.as_bytes());
+    }
+
+    {
+        let mut writer =
+            Writer::from_path(bcf_path, &header, false, Format::Bcf).expect("open BCF writer");
+
+        for rec in records {
+            let mut record = writer.empty_record();
+            record.set_rid(Some(0));
+            record.set_pos(rec.pos);
+
+            let mut alleles: Vec<&[u8]> = Vec::with_capacity(1 + rec.alts.len());
+            alleles.push(rec.ref_allele);
+            for a in &rec.alts {
+                alleles.push(a);
+            }
+            record.set_alleles(&alleles).expect("set alleles");
+
+            let gt_alleles: Vec<GenotypeAllele> =
+                rec.gt.iter().map(|&i| GenotypeAllele::Phased(i)).collect();
+            record.push_genotypes(&gt_alleles).expect("push genotypes");
+
+            writer.write(&record).expect("write record");
+        }
+    }
+
+    rust_htslib::bcf::index::build(bcf_path, None, 0, rust_htslib::bcf::index::Type::Csi(14))
+        .expect("build BCF index");
+}
+
+pub fn read_u32_bin(path: &Path) -> Vec<u32> {
+    let bytes = std::fs::read(path).expect("read u32 bin");
+    bytes
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+pub fn read_offsets_npy(path: &Path) -> Vec<u64> {
+    let arr: ndarray::Array1<u64> = ndarray_npy::read_npy(path).expect("read offsets npy");
+    arr.to_vec()
+}
+```
+
+- [ ] **Step 2: Rewrite `tests/test_e2e.rs` to use the harness and drop the obsolete negative tests**
+
+Replace the top of `tests/test_e2e.rs` (the imports + the moved harness `SynthRecord` / `build_bcf_with_index` / `read_u32_bin` / `read_offsets_npy` definitions) with a `mod common;` include, and **delete** the two `#[should_panic]` tests `test_reader_panics_on_multi_allelic` and `test_reader_panics_on_complex_variant` (that behavior is being removed). Keep `test_e2e_normalized_bcf_pipeline`, `test_e2e_mutation_conservation`, `test_reader_accepts_pure_del`, and `test_missing_chrom_returns_err`, changing their references to the harness items to `common::...`.
+
+Concretely, the new header of `tests/test_e2e.rs`:
+
+```rust
+// End-to-end pipeline test: builds tiny synthetic BCFs and validates the final
+// sample-major sparse outputs against hand-computed ground truth.
+mod common;
+
+use common::{SynthRecord, build_bcf_with_index, read_offsets_npy, read_u32_bin};
+
+use genoray_core::process_chromosome;
+use genoray_core::rvk::{decode_alt_inline, unpack_snp_keys};
+use genoray_core::vcf_reader::VcfChunkReader;
+
+use std::path::Path;
+use tempfile::tempdir;
+```
+
+Leave the four retained test functions and the `DecodedKey` / `decode_key` helpers as-is (they already refer to `SynthRecord` etc., now imported from `common`). Update the doc comment on `test_reader_accepts_pure_del` to drop the "assert-panic contract" framing.
+
+- [ ] **Step 3: Run the e2e tests to verify they still pass**
+
+Run: `pixi run -e lint cargo test --no-default-features --test test_e2e`
+Expected: PASS — 4 tests (`test_e2e_normalized_bcf_pipeline`, `test_e2e_mutation_conservation`, `test_reader_accepts_pure_del`, `test_missing_chrom_returns_err`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/common/mod.rs tests/test_e2e.rs
+git commit -m "test(svar-2): extract shared BCF harness; drop obsolete reader-panic tests"
+```
+
+---
+
+### Task 3: Reader restructure — reorder buffer, genotype remapping, atomized chunks
+
+**Files:**
+- Modify: `src/vcf_reader.rs` (full restructure of `VcfChunkReader`)
+- Create: `tests/test_atomize_e2e.rs`
+- Test: `tests/test_atomize_e2e.rs`
+
+**Interfaces:**
+- Consumes: `genoray_core::normalize::{Atom, atomize_record}` (Task 1); `common::*` harness (Task 2); `crate::types::{BitGrid3, DenseChunk}`.
+- Produces: unchanged public surface — `VcfChunkReader::new(vcf_path: &str, chrom: &str, samples: &[&str], htslib_threads: usize, ploidy: usize) -> Self` and `read_next_chunk(&mut self, chunk_size: usize, chunk_id: usize) -> Option<DenseChunk>`. `DenseChunk` now holds one row per **atom** (globally position-sorted across chunks) instead of one row per input record.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `tests/test_atomize_e2e.rs`:
+
+```rust
+// End-to-end atomization/normalization: feed un-normalized records and assert the
+// reader emits correctly split, atomized, and globally position-sorted DenseChunks.
+mod common;
+
+use common::{SynthRecord, build_bcf_with_index};
+use genoray_core::vcf_reader::VcfChunkReader;
+use std::path::Path;
+use tempfile::tempdir;
+
+// Collect every atom the reader emits across all chunks, as (pos, ilen) plus the
+// per-column presence bits, in emission order.
+fn drain_reader(
+    bcf_path: &Path,
+    chrom: &str,
+    samples: &[&str],
+    ploidy: usize,
+    chunk_size: usize,
+) -> Vec<(u32, i32, Vec<bool>)> {
+    let mut reader = VcfChunkReader::new(bcf_path.to_str().unwrap(), chrom, samples, 1, ploidy);
+    let columns = samples.len() * ploidy;
+    let mut out = Vec::new();
+    let mut chunk_id = 0;
+    while let Some(chunk) = reader.read_next_chunk(chunk_size, chunk_id) {
+        let v = chunk.pos.len();
+        for i in 0..v {
+            let mut presence = Vec::with_capacity(columns);
+            for col in 0..columns {
+                presence.push(chunk.genos.get_bit(i * columns + col));
+            }
+            out.push((chunk.pos[i], chunk.ilens[i], presence));
+        }
+        chunk_id += 1;
+    }
+    out
+}
+
+#[test]
+fn multiallelic_site_splits_and_remaps_genotypes() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("multi.bcf");
+    let samples = vec!["S0"];
+    // One diploid sample, genotype 1|2 at a 2-ALT site A>C,G.
+    let records = vec![SynthRecord {
+        pos: 100,
+        ref_allele: b"A",
+        alts: vec![&b"C"[..], &b"G"[..]],
+        gt: vec![1, 2],
+    }];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
+    // Two SNP atoms at pos 100: ALT C carried on hap0 only, ALT G on hap1 only.
+    assert_eq!(atoms.len(), 2);
+    assert_eq!((atoms[0].0, atoms[0].1), (100, 0));
+    assert_eq!((atoms[1].0, atoms[1].1), (100, 0));
+    assert_eq!(atoms[0].2, vec![true, false]); // source ALT 1 (C) → hap0
+    assert_eq!(atoms[1].2, vec![false, true]); // source ALT 2 (G) → hap1
+}
+
+#[test]
+fn mnp_atomizes_to_snps_shared_presence() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("mnp.bcf");
+    let samples = vec!["S0"];
+    // AC>GT MNP, sample homozygous for the ALT on both haps.
+    let records = vec![SynthRecord {
+        pos: 100,
+        ref_allele: b"AC",
+        alts: vec![&b"GT"[..]],
+        gt: vec![1, 1],
+    }];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
+    // Two SNP atoms (A>G@100, C>T@101), both carried on both haps.
+    assert_eq!(atoms.len(), 2);
+    assert_eq!((atoms[0].0, atoms[0].1), (100, 0));
+    assert_eq!((atoms[1].0, atoms[1].1), (101, 0));
+    assert_eq!(atoms[0].2, vec![true, true]);
+    assert_eq!(atoms[1].2, vec![true, true]);
+}
+
+#[test]
+fn atoms_are_globally_position_sorted_across_records() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("sorted.bcf");
+    let samples = vec!["S0"];
+    // An MNP at 100 spans to 104; a SNP record starts at 102 — its atom would land
+    // between the MNP's atoms unless the reader reorders. Also force small chunks so
+    // the ordering must hold ACROSS chunk boundaries.
+    let records = vec![
+        SynthRecord { pos: 100, ref_allele: b"ACGTA", alts: vec![&b"GCGTG"[..]], gt: vec![1, 1] },
+        SynthRecord { pos: 102, ref_allele: b"A", alts: vec![&b"T"[..]], gt: vec![1, 0] },
+    ];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    // chunk_size = 1 → every atom lands in its own chunk; emission order must still
+    // be globally sorted.
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 1);
+    let positions: Vec<u32> = atoms.iter().map(|a| a.0).collect();
+    // MNP → A>G@100, A>G@104; SNP → T@102. Sorted: 100, 102, 104.
+    assert_eq!(positions, vec![100, 102, 104]);
+    let mut sorted = positions.clone();
+    sorted.sort();
+    assert_eq!(positions, sorted, "emitted positions must be globally sorted");
+}
+
+#[test]
+fn complex_deletion_with_substituted_anchor() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("complex.bcf");
+    let samples = vec!["S0"];
+    // ATG>CG (previously rejected as "complex"): → SNV(A>C)@100 + DEL(ilen=-1)@100.
+    let records = vec![SynthRecord {
+        pos: 100,
+        ref_allele: b"ATG",
+        alts: vec![&b"CG"[..]],
+        gt: vec![1, 1],
+    }];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
+    assert_eq!(atoms.len(), 2);
+    assert_eq!((atoms[0].0, atoms[0].1), (100, 0));  // SNV A>C
+    assert_eq!((atoms[1].0, atoms[1].1), (100, -1)); // DEL
+    assert_eq!(atoms[0].2, vec![true, true]);
+    assert_eq!(atoms[1].2, vec![true, true]);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pixi run -e lint cargo test --no-default-features --test test_atomize_e2e`
+Expected: FAIL — the current reader panics on the multi-allelic / complex inputs (`must be normalized` / `must be atomized`) and does not atomize MNPs.
+
+- [ ] **Step 3: Restructure `src/vcf_reader.rs`**
+
+Replace the entire contents of `src/vcf_reader.rs` with:
+
+```rust
+use crate::normalize::atomize_record;
+use crate::types::{BitGrid3, DenseChunk};
+use rust_htslib::bcf::record::Record;
+use rust_htslib::bcf::{IndexedReader, Read};
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::rc::Rc;
+
+// A decomposed atom awaiting emission. Carries a shared handle to its source record's
+// per-column allele indices so genotype presence is computed at chunk-build time.
+struct PendingAtom {
+    pos: u32,
+    ilen: i32,
+    alt: Vec<u8>,
+    source_alt_index: u16,
+    gt: Rc<Vec<i32>>, // len = num_samples * ploidy; allele index per column (-1 = missing)
+    seq: u64,         // stable tiebreak for equal positions
+}
+
+impl PartialEq for PendingAtom {
+    fn eq(&self, other: &Self) -> bool {
+        self.pos == other.pos && self.seq == other.seq
+    }
+}
+impl Eq for PendingAtom {}
+impl PartialOrd for PendingAtom {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for PendingAtom {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.pos.cmp(&other.pos).then(self.seq.cmp(&other.seq))
+    }
+}
+
+pub struct VcfChunkReader {
+    inner_reader: IndexedReader,
+    num_samples: usize,
+    ploidy: usize,
+    sample_indices: Vec<usize>,
+
+    // Reorder state, persisted across read_next_chunk calls.
+    record: Record,
+    heap: BinaryHeap<Reverse<PendingAtom>>,
+    frontier: u32, // start pos of the most recently read record: all future atoms have pos >= this
+    eof: bool,
+    next_seq: u64,
+}
+
+impl VcfChunkReader {
+    // opens the file, applies the sample filter at the C-level, and jumps to the chromosome.
+    pub fn new(
+        vcf_path: &str,
+        chrom: &str,
+        samples: &[&str],
+        htslib_threads: usize,
+        ploidy: usize,
+    ) -> Self {
+        let mut reader = IndexedReader::from_path(vcf_path)
+            .expect("Failed to open VCF/BCF index. Is there a .tbi or .csi file?");
+
+        reader
+            .set_threads(htslib_threads)
+            .expect("Failed to allocate HTSlib background threads");
+
+        let header = reader.header().clone();
+
+        let rid = header
+            .name2rid(chrom.as_bytes())
+            .expect("Chromosome not found in VCF header");
+
+        reader
+            .fetch(rid, 0, None)
+            .expect("Failed to fetch chromosome region");
+
+        let sample_indices: Vec<usize> = samples
+            .iter()
+            .map(|name| {
+                header
+                    .sample_id(name.as_bytes())
+                    .unwrap_or_else(|| panic!("Sample {} not found in VCF", name))
+            })
+            .collect();
+
+        let record = reader.empty_record();
+
+        Self {
+            inner_reader: reader,
+            num_samples: samples.len(),
+            ploidy,
+            sample_indices,
+            record,
+            heap: BinaryHeap::new(),
+            frontier: 0,
+            eof: false,
+            next_seq: 0,
+        }
+    }
+
+    // Decompose `self.record` into atoms and push them onto the reorder heap, sharing
+    // one decoded genotype vector across all atoms of the record.
+    fn decompose_current_record(&mut self) {
+        let pos = self.record.pos() as u32;
+
+        // Own the alleles so the record borrow is released before we mutate self.
+        let ref_allele: Vec<u8>;
+        let alts_owned: Vec<Vec<u8>>;
+        {
+            let alleles = self.record.alleles();
+            ref_allele = alleles[0].to_vec();
+            alts_owned = alleles[1..].iter().map(|a| a.to_vec()).collect();
+        }
+
+        // Decode per-column allele indices (-1 = missing).
+        let columns = self.num_samples * self.ploidy;
+        let mut gt = vec![-1i32; columns];
+        {
+            let genotypes = self.record.genotypes().expect("Failed to read genotypes");
+            for (s_idx, &vcf_idx) in self.sample_indices.iter().enumerate() {
+                let sample_gt = genotypes.get(vcf_idx);
+                for p in 0..self.ploidy {
+                    let idx = if p < sample_gt.len() {
+                        sample_gt[p].index().map(|v| v as i32).unwrap_or(-1)
+                    } else {
+                        -1
+                    };
+                    gt[s_idx * self.ploidy + p] = idx;
+                }
+            }
+        }
+        let gt = Rc::new(gt);
+
+        let alt_refs: Vec<&[u8]> = alts_owned.iter().map(|a| a.as_slice()).collect();
+        let mut atoms = Vec::new();
+        atomize_record(pos, &ref_allele, &alt_refs, &mut atoms)
+            .expect("symbolic/breakend ALT is out of scope for SVAR2 (short-read only)");
+
+        for atom in atoms {
+            let seq = self.next_seq;
+            self.next_seq += 1;
+            self.heap.push(Reverse(PendingAtom {
+                pos: atom.pos,
+                ilen: atom.ilen,
+                alt: atom.alt,
+                source_alt_index: atom.source_alt_index,
+                gt: Rc::clone(&gt),
+                seq,
+            }));
+        }
+    }
+
+    // Yield the next atom in global position order, reading and decomposing more
+    // records as needed. An atom is safe to emit once its position is strictly below
+    // the read frontier (no future atom can precede the frontier, since there is no
+    // left-alignment) or once the input is exhausted.
+    fn next_atom(&mut self) -> Option<PendingAtom> {
+        loop {
+            if let Some(Reverse(top)) = self.heap.peek() {
+                if self.eof || top.pos < self.frontier {
+                    return Some(self.heap.pop().unwrap().0);
+                }
+            } else if self.eof {
+                return None;
+            }
+
+            match self.inner_reader.read(&mut self.record) {
+                Some(Ok(())) => {
+                    self.frontier = self.record.pos() as u32;
+                    self.decompose_current_record();
+                }
+                Some(Err(e)) => panic!("VCF Read Error: {}", e),
+                None => self.eof = true,
+            }
+        }
+    }
+
+    // Pull up to `chunk_size` atoms (already globally position-sorted) and pack them
+    // into a variant-major DenseChunk. Returns None once no atoms remain.
+    pub fn read_next_chunk(&mut self, chunk_size: usize, chunk_id: usize) -> Option<DenseChunk> {
+        let mut atoms: Vec<PendingAtom> = Vec::with_capacity(chunk_size);
+        while atoms.len() < chunk_size {
+            match self.next_atom() {
+                Some(a) => atoms.push(a),
+                None => break,
+            }
+        }
+        if atoms.is_empty() {
+            return None;
+        }
+
+        let v = atoms.len();
+        let columns = self.num_samples * self.ploidy;
+
+        let mut pos = Vec::with_capacity(v);
+        let mut ilens = Vec::with_capacity(v);
+        let mut alt = Vec::with_capacity(v * 2);
+        let mut alt_offsets = Vec::with_capacity(v + 1);
+        alt_offsets.push(0u32);
+        let mut genos = BitGrid3::zeros(v, self.num_samples, self.ploidy);
+
+        let mut off = 0u32;
+        for (vi, a) in atoms.iter().enumerate() {
+            pos.push(a.pos);
+            ilens.push(a.ilen);
+            alt.extend_from_slice(&a.alt);
+            off += a.alt.len() as u32;
+            alt_offsets.push(off);
+
+            let src = a.source_alt_index as i32;
+            let base = vi * columns;
+            for col in 0..columns {
+                genos.or_bit(base + col, a.gt[col] == src);
+            }
+        }
+
+        Some(DenseChunk {
+            chunk_id,
+            pos,
+            ilens,
+            alt,
+            alt_offsets,
+            genos,
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Run the new integration tests to verify they pass**
+
+Run: `pixi run -e lint cargo test --no-default-features --test test_atomize_e2e`
+Expected: PASS — all 4 tests.
+
+- [ ] **Step 5: Run the full Rust test suite (regression check)**
+
+Run: `pixi run -e lint cargo test --no-default-features`
+Expected: PASS — including the retained `test_e2e` tests (already-atomized inputs round-trip unchanged) and all in-source unit/proptests.
+
+- [ ] **Step 6: Lint**
+
+Run: `pixi run -e lint cargo clippy --no-default-features -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/vcf_reader.rs tests/test_atomize_e2e.rs
+git commit -m "feat(svar-2): atomize + reorder in the reader; accept un-normalized VCFs"
+```
+
+---
+
+### Task 4: Reconcile roadmap + data-model docs
+
+**Files:**
+- Modify: `docs/roadmap/svar-2.md`
+- Modify: `docs/roadmap/data-model.md`
+
+**Interfaces:**
+- Consumes: nothing (docs).
+- Produces: nothing (docs).
+
+- [ ] **Step 1: Update the M2 milestone in `docs/roadmap/svar-2.md`**
+
+Change the M2 checkbox from `[ ]` to `[~]` and rewrite its body to reflect the shipped scope (split + atomize) and the deferral. Then add a new `M2b` entry directly after it. Replace the existing M2 bullet with:
+
+```markdown
+- [~] **M2. Variant normalization during conversion.** Atomization and biallelic
+  splitting (split multi-allelic sites) applied inline as variants stream through. See
+  [`data-model.md`](data-model.md#variant-normalization). *Shipped:* the reader accepts
+  un-normalized VCFs — a pure `normalize.rs` decomposes each record into atomic
+  biallelic primitives (SNP / anchored INS / anchored DEL) mirroring bcftools
+  `_atomize_allele`, and a position-keyed reorder buffer preserves the merge's
+  sorted-position invariant across chunk boundaries. Genotypes are remapped by comparing
+  each haplotype's integer allele index to the atom's source ALT index. The former
+  "input must be normalized" asserts are gone; symbolic/breakend ALTs are rejected and
+  `*`/`.` alleles are skipped.
+- [ ] **M2b. Left-alignment during conversion.** Shift indels to their leftmost
+  equivalent position. Deferred from M2 because it is the only normalization step that
+  needs a reference genome (FASTA/faidx) and a new required conversion argument, and it
+  widens the reorder-buffer bound (leftward shifts). See
+  [`data-model.md`](data-model.md#variant-normalization).
+```
+
+- [ ] **Step 2: Update the normalization section in `docs/roadmap/data-model.md`**
+
+Replace the `## Variant normalization` section body so left-alignment is flagged as a separate milestone:
+
+```markdown
+## Variant normalization
+
+Conversion normalizes variants inline as they stream through, so the on-disk model is
+always normalized:
+
+- **Atomization (M2)** — break complex/MNV records into atomic primitives (SNP /
+  anchored INS / anchored DEL), mirroring bcftools `_atomize_allele`.
+- **Biallelic split (M2)** — split multi-allelic sites into separate biallelic records,
+  remapping genotypes by original ALT index.
+- **Left-alignment (M2b, deferred)** — shift indels to their leftmost equivalent
+  position. Deferred because it is the only step requiring a reference genome.
+
+This keeps `ILEN`/ALT semantics simple and makes the inline encoding well-defined.
+Because atomization spreads atom positions rightward (and, once M2b lands,
+left-alignment shifts them leftward), the reader emits atoms through a position-keyed
+reorder buffer so each per-`(sample, ploid)` stream stays position-sorted for the
+interleaving merge.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/roadmap/svar-2.md docs/roadmap/data-model.md
+git commit -m "docs(svar-2): reconcile M2 (split+atomize shipped; left-align → M2b)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Biallelic split → Task 1 (`atomize_record` loops ALTs) + Task 3 test `multiallelic_site_splits_and_remaps_genotypes`. ✓
+- Atomization (MNP + complex) → Task 1 impl + tests; Task 3 e2e. ✓
+- Left-alignment deferred → Task 4 (M2b). ✓
+- `*`/`.` skipped, symbolic rejected → Task 1 (`atomize_record`, `is_symbolic`) + tests. ✓
+- Genotype remapping via integer allele index → Task 3 `decompose_current_record` + tests. ✓
+- Reorder buffer preserves sorted invariant → Task 3 `next_atom` + `atoms_are_globally_position_sorted_across_records`. ✓
+- Encode seam / executor / merge / Python API unchanged → no tasks touch them; enforced by Global Constraints and the passing `test_e2e` regression. ✓
+- Error handling (symbolic → typed error at boundary) → Task 1 `NormalizeError`; the reader `.expect()`s it, surfacing via the existing thread-panic→`ConversionError::WorkerPanicked` path (consistent with `error.rs`'s "worker hot loops panic" note and `test_missing_chrom_returns_err`). ✓
+- e2e vs bcftools oracle → covered structurally by hand-built fixtures in Task 3 (`bcftools`-on-PATH oracle noted as optional in the spec; hand fixtures chosen to avoid a hard external-tool dependency in CI).
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✓
+
+**Type consistency:** `Atom { pos: u32, ilen: i32, alt: Vec<u8>, source_alt_index: u16 }` and `atomize_record(pos, ref_allele, alts, out) -> Result<(), NormalizeError>` are identical in Task 1 definition and Task 3 use. `VcfChunkReader::{new, read_next_chunk}` signatures match the pre-existing public API the tests call. `common::{SynthRecord, build_bcf_with_index, read_u32_bin, read_offsets_npy}` defined in Task 2 and consumed in Tasks 2–3. ✓

--- a/docs/superpowers/specs/2026-07-01-svar2-m2-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-01-svar2-m2-normalization-design.md
@@ -1,0 +1,197 @@
+# SVAR 2.0 — M2: Variant normalization during conversion (split + atomize)
+
+> Spec for roadmap milestone **M2** (`docs/roadmap/svar-2.md`). Branch:
+> `svar-2-m2-normalize` (worktree under `.claude/worktrees`). Companion docs:
+> [`data-model.md#variant-normalization`](../../roadmap/data-model.md) and
+> [`architecture.md#conversion-pipeline`](../../roadmap/architecture.md).
+
+## Goal
+
+Remove the reader's "input must already be normalized" preconditions so conversion
+accepts un-normalized VCFs directly. Today `vcf_reader.rs` asserts biallelic
+(`alleles.len() <= 2`) and non-complex (`!(alt_len>1 && alt_len<ref_len)`) input and
+panics otherwise. After M2, multi-allelic, MNP, and complex records flow through an
+inline normalization step that emits atomized biallelic primitives.
+
+## Scope
+
+In scope:
+
+- **Biallelic split** — a site with ALTs `A₁,…,Aₙ` becomes `n` independent biallelic
+  variants, one per ALT.
+- **Atomization** — MNPs decompose into per-position SNPs; complex REF/ALT pairs
+  decompose into SNP atoms plus one anchored indel, mirroring bcftools'
+  `_atomize_allele` (`abuf.c`).
+
+Explicitly **out of scope** (deferred):
+
+- **Left-alignment → M2b.** It is the *only* part of roadmap M2 that requires a
+  reference genome (FASTA/faidx) dependency and a new required conversion argument, and
+  it complicates the position-reorder bound (leftward shifts). Deferring it keeps this
+  PR self-contained and reference-free. The roadmap's M2 entry will be updated to note
+  the split.
+
+Non-goals this PR:
+
+- **Symbolic / breakend ALTs** (`<DEL>`, `<INS>`, `N[chr:pos[`, …) — long-read/SV
+  territory, out of scope for the short-read format. The reader returns a
+  `ConversionError` rather than panicking.
+- **`*` spanning-deletion ALTs** — skipped (no atom emitted). Presence for a haplotype
+  covered by an upstream deletion is carried by that deletion's own record.
+
+No change to the Python API signature (`run_conversion_pipeline`) or the on-disk
+layout — this PR purely widens input acceptance.
+
+## Background: how bcftools atomizes
+
+`_atomize_allele` (bcftools `abuf.c`, referenced from `vcfnorm.c#L2629`):
+
+1. Trim the shared **suffix**: `while rlen>1 && alen>1 && ref[rlen-1]==alt[alen-1] { rlen--; alen-- }`
+   (keeps ≥1 base per side).
+2. Walk positions left→right over the overlap. Emit a **SNV atom** at each position
+   where `ref[i] != alt[i]`.
+3. At the length-difference boundary (`i+1>=rlen || i+1>=alen`), emit a **left-anchored
+   indel** atom: a single anchor base plus the inserted/deleted tail.
+
+The three resulting atom shapes — SNV, anchored insertion, anchored deletion — map
+exactly onto the shapes the existing encode seam already accepts:
+
+| Atom | ref_len | alt_len | `ilen` | Encoder path |
+| --- | --- | --- | --- | --- |
+| SNP | 1 | 1 | 0 | `encode_snp_2bit` (2-bit SNP stream) |
+| Insertion (anchored) | 1 | ≥2 | >0 | `pack_variant` INS (`alt` = anchor+inserted) |
+| Deletion (anchored) | ≥2 | 1 | <0 | `pack_variant` DEL (`alt` = anchor base) |
+
+Because atoms are exactly these shapes, `rvk.rs` / `streams.rs` / the executor / the
+merge are **untouched** — the encoding seam stays sealed.
+
+## Design
+
+### Component 1 — `normalize.rs` (pure, isolated)
+
+A single pure function is the algorithmic core, with no I/O and no genotype knowledge,
+so it is trivially unit- and property-testable in isolation:
+
+```rust
+pub struct Atom {
+    pub pos: u32,               // 0-based atom start
+    pub ilen: i32,              // len(alt) - len(ref): 0=SNP, >0=INS, <0=DEL
+    pub alt: SmallVec<[u8; 4]>, // SNP: 1 base; INS: anchor+inserted; DEL: 1 anchor base
+    pub source_alt_index: u16,  // 1-based index into the record's original ALTs (GT remap)
+}
+
+/// Decompose one VCF record (already split across its ALTs internally) into atomic
+/// biallelic primitives, appended to `out`. Skips `*` ALTs. Returns an error for
+/// symbolic/breakend/invalid alleles.
+pub fn atomize_record(
+    pos: u32,
+    ref_allele: &[u8],
+    alts: &[&[u8]],
+    out: &mut Vec<Atom>,
+) -> Result<(), NormalizeError>;
+```
+
+Guarantees (enforced by construction and asserted in tests):
+
+- Every emitted `Atom` is one of the three encoder-valid shapes above.
+- `atom.pos ∈ [pos, pos + ref_len)` (no left-alignment ⇒ atoms never precede the
+  record start).
+- `source_alt_index` identifies which original ALT the atom came from, for genotype
+  remapping upstream.
+
+This is the **only** module that knows atomization rules.
+
+### Component 2 — reader restructure + reorder buffer (`vcf_reader.rs`)
+
+Two consequences of normalization the current reader cannot handle:
+
+**(a) Variable atom count per record.** One record now yields 0..n atoms. The reader can
+no longer pre-size `BitGrid3` to `chunk_size` rows up front.
+
+**(b) Position reordering.** Atomization spreads atom positions rightward: an MNP at
+pos 100 emits atoms at 100, 101, 102, … which can leapfrog a following record's start
+(records may overlap). The Phase-2 merge is a pure **interleaving** merge — it assumes
+each per-`(sample, ploid)` stream is already position-sorted. Atomization can violate
+that, so the reader must restore global position order.
+
+Changes:
+
+- **Genotype remapping.** Read the *integer* allele index per `(sample, ploid)` via
+  `GenotypeAllele::index()` (not the current `== 1` match). An atom's presence bit for a
+  haplotype is `allele_index == atom.source_alt_index`. MNP- and complex-derived atoms
+  inherit their parent ALT's presence, so heterozygous `1/2` calls are handled naturally
+  by the per-`(sample, ploid)` grid. Missing/`.` alleles (`index() == None`) and
+  reference (`0`) set no presence bit.
+
+- **Reorder buffer.** A min-heap of pending atoms keyed by `pos`, held as reader state
+  across `read_next_chunk` calls. With no left-alignment, every atom's position is
+  ≥ its source record's start ≥ the current read frontier. So the exact (non-heuristic)
+  flush rule is:
+
+  > pop and emit all buffered atoms with `pos < current_record_start`; at EOF, flush
+  > everything.
+
+  This yields globally position-sorted emission across chunk boundaries with no
+  arbitrary lookahead window. Buffered atoms reference their source record's decoded
+  genotypes (shared, not copied per atom), so buffer memory stays ~one genotype vector
+  per still-open overlapping record.
+
+- **Chunk building.** Accumulate flushed atoms until `chunk_size`, then build a
+  `DenseChunk` (`BitGrid3` sized to the actual atom count, plus `pos` / `ilens` / `alt` /
+  `alt_offsets`). `DenseChunk`, the executor, the encode seam, and the merge are
+  unchanged. `chunk_size` now counts **output atoms** rather than input records.
+
+### Component 3 — error handling & API
+
+- Remove the two `assert!`s (biallelic, non-complex) in `vcf_reader.rs`.
+- Add `ConversionError` variants (or a `NormalizeError` mapped into it) for symbolic /
+  breakend / invalid alleles, surfaced as a Python `RuntimeError` (matching the existing
+  error path), not a panic.
+- `run_conversion_pipeline` signature, on-disk layout, and `meta.json` are unchanged.
+
+## Testing (TDD)
+
+`normalize.rs` unit tests:
+
+- SNP passthrough (`A>C`).
+- Biallelic split (`A>C,G` → two atoms, `source_alt_index` 1 and 2).
+- MNP → per-position SNPs (`AC>GT` → `A>G`@pos, `C>T`@pos+1; equal bases skipped).
+- Anchored insertion (`A>AGG`) and deletion (`ATG>A`).
+- Complex `GCG>GTGA` → SNV(s) + one anchored indel at the expected positions.
+- Shared prefix/suffix trimming.
+- `*` ALT skipped; symbolic/BND ALT → error.
+
+`normalize.rs` property tests:
+
+- Every emitted atom is encoder-valid (one of the three ref/alt shapes) and
+  `pos ∈ [record_pos, record_pos + ref_len)`.
+
+Reader-level tests:
+
+- Overlapping and MNP-spanning records emit **globally position-sorted** atoms across
+  chunk boundaries.
+- Genotype remapping: multiallelic `1/2` produces correct per-atom presence.
+
+End-to-end:
+
+- Convert an un-normalized VCF and cross-check positions / ALTs / genotypes against
+  `bcftools norm -m -any --atomize` as an oracle when `bcftools` is on `PATH`; otherwise
+  a hand-built fixture with expected atoms.
+
+## Roadmap bookkeeping
+
+Per the SVAR 2.0 working agreement, in the implementing PR:
+
+- Update `svar-2.md` M2 status and note left-alignment split to a new **M2b** entry.
+- Reconcile `data-model.md#variant-normalization` (it currently lists all three
+  transforms as one milestone) to reflect that left-alignment ships separately.
+
+## Open questions
+
+- **Complex-variant decomposition parity.** Match bcftools `_atomize_allele` exactly for
+  the anchored-indel boundary, or accept a simpler documented rule where they diverge on
+  rare pathological inputs? Default: mirror bcftools; pin exact behavior in the plan
+  against the `abuf.c` source.
+- **`chunk_size` semantics.** Confirm counting output atoms (not input records) is
+  acceptable given downstream memory assumptions; document the change where `chunk_size`
+  is exposed.

--- a/docs/superpowers/specs/2026-07-01-svar2-m4-dense-cost-model-design.md
+++ b/docs/superpowers/specs/2026-07-01-svar2-m4-dense-cost-model-design.md
@@ -1,0 +1,277 @@
+# SVAR 2.0 — M4: Dense Representation + Cost-Model Routing — Design
+
+> Roadmap milestone **M4** (see [`svar-2.md`](../../roadmap/svar-2.md)). Adds the
+> 1-bit dense genotype matrix and the deterministic per-variant dense/sparse
+> routing decision on top of the M1 `var_key` pipeline (PR #79, now merged).
+>
+> Per the SVAR 2.0 working agreement, the PR that implements this MUST reconcile
+> [`data-model.md`](../../roadmap/data-model.md) and
+> [`architecture.md`](../../roadmap/architecture.md) with the decisions here — the
+> concrete doc edits are enumerated in [§9](#9-documentation-reconciliation).
+
+## Context
+
+After M1, every set genotype bit is stored inline per-call in one of two
+`var_key` sub-streams (`snp` 2-bit, `indel` 32-bit), consolidated by the tile
+merge. This is cheapest for **low-frequency** variants but wasteful for common
+ones: a variant carried by half the cohort pays a `u32` position **plus** a key
+for *every* carrier.
+
+M4 adds the **dense** representation — a 1-bit `(sample, ploid, variant)` matrix
+plus a per-variant table — and a **cost model** that routes each variant to
+whichever representation is cheaper on disk. This turns SVAR2 into the hybrid
+store the vision describes.
+
+Two facts (verified against the current code) make M4 tractable:
+
+- **A variant's full allele count is local to one chunk.** `VcfChunkReader`
+  reads `chunk_size` *complete* variant rows, so the popcount of a variant's
+  `(S,P)` plane — a contiguous bit range in `BitGrid3` at
+  `[v·S·P, (v+1)·S·P)` — is exactly its total call count `x`. Routing is a
+  per-variant local decision; no cross-chunk aggregation.
+- **The key encoding is representation-independent.** The encoder in `rvk.rs`
+  produces the same key bits regardless of where they are stored. Dense reuses
+  `classify_variant`/`pack_variant` unchanged; only *storage* forks.
+
+## Scope
+
+**In scope (M4):**
+
+1. A pure, deterministic cost model choosing `VarKey` vs `Dense` per variant.
+2. Representation-aware routing in the executor transpose.
+3. Dense per-chunk output, writer, and a rectangular dense merge producing
+   `dense/{snp,indel}/{positions, alleles, genotypes}`.
+4. Promoting the long-allele LUT to a **single shared per-contig indel table**
+   referenced by both representations.
+5. Doc reconciliation ([§9](#9-documentation-reconciliation)).
+
+**Out of scope (owned by other milestones):**
+
+- `max_del.npy` and deletion-overlap handling — **M5** (queries). Dense indel
+  deletions will need the same treatment; noted, not built here.
+- `meta.json` — **M3**. M4 avoids depending on it: every dense array's shape is
+  derivable from `positions` length + global `(n, ploidy)`.
+- `.bin`↔`.npy` final-sidecar wire-format cleanup — **M3**.
+- The `pointer` representation and its cost-model term — **M11**. The cost model
+  is written so adding a third branch is a local change.
+
+## 1. The two-axis model
+
+A variant is placed by two orthogonal axes:
+
+- **class** ∈ {`Snp`, `Indel`} — from `ilen` (unchanged from M1). Fixes key
+  width (2-bit vs 32-bit) and LUT applicability.
+- **representation** ∈ {`VarKey`, `Dense`} — from the cost model (new).
+
+Cross product = four buckets: `var_key/{snp,indel}`, `dense/{snp,indel}`. Each
+variant lives in exactly one.
+
+M1's `StreamTag` enum fuses class into the *per-call* stream machinery
+(`SparseSubStream` + tile merge). Dense is a **different storage shape**
+(per-variant table + fixed bit matrix), so it does **not** extend
+`StreamTag`/`REGISTRY` — that registry stays the "per-call sub-stream" registry
+(`var_key` now, `pointer` later). Dense gets a small parallel structure keyed by
+class. This keeps each machinery's types honest rather than forcing a matrix into
+a `SparseSubStream`.
+
+## 2. Cost model (`cost_model.rs`, new module)
+
+A pure function, no I/O, fully unit-testable:
+
+```rust
+pub enum Representation { VarKey, Dense }
+
+pub fn choose_representation(
+    class: Class,        // Snp | Indel
+    n_samples: usize,
+    ploidy: usize,
+    x_calls: usize,      // popcount of the variant's plane
+) -> Representation
+```
+
+Cost = **actual on-disk bytes for one variant** (decision: positions count —
+see below). With `np = n_samples · ploidy`:
+
+| representation | byte cost for one variant |
+| --- | --- |
+| `VarKey` | `x · (POS_BYTES + key_bytes(class))` |
+| `Dense`  | `POS_BYTES + key_bytes(class) + ⌈np/8⌉` |
+
+Route to `Dense` iff its cost is **strictly** less than `VarKey`'s; ties → `VarKey`
+(deterministic, documented). Constants live in one place and are tunable:
+
+- `POS_BYTES = 4` (u32 position; per-call in var_key, once in dense).
+- `key_bytes(Snp) = 0.25` (2 bits), `key_bytes(Indel) = 4`. Represented as an
+  exact rational (e.g. bits, integer arithmetic) to avoid float rounding at the
+  crossover.
+
+**Decision — positions count toward cost.** The roadmap's provisional model
+(`s·x` vs `s + ⌈np/8⌉`) left open whether the per-call `u32` position is part of
+`s`. It is: var_key stores a position for *every* call (`SparseSubStream.
+call_positions`), and for SNPs that 4 bytes dwarfs the 2-bit key. Excluding it
+would misprice the crossover badly (dense would almost never win for SNPs).
+Costing actual bytes is the principled ("measure, don't guess") choice.
+
+Worked SNP example (`n=1000`, diploid → `np=2000`, `⌈np/8⌉=250`): dense wins when
+`250 + 4.25 < 4.25·x`, i.e. `x ≳ 60` calls (allele frequency ≳ 3%). Sanity-checks
+as a reasonable crossover.
+
+**Tests:** monotonicity (once `Dense` wins at `x`, it wins for all `x' > x`);
+crossover index matches the closed-form solution of the inequality; class- and
+`np`-boundary cases; `x=0` and `x=np` extremes.
+
+## 3. Routing in the executor (`rvk.rs`)
+
+`dense2sparse_vk` already runs a per-variant pre-pass to encode keys once. Extend
+it to also compute `x` (plane popcount) and call the cost model, yielding a
+per-variant routing record:
+
+```rust
+struct Routed { rep: Representation, key: VarKey }  // key carries class (Snp/Indel)
+let routed: Vec<Routed> = /* one per variant in the chunk */;
+```
+
+Popcount is cheap: the plane is a contiguous bit range, so it is a
+word-wise `count_ones` over `BitGrid3.words` (add `BitGrid3::popcount_plane(v)`).
+
+The sample-major transpose loop then routes each **set** bit by `routed[v].rep`:
+
+- `VarKey` → `push_call` into the matching `SparseSubStream` (**exactly as M1**).
+- `Dense` → append the bit to this column's dense row for the matching class
+  (see §4). var_key streams simply never see dense variants' calls.
+
+Because the loop is already `for s { for p { for v { … } } }`, each hap's dense
+bits are produced **in variant order** — i.e. directly in the target
+`(sample, ploid, variant)` C-order, one row at a time. No extra transpose.
+
+**Conservation invariant (tested):** for every chunk, `popcount(genos)` ==
+(total var_key calls) + (total dense set bits). Every set bit is stored exactly
+once, in exactly one representation.
+
+## 4. Dense per-chunk output + writer
+
+Add dense payloads to the chunk the executor emits (extend `SparseChunk`, or a
+sibling `DenseChunk` field — naming settled in the plan). Per dense **class**:
+
+- **Genotype block:** a hap-major bit block sized `(S, P, V_dense_chunk)` —
+  built directly by the transpose loop above. `V_dense_chunk` is the number of
+  dense variants of that class in the chunk (**identical for every hap**).
+- **Variant metadata (once per variant, not per hap):** `positions: Vec<u32>`
+  and `keys` (2-bit codes for snp, `u32` for indel) in variant order.
+
+**Dense ledger is trivial.** Unlike var_key's ragged per-column counts, every hap
+contributes the same `V_dense_chunk` bits, so the merge needs only
+`dense_variants_per_chunk[class]` — a scalar per chunk, not a per-column matrix.
+
+The dense writer streams each chunk's genotype block and metadata to per-chunk
+temp files under `dense/{snp,indel}/`, mirroring the var_key writer's
+`chunk_{id}_*` convention.
+
+## 5. Dense merge (rectangular)
+
+Mirrors the existing tile/`pwrite` merge but is **rectangular** (uniform
+per-chunk counts) rather than ragged:
+
+- **Genotypes:** for each hap (parallelizable across haps, the natural tile
+  unit), **bit-concatenate** its per-chunk rows in chunk order into that hap's
+  slice of `genotypes.bin`. Chunk boundaries are bit-aligned, not byte-aligned
+  (`V_dense_chunk` need not be a multiple of 8), so concatenation is bitwise —
+  a small bit-append routine (or a shared `BitWriter`). Output is raw
+  bit-packed `⌈np · V_dense/8⌉` bytes; shape `(n, p, V_dense)` is **derivable**
+  from `len(positions)` + global `(n, ploidy)`, so no shape sidecar is needed.
+- **Variant table:** concatenate `positions` and `keys` across chunks in chunk
+  order → `positions` + `alleles`. SNP `alleles` are 2-bit-packed post-merge via
+  the existing `pack_snp_keys` (reuse the `post_merge` hook shape).
+
+`genotypes.bin` is a raw bit-packed matrix (**not** an `.npy` bool array, which
+would be 8× larger and violate the "1-bit" requirement).
+
+## 6. Shared long-allele LUT
+
+**Decision — one shared per-contig indel LUT.** Both `var_key/indel` and
+`dense/indel` spilled alleles reference a single table. This keeps the executor's
+**single `LongAlleleTableWriter`** unchanged (it is already
+representation-agnostic — it only hands out monotonic 31-bit row indices) and
+makes a spilled key's meaning representation-portable, consistent with the
+encoding seam.
+
+Move the LUT from `var_key/indel/` to a contig-level home shared by both indel
+sub-streams, e.g. `{contig}/indel/long_alleles.{bin,offsets}` (exact path fixed
+in `layout.rs`; the plan settles it). Update `ContigPaths` and
+`LongAlleleReader::new` to the shared path. SNP streams never spill, so no SNP
+LUT exists in either representation.
+
+## 7. On-disk layout additions (`layout.rs`)
+
+`layout.rs` remains the single source of truth. Add dense paths:
+
+```
+{contig}/
+├── indel/long_alleles.{bin,offsets}     # shared LUT (moved; §6)
+├── var_key/{snp,indel}/…                # unchanged (M1)
+└── dense/
+    ├── snp/   { positions, alleles (2-bit packed), genotypes.bin }
+    └── indel/ { positions, alleles (u32),          genotypes.bin }
+```
+
+`genotypes.bin` is raw bit-packed. Final sidecar file *extensions* (`.bin` vs
+`.npy`) inherit whatever M3 settles; M4 introduces no new naming policy, only new
+files.
+
+## 8. Component boundaries
+
+| Unit | Responsibility | Depends on |
+| --- | --- | --- |
+| `cost_model.rs` | pure `choose_representation` + constants | nothing (leaf) |
+| `rvk.rs` (extended) | popcount, route, build var_key + dense chunk payloads | `cost_model`, `BitGrid3`, encoder |
+| dense writer | stream per-chunk dense temp files | chunk payload types |
+| dense merge | rectangular bit-concat + table concat + SNP pack | `layout`, dense ledger |
+| `layout.rs` (extended) | dense + shared-LUT paths | — |
+| `nrvk.rs` (touched) | shared-LUT path in `ContigPaths`/reader | `layout` |
+
+Each is understandable and testable in isolation; the cost model in particular
+is a pure leaf with exhaustive proptests.
+
+## 9. Documentation reconciliation
+
+The implementing PR updates, in the same PR:
+
+- **`data-model.md` — cost model:** state that `s` **includes** the per-call
+  position (`POS_BYTES`), give the concrete per-representation byte costs from
+  §2, and mark the "does packed-position count?" open question resolved.
+- **`data-model.md` — LUT / on-disk layout:** the indel LUT is a **single shared
+  per-contig table**, not per-representation; move it out of
+  `var_key/indel/`/`dense/indel/` in the layout tree.
+- **`data-model.md` — dense representation:** `genotypes` is a raw bit-packed
+  matrix whose shape is derived from `positions` length + `(n, ploidy)`.
+- **`architecture.md` — open question "routing granularity":** resolved —
+  strictly per variant, decided locally within a chunk from the plane popcount.
+- **`svar-2.md`:** flip **M4** to `[~]`/`[x]` as appropriate and update the M4
+  status line.
+
+## 10. Testing strategy
+
+- **Cost model:** unit + proptests (monotonicity, crossover, boundaries) — §2.
+- **Routing/conservation:** proptest — `popcount(genos)` == var_key calls +
+  dense set bits, over random chunks with mixed classes and frequencies.
+- **Dense merge:** rectangular analog of the existing merge proptests — the
+  reassembled `(S,P,V)` matrix equals the per-hap chunk-order bit-concatenation;
+  metadata concatenates in variant order; SNP alleles round-trip through pack.
+- **End-to-end:** a synthetic VCF with both rare and common variants routes as
+  the cost model predicts; decoding var_key ∪ dense reproduces the input
+  genotype matrix bit-for-bit. (Extends the existing e2e suite.)
+
+## 11. Open questions
+
+- **Dense merge tiling unit.** Per-hap is the obvious parallel unit; whether to
+  further tile very wide cohorts (millions of haps) to bound RAM like the
+  var_key merge's `TILE_RAM_BUDGET_BYTES` is a tuning question deferred until we
+  measure.
+- **Cost-model constants.** `POS_BYTES` and `key_bytes` are principled but still
+  want validation against real conversions; the module centralizes them for easy
+  revision (shared with the roadmap's existing cost-model-constants question).
+- **`SparseChunk` vs sibling struct.** Whether dense payloads extend
+  `SparseChunk` or ride a parallel channel is an implementation-shape call for
+  the plan, not a data-model decision.
+</content>
+</invoke>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod executor;
 pub mod layout;
 pub mod merge;
 pub mod monitor;
+pub mod normalize;
 pub mod nrvk;
 pub mod orchestrator;
 pub mod rvk;

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -55,6 +55,12 @@ fn is_symbolic(alt: &[u8]) -> bool {
 /// single left-anchored indel at the last aligned index. The one deviation is the
 /// substituted-deletion-anchor case (see below), forced by the pure-DEL encoding.
 fn atomize_biallelic(pos: u32, ref_allele: &[u8], alt: &[u8], src: u16, out: &mut Vec<Atom>) {
+    // Valid VCF guarantees non-empty REF/ALT; a `*`/`.`/symbolic ALT is filtered by the
+    // caller. Fail fast on the precondition — otherwise `k = n - 1` below underflows.
+    debug_assert!(
+        !ref_allele.is_empty() && !alt.is_empty(),
+        "atomize_biallelic requires non-empty REF and ALT"
+    );
     // 1. Trim shared suffix, keeping >= 1 base on each side.
     let mut rlen = ref_allele.len();
     let mut alen = alt.len();

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -1,0 +1,266 @@
+//! Variant normalization: biallelic split + atomization (no left-alignment; roadmap M2).
+//! Pure functions over (pos, REF, ALTs) → atomic biallelic primitives. This is the only
+//! module that knows atomization rules; the encode seam downstream stays sealed.
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum NormalizeError {
+    #[error("symbolic/breakend ALT '{alt}' at pos {pos} is out of scope (short-read only)")]
+    SymbolicAllele { pos: u32, alt: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Atom {
+    /// 0-based start position of the atom.
+    pub pos: u32,
+    /// len(alt) - len(ref): 0 = SNP, > 0 = INS, < 0 = DEL.
+    pub ilen: i32,
+    /// SNP: the single ALT base. INS: anchor + inserted bases. DEL: the anchor base.
+    pub alt: Vec<u8>,
+    /// 1-based index into the record's original ALTs, for genotype remapping.
+    pub source_alt_index: u16,
+}
+
+/// Decompose one VCF record into atomic biallelic primitives, appended to `out`.
+/// `alts` are the ALT alleles only (REF excluded). `*` / `.` alleles are skipped;
+/// symbolic/breakend alleles return an error.
+pub fn atomize_record(
+    pos: u32,
+    ref_allele: &[u8],
+    alts: &[&[u8]],
+    out: &mut Vec<Atom>,
+) -> Result<(), NormalizeError> {
+    for (j, &alt) in alts.iter().enumerate() {
+        let src = (j + 1) as u16;
+        if alt == b"*" || alt == b"." {
+            continue;
+        }
+        if is_symbolic(alt) {
+            return Err(NormalizeError::SymbolicAllele {
+                pos,
+                alt: String::from_utf8_lossy(alt).into_owned(),
+            });
+        }
+        atomize_biallelic(pos, ref_allele, alt, src, out);
+    }
+    Ok(())
+}
+
+#[inline]
+fn is_symbolic(alt: &[u8]) -> bool {
+    alt.first() == Some(&b'<') || alt.contains(&b'[') || alt.contains(&b']')
+}
+
+/// Decompose a single REF/ALT pair. Mirrors bcftools `_atomize_allele`: trim the
+/// shared suffix, emit a SNV per interior mismatch, and attach any length change as a
+/// single left-anchored indel at the last aligned index. The one deviation is the
+/// substituted-deletion-anchor case (see below), forced by the pure-DEL encoding.
+fn atomize_biallelic(pos: u32, ref_allele: &[u8], alt: &[u8], src: u16, out: &mut Vec<Atom>) {
+    // 1. Trim shared suffix, keeping >= 1 base on each side.
+    let mut rlen = ref_allele.len();
+    let mut alen = alt.len();
+    while rlen > 1 && alen > 1 && ref_allele[rlen - 1] == alt[alen - 1] {
+        rlen -= 1;
+        alen -= 1;
+    }
+    let r = &ref_allele[..rlen];
+    let a = &alt[..alen];
+
+    let n = rlen.min(alen);
+    let k = n - 1; // last aligned index; the indel (if any) anchors here
+
+    // 2. Interior aligned positions [0, k): one SNV per mismatch.
+    for i in 0..k {
+        if r[i] != a[i] {
+            out.push(Atom {
+                pos: pos + i as u32,
+                ilen: 0,
+                alt: vec![a[i]],
+                source_alt_index: src,
+            });
+        }
+    }
+
+    // 3. Boundary at k.
+    let apos = pos + k as u32;
+    if rlen == alen {
+        // Pure substitution tail.
+        if r[k] != a[k] {
+            out.push(Atom {
+                pos: apos,
+                ilen: 0,
+                alt: vec![a[k]],
+                source_alt_index: src,
+            });
+        }
+    } else if alen > rlen {
+        // Insertion anchored at k. ref[k..] is a single base; alt[k..] carries the
+        // (possibly substituted) anchor + inserted bases — the full alt is stored, so a
+        // substituted anchor is faithfully represented.
+        let ins_alt = a[k..alen].to_vec();
+        let ilen = ins_alt.len() as i32 - 1; // ref_len == 1
+        out.push(Atom {
+            pos: apos,
+            ilen,
+            alt: ins_alt,
+            source_alt_index: src,
+        });
+    } else {
+        // Deletion anchored at k. alt[k..] is a single base.
+        let del_ref_len = (rlen - k) as i32; // >= 2
+        let ilen = 1 - del_ref_len; // alt_len(1) - ref_len
+        if r[k] == a[k] {
+            // Clean anchor → pure DEL (alt = the anchor base).
+            out.push(Atom {
+                pos: apos,
+                ilen,
+                alt: vec![a[k]],
+                source_alt_index: src,
+            });
+        } else {
+            // Substituted anchor: the pure-DEL encoding reconstructs the anchor from
+            // the reference, so it cannot carry a substitution. Split into a SNV plus a
+            // clean DEL whose anchor is the unchanged reference base.
+            out.push(Atom {
+                pos: apos,
+                ilen: 0,
+                alt: vec![a[k]],
+                source_alt_index: src,
+            });
+            out.push(Atom {
+                pos: apos,
+                ilen,
+                alt: vec![r[k]],
+                source_alt_index: src,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn atoms(pos: u32, r: &[u8], alts: &[&[u8]]) -> Vec<Atom> {
+        let mut out = Vec::new();
+        atomize_record(pos, r, alts, &mut out).unwrap();
+        out
+    }
+
+    fn atom(pos: u32, ilen: i32, alt: &[u8], src: u16) -> Atom {
+        Atom {
+            pos,
+            ilen,
+            alt: alt.to_vec(),
+            source_alt_index: src,
+        }
+    }
+
+    #[test]
+    fn snp_passthrough() {
+        assert_eq!(atoms(100, b"A", &[b"C"]), vec![atom(100, 0, b"C", 1)]);
+    }
+
+    #[test]
+    fn biallelic_split_tags_source_index() {
+        // A>C,G → two independent SNPs carrying source indices 1 and 2.
+        assert_eq!(
+            atoms(100, b"A", &[b"C", b"G"]),
+            vec![atom(100, 0, b"C", 1), atom(100, 0, b"G", 2)]
+        );
+    }
+
+    #[test]
+    fn mnp_becomes_per_position_snps() {
+        // AC>GT → A>G@100, C>T@101 (both differ).
+        assert_eq!(
+            atoms(100, b"AC", &[b"GT"]),
+            vec![atom(100, 0, b"G", 1), atom(101, 0, b"T", 1)]
+        );
+    }
+
+    #[test]
+    fn mnp_skips_matching_bases() {
+        // ACA>ATA → only the middle base changes.
+        assert_eq!(atoms(100, b"ACA", &[b"ATA"]), vec![atom(101, 0, b"T", 1)]);
+    }
+
+    #[test]
+    fn simple_insertion_anchored() {
+        // A>AT → anchored INS, ilen=+1, full alt stored.
+        assert_eq!(atoms(100, b"A", &[b"AT"]), vec![atom(100, 1, b"AT", 1)]);
+    }
+
+    #[test]
+    fn simple_deletion_anchored() {
+        // ATG>A → pure DEL, ilen=-2, alt = anchor base.
+        assert_eq!(atoms(100, b"ATG", &[b"A"]), vec![atom(100, -2, b"A", 1)]);
+    }
+
+    #[test]
+    fn shared_suffix_is_trimmed() {
+        // ATG>CG shares suffix G → AT>C: anchor substitutes (A→C), so split into
+        // SNV(A>C)@100 plus a clean DEL(anchor=ref base A, delete T)@100.
+        assert_eq!(
+            atoms(100, b"ATG", &[b"CG"]),
+            vec![atom(100, 0, b"C", 1), atom(100, -1, b"A", 1)]
+        );
+    }
+
+    #[test]
+    fn complex_snv_plus_insertion() {
+        // GCG>GTGA (the bcftools abuf.c example): interior SNV C>T@101, then an
+        // anchored INS G>GA@102.
+        assert_eq!(
+            atoms(100, b"GCG", &[b"GTGA"]),
+            vec![atom(101, 0, b"T", 1), atom(102, 1, b"GA", 1)]
+        );
+    }
+
+    #[test]
+    fn star_and_missing_alleles_skipped() {
+        assert_eq!(atoms(100, b"A", &[b"*"]), vec![]);
+        assert_eq!(atoms(100, b"A", &[b"."]), vec![]);
+        // still processes the real ALT alongside a skipped one
+        assert_eq!(atoms(100, b"A", &[b"*", b"C"]), vec![atom(100, 0, b"C", 2)]);
+    }
+
+    #[test]
+    fn symbolic_allele_errors() {
+        let mut out = Vec::new();
+        assert!(matches!(
+            atomize_record(100, b"A", &[b"<DEL>"], &mut out),
+            Err(NormalizeError::SymbolicAllele { .. })
+        ));
+        assert!(matches!(
+            atomize_record(100, b"A", &[b"A[chr2:321[".as_slice()], &mut out),
+            Err(NormalizeError::SymbolicAllele { .. })
+        ));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2000))]
+
+        // Every atom is encoder-valid and starts within the record's reference span.
+        #[test]
+        fn atoms_are_encoder_valid(
+            pos in 0u32..1_000_000,
+            r in proptest::collection::vec(prop_oneof![Just(b'A'), Just(b'C'), Just(b'G'), Just(b'T')], 1..12),
+            a in proptest::collection::vec(prop_oneof![Just(b'A'), Just(b'C'), Just(b'G'), Just(b'T')], 1..12),
+        ) {
+            let mut out = Vec::new();
+            let ref_bytes: Vec<u8> = r;
+            let alt_bytes: Vec<u8> = a;
+            atomize_record(pos, &ref_bytes, &[alt_bytes.as_slice()], &mut out).unwrap();
+            for at in &out {
+                let alt_len = at.alt.len() as i32;
+                let valid = (at.ilen == 0 && alt_len == 1)
+                    || (at.ilen > 0 && alt_len == at.ilen + 1)  // INS: ref_len 1
+                    || (at.ilen < 0 && alt_len == 1);           // DEL: alt_len 1
+                prop_assert!(valid, "atom not encoder-valid: {:?}", at);
+                prop_assert!(at.pos >= pos, "atom before record start");
+                prop_assert!(at.pos < pos + ref_bytes.len() as u32, "atom past reference span");
+            }
+        }
+    }
+}

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -154,6 +154,12 @@ impl VcfChunkReader {
     // records as needed. An atom is safe to emit once its position is strictly below
     // the read frontier (no future atom can precede the frontier, since there is no
     // left-alignment) or once the input is exhausted.
+    //
+    // Memory note: the heap holds every atom whose pos == frontier until a record with a
+    // strictly greater start pos advances the frontier (or EOF). For coordinate-sorted
+    // input this is bounded by the atoms at a single position; a pathological run of many
+    // records sharing one start pos would grow it. M2b (left-alignment) weakens the
+    // `pos >= record_start` premise and must revisit this bound.
     fn next_atom(&mut self) -> Option<PendingAtom> {
         loop {
             if let Some(Reverse(top)) = self.heap.peek() {

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -1,11 +1,51 @@
+use crate::normalize::atomize_record;
 use crate::types::{BitGrid3, DenseChunk};
-use rust_htslib::bcf::{IndexedReader, Read, record::GenotypeAllele};
+use rust_htslib::bcf::record::Record;
+use rust_htslib::bcf::{IndexedReader, Read};
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::rc::Rc;
+
+// A decomposed atom awaiting emission. Carries a shared handle to its source record's
+// per-column allele indices so genotype presence is computed at chunk-build time.
+struct PendingAtom {
+    pos: u32,
+    ilen: i32,
+    alt: Vec<u8>,
+    source_alt_index: u16,
+    gt: Rc<Vec<i32>>, // len = num_samples * ploidy; allele index per column (-1 = missing)
+    seq: u64,         // stable tiebreak for equal positions
+}
+
+impl PartialEq for PendingAtom {
+    fn eq(&self, other: &Self) -> bool {
+        self.pos == other.pos && self.seq == other.seq
+    }
+}
+impl Eq for PendingAtom {}
+impl PartialOrd for PendingAtom {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for PendingAtom {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.pos.cmp(&other.pos).then(self.seq.cmp(&other.seq))
+    }
+}
 
 pub struct VcfChunkReader {
     inner_reader: IndexedReader,
     num_samples: usize,
     ploidy: usize,
     sample_indices: Vec<usize>,
+
+    // Reorder state, persisted across read_next_chunk calls.
+    record: Record,
+    heap: BinaryHeap<Reverse<PendingAtom>>,
+    frontier: u32, // start pos of the most recently read record: all future atoms have pos >= this
+    eof: bool,
+    next_seq: u64,
 }
 
 impl VcfChunkReader {
@@ -20,25 +60,20 @@ impl VcfChunkReader {
         let mut reader = IndexedReader::from_path(vcf_path)
             .expect("Failed to open VCF/BCF index. Is there a .tbi or .csi file?");
 
-        // Tells C library to spawn exactly N background decompression threads.
         reader
             .set_threads(htslib_threads)
             .expect("Failed to allocate HTSlib background threads");
 
-        // Clone the header to extract Region IDs and Sample IDs
         let header = reader.header().clone();
 
-        // Resolve the string to a numeric Region ID (rid)
         let rid = header
             .name2rid(chrom.as_bytes())
             .expect("Chromosome not found in VCF header");
 
-        // Fetch the entire chromosome (start: 0, end: None)
         reader
             .fetch(rid, 0, None)
             .expect("Failed to fetch chromosome region");
 
-        // Map requested sample strings to their integer indices in the VCF
         let sample_indices: Vec<usize> = samples
             .iter()
             .map(|name| {
@@ -48,138 +83,136 @@ impl VcfChunkReader {
             })
             .collect();
 
+        let record = reader.empty_record();
+
         Self {
             inner_reader: reader,
             num_samples: samples.len(),
-            ploidy, //: 2, // hardcoded to diploid for this package -> can be changed later (can cause issues)
+            ploidy,
             sample_indices,
+            record,
+            heap: BinaryHeap::new(),
+            frontier: 0,
+            eof: false,
+            next_seq: 0,
         }
     }
 
-    // pulls the next `chunk_size` variants from the disk and builds the DenseChunk
-    // returns Option so that the thread knows exactly when EOF is reached
-    pub fn read_next_chunk(&mut self, chunk_size: usize, chunk_id: usize) -> Option<DenseChunk> {
-        // pre-allocate the arrays
-        let mut pos = Vec::with_capacity(chunk_size);
-        let mut ilens = Vec::with_capacity(chunk_size);
+    // Decompose `self.record` into atoms and push them onto the reorder heap, sharing
+    // one decoded genotype vector across all atoms of the record.
+    fn decompose_current_record(&mut self) {
+        let pos = self.record.pos() as u32;
 
-        let mut alt = Vec::with_capacity(chunk_size * 5); // flat array of all ALT characters
-        let mut alt_offsets = Vec::with_capacity(chunk_size + 1);
-        alt_offsets.push(0u32);
-
-        // Bit-packed dense grid: 1 bit per (variant, sample, ploidy) entry.
-        // 8x smaller than Vec<bool> for the same logical layout.
-        let mut genos = BitGrid3::zeros(chunk_size, self.num_samples, self.ploidy);
-
-        let mut current_v_idx = 0;
-        let mut current_alt_offset = 0u32;
-
-        let mut record = self.inner_reader.empty_record();
-
-        while current_v_idx < chunk_size {
-            // read the next row. If it fails, we've hit EOF for this chromosome.
-            match self.inner_reader.read(&mut record) {
-                Some(Ok(_)) => {}
-                Some(Err(e)) => panic!("VCF Read Error: {}", e), // fail on corruption
-                None => break, // End of file (or end of chromosome region)
-            }
-
-            // position
-            pos.push(record.pos() as u32);
-
-            // alleles ALT and ILEN
-            let alleles = record.alleles();
-
-            // Bi-allelic invariant: input must be normalized with `bcftools norm -m -any`.
-            // Multi-allelic records would silently lose ALT[2..], so we panic loudly.
-            assert!(
-                alleles.len() <= 2,
-                "VCF must be normalized with `bcftools norm -m -any`. \
-                 Multi-allelic record at pos {} has {} alleles.",
-                record.pos(),
-                alleles.len(),
-            );
-
-            let ref_len = alleles[0].len() as i32;
-            let mut alt_len = 0i32;
-
-            // handling ALT -> exactly one ALT after the bi-allelic check above
-            if alleles.len() > 1 {
-                let alt_allele = alleles[1];
-                alt_len = alt_allele.len() as i32;
-
-                // Atomized invariant: complex variants (alt_len > 1 AND alt_len < ref_len)
-                // can't be encoded inline by the 1-bit-tag scheme. `bcftools norm --atomize`
-                // splits these into SNPs/INS/pure-DEL primitives. Panic if we see one.
-                assert!(
-                    !(alt_len > 1 && alt_len < ref_len),
-                    "VCF must be atomized with `bcftools norm --atomize`. \
-                     Complex record at pos {} has REF_LEN={} ALT_LEN={} (cannot be encoded inline).",
-                    record.pos(),
-                    ref_len,
-                    alt_len,
-                );
-
-                alt.extend_from_slice(alt_allele);
-                current_alt_offset += alt_len as u32;
-            }
-            // if there is no ALT allele, the offset doesn't change
-            alt_offsets.push(current_alt_offset);
-            ilens.push(alt_len - ref_len); // storing ilen directly
-
-            // genotypes
-            let genotypes = record.genotypes().expect("Failed to read genotypes");
-
-            // Loop through your pre-mapped sample indices instead!
-            for (s_idx, &real_vcf_idx) in self.sample_indices.iter().enumerate() {
-                if s_idx >= self.num_samples {
-                    break;
-                }
-
-                // Fetch the genotype for this specific sample
-                let sample_gt = genotypes.get(real_vcf_idx);
-
-                let allele_1 = matches!(
-                    sample_gt[0],
-                    GenotypeAllele::Unphased(1) | GenotypeAllele::Phased(1)
-                );
-
-                let allele_2 = if sample_gt.len() > 1 {
-                    matches!(
-                        sample_gt[1],
-                        GenotypeAllele::Unphased(1) | GenotypeAllele::Phased(1)
-                    )
-                } else {
-                    false
-                };
-
-                // 1D to 3D Memory Mapping (matches BitGrid3 row-major C-order)
-                let base_idx =
-                    (current_v_idx * self.num_samples * self.ploidy) + (s_idx * self.ploidy);
-                genos.or_bit(base_idx, allele_1);
-                genos.or_bit(base_idx + 1, allele_2);
-
-                //this is for the ravel operation - need to check on this
-                // // The shape of our tensor block
-                // let shape = [chunk_size, self.num_samples, self.ploidy];
-
-                // // Raveling the 3D coordinates into a 1D memory pointer
-                // let base_idx = ravel!(shape, [current_v_idx, s_idx, 0]);
-
-                // genos_flat[base_idx] = allele_1;
-                // genos_flat[base_idx + 1] = allele_2;
-            }
-
-            current_v_idx += 1;
+        // Own the alleles so the record borrow is released before we mutate self.
+        let ref_allele: Vec<u8>;
+        let alts_owned: Vec<Vec<u8>>;
+        {
+            let alleles = self.record.alleles();
+            ref_allele = alleles[0].to_vec();
+            alts_owned = alleles[1..].iter().map(|a| a.to_vec()).collect();
         }
 
-        // if no read, return None to signal EOF
-        if current_v_idx == 0 {
+        // Decode per-column allele indices (-1 = missing).
+        let columns = self.num_samples * self.ploidy;
+        let mut gt = vec![-1i32; columns];
+        {
+            let genotypes = self.record.genotypes().expect("Failed to read genotypes");
+            for (s_idx, &vcf_idx) in self.sample_indices.iter().enumerate() {
+                let sample_gt = genotypes.get(vcf_idx);
+                for p in 0..self.ploidy {
+                    let idx = if p < sample_gt.len() {
+                        sample_gt[p].index().map(|v| v as i32).unwrap_or(-1)
+                    } else {
+                        -1
+                    };
+                    gt[s_idx * self.ploidy + p] = idx;
+                }
+            }
+        }
+        let gt = Rc::new(gt);
+
+        let alt_refs: Vec<&[u8]> = alts_owned.iter().map(|a| a.as_slice()).collect();
+        let mut atoms = Vec::new();
+        atomize_record(pos, &ref_allele, &alt_refs, &mut atoms)
+            .expect("symbolic/breakend ALT is out of scope for SVAR2 (short-read only)");
+
+        for atom in atoms {
+            let seq = self.next_seq;
+            self.next_seq += 1;
+            self.heap.push(Reverse(PendingAtom {
+                pos: atom.pos,
+                ilen: atom.ilen,
+                alt: atom.alt,
+                source_alt_index: atom.source_alt_index,
+                gt: Rc::clone(&gt),
+                seq,
+            }));
+        }
+    }
+
+    // Yield the next atom in global position order, reading and decomposing more
+    // records as needed. An atom is safe to emit once its position is strictly below
+    // the read frontier (no future atom can precede the frontier, since there is no
+    // left-alignment) or once the input is exhausted.
+    fn next_atom(&mut self) -> Option<PendingAtom> {
+        loop {
+            if let Some(Reverse(top)) = self.heap.peek() {
+                if self.eof || top.pos < self.frontier {
+                    return Some(self.heap.pop().unwrap().0);
+                }
+            } else if self.eof {
+                return None;
+            }
+
+            match self.inner_reader.read(&mut self.record) {
+                Some(Ok(())) => {
+                    self.frontier = self.record.pos() as u32;
+                    self.decompose_current_record();
+                }
+                Some(Err(e)) => panic!("VCF Read Error: {}", e),
+                None => self.eof = true,
+            }
+        }
+    }
+
+    // Pull up to `chunk_size` atoms (already globally position-sorted) and pack them
+    // into a variant-major DenseChunk. Returns None once no atoms remain.
+    pub fn read_next_chunk(&mut self, chunk_size: usize, chunk_id: usize) -> Option<DenseChunk> {
+        let mut atoms: Vec<PendingAtom> = Vec::with_capacity(chunk_size);
+        while atoms.len() < chunk_size {
+            match self.next_atom() {
+                Some(a) => atoms.push(a),
+                None => break,
+            }
+        }
+        if atoms.is_empty() {
             return None;
         }
 
-        // shrink V dim if we hit EOF before filling the whole chunk size
-        genos.truncate_v(current_v_idx);
+        let v = atoms.len();
+        let columns = self.num_samples * self.ploidy;
+
+        let mut pos = Vec::with_capacity(v);
+        let mut ilens = Vec::with_capacity(v);
+        let mut alt = Vec::with_capacity(v * 2);
+        let mut alt_offsets = Vec::with_capacity(v + 1);
+        alt_offsets.push(0u32);
+        let mut genos = BitGrid3::zeros(v, self.num_samples, self.ploidy);
+
+        let mut off = 0u32;
+        for (vi, a) in atoms.iter().enumerate() {
+            pos.push(a.pos);
+            ilens.push(a.ilen);
+            alt.extend_from_slice(&a.alt);
+            off += a.alt.len() as u32;
+            alt_offsets.push(off);
+
+            let src = a.source_alt_index as i32;
+            let base = vi * columns;
+            for col in 0..columns {
+                genos.or_bit(base + col, a.gt[col] == src);
+            }
+        }
 
         Some(DenseChunk {
             chunk_id,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,5 @@
-// Shared BCF test harness: synthetic record builder, binary I/O helpers, and key decoders
+// Shared BCF test harness: synthetic record builder and binary I/O helpers
 // for E2E pipeline testing.
-
-use genoray_core::rvk::decode_alt_inline;
 
 use rust_htslib::bcf::record::GenotypeAllele;
 use rust_htslib::bcf::{Format, Header, Writer};
@@ -80,29 +78,4 @@ pub fn read_u32_bin(path: &Path) -> Vec<u32> {
 pub fn read_offsets_npy(path: &Path) -> Vec<u64> {
     let arr: ndarray::Array1<u64> = ndarray_npy::read_npy(path).expect("read offsets npy");
     arr.to_vec()
-}
-
-/// Decode a single packed key. Discriminator:
-///   bit 0 = 1                 → lookup (long allele bank row index)
-///   bit 0 = 0 AND bit 31 = 1  → pure DEL (signed ilen in upper 31 bits)
-///   bit 0 = 0 AND bit 31 = 0  → inline ALT (top 5 bits hold the length field)
-#[derive(Debug, PartialEq)]
-pub enum DecodedKey {
-    Inline { alt: Vec<u8> },
-    PureDel { ilen: i32 },
-    Lookup { row: u32 },
-}
-
-pub fn decode_key(key: u32) -> DecodedKey {
-    if key & 1 == 1 {
-        DecodedKey::Lookup { row: key >> 1 }
-    } else if (key as i32) < 0 {
-        DecodedKey::PureDel {
-            ilen: (key as i32) >> 1,
-        }
-    } else {
-        DecodedKey::Inline {
-            alt: decode_alt_inline(key),
-        }
-    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,108 @@
+// Shared BCF test harness: synthetic record builder, binary I/O helpers, and key decoders
+// for E2E pipeline testing.
+
+use genoray_core::rvk::decode_alt_inline;
+
+use rust_htslib::bcf::record::GenotypeAllele;
+use rust_htslib::bcf::{Format, Header, Writer};
+
+use std::path::Path;
+
+/// One synthetic VCF record: position, ref allele, list of alt alleles, and a
+/// flat genotype vector laid out as [s0_p0, s0_p1, s1_p0, s1_p1, ...] holding
+/// allele indices (0 = ref, 1 = first alt, …).
+pub struct SynthRecord<'a> {
+    pub pos: i64,
+    pub ref_allele: &'a [u8],
+    pub alts: Vec<&'a [u8]>,
+    pub gt: Vec<i32>,
+}
+
+pub fn build_bcf_with_index(
+    bcf_path: &Path,
+    chrom: &str,
+    chrom_len: u64,
+    samples: &[&str],
+    records: &[SynthRecord],
+) {
+    let mut header = Header::new();
+    let contig = format!("##contig=<ID={},length={}>", chrom, chrom_len);
+    header.push_record(contig.as_bytes());
+    header.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+    for s in samples {
+        header.push_sample(s.as_bytes());
+    }
+
+    {
+        let mut writer =
+            Writer::from_path(bcf_path, &header, false, Format::Bcf).expect("open BCF writer");
+
+        for rec in records {
+            let mut record = writer.empty_record();
+            record.set_rid(Some(0));
+            record.set_pos(rec.pos);
+
+            // set_alleles wants &[&[u8]] starting with ref then alts
+            let mut alleles: Vec<&[u8]> = Vec::with_capacity(1 + rec.alts.len());
+            alleles.push(rec.ref_allele);
+            for a in &rec.alts {
+                alleles.push(a);
+            }
+            record.set_alleles(&alleles).expect("set alleles");
+
+            let gt_alleles: Vec<GenotypeAllele> =
+                rec.gt.iter().map(|&i| GenotypeAllele::Phased(i)).collect();
+            record.push_genotypes(&gt_alleles).expect("push genotypes");
+
+            writer.write(&record).expect("write record");
+        }
+        // writer drops here, finalizing the BCF file
+    }
+
+    // Build CSI index alongside the BCF so IndexedReader can fetch by chrom.
+    // BCF only supports CSI (TBI is text-VCF-only). min_shift=14 is the htslib
+    // standard for genomic data; n_threads=0 means synchronous build.
+    rust_htslib::bcf::index::build(bcf_path, None, 0, rust_htslib::bcf::index::Type::Csi(14))
+        .expect("build BCF index");
+}
+
+pub fn read_u32_bin(path: &Path) -> Vec<u32> {
+    // Alignment-agnostic decode: std::fs::read can hand back a Vec<u8> whose
+    // pointer isn't 4-byte aligned (especially when empty), which would trip
+    // bytemuck::cast_slice's TargetAlignmentGreater check.
+    let bytes = std::fs::read(path).expect("read u32 bin");
+    bytes
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+pub fn read_offsets_npy(path: &Path) -> Vec<u64> {
+    let arr: ndarray::Array1<u64> = ndarray_npy::read_npy(path).expect("read offsets npy");
+    arr.to_vec()
+}
+
+/// Decode a single packed key. Discriminator:
+///   bit 0 = 1                 → lookup (long allele bank row index)
+///   bit 0 = 0 AND bit 31 = 1  → pure DEL (signed ilen in upper 31 bits)
+///   bit 0 = 0 AND bit 31 = 0  → inline ALT (top 5 bits hold the length field)
+#[derive(Debug, PartialEq)]
+pub enum DecodedKey {
+    Inline { alt: Vec<u8> },
+    PureDel { ilen: i32 },
+    Lookup { row: u32 },
+}
+
+pub fn decode_key(key: u32) -> DecodedKey {
+    if key & 1 == 1 {
+        DecodedKey::Lookup { row: key >> 1 }
+    } else if (key as i32) < 0 {
+        DecodedKey::PureDel {
+            ilen: (key as i32) >> 1,
+        }
+    } else {
+        DecodedKey::Inline {
+            alt: decode_alt_inline(key),
+        }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -64,6 +64,11 @@ pub fn build_bcf_with_index(
         .expect("build BCF index");
 }
 
+// Not every integration-test binary that pulls in this shared `mod common;` calls
+// every helper (e.g. test_atomize_e2e.rs never reads on-disk binary output). Each
+// test file is its own compilation unit, so clippy's dead-code pass is per-binary;
+// allow(dead_code) keeps `cargo clippy --tests -D warnings` clean across all of them.
+#[allow(dead_code)]
 pub fn read_u32_bin(path: &Path) -> Vec<u32> {
     // Alignment-agnostic decode: std::fs::read can hand back a Vec<u8> whose
     // pointer isn't 4-byte aligned (especially when empty), which would trip
@@ -75,6 +80,7 @@ pub fn read_u32_bin(path: &Path) -> Vec<u32> {
         .collect()
 }
 
+#[allow(dead_code)]
 pub fn read_offsets_npy(path: &Path) -> Vec<u64> {
     let arr: ndarray::Array1<u64> = ndarray_npy::read_npy(path).expect("read offsets npy");
     arr.to_vec()

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -1,0 +1,141 @@
+// End-to-end atomization/normalization: feed un-normalized records and assert the
+// reader emits correctly split, atomized, and globally position-sorted DenseChunks.
+mod common;
+
+use common::{SynthRecord, build_bcf_with_index};
+use genoray_core::vcf_reader::VcfChunkReader;
+use std::path::Path;
+use tempfile::tempdir;
+
+// Collect every atom the reader emits across all chunks, as (pos, ilen) plus the
+// per-column presence bits, in emission order.
+fn drain_reader(
+    bcf_path: &Path,
+    chrom: &str,
+    samples: &[&str],
+    ploidy: usize,
+    chunk_size: usize,
+) -> Vec<(u32, i32, Vec<bool>)> {
+    let mut reader = VcfChunkReader::new(bcf_path.to_str().unwrap(), chrom, samples, 1, ploidy);
+    let columns = samples.len() * ploidy;
+    let mut out = Vec::new();
+    let mut chunk_id = 0;
+    while let Some(chunk) = reader.read_next_chunk(chunk_size, chunk_id) {
+        let v = chunk.pos.len();
+        for i in 0..v {
+            let mut presence = Vec::with_capacity(columns);
+            for col in 0..columns {
+                presence.push(chunk.genos.get_bit(i * columns + col));
+            }
+            out.push((chunk.pos[i], chunk.ilens[i], presence));
+        }
+        chunk_id += 1;
+    }
+    out
+}
+
+#[test]
+fn multiallelic_site_splits_and_remaps_genotypes() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("multi.bcf");
+    let samples = vec!["S0"];
+    // One diploid sample, genotype 1|2 at a 2-ALT site A>C,G.
+    let records = vec![SynthRecord {
+        pos: 100,
+        ref_allele: b"A",
+        alts: vec![&b"C"[..], &b"G"[..]],
+        gt: vec![1, 2],
+    }];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
+    // Two SNP atoms at pos 100: ALT C carried on hap0 only, ALT G on hap1 only.
+    assert_eq!(atoms.len(), 2);
+    assert_eq!((atoms[0].0, atoms[0].1), (100, 0));
+    assert_eq!((atoms[1].0, atoms[1].1), (100, 0));
+    assert_eq!(atoms[0].2, vec![true, false]); // source ALT 1 (C) → hap0
+    assert_eq!(atoms[1].2, vec![false, true]); // source ALT 2 (G) → hap1
+}
+
+#[test]
+fn mnp_atomizes_to_snps_shared_presence() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("mnp.bcf");
+    let samples = vec!["S0"];
+    // AC>GT MNP, sample homozygous for the ALT on both haps.
+    let records = vec![SynthRecord {
+        pos: 100,
+        ref_allele: b"AC",
+        alts: vec![&b"GT"[..]],
+        gt: vec![1, 1],
+    }];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
+    // Two SNP atoms (A>G@100, C>T@101), both carried on both haps.
+    assert_eq!(atoms.len(), 2);
+    assert_eq!((atoms[0].0, atoms[0].1), (100, 0));
+    assert_eq!((atoms[1].0, atoms[1].1), (101, 0));
+    assert_eq!(atoms[0].2, vec![true, true]);
+    assert_eq!(atoms[1].2, vec![true, true]);
+}
+
+#[test]
+fn atoms_are_globally_position_sorted_across_records() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("sorted.bcf");
+    let samples = vec!["S0"];
+    // An MNP at 100 spans to 104; a SNP record starts at 102 — its atom would land
+    // between the MNP's atoms unless the reader reorders. Also force small chunks so
+    // the ordering must hold ACROSS chunk boundaries.
+    let records = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"ACGTA",
+            alts: vec![&b"GCGTG"[..]],
+            gt: vec![1, 1],
+        },
+        SynthRecord {
+            pos: 102,
+            ref_allele: b"A",
+            alts: vec![&b"T"[..]],
+            gt: vec![1, 0],
+        },
+    ];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    // chunk_size = 1 → every atom lands in its own chunk; emission order must still
+    // be globally sorted.
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 1);
+    let positions: Vec<u32> = atoms.iter().map(|a| a.0).collect();
+    // MNP → A>G@100, A>G@104; SNP → T@102. Sorted: 100, 102, 104.
+    assert_eq!(positions, vec![100, 102, 104]);
+    let mut sorted = positions.clone();
+    sorted.sort();
+    assert_eq!(
+        positions, sorted,
+        "emitted positions must be globally sorted"
+    );
+}
+
+#[test]
+fn complex_deletion_with_substituted_anchor() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("complex.bcf");
+    let samples = vec!["S0"];
+    // ATG>CG (previously rejected as "complex"): → SNV(A>C)@100 + DEL(ilen=-1)@100.
+    let records = vec![SynthRecord {
+        pos: 100,
+        ref_allele: b"ATG",
+        alts: vec![&b"CG"[..]],
+        gt: vec![1, 1],
+    }];
+    build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+
+    let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
+    assert_eq!(atoms.len(), 2);
+    assert_eq!((atoms[0].0, atoms[0].1), (100, 0)); // SNV A>C
+    assert_eq!((atoms[1].0, atoms[1].1), (100, -1)); // DEL
+    assert_eq!(atoms[0].2, vec![true, true]);
+    assert_eq!(atoms[1].2, vec![true, true]);
+}

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -4,119 +4,17 @@
 // pushes it through the full process_chromosome → merge pipeline, and
 // validates the final sample-major sparse outputs against hand-computed
 // ground truth.
-//
-// Also covers the negative side of the atomization contract: multi-allelic
-// records and complex variants must panic at the reader, not silently corrupt
-// downstream data.
 
+mod common;
+
+use common::{
+    DecodedKey, SynthRecord, build_bcf_with_index, decode_key, read_offsets_npy, read_u32_bin,
+};
 use genoray_core::process_chromosome;
-use genoray_core::rvk::{decode_alt_inline, unpack_snp_keys};
+use genoray_core::rvk::unpack_snp_keys;
 use genoray_core::vcf_reader::VcfChunkReader;
 
-use rust_htslib::bcf::record::GenotypeAllele;
-use rust_htslib::bcf::{Format, Header, Writer};
-
-use std::path::Path;
 use tempfile::tempdir;
-
-// One synthetic VCF record: position, ref allele, list of alt alleles, and a
-// flat genotype vector laid out as [s0_p0, s0_p1, s1_p0, s1_p1, ...] holding
-// allele indices (0 = ref, 1 = first alt, …).
-struct SynthRecord<'a> {
-    pos: i64,
-    ref_allele: &'a [u8],
-    alts: Vec<&'a [u8]>,
-    gt: Vec<i32>,
-}
-
-fn build_bcf_with_index(
-    bcf_path: &Path,
-    chrom: &str,
-    chrom_len: u64,
-    samples: &[&str],
-    records: &[SynthRecord],
-) {
-    let mut header = Header::new();
-    let contig = format!("##contig=<ID={},length={}>", chrom, chrom_len);
-    header.push_record(contig.as_bytes());
-    header.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
-    for s in samples {
-        header.push_sample(s.as_bytes());
-    }
-
-    {
-        let mut writer =
-            Writer::from_path(bcf_path, &header, false, Format::Bcf).expect("open BCF writer");
-
-        for rec in records {
-            let mut record = writer.empty_record();
-            record.set_rid(Some(0));
-            record.set_pos(rec.pos);
-
-            // set_alleles wants &[&[u8]] starting with ref then alts
-            let mut alleles: Vec<&[u8]> = Vec::with_capacity(1 + rec.alts.len());
-            alleles.push(rec.ref_allele);
-            for a in &rec.alts {
-                alleles.push(a);
-            }
-            record.set_alleles(&alleles).expect("set alleles");
-
-            let gt_alleles: Vec<GenotypeAllele> =
-                rec.gt.iter().map(|&i| GenotypeAllele::Phased(i)).collect();
-            record.push_genotypes(&gt_alleles).expect("push genotypes");
-
-            writer.write(&record).expect("write record");
-        }
-        // writer drops here, finalizing the BCF file
-    }
-
-    // Build CSI index alongside the BCF so IndexedReader can fetch by chrom.
-    // BCF only supports CSI (TBI is text-VCF-only). min_shift=14 is the htslib
-    // standard for genomic data; n_threads=0 means synchronous build.
-    rust_htslib::bcf::index::build(bcf_path, None, 0, rust_htslib::bcf::index::Type::Csi(14))
-        .expect("build BCF index");
-}
-
-fn read_u32_bin(path: &Path) -> Vec<u32> {
-    // Alignment-agnostic decode: std::fs::read can hand back a Vec<u8> whose
-    // pointer isn't 4-byte aligned (especially when empty), which would trip
-    // bytemuck::cast_slice's TargetAlignmentGreater check.
-    let bytes = std::fs::read(path).expect("read u32 bin");
-    bytes
-        .chunks_exact(4)
-        .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-        .collect()
-}
-
-fn read_offsets_npy(path: &Path) -> Vec<u64> {
-    let arr: ndarray::Array1<u64> = ndarray_npy::read_npy(path).expect("read offsets npy");
-    arr.to_vec()
-}
-
-// Decode a single packed key. Discriminator:
-//   bit 0 = 1                 → lookup (long allele bank row index)
-//   bit 0 = 0 AND bit 31 = 1  → pure DEL (signed ilen in upper 31 bits)
-//   bit 0 = 0 AND bit 31 = 0  → inline ALT (top 5 bits hold the length field)
-#[derive(Debug, PartialEq)]
-enum DecodedKey {
-    Inline { alt: Vec<u8> },
-    PureDel { ilen: i32 },
-    Lookup { row: u32 },
-}
-
-fn decode_key(key: u32) -> DecodedKey {
-    if key & 1 == 1 {
-        DecodedKey::Lookup { row: key >> 1 }
-    } else if (key as i32) < 0 {
-        DecodedKey::PureDel {
-            ilen: (key as i32) >> 1,
-        }
-    } else {
-        DecodedKey::Inline {
-            alt: decode_alt_inline(key),
-        }
-    }
-}
 
 // Positive E2E: 3 records spanning SNP / INS / pure DEL across 2 samples diploid.
 //   pos=100  A  → C    (SNP)        gt = [1, 0, 1, 1]   → haps 0, 2, 3 carry it
@@ -283,61 +181,7 @@ fn test_e2e_mutation_conservation() {
     assert_eq!(indel_pos.len(), 0);
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-// Negative tests — the reader must panic on inputs that violate the
-// `bcftools norm -m -any --atomize` contract. We invoke VcfChunkReader
-// directly so the panic surfaces in the test thread (process_chromosome
-// would route it through JoinHandle::unwrap, masking the message).
-// ─────────────────────────────────────────────────────────────────────────
-
-#[test]
-#[should_panic(expected = "must be normalized")]
-fn test_reader_panics_on_multi_allelic() {
-    let tmp = tempdir().unwrap();
-    let bcf_path = tmp.path().join("multi.bcf");
-
-    let samples = vec!["S0"];
-    let records = vec![
-        // 3-allele record: REF + 2 ALTs → forbidden by `bcftools norm -m -any`
-        SynthRecord {
-            pos: 100,
-            ref_allele: b"A",
-            alts: vec![&b"C"[..], &b"G"[..]],
-            gt: vec![1, 2],
-        },
-    ];
-    build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
-
-    let mut reader = VcfChunkReader::new(bcf_path.to_str().unwrap(), "chr1", &samples, 1, 2);
-    let _ = reader.read_next_chunk(100, 0); // panics here
-}
-
-#[test]
-#[should_panic(expected = "must be atomized")]
-fn test_reader_panics_on_complex_variant() {
-    let tmp = tempdir().unwrap();
-    let bcf_path = tmp.path().join("complex.bcf");
-
-    let samples = vec!["S0"];
-    let records = vec![
-        // Complex variant: ref=ATG (3bp), alt=CG (2bp).
-        // alt_len=2 > 1 AND alt_len=2 < ref_len=3 → forbidden by `bcftools norm --atomize`
-        SynthRecord {
-            pos: 100,
-            ref_allele: b"ATG",
-            alts: vec![&b"CG"[..]],
-            gt: vec![1, 1],
-        },
-    ];
-    build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
-
-    let mut reader = VcfChunkReader::new(bcf_path.to_str().unwrap(), "chr1", &samples, 1, 2);
-    let _ = reader.read_next_chunk(100, 0); // panics here
-}
-
-// Sanity: a clean, properly atomized DEL (alt_len=1) does NOT trip the panic.
-// Acts as a regression guard: we don't want the atomization assert to false-
-// positive on legitimate pure deletions.
+// Sanity: a clean, properly atomized DEL (alt_len=1) passes the reader.
 #[test]
 fn test_reader_accepts_pure_del() {
     let tmp = tempdir().unwrap();

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -7,14 +7,37 @@
 
 mod common;
 
-use common::{
-    DecodedKey, SynthRecord, build_bcf_with_index, decode_key, read_offsets_npy, read_u32_bin,
-};
+use common::{SynthRecord, build_bcf_with_index, read_offsets_npy, read_u32_bin};
 use genoray_core::process_chromosome;
-use genoray_core::rvk::unpack_snp_keys;
+use genoray_core::rvk::{decode_alt_inline, unpack_snp_keys};
 use genoray_core::vcf_reader::VcfChunkReader;
 
 use tempfile::tempdir;
+
+/// Decode a single packed key. Discriminator:
+///   bit 0 = 1                 → lookup (long allele bank row index)
+///   bit 0 = 0 AND bit 31 = 1  → pure DEL (signed ilen in upper 31 bits)
+///   bit 0 = 0 AND bit 31 = 0  → inline ALT (top 5 bits hold the length field)
+#[derive(Debug, PartialEq)]
+enum DecodedKey {
+    Inline { alt: Vec<u8> },
+    PureDel { ilen: i32 },
+    Lookup { row: u32 },
+}
+
+fn decode_key(key: u32) -> DecodedKey {
+    if key & 1 == 1 {
+        DecodedKey::Lookup { row: key >> 1 }
+    } else if (key as i32) < 0 {
+        DecodedKey::PureDel {
+            ilen: (key as i32) >> 1,
+        }
+    } else {
+        DecodedKey::Inline {
+            alt: decode_alt_inline(key),
+        }
+    }
+}
 
 // Positive E2E: 3 records spanning SNP / INS / pure DEL across 2 samples diploid.
 //   pos=100  A  → C    (SNP)        gt = [1, 0, 1, 1]   → haps 0, 2, 3 carry it


### PR DESCRIPTION
## SVAR 2.0 M2 — Variant normalization (split + atomize)

Makes SVAR2 conversion accept **un-normalized VCFs** by decomposing multi-allelic / MNP / complex records into atomized biallelic primitives inline as they stream through the reader. Left-alignment is explicitly deferred to a follow-up (M2b).

### What changed
- **`src/normalize.rs` (new)** — pure atomization core. `atomize_record` decomposes one record into encoder-valid `Atom`s (SNP / anchored INS / anchored DEL), mirroring bcftools `_atomize_allele`. Biallelic split over ALTs; `*`/`.` skipped; symbolic/breakend ALTs rejected via a typed `NormalizeError`. Covered by unit tests + a 2000-case proptest asserting every atom is encoder-valid.
- **`src/vcf_reader.rs` (restructure)** — `VcfChunkReader` now atomizes each record and emits atoms through a **position-keyed min-heap reorder buffer**, so atomization (which spreads atom positions rightward) still yields globally position-sorted `DenseChunk`s across chunk boundaries — preserving the invariant the interleaving merge depends on. Genotypes are remapped by comparing each haplotype's integer allele index to the atom's source ALT index (haplotype-resolved multi-allelic split). Public API unchanged.
- **`tests/common/mod.rs` (new)** — shared synthetic-BCF harness extracted from `test_e2e.rs`; obsolete reader-panic tests dropped. New `tests/test_atomize_e2e.rs` covers multi-allelic split+remap, MNP atomization, cross-record/cross-chunk reordering, and substituted-anchor complex deletions.
- **docs** — roadmap/data-model reconciled: M2 marked shipped (split+atomize), left-alignment split out as deferred **M2b**.

### Invariants preserved
- Encode seam (`rvk.rs`, `streams.rs`), executor, merge, and the Python API (`run_conversion_pipeline`, on-disk layout, `meta.json`) are **byte-unchanged**.
- No left-alignment → every atom `pos >= its record start`; the reorder buffer relies on this.

### Testing
`pixi run -e lint cargo test --no-default-features`: **68/68 pass** (60 unit incl. proptest + 4 atomize-e2e + 4 retained e2e). `clippy --tests -D warnings`: clean.

### Review
Executed via subagent-driven development: each task passed an individual spec+quality review; a final whole-branch review (independently tracing the reorder-buffer safety/liveness and genotype remapping) returned **ready to merge**. Two near-zero-cost hardening one-liners were folded in (a `debug_assert` on non-empty REF/ALT; a memory-bound comment on the reorder buffer for M2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
