### PR TITLE
feat(svar-2): M3 format finalization (spec filenames + meta.json)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "pyo3",
  "rayon",
  "rust-htslib",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -547,6 +548,12 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -1159,6 +1166,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1538,12 @@ name = "zlib-rs"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rayon = "1.11.0"
 # vendored by hts-sys and built with the conda C/C++ compilers. hts-sys forces
 # bindgen, so the build needs libclang (provided via pixi: clang/clangdev).
 rust-htslib = { version = "1.0", default-features = false }
+serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]

--- a/docs/roadmap/data-model.md
+++ b/docs/roadmap/data-model.md
@@ -138,12 +138,12 @@ switch to a **dense 1-bit genotype matrix**, chosen **strictly per variant** (se
   by class is free (same total bits) and shrinks the SNP variant table's `alleles`
   column 4 B → 0.25 B per variant — a large win whenever annotations are sparse and
   `alleles` dominates the row.
-- **Provisional filenames.** Like `var_key` (see [Open questions](#open-questions)),
-  the current scratch implementation writes raw `.bin` final files —
-  `final_positions.bin` / `final_keys.bin` / `final_genotypes.bin` under
-  `{contig}/dense/{snp,indel}/` — mirroring the `var_key` naming rather than the
-  `.npy` names in the layout tree below. These will be unified with the `var_key`
-  wire format before the decode path (M6), as part of M3.
+- **On-disk filenames.** The dense final files share `var_key`'s wire-format
+  convention (see [Open questions](#open-questions) → resolved): `positions.bin` /
+  `alleles.bin` / `genotypes.bin` under `{contig}/dense/{snp,indel}/`, all raw
+  little-endian `.bin`. The dense representation has no ragged `offsets` sidecar —
+  every hap contributes the same per-variant count, so the matrix shape is derived
+  from `len(positions)` and `(n_samples, ploidy)` from `meta.json`.
 
 ## Dense vs. sparse cost model
 
@@ -211,15 +211,15 @@ svar2/
     │   └── long_allele_offsets.npy # row offsets into the packed ALT bytes above
     ├── dense/
     │   ├── snp/
-    │   │   ├── positions.npy       # sidecar SNP-variant positions (sorted)
-    │   │   ├── alleles.npy         # 2-bit packed keys, one per SNP variant (no LUT)
+    │   │   ├── positions.bin       # sidecar SNP-variant positions (sorted), u32 LE
+    │   │   ├── alleles.bin         # 2-bit packed keys, one per SNP variant (no LUT), u8
     │   │   ├── {field}.npy         # per-variant INFO/FORMAT fields
-    │   │   └── genotypes.npy       # 1-bit (sample, ploid, snp_variant) matrix, C-order
+    │   │   └── genotypes.bin       # 1-bit (sample, ploid, snp_variant) matrix, C-order, u8
     │   └── indel/
-    │       ├── positions.npy
-    │       ├── alleles.npy         # 32-bit keys, one per indel variant (points into shared LUT)
+    │       ├── positions.bin       # u32 LE
+    │       ├── alleles.bin         # 32-bit keys, one per indel variant (points into shared LUT), u32 LE
     │       ├── {field}.npy
-    │       └── genotypes.npy       # 1-bit (sample, ploid, indel_variant) matrix, C-order
+    │       └── genotypes.bin       # 1-bit (sample, ploid, indel_variant) matrix, C-order, u8
     ├── pointer/                    # = SVAR 1.0 representation (longer-term, M11)
     │   ├── snp/
     │   │   ├── positions.npy
@@ -235,14 +235,14 @@ svar2/
     │       └── offsets.npy
     └── var_key/
         ├── snp/
-        │   ├── positions.npy       # per-call SNP positions (sorted within each hap)
-        │   ├── alleles.npy         # 2-bit packed ALT, 4 calls/byte (uint8), no LUT
-        │   ├── offsets.npy         # per (sample, ploid) ragged offsets into snp calls
+        │   ├── positions.bin       # per-call SNP positions (sorted within each hap), u32 LE
+        │   ├── alleles.bin         # 2-bit packed ALT, 4 calls/byte (uint8), no LUT
+        │   ├── offsets.npy         # per (sample, ploid) ragged offsets into snp calls, u64
         │   └── {field}.npy         # per-call INFO/FORMAT for SNP calls
         └── indel/
-            ├── positions.npy       # per-call indel positions (sorted within each hap)
-            ├── alleles.npy         # 32-bit keys, one per call (ragged, points into shared LUT)
-            ├── offsets.npy         # per (sample, ploid) ragged offsets into alleles
+            ├── positions.bin       # per-call indel positions (sorted within each hap), u32 LE
+            ├── alleles.bin         # 32-bit keys, one per call (ragged, points into shared LUT), u32 LE
+            ├── offsets.npy         # per (sample, ploid) ragged offsets into alleles, u64
             └── {field}.npy
 ```
 
@@ -251,6 +251,17 @@ contig list, and ploidy. The per-stream maximum deletion length needed for overl
 queries lives in a separate `max_del.npy` per contig (see below) rather than in
 `meta.json`, because it is a structured, potentially large array (e.g. 1M diploid
 samples × 20 contigs).
+
+**Array dtypes are a `format_version` convention, not duplicated in `meta.json`.**
+For `format_version = 1`: `positions.bin` is `u32` little-endian; `alleles.bin` is
+`u8` (2-bit-packed SNP codes, 4/byte) in `snp/` and `u32` little-endian (inline value
+or shared-LUT pointer) in `indel/`; `genotypes.bin` is `u8` (raw 1-bit hap-major
+matrix, LSB-first); `offsets.npy` and `long_allele_offsets.npy` are `u64`;
+`long_alleles.bin` is `u8`. The bulk parallel-`pwrite`n arrays (`positions` /
+`alleles` / `genotypes`) are raw `.bin` — mmap-friendly, no npy-header offset to align
+every `pwrite` past — and Python reads them with `np.memmap(path, dtype=…, mode='r')`,
+deriving shape from `len(positions)` and `meta.json`. The small one-shot index/metadata
+sidecars (`offsets`, `long_allele_offsets`) stay self-describing `.npy`.
 
 A contig query reads both sub-streams of each representation it touches and merges the
 results in position order. `max_del.npy` describes the **indel sub-streams only**; SNP
@@ -334,11 +345,15 @@ SVAR2 is a **compute-oriented, derived format — not an archival format.**
   SNPs encoded as `ILEN = 0` and the ALT base in bits `[26:25]`; the split supersedes
   it. The encoder's SNP fast path (`encode_snp`) still applies — it now emits the bare
   2-bit code into the SNP stream instead of shifting it to bits `[26:25]`.
-- **`var_key` sidecar wire format.** The merge currently writes positions and keys as
-  raw little-endian `.bin` (`final_positions.bin` / `final_keys.bin`, via `bytemuck`)
-  and offsets as `final_offsets.npy`, whereas the layout spec above names them `.npy`.
-  Settle on one (raw `.bin` is mmap-friendly and avoids the npy header; `.npy` is
-  self-describing) and align the names before the decode path (M6) is built.
+- **`var_key` sidecar wire format.** *Resolved (M3): raw `.bin` for pwritten data
+  arrays, `.npy` for one-shot sidecars.* The bulk arrays the tile merge writes via
+  concurrent positional `pwrite` (`positions.bin`, `alleles.bin`, and dense
+  `genotypes.bin`) are raw little-endian `.bin`: they carry no logical shape in the
+  file (2-bit-packed SNP / 1-bit-packed genotype bytes), and wrapping them in `.npy`
+  would force a hand-rolled 64-byte-aligned header that every `pwrite` must offset past
+  — real fragility for no gain. The small one-shot index/metadata sidecars
+  (`offsets.npy`, `long_allele_offsets.npy`) stay self-describing `.npy`. Array dtypes
+  are keyed to `format_version` (see [On-disk layout](#on-disk-layout)).
 - **Cost-model constants (pointer representation only).** `var_key` vs. `dense` are
   implemented and measured in exact integer bits (see
   [cost model](#dense-vs-sparse-cost-model)); the remaining open constant is the

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -87,16 +87,19 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   needs a reference genome (FASTA/faidx) and a new required conversion argument, and it
   widens the reorder-buffer bound (leftward shifts). See
   [`data-model.md`](data-model.md#variant-normalization).
-- [~] **M3. Per-contig split + sidecar positions.** Partition the SVAR2 directory by
-  contig; keep positions as sidecar arrays. See
-  [`architecture.md`](architecture.md#on-disk-layout).
-  *Core done:* output is partitioned per contig (`{out}/{contig}/var_key/`) and the
-  merge emits sorted position + offset sidecars. *Provisional / remaining:* the current
-  scratch filenames live under `{out}/{contig}/var_key/{snp,indel}/` as
-  `final_positions.bin` / `final_keys.bin` (raw little-endian via bytemuck) and
-  `final_offsets.npy`, plus `long_alleles.bin` + `long_allele_offsets.npy` under
-  `indel/`, which differ from the `.npy` names in the layout spec; `meta.json` and
-  the per-contig `max_del.npy` are not yet written.
+- [x] **M3. Per-contig split + sidecar positions + format finalization.** Partition the
+  SVAR2 directory by contig; keep positions as sidecar arrays; finalize the on-disk
+  format. See [`architecture.md`](architecture.md#on-disk-layout).
+  *Done:* output is partitioned per contig
+  (`{out}/{contig}/{var_key,dense}/{snp,indel}/`) and the merge emits sorted position +
+  offset sidecars. The final per-stream files use their spec base names —
+  `positions.bin` / `alleles.bin` / `genotypes.bin` (raw little-endian, mmap-friendly)
+  and `offsets.npy` (one-shot) — plus the shared `long_alleles.bin` +
+  `long_allele_offsets.npy` under `indel/`. A top-level `meta.json`
+  (`format_version` / `samples` / `contigs` / `ploidy`) is written once after all
+  contigs succeed. Array dtypes are a `format_version` convention documented in
+  [`data-model.md`](data-model.md#on-disk-layout). *(The per-contig `max_del.npy` is
+  produced and consumed by the overlap search, so it lands with M5, not here.)*
 - [x] **M4. Dense representation + cost-model routing.** Implement the 1-bit dense
   genotype matrix and the deterministic per-variant dense/sparse decision. See
   [`data-model.md`](data-model.md#dense-vs-sparse-cost-model).
@@ -113,11 +116,11 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   shared per-contig LUT (see [`data-model.md`](data-model.md#long-allele-lookup-table-lut)).
   Covered by unit/proptests in `cost_model.rs`, `dense.rs`, `dense_merge.rs`, `bits.rs`,
   and `rvk.rs`, plus an e2e dense round-trip test. *Out of scope (deferred to later
-  milestones):* `max_del.npy` / overlap queries (M5), `meta.json` (M3), and the
-  `pointer` representation (M11) are not implemented here; the dense final filenames
-  are provisional and mirror `var_key`'s (see the dense-representation section of
-  [`data-model.md`](data-model.md#dense-representation-dense)), to be unified as part
-  of M3.
+  milestones):* `max_del.npy` / overlap queries (M5) and the `pointer` representation
+  (M11) are not implemented here. `meta.json` and the unification of the dense final
+  filenames with `var_key`'s spec base names (`positions.bin` / `alleles.bin` /
+  `genotypes.bin`; see the dense-representation section of
+  [`data-model.md`](data-model.md#dense-representation-dense)) landed in M3.
 - [ ] **M5. `(range, sample)` queries.** Fast overlap queries via binary search,
   starting from the [left-tree static search tree](https://curiouscoding.nl/posts/static-search-tree/#left-tree).
   Must handle deletions spanning the query start (see

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -68,7 +68,7 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   in-source unit/proptests + 5 e2e tests. An optional per-contig monitoring sampler
   (`GENORAY_SAMPLE_INTERVAL`) reports channel fill and per-thread CPU%. *Remaining:*
   variant normalization (M2, currently a precondition — see below); the on-disk
-  filenames are still provisional (see M3). The
+  filenames were finalized in M3. The
   `var_key` stream is now split into 2-bit `snp/` and 32-bit `indel/`
   sub-streams per [`data-model.md`](data-model.md#on-disk-layout); the SNP stream
   is 2-bit-packed post-merge and carries no LUT.

--- a/docs/superpowers/specs/2026-07-02-svar2-m3-format-finalization-design.md
+++ b/docs/superpowers/specs/2026-07-02-svar2-m3-format-finalization-design.md
@@ -1,0 +1,122 @@
+# SVAR 2.0 — M3: per-contig format finalization (design)
+
+> Spec for roadmap milestone **M3** in
+> [`docs/roadmap/svar-2.md`](../../roadmap/svar-2.md).
+> Supplements: [`architecture.md`](../../roadmap/architecture.md#on-disk-layout),
+> [`data-model.md`](../../roadmap/data-model.md#on-disk-layout).
+> Branch off `svar-2`, own worktree.
+
+## Context
+
+M3's core is already done: output is partitioned per contig (`{out}/{contig}/…`) and the
+merge emits sorted position + offset sidecars. What remains is **format finalization** — the
+on-disk names are still provisional scratch names (`final_*`) that differ from the layout
+spec, no `meta.json` is written, and the wire-format open question is unsettled. Until this
+lands, the M5/M6 read path would be built against churny names.
+
+This is a small, write-side, mostly-mechanical PR. It does **not** add the query path.
+
+## Scope
+
+**In:**
+
+1. Rename the provisional `final_*` files to their spec base names and **settle the
+   wire-format open question** (`.bin` vs `.npy`).
+2. Emit a top-level `meta.json`.
+3. Reconcile the roadmap + supplements (required by the working agreement), including moving
+   `max_del.npy` cleanly under M5 to remove the current M3/M5 contradiction.
+
+**Out:**
+
+- `max_del.npy` — deferred to M5 (produced at conversion time but consumed only by the
+  overlap algorithm; co-located with its consumer to prevent deletion-span drift).
+- `{field}.npy` INFO/FORMAT per-variant columns (not yet extracted in the MVP).
+- The `pointer` representation (M11) and the M5 search tree / query path.
+
+## Design
+
+### 1. Wire format — raw `.bin` for pwritten arrays, `.npy` for one-shot metadata
+
+**Decision.** The tile merge writes `positions` / `alleles` / `genotypes` via concurrent
+positional `pwrite` into a pre-sized file ([`merge.rs`](../../../src/merge.rs),
+[`dense_merge.rs`](../../../src/dense_merge.rs)). Wrapping those in `.npy` would require
+hand-rolling a fixed, 64-byte-aligned npy header and offsetting every `pwrite` past it — real
+fragility for marginal gain, since these streams carry **no logical shape in the file** anyway
+(2-bit-packed SNP / 1-bit-packed genotype bytes; shape is derived from `len(positions)` +
+`meta.json`). So:
+
+| Stream | Format | dtype | Written by |
+| --- | --- | --- | --- |
+| `positions.bin` | raw LE | `u32` | concurrent `pwrite` |
+| `alleles.bin` | raw LE | `u8` (packed SNP) / `u32` (indel) | concurrent `pwrite` |
+| `genotypes.bin` | raw LE | `u8` (packed 1-bit matrix) | concurrent `pwrite` |
+| `offsets.npy` | npy | `u64` | one-shot `write_npy` |
+| `long_alleles.bin` | raw LE | `u8` | streaming append (unchanged) |
+| `long_allele_offsets.npy` | npy | `u64` | one-shot `write_npy` (unchanged) |
+
+Principle: **bulk parallel-pwritten data arrays are raw `.bin` (mmap-friendly, no header
+friction); small one-shot index/metadata sidecars stay self-describing `.npy`.** Array dtypes
+are fixed by `format_version` and documented in `data-model.md`; Python reads the `.bin`
+arrays via `np.memmap(path, dtype=…, mode='r')`.
+
+### Concrete renames (`layout.rs` + doc only — no pwrite refactor)
+
+Applies identically under `var_key/{snp,indel}/` and `dense/{snp,indel}/`:
+
+| now | → |
+| --- | --- |
+| `final_positions.bin` | `positions.bin` |
+| `final_keys.bin` | `alleles.bin` |
+| `final_offsets.npy` | `offsets.npy` |
+| `final_genotypes.bin` | `genotypes.bin` |
+
+`final_keys` → `alleles` unifies naming with the layout spec (which already calls the packed
+keys `alleles`). The doc tree currently names positions/alleles/genotypes `.npy`; flip those
+three to `.bin` and record the resolution in the "var_key sidecar wire format" open question.
+
+### 2. `meta.json`
+
+Top-level `{output_dir}/meta.json`, written **once** in
+[`run_conversion_pipeline`](../../../src/lib.rs) after all contigs succeed — the only scope
+that knows the full `chroms` / `samples` / `ploidy`. Per-contig `process_chromosome` cannot
+own it. Minimal, spec-matching schema:
+
+```json
+{ "format_version": 1, "samples": ["…"], "contigs": ["…"], "ploidy": 2 }
+```
+
+- `format_version` is an integer schema version for `SparseVar2` negotiation; bump on any
+  breaking layout/dtype change.
+- Array dtypes are **not** duplicated here — they are a `format_version` convention documented
+  in `data-model.md`.
+- New dep: `serde_json` only (build a `json!` value and `to_writer`; no `derive`, and Rust
+  never reads it back — Python does via `json.load`).
+- Extract a `write_meta(output_dir, format_version, samples, contigs, ploidy)` helper so it is
+  unit-testable without going through the pyfunction.
+
+### 3. Doc + test reconciliation
+
+Required by the roadmap working agreement — same PR:
+
+- **`data-model.md`**: flip the three filenames to `.bin` in the on-disk-layout tree; resolve
+  the "var_key sidecar wire format" open question (record the `.bin`-for-pwritten /
+  `.npy`-for-one-shot rationale); drop the "provisional filenames" notes in the dense +
+  var_key sections; document the array dtype convention keyed to `format_version`.
+- **`svar-2.md`**: M3 `[~]` → `[x]`; rewrite the remaining-text; **remove `max_del.npy` from
+  M3's remaining list**, leaving it under M5 (fixes the contradiction); update M4's "unify
+  dense filenames as part of M3" note to done.
+- **`architecture.md`**: verify the `meta.json` / on-disk-layout bullets still read true.
+- **Tests**: update name assertions in [`merge.rs`](../../../src/merge.rs),
+  [`dense_merge.rs`](../../../src/dense_merge.rs), and [`layout.rs`](../../../src/layout.rs);
+  add a `write_meta` unit test (round-trip the JSON and assert fields); existing e2e tests
+  (which call `process_chromosome` per contig) get the renamed-file assertions.
+
+## Worktree & dependencies
+
+- Worktree: `.claude/worktrees/svar-2-m3-format-finalize`, branch off `svar-2`, PR into
+  `svar-2`. Install prek hooks before committing.
+- Blocks the **disk-integration** half of M5/M6 (they read this format), but not M5's
+  format-independent search core — see
+  [`2026-07-02-svar2-m5-partial-search-tree-design.md`](2026-07-02-svar2-m5-partial-search-tree-design.md),
+  which can proceed fully in parallel.
+</content>

--- a/docs/superpowers/specs/2026-07-02-svar2-m5-partial-search-tree-design.md
+++ b/docs/superpowers/specs/2026-07-02-svar2-m5-partial-search-tree-design.md
@@ -1,0 +1,122 @@
+# SVAR 2.0 — M5 (partial): format-independent overlap search core (design)
+
+> Partial spec for roadmap milestone **M5** in
+> [`docs/roadmap/svar-2.md`](../../roadmap/svar-2.md).
+> Supplements: [`architecture.md`](../../roadmap/architecture.md#query-path),
+> [`data-model.md`](../../roadmap/data-model.md#overlap-queries-and-deletions).
+> Branch off `svar-2`, own worktree; can proceed in parallel with M3.
+
+## Context
+
+M5 is `(range, sample)` overlap queries. It has two separable halves:
+
+1. **A format-independent algorithmic core** — a static search tree over a sorted `u32`
+   position array plus the overlap lower-bound/upper-bound resolution that handles
+   deletions spanning the query start. This depends only on in-memory arrays.
+2. **Disk integration** — reading a real SVAR2 contig (positions/offsets/`max_del` across
+   the `var_key`/`dense` × `snp`/`indel` sub-streams), merging results in position order,
+   and gathering per-sample genotypes.
+
+This spec covers **only half 1**. It is deliberately decoupled so it can be built and
+proptested against synthetic arrays *before* M3 finalizes the on-disk format and *before*
+M5's `max_del.npy` producer exists — the two halves touch disjoint files.
+
+The existing SVAR 1.0 reader already implements this shape in Python
+([`_var_ranges.py::var_ranges`](../../../python/genoray/_var_ranges.py): `np.searchsorted`
+for LB/UB, then numba `_forward_sub_scan` / `_backward_sub_scan` to trim to true
+overlaps). This spec generalizes that into the Rust core, swapping `searchsorted` for the
+cache-friendly [left-tree static search tree](https://curiouscoding.nl/posts/static-search-tree/#left-tree).
+
+## Scope
+
+**In:**
+
+- A **static search tree** built over a sorted, ascending `u32` array, exposing
+  `lower_bound(x)` (first index with `arr[i] >= x`) and `upper_bound(x)` (first index with
+  `arr[i] > x`), following the left-tree layout for cache-friendly probes.
+- An **overlap-range resolver**: given sorted `v_starts: &[u32]`, a `max_region_length:
+  u32` bound (the max-deletion span, passed as a **parameter** — not read from disk), and a
+  query `[q_start, q_end)`, return the `[s_idx, e_idx)` index range of variants that truly
+  overlap, mirroring `var_ranges`:
+  - LB = search on `v_starts + max_region_length` for `q_start`;
+  - UB = search on `v_starts` for `q_end`;
+  - forward sub-scan for the first `q_start < v_end`, backward sub-scan for the last, where
+    `v_end` is reconstructed from `v_start` and the deletion length.
+- Correctness validated by **proptest against a brute-force linear-scan oracle** over
+  random sorted arrays, random queries, and random deletion lengths (including the SNP case
+  `max_region_length == 0`, empty arrays, and no-overlap queries).
+
+**Out (deferred to full M5 / M6):**
+
+- Reading `positions.bin` / `offsets.npy` / `max_del.npy` from a SVAR2 directory (needs
+  the M3 format contract and the M5 `max_del` producer).
+- Producing `max_del.npy` at conversion time (the write-side other half of M5).
+- Combining results across the up-to-six sub-streams (`var_key`/`dense` × `snp`/`indel`)
+  and the sorted-union merge (that union is M6 decode territory).
+- Per-sample genotype gather and the `SparseVar2` Python class.
+- Batched/multi-query vectorization (SVAR 1.0 does many ranges at once; the core here is
+  single-query — batching is a thin wrapper added during integration).
+
+## Design
+
+### Module
+
+A self-contained Rust module (e.g. `src/search.rs`) with no dependency on `layout.rs`,
+`merge.rs`, or any on-disk type. Inputs are borrowed slices; outputs are index ranges.
+
+### `v_end` reconstruction
+
+A SNP spans one base (`v_end = v_start + 1`); an indel deletion of length `d` spans
+`v_end = v_start + 1 + d` (0-based, exclusive), matching the SVAR 1.0 formula
+`v_end = POS - min(ILEN, 0)` after the 0-based shift. The resolver takes `v_ends` (or the
+data to compute them) alongside `v_starts`; how deletion length reaches the core (explicit
+`v_ends` slice vs. `(v_starts, ilens)`) is an implementation detail to settle in the plan.
+
+### Why a search tree over `searchsorted`
+
+The static search tree amortizes branchy binary search into a flat, prefetch-friendly
+layout — the win the [reference post](https://curiouscoding.nl/posts/static-search-tree/#left-tree)
+documents for repeated queries against a fixed sorted array, which is exactly the
+per-contig position sidecar accessed across many range queries. The tree is **built once
+per sorted array** and reused across queries.
+
+### Overlap algorithm (single query)
+
+Mirrors `var_ranges` in [`_var_ranges.py`](../../../python/genoray/_var_ranges.py):
+
+1. `lb = tree_over(v_starts + max_region_length).lower_bound(q_start)` — leftmost variant
+   whose start could still reach `q_start` given the max deletion span.
+2. `ub = tree_over(v_starts).lower_bound(q_end)` — one past the last variant starting
+   before `q_end`.
+3. Forward sub-scan `[lb, ub)` for the first `i` with `q_start < v_ends[i]` → `s_idx`.
+4. Backward sub-scan `(lb, ub]` for the last such `i` → `e_idx` (exclusive).
+5. Empty result when `s_idx == ub` (no overlap).
+
+Note the two searches are over two different key arrays (`v_starts + max_region_length` and
+`v_starts`); whether that is two trees or one tree plus an offset probe is a plan-time
+decision.
+
+## Testing
+
+- **Oracle proptest:** brute-force `O(n)` overlap over random `(sorted v_starts, deletion
+  lengths, query)` must match the tree+scan result exactly. This is the primary
+  correctness gate.
+- **Edge cases:** empty array; single element; `max_region_length == 0` (pure SNP stream,
+  reduces to half-open `[lb, ub)`); query entirely left/right of all variants; deletion
+  that starts before the query and spans into it; adjacent-but-non-overlapping
+  (`v_end == q_start`).
+- **Search-tree unit tests:** `lower_bound`/`upper_bound` against `slice::partition_point`
+  as an independent reference, across sizes that exercise the tree's block boundaries.
+
+## Worktree & dependencies
+
+- Worktree: `.claude/worktrees/svar-2-m5-search-core`, branch off `svar-2`, PR into
+  `svar-2`. Install prek hooks before committing.
+- **No dependency on M3.** Operates on in-memory arrays; touches only the new `search.rs`
+  (+ its tests). Disk integration — reading M3's finalized sidecars and M5's own
+  `max_del.npy` — is a follow-up once both this core and M3 have merged.
+- When the write-side of M5 (the `max_del.npy` producer) is specced, it pairs with this
+  core: this module *consumes* `max_region_length`; the producer *emits* it per
+  `(contig, sample, ploid)`.
+</content>
+</invoke>

--- a/src/dense_merge.rs
+++ b/src/dense_merge.rs
@@ -41,13 +41,13 @@ pub fn merge_dense_class(
         positions.extend_from_slice(&fs::read(layout::chunk_pos(dir, c)).expect("read dense pos"));
         keys.extend_from_slice(&fs::read(layout::chunk_key(dir, c)).expect("read dense key"));
     }
-    write_all(&layout::final_positions(dir), &positions);
+    write_all(&layout::positions(dir), &positions);
     let final_key_bytes = if pack_snp {
         pack_snp_keys(&keys) // keys are one raw 2-bit code per variant
     } else {
         keys
     };
-    write_all(&layout::final_keys(dir), &final_key_bytes);
+    write_all(&layout::alleles(dir), &final_key_bytes);
 
     // ---- genotypes: per-hap bit concatenation across chunks ----
     // output bit (hap h, global col g) at flat index h * v_total + g.
@@ -73,7 +73,7 @@ pub fn merge_dense_class(
             copy_bits(&mut out, dst_bit, &block, src_bit, v_c);
         }
     }
-    write_all(&layout::final_genotypes(dir), &out);
+    write_all(&layout::genotypes(dir), &out);
 
     // ---- cleanup per-chunk temp files ----
     for c in 0..num_chunks {
@@ -147,12 +147,12 @@ mod tests {
         );
 
         // positions concat in chunk order
-        assert_eq!(read_u32(&layout::final_positions(dir)), vec![100, 200, 300]);
+        assert_eq!(read_u32(&layout::positions(dir)), vec![100, 200, 300]);
         // keys concat (pack_snp=false → raw)
-        assert_eq!(fs::read(layout::final_keys(dir)).unwrap(), vec![1u8, 2, 3]);
+        assert_eq!(fs::read(layout::alleles(dir)).unwrap(), vec![1u8, 2, 3]);
 
         // genotypes: hap0 row = [1,0,1], hap1 row = [0,1,0], flat h*v_total+g.
-        let geno = fs::read(layout::final_genotypes(dir)).unwrap();
+        let geno = fs::read(layout::genotypes(dir)).unwrap();
         let expect_bits = [
             (0usize, true),
             (1, false),
@@ -173,8 +173,8 @@ mod tests {
         let tmp = tempdir().unwrap();
         let dir = tmp.path();
         merge_dense_class(1, 2, 2, 1, true, dir.to_str().unwrap(), vec![0]);
-        assert_eq!(fs::read(layout::final_positions(dir)).unwrap().len(), 0);
-        assert_eq!(fs::read(layout::final_genotypes(dir)).unwrap().len(), 0);
+        assert_eq!(fs::read(layout::positions(dir)).unwrap().len(), 0);
+        assert_eq!(fs::read(layout::genotypes(dir)).unwrap().len(), 0);
     }
 
     #[test]
@@ -192,9 +192,6 @@ mod tests {
         );
         merge_dense_class(1, 1, 1, 1, true, dir.to_str().unwrap(), vec![5]);
         // pack_snp_keys([1,2,3,0,1]) == [0x39, 0x01] (see rvk.rs test)
-        assert_eq!(
-            fs::read(layout::final_keys(dir)).unwrap(),
-            vec![0x39u8, 0x01]
-        );
+        assert_eq!(fs::read(layout::alleles(dir)).unwrap(), vec![0x39u8, 0x01]);
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,6 @@
 //! Single source of truth for the SVAR2 on-disk directory + file layout. Every
-//! path the pipeline reads or writes is constructed here so the (still
-//! provisional) filenames can be changed in exactly one place before M6 decode.
+//! path the pipeline reads or writes is constructed here, so the finalized
+//! on-disk file names are defined in exactly one place.
 
 use std::path::{Path, PathBuf};
 
@@ -62,20 +62,20 @@ pub fn chunk_pos(dir: &Path, chunk_id: usize) -> PathBuf {
 pub fn chunk_key(dir: &Path, chunk_id: usize) -> PathBuf {
     dir.join(format!("chunk_{}_key.bin", chunk_id))
 }
-pub fn final_positions(dir: &Path) -> PathBuf {
-    dir.join("final_positions.bin")
+pub fn positions(dir: &Path) -> PathBuf {
+    dir.join("positions.bin")
 }
-pub fn final_keys(dir: &Path) -> PathBuf {
-    dir.join("final_keys.bin")
+pub fn alleles(dir: &Path) -> PathBuf {
+    dir.join("alleles.bin")
 }
-pub fn final_offsets(dir: &Path) -> PathBuf {
-    dir.join("final_offsets.npy")
+pub fn offsets(dir: &Path) -> PathBuf {
+    dir.join("offsets.npy")
 }
 pub fn chunk_geno(dir: &Path, chunk_id: usize) -> PathBuf {
     dir.join(format!("chunk_{}_geno.bin", chunk_id))
 }
-pub fn final_genotypes(dir: &Path) -> PathBuf {
-    dir.join("final_genotypes.bin")
+pub fn genotypes(dir: &Path) -> PathBuf {
+    dir.join("genotypes.bin")
 }
 
 #[cfg(test)]
@@ -117,8 +117,8 @@ mod tests {
             Path::new("/out/chr1/dense/snp/chunk_2_geno.bin")
         );
         assert_eq!(
-            final_genotypes(dir),
-            Path::new("/out/chr1/dense/snp/final_genotypes.bin")
+            genotypes(dir),
+            Path::new("/out/chr1/dense/snp/genotypes.bin")
         );
     }
 
@@ -134,16 +134,10 @@ mod tests {
             Path::new("/out/chr1/var_key/snp/chunk_3_key.bin")
         );
         assert_eq!(
-            final_positions(dir),
-            Path::new("/out/chr1/var_key/snp/final_positions.bin")
+            positions(dir),
+            Path::new("/out/chr1/var_key/snp/positions.bin")
         );
-        assert_eq!(
-            final_keys(dir),
-            Path::new("/out/chr1/var_key/snp/final_keys.bin")
-        );
-        assert_eq!(
-            final_offsets(dir),
-            Path::new("/out/chr1/var_key/snp/final_offsets.npy")
-        );
+        assert_eq!(alleles(dir), Path::new("/out/chr1/var_key/snp/alleles.bin"));
+        assert_eq!(offsets(dir), Path::new("/out/chr1/var_key/snp/offsets.npy"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod executor;
 pub mod layout;
 pub mod merge;
+pub mod meta;
 pub mod monitor;
 pub mod normalize;
 pub mod nrvk;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,18 @@ fn run_conversion_pipeline(
         r.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
     }
 
+    // All contigs converted — write the top-level meta.json describing the cohort.
+    crate::meta::write_meta(
+        std::path::Path::new(&output_dir),
+        crate::meta::FORMAT_VERSION,
+        &samples,
+        &chroms,
+        ploidy,
+    )
+    .map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!("failed to write meta.json: {e}"))
+    })?;
+
     Ok(())
 }
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -15,11 +15,11 @@ const TILE_RAM_BUDGET_BYTES: u64 = 256 * 1024 * 1024;
 /// Performs the Tile-Based Interleaving Merge.
 ///
 /// Phase A: in-memory metadata pass — derives global per-column offsets and per-chunk
-///          local offsets from the RAM Ledger, writes `final_offsets.npy`.
+///          local offsets from the RAM Ledger, writes `offsets.npy`.
 /// Phase B: parallel tile gather — each rayon worker owns one tile, reads the slice
 ///          of every chunk via positional reads, scatters into per-column slots,
 ///          then `pwrite`s the assembled tile to its pre-computed byte range in
-///          `final_positions.bin` / `final_keys.bin`.
+///          `positions.bin` / `alleles.bin`.
 /// Phase C: cleanup of per-chunk temp files.
 pub fn merge_mini_sc(
     key_bytes: usize,
@@ -52,7 +52,7 @@ pub fn merge_mini_sc(
 
     // save the global offsets array immediately
     let offsets_array = Array1::from_vec(final_offsets.clone());
-    write_npy(layout::final_offsets(output_dir_path), &offsets_array)
+    write_npy(layout::offsets(output_dir_path), &offsets_array)
         .expect("Failed to write final offsets");
 
     let total_items: u64 = final_offsets[total_columns];
@@ -64,16 +64,16 @@ pub fn merge_mini_sc(
     // Pre-create the monolithic outputs at full size so worker pwrites land in
     // disjoint byte ranges. set_len doesn't allocate disk space (sparse file)
     // until each tile actually writes.
-    let final_pos_file = File::create(layout::final_positions(output_dir_path))
-        .expect("Failed to create final_positions.bin");
+    let final_pos_file =
+        File::create(layout::positions(output_dir_path)).expect("Failed to create positions.bin");
     final_pos_file
         .set_len(pos_total_bytes)
-        .expect("Failed to size final_positions.bin");
+        .expect("Failed to size positions.bin");
     let final_key_file =
-        File::create(layout::final_keys(output_dir_path)).expect("Failed to create final_keys.bin");
+        File::create(layout::alleles(output_dir_path)).expect("Failed to create alleles.bin");
     final_key_file
         .set_len(key_total_bytes)
-        .expect("Failed to size final_keys.bin");
+        .expect("Failed to size alleles.bin");
 
     // Open every chunk's pos/key file exactly once; pread() is stateless and
     // safe to call concurrently from multiple rayon workers.
@@ -206,10 +206,10 @@ pub fn merge_mini_sc(
         let tile_pos_bytes: &[u8] = bytemuck::cast_slice(&tile_pos_buffer);
         final_pos_ref
             .write_all_at(tile_pos_bytes, tile_pos_byte_offset)
-            .expect("Failed to pwrite tile to final_positions.bin");
+            .expect("Failed to pwrite tile to positions.bin");
         final_key_ref
             .write_all_at(&tile_key_buffer, tile_key_byte_offset)
-            .expect("Failed to pwrite tile to final_keys.bin");
+            .expect("Failed to pwrite tile to alleles.bin");
     });
 
     // Drop file handles to flush metadata before cleanup
@@ -277,9 +277,9 @@ mod tests {
 
         merge_mini_sc(4, 1, 2, 2, dir.to_str().unwrap(), ram_ledger);
 
-        let final_pos = read_u32_bin(&dir.join("final_positions.bin"));
-        let final_key = read_u32_bin(&dir.join("final_keys.bin"));
-        let final_off = read_offsets_npy(&dir.join("final_offsets.npy"));
+        let final_pos = read_u32_bin(&dir.join("positions.bin"));
+        let final_key = read_u32_bin(&dir.join("alleles.bin"));
+        let final_off = read_offsets_npy(&dir.join("offsets.npy"));
 
         assert_eq!(final_pos, pos);
         assert_eq!(final_key, key);
@@ -306,9 +306,9 @@ mod tests {
 
         merge_mini_sc(4, 2, 2, 1, dir.to_str().unwrap(), ram_ledger);
 
-        let final_pos = read_u32_bin(&dir.join("final_positions.bin"));
-        let final_key = read_u32_bin(&dir.join("final_keys.bin"));
-        let final_off = read_offsets_npy(&dir.join("final_offsets.npy"));
+        let final_pos = read_u32_bin(&dir.join("positions.bin"));
+        let final_key = read_u32_bin(&dir.join("alleles.bin"));
+        let final_off = read_offsets_npy(&dir.join("offsets.npy"));
 
         assert_eq!(final_pos, vec![100, 200, 400, 300, 500, 600]);
         assert_eq!(final_key, vec![1, 2, 4, 3, 5, 6]);
@@ -326,8 +326,8 @@ mod tests {
 
         merge_mini_sc(4, 1, 2, 2, dir.to_str().unwrap(), ram_ledger);
 
-        let final_pos = read_u32_bin(&dir.join("final_positions.bin"));
-        let final_off = read_offsets_npy(&dir.join("final_offsets.npy"));
+        let final_pos = read_u32_bin(&dir.join("positions.bin"));
+        let final_off = read_offsets_npy(&dir.join("offsets.npy"));
 
         assert_eq!(final_pos.len(), 0);
         assert_eq!(final_off, vec![0u64; 5]);
@@ -346,8 +346,8 @@ mod tests {
 
         merge_mini_sc(4, 2, 2, 1, dir.to_str().unwrap(), ram_ledger);
 
-        let final_pos = read_u32_bin(&dir.join("final_positions.bin"));
-        let final_off = read_offsets_npy(&dir.join("final_offsets.npy"));
+        let final_pos = read_u32_bin(&dir.join("positions.bin"));
+        let final_off = read_offsets_npy(&dir.join("offsets.npy"));
 
         assert_eq!(final_pos, vec![10, 20, 30, 40, 50]);
         assert_eq!(final_off, vec![0u64, 3, 5]);
@@ -383,9 +383,9 @@ mod tests {
 
         merge_mini_sc(1, 2, 2, 1, dir.to_str().unwrap(), ram_ledger);
 
-        let final_pos = read_u32_bin(&dir.join("final_positions.bin"));
-        let final_key = read_u8_bin(&dir.join("final_keys.bin"));
-        let final_off = read_offsets_npy(&dir.join("final_offsets.npy"));
+        let final_pos = read_u32_bin(&dir.join("positions.bin"));
+        let final_key = read_u8_bin(&dir.join("alleles.bin"));
+        let final_off = read_offsets_npy(&dir.join("offsets.npy"));
 
         assert_eq!(final_pos, vec![100, 200, 400, 300, 500, 600]);
         assert_eq!(final_key, vec![1, 2, 4, 3, 5, 6]);
@@ -449,9 +449,9 @@ mod tests {
 
             merge_mini_sc(4, num_chunks, num_samples, ploidy, dir.to_str().unwrap(), ram_ledger.clone());
 
-            let final_pos = read_u32_bin(&dir.join("final_positions.bin"));
-            let final_key = read_u32_bin(&dir.join("final_keys.bin"));
-            let final_off = read_offsets_npy(&dir.join("final_positions.bin").with_file_name("final_offsets.npy"));
+            let final_pos = read_u32_bin(&dir.join("positions.bin"));
+            let final_key = read_u32_bin(&dir.join("alleles.bin"));
+            let final_off = read_offsets_npy(&dir.join("positions.bin").with_file_name("offsets.npy"));
 
             // Build expected: walk columns, then chunks within each column.
             let mut expected_pos: Vec<u32> = Vec::new();

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,0 +1,55 @@
+//! Top-level `meta.json` writer. Written once by the conversion pipeline after
+//! every contig succeeds — the only scope that knows the full samples / contigs
+//! / ploidy. Rust never reads this back; Python does (via `json.load`).
+
+use serde_json::json;
+use std::path::Path;
+
+/// Integer schema version for the on-disk SVAR2 layout, used by `SparseVar2` to
+/// negotiate. Bump on any breaking layout/dtype change. Array dtypes are keyed
+/// to this version (see `docs/roadmap/data-model.md`), not duplicated in the JSON.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Write the top-level `{output_dir}/meta.json`. Called once, after all contigs
+/// convert successfully.
+pub fn write_meta(
+    output_dir: &Path,
+    format_version: u32,
+    samples: &[String],
+    contigs: &[String],
+    ploidy: usize,
+) -> std::io::Result<()> {
+    let meta = json!({
+        "format_version": format_version,
+        "samples": samples,
+        "contigs": contigs,
+        "ploidy": ploidy,
+    });
+    // Serializing a serde_json::Value cannot fail (no custom Serialize), so the
+    // only real error is the filesystem write.
+    let bytes = serde_json::to_vec_pretty(&meta).expect("serialize meta.json value");
+    std::fs::write(output_dir.join("meta.json"), bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_write_meta_round_trip() {
+        let tmp = tempdir().unwrap();
+        let samples = vec!["s1".to_string(), "s2".to_string()];
+        let contigs = vec!["chr1".to_string(), "chr2".to_string()];
+
+        write_meta(tmp.path(), FORMAT_VERSION, &samples, &contigs, 2).unwrap();
+
+        let text = std::fs::read_to_string(tmp.path().join("meta.json")).unwrap();
+        let v: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["format_version"], 1);
+        assert_eq!(v["samples"], serde_json::json!(["s1", "s2"]));
+        assert_eq!(v["contigs"], serde_json::json!(["chr1", "chr2"]));
+        assert_eq!(v["ploidy"], 2);
+    }
+}

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -25,9 +25,10 @@ pub fn write_meta(
         "contigs": contigs,
         "ploidy": ploidy,
     });
-    // Serializing a serde_json::Value cannot fail (no custom Serialize), so the
-    // only real error is the filesystem write.
-    let bytes = serde_json::to_vec_pretty(&meta).expect("serialize meta.json value");
+    // Serializing a plain serde_json::Value effectively cannot fail (no custom
+    // Serialize), but propagate rather than panic to keep the io::Result contract
+    // uniform; the real error is almost always the filesystem write below.
+    let bytes = serde_json::to_vec_pretty(&meta).map_err(std::io::Error::other)?;
     std::fs::write(output_dir.join("meta.json"), bytes)
 }
 

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -144,15 +144,15 @@ pub fn unpack_snp_keys(packed: &[u8], n: usize) -> Vec<u8> {
         .collect()
 }
 
-// Post-merge pass for the SNP stream: read the merged `final_keys.bin` (one
+// Post-merge pass for the SNP stream: read the merged `alleles.bin` (one
 // u8 code per call) and rewrite it 2-bit packed (4 calls/byte). Streams in
 // 4-MiB blocks (a multiple of 4, so no pack straddles a block boundary except
 // the genuine EOF tail). Offsets are call-indexed and need no change.
 pub fn pack_snp_key_file(dir: &str) {
-    let src = format!("{}/final_keys.bin", dir);
-    let tmp = format!("{}/final_keys.packed.tmp", dir);
+    let src = format!("{}/alleles.bin", dir);
+    let tmp = format!("{}/alleles.packed.tmp", dir);
 
-    let mut reader = BufReader::new(File::open(&src).expect("open snp final_keys.bin"));
+    let mut reader = BufReader::new(File::open(&src).expect("open snp alleles.bin"));
     let mut writer = BufWriter::new(File::create(&tmp).expect("create packed tmp"));
 
     const BLOCK: usize = 4 * 1024 * 1024; // multiple of 4
@@ -180,7 +180,7 @@ pub fn pack_snp_key_file(dir: &str) {
     drop(writer);
     drop(reader);
 
-    std::fs::rename(&tmp, &src).expect("replace snp final_keys.bin with packed");
+    std::fs::rename(&tmp, &src).expect("replace snp alleles.bin with packed");
 }
 
 // Packs up to 13 DNA bases into a single u32 with the inline-encoding layout:

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -1,5 +1,6 @@
 use crate::cost_model::{Class, Representation, choose_representation};
 use crate::dense::{DenseClass, DenseMap};
+use crate::layout;
 use crate::nrvk::LongAlleleTableWriter;
 use crate::streams::StreamTag;
 use crate::types::{
@@ -7,6 +8,7 @@ use crate::types::{
 };
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
 
 // Reversed byte loading
 //
@@ -148,9 +150,9 @@ pub fn unpack_snp_keys(packed: &[u8], n: usize) -> Vec<u8> {
 // u8 code per call) and rewrite it 2-bit packed (4 calls/byte). Streams in
 // 4-MiB blocks (a multiple of 4, so no pack straddles a block boundary except
 // the genuine EOF tail). Offsets are call-indexed and need no change.
-pub fn pack_snp_key_file(dir: &str) {
-    let src = format!("{}/alleles.bin", dir);
-    let tmp = format!("{}/alleles.packed.tmp", dir);
+pub fn pack_snp_key_file(dir: &Path) {
+    let src = layout::alleles(dir);
+    let tmp = dir.join("alleles.packed.tmp");
 
     let mut reader = BufReader::new(File::open(&src).expect("open snp alleles.bin"));
     let mut writer = BufWriter::new(File::create(&tmp).expect("create packed tmp"));

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -37,7 +37,7 @@ pub const REGISTRY: [StreamSpec; StreamTag::COUNT] = [
         tag: StreamTag::VarKeySnp,
         subdir: "var_key/snp",
         key_bytes: 1,
-        post_merge: Some(pack_snp_key_file_path),
+        post_merge: Some(pack_snp_key_file),
     },
     StreamSpec {
         tag: StreamTag::VarKeyIndel,
@@ -46,11 +46,6 @@ pub const REGISTRY: [StreamSpec; StreamTag::COUNT] = [
         post_merge: None,
     },
 ];
-
-// pack_snp_key_file currently takes &str; adapt to the fn(&Path) hook shape.
-fn pack_snp_key_file_path(dir: &Path) {
-    pack_snp_key_file(dir.to_str().expect("stream dir is valid UTF-8"));
-}
 
 /// Fixed-size map keyed by `StreamTag`, backed by an array (O(1), no hashing).
 pub struct StreamMap<T> {

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -49,8 +49,8 @@ fn decode_key(key: u32) -> DecodedKey {
 //   hap 1 (S0_p1): [200, 300]
 //   hap 2 (S1_p0): [100]
 //   hap 3 (S1_p1): [100]
-// → final_offsets = [0, 2, 4, 5, 6]
-// → final_positions = [100, 300,  200, 300,  100,  100]
+// → offsets = [0, 2, 4, 5, 6]
+// → positions = [100, 300,  200, 300,  100,  100]
 #[test]
 fn test_e2e_normalized_bcf_pipeline() {
     let tmp = tempdir().unwrap();
@@ -106,9 +106,9 @@ fn test_e2e_normalized_bcf_pipeline() {
     let vk_indel = out_dir.join("chr1/var_key/indel");
 
     // dense/snp: 1 variant @100, geno bits for haps 0,2,3.
-    let dsnp_pos = read_u32_bin(&dsnp.join("final_positions.bin"));
+    let dsnp_pos = read_u32_bin(&dsnp.join("positions.bin"));
     assert_eq!(dsnp_pos, vec![100]);
-    let dsnp_geno = std::fs::read(dsnp.join("final_genotypes.bin")).unwrap();
+    let dsnp_geno = std::fs::read(dsnp.join("genotypes.bin")).unwrap();
     // np=4, v_dense=1 → bit h*1+0. Carriers = haps 0,2,3 (gt [1,0,1,1]).
     assert!(genoray_core::bits::get_bit(&dsnp_geno, 0));
     assert!(!genoray_core::bits::get_bit(&dsnp_geno, 1));
@@ -119,9 +119,9 @@ fn test_e2e_normalized_bcf_pipeline() {
     // orchestrator already drives var_key merge via `REGISTRY`). Also decode
     // the key to confirm it's the inline "AT" insertion, not a pure DEL or
     // lookup row.
-    let vki_pos = read_u32_bin(&vk_indel.join("final_positions.bin"));
-    let vki_off = read_offsets_npy(&vk_indel.join("final_offsets.npy"));
-    let vki_key = read_u32_bin(&vk_indel.join("final_keys.bin"));
+    let vki_pos = read_u32_bin(&vk_indel.join("positions.bin"));
+    let vki_off = read_offsets_npy(&vk_indel.join("offsets.npy"));
+    let vki_key = read_u32_bin(&vk_indel.join("alleles.bin"));
     assert_eq!(vki_off, vec![0u64, 0, 1, 1, 1]); // hap1 has the single INS call
     assert_eq!(vki_pos, vec![200]);
     match decode_key(vki_key[0]) {
@@ -130,9 +130,9 @@ fn test_e2e_normalized_bcf_pipeline() {
     }
 
     // dense/indel: DEL@300 (x=2, haps 0,1).
-    let dindel_pos = read_u32_bin(&dindel.join("final_positions.bin"));
+    let dindel_pos = read_u32_bin(&dindel.join("positions.bin"));
     assert_eq!(dindel_pos, vec![300]);
-    let dindel_geno = std::fs::read(dindel.join("final_genotypes.bin")).unwrap();
+    let dindel_geno = std::fs::read(dindel.join("genotypes.bin")).unwrap();
     assert!(genoray_core::bits::get_bit(&dindel_geno, 0)); // hap0
     assert!(genoray_core::bits::get_bit(&dindel_geno, 1)); // hap1
     assert!(!genoray_core::bits::get_bit(&dindel_geno, 2));
@@ -140,7 +140,7 @@ fn test_e2e_normalized_bcf_pipeline() {
 }
 
 // Dense round-trip: a SNP carried by most of a small cohort must be routed to
-// dense/snp and its genotype bits reconstructable from final_genotypes.bin.
+// dense/snp and its genotype bits reconstructable from genotypes.bin.
 #[test]
 fn test_e2e_dense_snp_roundtrip() {
     let tmp = tempdir().unwrap();
@@ -172,16 +172,16 @@ fn test_e2e_dense_snp_roundtrip() {
     .expect("conversion");
 
     let dsnp = out_dir.join("chr1/dense/snp");
-    let pos = read_u32_bin(&dsnp.join("final_positions.bin"));
+    let pos = read_u32_bin(&dsnp.join("positions.bin"));
     assert_eq!(pos, vec![500]);
     // packed key: 'C' code 1, 1 variant → pack_snp_keys([1]) == [0x01]
     assert_eq!(
-        std::fs::read(dsnp.join("final_keys.bin")).unwrap(),
+        std::fs::read(dsnp.join("alleles.bin")).unwrap(),
         vec![0x01u8]
     );
 
     // genotypes: np=6, v_dense=1 → bit h. Haps 0..5 carriers = [1,1,1,1,1,0].
-    let geno = std::fs::read(dsnp.join("final_genotypes.bin")).unwrap();
+    let geno = std::fs::read(dsnp.join("genotypes.bin")).unwrap();
     for h in 0..5 {
         assert!(genoray_core::bits::get_bit(&geno, h), "hap {}", h);
     }
@@ -189,7 +189,7 @@ fn test_e2e_dense_snp_roundtrip() {
 }
 
 // Mutation conservation across the full pipeline: the total length of
-// final_positions equals the total number of true genotype calls in the input.
+// positions equals the total number of true genotype calls in the input.
 // Catches drops anywhere — reader, transpose, writer, merge.
 #[test]
 fn test_e2e_mutation_conservation() {
@@ -242,18 +242,18 @@ fn test_e2e_mutation_conservation() {
     // Routing (np=6): all three SNPs have x=3,3,4 carriers — every one clears
     // the dense crossover (34*x > 34+np=40), so they ALL route to dense/snp
     // and var_key/snp is empty. Conservation must therefore be checked
-    // across every bucket: var_key final_positions lengths + dense genotype
+    // across every bucket: var_key positions lengths + dense genotype
     // popcounts — both merged by the orchestrator (Task 11 wires the dense
     // merge alongside the pre-existing var_key merge via `REGISTRY`).
     let mut total = 0usize;
     for sub in ["var_key/snp", "var_key/indel"] {
-        let p = out_dir.join(format!("chr1/{sub}/final_positions.bin"));
+        let p = out_dir.join(format!("chr1/{sub}/positions.bin"));
         if p.exists() {
             total += read_u32_bin(&p).len();
         }
     }
     for sub in ["dense/snp", "dense/indel"] {
-        let g = out_dir.join(format!("chr1/{sub}/final_genotypes.bin"));
+        let g = out_dir.join(format!("chr1/{sub}/genotypes.bin"));
         if g.exists() {
             total += std::fs::read(&g)
                 .unwrap()


### PR DESCRIPTION
## Summary

Finalizes the SVAR2 on-disk format (M3). A mechanical, write-side change: the tile merge already writes correct bytes — this renames the provisional `final_*` scratch files to their spec base names (via the single-source-of-truth `layout.rs`), settles the `.bin` vs `.npy` wire-format question, emits a top-level `meta.json`, and reconciles the roadmap docs.

## What changed

- **Rename `final_*` sidecars → spec base names** (`src/layout.rs` + callers in `merge.rs`/`dense_merge.rs`/`rvk.rs`, e2e + in-source tests). Applies identically under `var_key/{snp,indel}/` and `dense/{snp,indel}/`:
  - `final_positions.bin` → `positions.bin` (u32 LE)
  - `final_keys.bin` → `alleles.bin` (u8 packed SNP / u32 indel)
  - `final_offsets.npy` → `offsets.npy` (u64)
  - `final_genotypes.bin` → `genotypes.bin` (u8 packed 1-bit matrix)
  - Behavior unchanged — only names moved. The in-memory `final_offsets` local (`Vec<u64>`) is left untouched.
- **New `src/meta.rs`**: `FORMAT_VERSION: u32 = 1` + `write_meta` one-shot JSON writer (new dep `serde_json` only) + round-trip unit test.
- **Wire `write_meta` into `run_conversion_pipeline`** (`src/lib.rs`): emits top-level `meta.json` `{ format_version, samples, contigs, ploidy }` once, after all contigs succeed.
- **Docs reconciliation**: `data-model.md` (flip filenames to `.bin`, resolve the sidecar wire-format open question, document the dtype-vs-`format_version` convention); `svar-2.md` (M3 → done, `max_del.npy` moved under M5, M4 note updated); `architecture.md` verified accurate (no edit needed).

## Wire-format decision (resolves the open question)

Bulk parallel-`pwrite`n data arrays (`positions.bin`, `alleles.bin`, `genotypes.bin`) are raw `.bin` — mmap-friendly, no npy-header offset to align every `pwrite` past. Small one-shot index/metadata sidecars (`offsets.npy`, `long_allele_offsets.npy`) stay self-describing `.npy`. Array dtypes are a `format_version` convention, not duplicated in `meta.json`.

## Testing

- Full Rust suite: **95/95 passing** (86 lib + 4 atomize e2e + 5 e2e), including the new `test_write_meta_round_trip`.
- `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- Each task was implemented TDD-style (red→green) and independently reviewed; a final whole-branch review confirmed rename completeness, docs↔code dtype consistency, and success-only `meta.json` wiring — verdict: ready to merge.

## Follow-ups (deferred, non-blocking)

- `rvk.rs` `pack_snp_key_file` hardcodes the `alleles.bin` literal rather than routing through `layout::alleles`; fold it in when the M6 read path is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
