### PR TITLE
feat(svar-2): M5 part 2a — max_del standalone post-pass (producer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ memray_flamegraphs/
 # Added by cargo
 
 /target
+
+# Claude Code worktrees
+.claude/worktrees/

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -133,10 +133,21 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   saturating subtraction against a `max_region_length` bound — collapsing the two
   `searchsorted` calls onto one tree instead of building a second. Gated by proptests
   vs `slice::partition_point` (bounds) and a brute-force O(n) oracle (overlap). Depends
-  only on in-memory slices — no on-disk types. *Remaining:* disk integration — the
-  `max_del.npy` producer/consumer, the sorted sub-stream union across `snp/`+`indel/`,
-  per-`(contig, sample, ploid)` wiring, and the genotype gather that turns an index
-  range into user-facing calls (the `(range, sample)` query proper).
+  only on in-memory slices — no on-disk types.
+  *Shipped — `max_del` producer post-pass (M5 part 2a):* a standalone `src/max_del.rs`
+  post-pass over a finished contig's indel key streams emits `max_del.npy`
+  (per-`(sample, ploid)`, `(n_samples, ploidy)` `u32`) and `dense/max_del.npy` (`(1,)`
+  `u32`), decoding each pure-DEL key's reference-base deletion length via
+  `rvk::deletion_len` (the single decode site for the 32-bit key layout) — no LUT,
+  reference genome, or merge-path coupling. All-zero artifacts are always written for a
+  no-deletion contig so the consumer never special-cases a missing file. Wired into the
+  orchestrator after each contig's merge; gated by unit tests, a brute-force per-column
+  oracle proptest, and an e2e round-trip that feeds the produced `max_del` into
+  `overlap_range`.
+  *Remaining:* disk integration — the `max_del.npy` **consumer**, the sorted sub-stream
+  union across `snp/`+`indel/`, per-`(contig, sample, ploid)` wiring, and the genotype
+  gather that turns an index range into user-facing calls (the `(range, sample)` query
+  proper).
 - [ ] **M6. Python decode.** Decode query results into user-facing structs/classes
   (to be spec'd). Requires fast sorted **unions** to merge data from multiple
   position-sorted sources. See [`architecture.md`](architecture.md#python-decode-path).

--- a/docs/superpowers/plans/2026-07-02-svar2-m5-max-del-postpass.md
+++ b/docs/superpowers/plans/2026-07-02-svar2-m5-max-del-postpass.md
@@ -1,0 +1,715 @@
+# SVAR 2.0 — M5 (part 2a): `max_del` standalone post-pass — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce, as a standalone post-pass over a finished SVAR2 contig directory, the per-`(sample, ploid)` and dense max-deletion-length artifacts (`max_del.npy`, `dense/max_del.npy`) that the `(range, sample)` overlap query will consume.
+
+**Architecture:** A deletion's reference-base length is fully recoverable from the already-written indel key streams — a pure DEL packs its signed `ilen` inline (`bit 31 = 1`, `bits[31:1] = signed ilen`), so no LUT, reference genome, or conversion-pipeline coupling is needed. The pass reads `var_key/indel/{offsets.npy, alleles.bin}` and `dense/indel/alleles.bin`, decodes each key's deletion length via a decoder exposed from `rvk.rs` (the single source of the bit layout), takes per-column and dense maxima, and writes two `.npy` files. It runs after a contig's merge completes, callable per-contig.
+
+**Tech Stack:** Rust 2024, `ndarray` + `ndarray-npy` (npy I/O, already used by `merge.rs`), `bytemuck` (byte↔u32 casting, already a dependency), `thiserror` (typed errors), `proptest` + `tempfile` (dev-only, already used by `search.rs`/`test_e2e.rs`).
+
+## Global Constraints
+
+- **Crate lib name is `genoray_core`** — integration tests under `tests/` import `genoray_core::...` (the package is `genoray`, but `[lib] name = "genoray_core"`).
+- **Run Rust tests with `--no-default-features`** so the test binary links libpython instead of building the pyo3 extension module. Canonical command in this repo: `pixi run cargo test --no-default-features <filter>`. Unit tests (in-crate `#[cfg(test)]`) use `--lib`; integration tests (under `tests/`) use `--test <name>`.
+- **Lint gate:** `pixi run -e lint cargo clippy --all-targets -- -D warnings` must pass (pre-commit hook). Run `pixi run -e lint cargo fmt --all` before committing. **prek git hooks must be installed** before committing/pushing (`prek install` if not already).
+- **Column convention is sample-major:** the flat column index is `c = s * ploidy + p` (see `src/rvk.rs` `dense2sparse_vk`, `base_idx = (s * ploidy) + p`; `total_columns = num_samples * ploidy` in `src/merge.rs`). A flat `(total_columns,)` array reshapes **row-major (C-order)** to `(n_samples, ploidy)` so that `arr[[s, p]] == flat[s*ploidy + p]`.
+- **On-disk key format:** `alleles.bin` in an indel stream dir is a raw little-endian `u32` array (4 bytes/key). `offsets.npy` is a 1-D `u64` array of length `total_columns + 1` (prefix sum). Read `alleles.bin` alignment-agnostically via `chunks_exact(4)` (a plain `std::fs::read` may hand back an unaligned buffer — the established pattern in `tests/common/mod.rs::read_u32_bin`).
+- **Frozen contract decisions (shared with the `(range, sample)` query spec):**
+  - `max_del.npy` — dtype `u32`, shape `(n_samples, ploidy)`, at `{contig_dir}/max_del.npy`. A pure-SNP / no-deletion contig still emits an all-zero array (consumer never special-cases a missing file).
+  - `dense/max_del.npy` — dtype `u32`, shape **`(1,)`** (a length-1 `Array1`, chosen over 0-d for round-trip simplicity with `ndarray_npy::read_npy`), at `{contig_dir}/dense/max_del.npy`. **Always written** (creating the `dense/` dir if absent), value `0` when there is no dense indel stream — symmetric with `max_del.npy`, so the consumer never special-cases absence.
+  - SNP sub-streams (`var_key/snp`, `dense/snp`) get **no** file — their overlap is a plain half-open range (`max_region_length == 0`).
+
+---
+
+## File Structure
+
+- **`src/rvk.rs`** (modify) — expose `pub fn deletion_len(key: u32) -> u32`, the single decoder for a deletion's reference-base length from a 32-bit indel key. Keeps the bit layout co-located with `pack_variant`.
+- **`src/layout.rs`** (modify) — add four contig-dir-relative path helpers used by the post-pass: `var_key_indel_dir`, `dense_indel_dir`, `max_del`, `dense_max_del`. Centralizes all paths the pass touches (layout.rs is the single source of on-disk paths).
+- **`src/error.rs`** (modify) — add a `ReadNpy` variant to `ConversionError` (reading `offsets.npy` can fail; the existing `Npy` variant is write-only).
+- **`src/max_del.rs`** (create) — the post-pass: `pub fn write_max_del(contig_dir, n_samples, ploidy) -> Result<(), ConversionError>` plus private `var_key_max_del` / `dense_max_del_scalar` / `read_keys` helpers. Owns all producer logic and its tests.
+- **`src/lib.rs`** (modify) — `pub mod max_del;`.
+- **`src/orchestrator.rs`** (modify) — invoke `write_max_del` per contig after the dense merge, so a normal conversion emits the artifacts end-to-end.
+- **`tests/test_e2e.rs`** (modify) — a new end-to-end test that runs a conversion with known deletions (one rare → `var_key/indel`, one common → `dense/indel`), asserts both artifacts' shapes/values, and feeds the produced `max_del` into `overlap_range` to close the producer↔consumer loop.
+
+---
+
+## Task 1: `rvk::deletion_len` decoder
+
+**Files:**
+- Modify: `src/rvk.rs` (add `deletion_len` near `pack_variant` at `src/rvk.rs:242-261`; add tests in the existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: the key layout defined by `pack_variant` (`src/rvk.rs:243`) — inline lane has `bit 0 == 0`; a pure DEL sets `bit 31` and stores signed `ilen` in `bits[31:1]`; long-INS lookup keys set `bit 0 == 1`.
+- Produces: `pub fn deletion_len(key: u32) -> u32` — reference-base deletion length (`-ilen` for a pure DEL; `0` for SNP/INS inline keys and long-INS lookup keys). Consumed by Task 3's `max_del.rs`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `mod tests` block in `src/rvk.rs` (alongside `test_pack_variant_pure_del` at line 620). These build keys via the real `pack_variant` encoder so the decoder is validated against the encoder, not against a re-derived layout:
+
+```rust
+    #[test]
+    fn test_deletion_len_snp_and_ins_are_zero() {
+        let mut bank = make_bank();
+        // SNP (ilen 0) and INS (ilen > 0) carry no deletion.
+        let snp = pack_variant(0, b"C", &mut bank);
+        let ins = pack_variant(2, b"ACG", &mut bank);
+        assert_eq!(deletion_len(snp), 0);
+        assert_eq!(deletion_len(ins), 0);
+    }
+
+    #[test]
+    fn test_deletion_len_small_and_large_del() {
+        let mut bank = make_bank();
+        // ref=ACGT alt=A → ilen=-3, deletion of 3 reference bases.
+        let small = pack_variant(-3, b"A", &mut bank);
+        assert_eq!(deletion_len(small), 3);
+        // Largest atomizable deletion: ilen == MIN_I31 → d == 1 << 30.
+        let large = pack_variant(crate::types::MIN_I31, b"A", &mut bank);
+        assert_eq!(deletion_len(large), (1u32 << 30));
+    }
+
+    #[test]
+    fn test_deletion_len_lookup_key_is_zero() {
+        // A long-INS lookup key sets the LSB. Even with the top bit set
+        // (a large row index), the LSB check must win → not a deletion.
+        assert_eq!(deletion_len(0x0000_0003), 0); // LSB set
+        assert_eq!(deletion_len(0xFFFF_FFFF), 0); // LSB set AND top bit set
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pixi run cargo test --no-default-features --lib deletion_len`
+Expected: FAIL — `cannot find function 'deletion_len' in this scope`.
+
+- [ ] **Step 3: Implement `deletion_len`**
+
+Insert immediately after `pack_variant` (after `src/rvk.rs:261`):
+
+```rust
+/// Reference-base deletion length encoded in a 32-bit indel `var_key`/`dense` key.
+///
+/// Inverse of the DEL lane of [`pack_variant`]: a pure DEL clears the lookup flag
+/// (`bit 0 == 0`) and sets the top bit (`bit 31 == 1`), storing its signed `ilen`
+/// in `bits[31:1]`; the deletion length is `-ilen`. Inline INS/SNP keys clear the
+/// top bit, and long-INS lookup keys set `bit 0`, so both yield `0`. This is the
+/// single decode site for the deletion length — the bit layout stays co-located
+/// with the encoder (respecting the encoding-agnostic seam).
+#[inline]
+pub fn deletion_len(key: u32) -> u32 {
+    // Long-INS lookup keys set the LSB; they are never deletions. Checked first
+    // because such a key can also have its top bit set (a large row index).
+    if key & 1 == 1 {
+        return 0;
+    }
+    // Inline lane. Pure DEL sets the top bit; INS/SNP clear it.
+    if key & (1 << 31) == 0 {
+        return 0;
+    }
+    let ilen = (key as i32) >> 1; // arithmetic shift recovers the signed i31
+    debug_assert!(ilen < 0, "top-bit-set inline key must be a negative-ilen DEL");
+    ilen.unsigned_abs()
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pixi run cargo test --no-default-features --lib deletion_len`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/rvk.rs
+git commit -m "feat(svar-2): expose rvk::deletion_len decoder for max_del post-pass"
+```
+
+---
+
+## Task 2: `layout` path helpers for the post-pass
+
+**Files:**
+- Modify: `src/layout.rs` (add four free functions after the existing `offsets`/`genotypes` free functions at `src/layout.rs:71-79`; add tests in the existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: nothing new (mirrors the on-disk layout already defined by `ContigPaths` and `merge.rs`).
+- Produces (all take `contig_dir: &Path` = `{out}/{contig}`):
+  - `pub fn var_key_indel_dir(contig_dir: &Path) -> PathBuf` → `{contig_dir}/var_key/indel`
+  - `pub fn dense_indel_dir(contig_dir: &Path) -> PathBuf` → `{contig_dir}/dense/indel`
+  - `pub fn max_del(contig_dir: &Path) -> PathBuf` → `{contig_dir}/max_del.npy`
+  - `pub fn dense_max_del(contig_dir: &Path) -> PathBuf` → `{contig_dir}/dense/max_del.npy`
+
+  Consumed by Task 3 (`max_del.rs`) and Task 5 (`orchestrator.rs`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `src/layout.rs` (after `test_dense_dirs` at line 110):
+
+```rust
+    #[test]
+    fn test_max_del_postpass_paths() {
+        let c = Path::new("/out/chr1");
+        assert_eq!(var_key_indel_dir(c), Path::new("/out/chr1/var_key/indel"));
+        assert_eq!(dense_indel_dir(c), Path::new("/out/chr1/dense/indel"));
+        assert_eq!(max_del(c), Path::new("/out/chr1/max_del.npy"));
+        assert_eq!(dense_max_del(c), Path::new("/out/chr1/dense/max_del.npy"));
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pixi run cargo test --no-default-features --lib test_max_del_postpass_paths`
+Expected: FAIL — `cannot find function 'var_key_indel_dir' in this scope`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Insert after the `genotypes` free function (after `src/layout.rs:79`), before the `#[cfg(test)]` block:
+
+```rust
+/// Contig-dir-relative path helpers for the standalone `max_del` post-pass. These
+/// take the contig directory (`{out}/{contig}`) directly, unlike the `ContigPaths`
+/// methods which build from `base_out_dir` + `chrom`. Keeping them here preserves
+/// layout.rs as the single source of on-disk paths.
+pub fn var_key_indel_dir(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("var_key").join("indel")
+}
+pub fn dense_indel_dir(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("dense").join("indel")
+}
+pub fn max_del(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("max_del.npy")
+}
+pub fn dense_max_del(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("dense").join("max_del.npy")
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pixi run cargo test --no-default-features --lib test_max_del_postpass_paths`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/layout.rs
+git commit -m "feat(svar-2): add max_del post-pass path helpers to layout"
+```
+
+---
+
+## Task 3: `max_del` module — the post-pass producer
+
+**Files:**
+- Modify: `src/error.rs` (add `ReadNpy` variant)
+- Create: `src/max_del.rs`
+- Modify: `src/lib.rs` (add `pub mod max_del;`)
+
+**Interfaces:**
+- Consumes: `rvk::deletion_len` (Task 1); `layout::{var_key_indel_dir, dense_indel_dir, max_del, dense_max_del, offsets, alleles}` (Task 2 + existing `src/layout.rs:68-73`); `error::ConversionError` (`src/error.rs`).
+- Produces: `pub fn write_max_del(contig_dir: &Path, n_samples: usize, ploidy: usize) -> Result<(), ConversionError>` — writes `{contig_dir}/max_del.npy` (shape `(n_samples, ploidy)`, `u32`) and `{contig_dir}/dense/max_del.npy` (shape `(1,)`, `u32`). Consumed by Task 4 (proptest) and Task 5 (orchestrator + e2e).
+
+- [ ] **Step 1: Add the `ReadNpy` error variant**
+
+In `src/error.rs`, add inside the `ConversionError` enum (after the `Npy` variant at `src/error.rs:15-20`):
+
+```rust
+    #[error("failed to read npy at {path}: {source}")]
+    ReadNpy {
+        path: String,
+        #[source]
+        source: ndarray_npy::ReadNpyError,
+    },
+```
+
+- [ ] **Step 2: Wire the module**
+
+In `src/lib.rs`, add the module declaration in alphabetical position (after `pub mod layout;` at line 12):
+
+```rust
+pub mod max_del;
+```
+
+- [ ] **Step 3: Write the failing integration tests**
+
+Create `src/max_del.rs` with ONLY the test module first (the `write_max_del` body comes in Step 5). This compiles against the not-yet-written `write_max_del`, so it fails to build — that is the intended red state.
+
+```rust
+//! Standalone `max_del` post-pass (SVAR 2.0, M5 part 2a).
+//!
+//! Scans a finished contig's indel key streams and emits the max-deletion-length
+//! artifacts consumed by the `(range, sample)` overlap query. A deletion's length
+//! is recoverable from the inline pure-DEL key alone (see [`crate::rvk::deletion_len`]),
+//! so this is a pure scan of `alleles.bin` — no LUT reads, no reference genome, no
+//! coupling to the conversion/merge write path. Runs after a contig's merge
+//! completes; callable per-contig or as a batch sweep over an existing directory.
+
+use crate::error::ConversionError;
+use crate::layout;
+use crate::rvk::deletion_len;
+use ndarray::{Array1, Array2};
+use ndarray_npy::write_npy;
+use std::path::Path;
+
+#[cfg(test)]
+mod tests {
+    // `use super::*` already brings `Array1`, `Array2`, `Path`, `layout`,
+    // `write_npy`, `deletion_len`, and `write_max_del` into scope.
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Pure-DEL key for a deletion of `d` reference bases (`ilen = -d`), matching
+    /// the pure-DEL lane of `rvk::pack_variant`. `d == 0` yields a non-deletion
+    /// inline key (deletion_len 0). The encoder↔decoder faithfulness itself is
+    /// proven in `rvk`'s `deletion_len` tests; here we only exercise the scan.
+    fn del_key(d: u32) -> u32 {
+        if d == 0 {
+            0 // inline lane, bit 31 clear → not a deletion
+        } else {
+            ((-(d as i32)) << 1) as u32
+        }
+    }
+
+    /// Write a synthetic `var_key/indel` stream: `offsets.npy` (u64 prefix sum,
+    /// len total_columns+1) and `alleles.bin` (raw le u32 keys).
+    fn write_var_key_indel(contig_dir: &Path, offsets: &[u64], keys: &[u32]) {
+        let dir = layout::var_key_indel_dir(contig_dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        write_npy(layout::offsets(&dir), &Array1::from_vec(offsets.to_vec())).unwrap();
+        std::fs::write(layout::alleles(&dir), bytemuck::cast_slice(keys)).unwrap();
+    }
+
+    /// Write a synthetic `dense/indel` stream: just `alleles.bin` (raw le u32 keys).
+    fn write_dense_indel(contig_dir: &Path, keys: &[u32]) {
+        let dir = layout::dense_indel_dir(contig_dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(layout::alleles(&dir), bytemuck::cast_slice(keys)).unwrap();
+    }
+
+    fn read_max_del(contig_dir: &Path) -> Array2<u32> {
+        ndarray_npy::read_npy(layout::max_del(contig_dir)).unwrap()
+    }
+
+    fn read_dense_max_del(contig_dir: &Path) -> Array1<u32> {
+        ndarray_npy::read_npy(layout::dense_max_del(contig_dir)).unwrap()
+    }
+
+    #[test]
+    fn absent_streams_emit_all_zero_artifacts() {
+        // No var_key/indel, no dense/indel dirs at all. Contract still holds:
+        // an all-zero (n_samples, ploidy) file and a [0] dense scalar.
+        let tmp = tempdir().unwrap();
+        let c = tmp.path();
+        write_max_del(c, 2, 2).unwrap();
+        assert_eq!(read_max_del(c), Array2::<u32>::zeros((2, 2)));
+        assert_eq!(read_dense_max_del(c), Array1::from_vec(vec![0u32]));
+    }
+
+    #[test]
+    fn per_column_max_over_var_key_indel() {
+        // np = 4 columns (2 samples x ploidy 2), sample-major c = s*ploidy + p.
+        //   col 0: dels {3, 1}      → 3
+        //   col 1: {} (empty)       → 0
+        //   col 2: SNP/INS only     → 0
+        //   col 3: dels {2}         → 2
+        let tmp = tempdir().unwrap();
+        let c = tmp.path();
+        let keys = vec![
+            del_key(3), del_key(1), // col 0
+            // col 1 empty
+            del_key(0), del_key(0), // col 2: non-deletion inline keys
+            del_key(2), // col 3
+        ];
+        let offsets = vec![0u64, 2, 2, 4, 5];
+        write_var_key_indel(c, &offsets, &keys);
+
+        write_max_del(c, 2, 2).unwrap();
+        let m = read_max_del(c);
+        // row-major reshape: [[col0, col1], [col2, col3]]
+        assert_eq!(m[[0, 0]], 3);
+        assert_eq!(m[[0, 1]], 0);
+        assert_eq!(m[[1, 0]], 0);
+        assert_eq!(m[[1, 1]], 2);
+        // No dense stream → dense scalar is 0.
+        assert_eq!(read_dense_max_del(c), Array1::from_vec(vec![0u32]));
+    }
+
+    #[test]
+    fn dense_scalar_is_single_max_over_shared_keys() {
+        let tmp = tempdir().unwrap();
+        let c = tmp.path();
+        // A pure-SNP var_key side (no deletions) + a dense indel table with dels.
+        write_var_key_indel(c, &[0u64, 0, 0, 0, 0], &[]);
+        write_dense_indel(c, &[del_key(5), del_key(2), del_key(0)]);
+
+        write_max_del(c, 2, 2).unwrap();
+        assert_eq!(read_max_del(c), Array2::<u32>::zeros((2, 2)));
+        assert_eq!(read_dense_max_del(c), Array1::from_vec(vec![5u32]));
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they fail (build error)**
+
+Run: `pixi run cargo test --no-default-features --lib max_del::`
+Expected: FAIL — `cannot find function 'write_max_del' in this scope` (function not yet defined).
+
+- [ ] **Step 5: Implement the producer**
+
+Insert the implementation into `src/max_del.rs` between the `use` block and the `#[cfg(test)] mod tests` block:
+
+```rust
+/// Emit `{contig_dir}/max_del.npy` (shape `(n_samples, ploidy)`, `u32`) and
+/// `{contig_dir}/dense/max_del.npy` (shape `(1,)`, `u32`). Both are always written
+/// — a contig with no deletions emits all-zero artifacts so the consumer never
+/// special-cases a missing file. `O(total indel calls)`; a single serial pass
+/// (measure before parallelizing — this is I/O-bound).
+pub fn write_max_del(
+    contig_dir: &Path,
+    n_samples: usize,
+    ploidy: usize,
+) -> Result<(), ConversionError> {
+    let var_key = var_key_max_del(contig_dir, n_samples, ploidy)?;
+    let out = layout::max_del(contig_dir);
+    write_npy(&out, &var_key).map_err(|source| ConversionError::Npy {
+        path: out.display().to_string(),
+        source,
+    })?;
+
+    let dense = dense_max_del_scalar(contig_dir)?;
+    let dense_out = layout::dense_max_del(contig_dir);
+    // dense/max_del.npy lives under {contig_dir}/dense, which may not exist for a
+    // contig without any dense stream. Create it so the write (and the contract)
+    // always succeeds.
+    if let Some(parent) = dense_out.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| ConversionError::Io {
+            context: format!("creating {}", parent.display()),
+            source,
+        })?;
+    }
+    let dense_arr = Array1::from_vec(vec![dense]); // shape (1,)
+    write_npy(&dense_out, &dense_arr).map_err(|source| ConversionError::Npy {
+        path: dense_out.display().to_string(),
+        source,
+    })?;
+    Ok(())
+}
+
+/// Per-column max deletion length over the `var_key/indel` stream, reshaped to
+/// `(n_samples, ploidy)`. Absent stream ⇒ all-zero (pure-SNP / no-indel contig).
+fn var_key_max_del(
+    contig_dir: &Path,
+    n_samples: usize,
+    ploidy: usize,
+) -> Result<Array2<u32>, ConversionError> {
+    let total_columns = n_samples * ploidy;
+    let indel_dir = layout::var_key_indel_dir(contig_dir);
+    let offsets_path = layout::offsets(&indel_dir);
+
+    // No offsets file ⇒ the stream was never written ⇒ zero output.
+    if !offsets_path.exists() {
+        return Ok(Array2::zeros((n_samples, ploidy)));
+    }
+
+    let offsets: Array1<u64> =
+        ndarray_npy::read_npy(&offsets_path).map_err(|source| ConversionError::ReadNpy {
+            path: offsets_path.display().to_string(),
+            source,
+        })?;
+    debug_assert_eq!(
+        offsets.len(),
+        total_columns + 1,
+        "offsets.npy length must be total_columns + 1"
+    );
+
+    let keys = read_keys(&layout::alleles(&indel_dir))?;
+
+    let mut per_col = vec![0u32; total_columns];
+    for (c, slot) in per_col.iter_mut().enumerate() {
+        let lo = offsets[c] as usize;
+        let hi = offsets[c + 1] as usize;
+        *slot = keys[lo..hi].iter().copied().map(deletion_len).max().unwrap_or(0);
+    }
+
+    // Sample-major columns (c = s*ploidy + p) ⇒ row-major reshape to (n_samples, ploidy).
+    Ok(Array2::from_shape_vec((n_samples, ploidy), per_col)
+        .expect("per_col length == n_samples * ploidy"))
+}
+
+/// Single max deletion length over the shared `dense/indel` key table. Absent
+/// stream ⇒ 0.
+fn dense_max_del_scalar(contig_dir: &Path) -> Result<u32, ConversionError> {
+    let keys = read_keys(&layout::alleles(&layout::dense_indel_dir(contig_dir)))?;
+    Ok(keys.iter().copied().map(deletion_len).max().unwrap_or(0))
+}
+
+/// Read a raw little-endian `u32` key file into a `Vec<u32>`. A missing file is
+/// treated as empty (an absent stream). Alignment-agnostic: `std::fs::read` may
+/// return an unaligned buffer, so decode via `chunks_exact(4)` rather than
+/// `bytemuck::cast_slice`.
+fn read_keys(path: &Path) -> Result<Vec<u32>, ConversionError> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(source) => Err(ConversionError::Io {
+            context: format!("reading {}", path.display()),
+            source,
+        }),
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pixi run cargo test --no-default-features --lib max_del::`
+Expected: PASS (3 tests: `absent_streams_emit_all_zero_artifacts`, `per_column_max_over_var_key_indel`, `dense_scalar_is_single_max_over_shared_keys`).
+
+- [ ] **Step 7: Lint**
+
+Run: `pixi run -e lint cargo fmt --all && pixi run -e lint cargo clippy --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/error.rs src/lib.rs src/max_del.rs
+git commit -m "feat(svar-2): max_del post-pass producer (var_key per-column + dense scalar)"
+```
+
+---
+
+## Task 4: Proptest oracle for `write_max_del`
+
+**Files:**
+- Modify: `src/max_del.rs` (add a `proptest!` block inside the existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `write_max_del` (Task 3) and the test helpers `del_key` / `write_var_key_indel` / `read_max_del` already defined in Task 3's test module.
+- Produces: nothing (test-only).
+
+- [ ] **Step 1: Write the failing proptest**
+
+Add inside `mod tests` in `src/max_del.rs` (after the three unit tests). It builds a random synthetic `var_key/indel` contig with known per-call deletion lengths across random columns, runs the pass, and asserts each `max_del[s, p]` equals the brute-force per-column max — the oracle style of `search.rs`:
+
+```rust
+    use proptest::prelude::*;
+
+    proptest! {
+        // Random per-column deletion lengths → the produced (n_samples, ploidy)
+        // max_del must equal the brute-force per-column maximum. `0` marks a
+        // non-deletion call (SNP/INS). This is the primary correctness gate for
+        // the scan + column slicing + reshape.
+        #[test]
+        fn prop_var_key_max_del_matches_oracle(
+            n_samples in 1usize..4,
+            ploidy in 1usize..3,
+            // per-column deletion lengths, flattened; sized/chunked below.
+            col_lens in proptest::collection::vec(0usize..6, 0..12),
+            del_seeds in proptest::collection::vec(0u32..1000, 0..64),
+        ) {
+            let total_columns = n_samples * ploidy;
+
+            // Deterministic per-column call counts (0..=5) derived from col_lens.
+            let counts: Vec<usize> =
+                (0..total_columns).map(|c| col_lens.get(c).copied().unwrap_or(0)).collect();
+
+            // Assign deletion lengths to calls from del_seeds (cycled), building
+            // both the key stream and the per-column oracle max in lockstep.
+            let mut keys: Vec<u32> = Vec::new();
+            let mut offsets: Vec<u64> = vec![0u64; total_columns + 1];
+            let mut oracle = vec![0u32; total_columns];
+            let mut seed_i = 0usize;
+            for c in 0..total_columns {
+                let mut col_max = 0u32;
+                for _ in 0..counts[c] {
+                    let d = del_seeds.get(seed_i % del_seeds.len().max(1)).copied().unwrap_or(0);
+                    seed_i += 1;
+                    keys.push(del_key(d));
+                    col_max = col_max.max(d);
+                }
+                offsets[c + 1] = offsets[c] + counts[c] as u64;
+                oracle[c] = col_max;
+            }
+
+            let tmp = tempdir().unwrap();
+            let cdir = tmp.path();
+            write_var_key_indel(cdir, &offsets, &keys);
+            write_max_del(cdir, n_samples, ploidy).unwrap();
+
+            let m = read_max_del(cdir);
+            prop_assert_eq!(m.shape(), &[n_samples, ploidy]);
+            for c in 0..total_columns {
+                let s = c / ploidy;
+                let p = c % ploidy;
+                prop_assert_eq!(m[[s, p]], oracle[c], "col {}", c);
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run the proptest to verify it is exercised**
+
+Run: `pixi run cargo test --no-default-features --lib max_del::tests::prop_var_key_max_del_matches_oracle`
+Expected: PASS (the implementation from Task 3 already satisfies it; if it fails, the Task 3 scan/reshape has a bug — fix there). If `del_seeds` is empty the `% .max(1)` guard keeps indexing safe; those calls get `d = 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/max_del.rs
+git commit -m "test(svar-2): brute-force oracle proptest for max_del per-column producer"
+```
+
+---
+
+## Task 5: Orchestrator wiring + end-to-end round-trip
+
+**Files:**
+- Modify: `src/orchestrator.rs` (call `write_max_del` after the dense merge loop at `src/orchestrator.rs:252`)
+- Modify: `tests/test_e2e.rs` (add a new e2e test)
+
+**Interfaces:**
+- Consumes: `write_max_del` (Task 3); `process_chromosome` (`src/orchestrator.rs:44`); `layout::{max_del, dense_max_del}` (Task 2); `search::{SearchTree, overlap_range}` (`src/search.rs:63,148`); test helpers `SynthRecord`, `build_bcf_with_index`, `read_u32_bin`, `read_offsets_npy` (`tests/common/mod.rs`).
+- Produces: a normal conversion now emits `max_del.npy` + `dense/max_del.npy` per contig.
+
+- [ ] **Step 1: Wire `write_max_del` into the orchestrator**
+
+In `src/orchestrator.rs`, insert after the dense-merge `for` loop (after `src/orchestrator.rs:252`, before the `println!("[{}] Pipeline Execution Finished..."` line):
+
+```rust
+    // M5 post-pass: emit max-deletion-length artifacts for the overlap query.
+    // A pure scan of the finished indel key streams — decoupled from the merge.
+    let contig_dir = std::path::Path::new(base_out_dir).join(chrom);
+    crate::max_del::write_max_del(&contig_dir, samples.len(), ploidy)?;
+```
+
+- [ ] **Step 2: Write the failing e2e test**
+
+Add to `tests/test_e2e.rs` (after `test_e2e_normalized_bcf_pipeline`, and add the search import at the top of the file). At the top, alongside the existing `use genoray_core::...` lines (near `tests/test_e2e.rs:11-13`), add:
+
+```rust
+use genoray_core::search::{overlap_range, SearchTree};
+```
+
+Then append the test:
+
+```rust
+// M5 max_del post-pass, end-to-end. Two deletions with known lengths:
+//   pos=100  ATTT → A  (d=3)  gt=[1,0,0,0]  x=1 → rare → var_key/indel (hap 0)
+//   pos=200  ATT  → A  (d=2)  gt=[1,1,1,0]  x=3 → common → dense/indel (shared)
+// Asserts the produced artifacts, then feeds max_del into overlap_range to prove
+// a deletion that starts left of the query but spans into it is recoverable.
+#[test]
+fn test_e2e_max_del_postpass() {
+    let tmp = tempdir().unwrap();
+    let bcf_path = tmp.path().join("maxdel.bcf");
+    let samples = vec!["S0", "S1"]; // np = 4
+
+    let records = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"ATTT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 0, 0, 0], // hap 0 only → var_key/indel
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"ATT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 1, 0], // haps 0,1,2 → dense/indel
+        },
+    ];
+    build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
+
+    let out_dir = tmp.path().join("out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    process_chromosome(
+        bcf_path.to_str().unwrap(),
+        "chr1",
+        out_dir.to_str().unwrap(),
+        &samples,
+        100,
+        2,
+        1,
+        4096,
+    )
+    .expect("conversion");
+
+    let contig_dir = out_dir.join("chr1");
+
+    // var_key max_del: shape (2, 2); only col 0 (S0_p0) carries the d=3 deletion.
+    let m: ndarray::Array2<u32> =
+        ndarray_npy::read_npy(contig_dir.join("max_del.npy")).unwrap();
+    assert_eq!(m.shape(), &[2, 2]);
+    assert_eq!(m[[0, 0]], 3);
+    assert_eq!(m[[0, 1]], 0);
+    assert_eq!(m[[1, 0]], 0);
+    assert_eq!(m[[1, 1]], 0);
+
+    // dense max_del: shape (1,); single max over the shared indel table = 2.
+    let dm: ndarray::Array1<u32> =
+        ndarray_npy::read_npy(contig_dir.join("dense/max_del.npy")).unwrap();
+    assert_eq!(dm, ndarray::Array1::from_vec(vec![2u32]));
+
+    // Close the producer -> consumer loop: the var_key/indel deletion for hap 0
+    // starts at pos 100 and spans 3 bases (v_end = 100 + 1 + 3 = 104). A query
+    // strictly right of the start but inside the deletion must still find it,
+    // using the produced max_del as max_region_length.
+    let vk_indel = contig_dir.join("var_key/indel");
+    let off = read_offsets_npy(&vk_indel.join("offsets.npy"));
+    let pos = read_u32_bin(&vk_indel.join("positions.bin"));
+    // hap 0 owns exactly the [off[0], off[1]) slice = one call at pos 100.
+    let col0 = &pos[off[0] as usize..off[1] as usize];
+    assert_eq!(col0, &[100u32]);
+
+    let v_starts: Vec<u32> = col0.to_vec();
+    let v_ends: Vec<u32> = vec![100 + 1 + 3]; // start + 1 + d, d = max_del[0,0]
+    let tree = SearchTree::new(&v_starts);
+    let max_region_length = m[[0, 0]];
+    // query [102, 103): starts right of variant start 100 but inside the deletion.
+    assert_eq!(overlap_range(&tree, &v_ends, max_region_length, 102, 103), (0, 1));
+}
+```
+
+- [ ] **Step 3: Run the e2e test to verify it fails (before wiring is proven)**
+
+If Step 1 is already applied, this passes; to see the red state first, the test build itself proves the wiring — run:
+
+Run: `pixi run cargo test --no-default-features --test test_e2e test_e2e_max_del_postpass`
+Expected: PASS (Step 1 wiring produces the files; the assertions confirm shapes/values and the overlap loop). If it fails with a missing-file error, Step 1's orchestrator wiring was not applied — apply it.
+
+- [ ] **Step 4: Run the full test suite to confirm no regressions**
+
+Run: `pixi run cargo test --no-default-features`
+Expected: PASS — all existing lib + integration tests plus the new ones. (`test_e2e_normalized_bcf_pipeline`, `test_e2e_mutation_conservation`, etc. are unaffected — the post-pass only adds files.)
+
+- [ ] **Step 5: Lint**
+
+Run: `pixi run -e lint cargo fmt --all && pixi run -e lint cargo clippy --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/orchestrator.rs tests/test_e2e.rs
+git commit -m "feat(svar-2): wire max_del post-pass into orchestrator + e2e round-trip"
+```
+
+---
+
+## Notes on deferred scope (from the design)
+
+- **Consuming `max_del.npy` in the disk query** — the `(range, sample)` spec. Task 5's e2e demonstrates the loop with `overlap_range` directly, but the full on-disk `(range, sample)` gather is out of scope here.
+- **No change to the conversion/merge write path** — this is strictly a post-pass; it does not piggyback on the merge, keeping it decoupled from the M2b left-alignment spec.
+- **`pointer/indel` (M11)** — no such stream exists yet; when it lands, its indel keys join the same per-`(sample, ploid)` max (extend `var_key_max_del` to fold that stream in).
+- **Batch-sweep entrypoint** — `write_max_del` is already usable standalone against any finished contig directory (a sweep is just a loop over contig dirs); a CLI/py entrypoint can be added later if needed.
+
+## Frozen-contract sync reminder
+
+The `(range, sample)` query spec MUST match these choices (kept in sync per the design's open questions):
+- `dense/max_del.npy` shape is **`(1,)`** `u32` (not 0-d), always present, `0` when no dense indels.
+- `max_del.npy` shape is `(n_samples, ploidy)` `u32`, row-major (`arr[[s, p]] == flat[s*ploidy + p]`), always present, all-zero for a no-deletion contig.
+- SNP sub-streams get no file.

--- a/docs/superpowers/specs/2026-07-02-svar2-m2b-left-alignment-design.md
+++ b/docs/superpowers/specs/2026-07-02-svar2-m2b-left-alignment-design.md
@@ -1,0 +1,128 @@
+# SVAR 2.0 — M2b: left-alignment during conversion (design)
+
+> Spec for roadmap milestone **M2b** in
+> [`docs/roadmap/svar-2.md`](../../roadmap/svar-2.md).
+> Supplements: [`data-model.md`](../../roadmap/data-model.md#variant-normalization).
+> Branch off `svar-2`, own worktree. **Parallel-safe** with both M5 specs (the `max_del`
+> post-pass and the `(range, sample)` query) — this spec edits the **read/normalize**
+> side (`vcf_reader.rs`, `normalize.rs`) while those edit the write/query side. It changes
+> variant *start positions* but not deletion *lengths* or the on-disk schema, so it does
+> not invalidate M5's inputs.
+
+## Context
+
+M2 shipped atomization + biallelic splitting (`src/normalize.rs`), leaving indels
+**anchored but not left-aligned**. M2b shifts each indel to its leftmost equivalent
+position, matching bcftools `norm`. It was deferred from M2 because it is the only
+normalization step that needs a **reference genome** (a new required conversion argument)
+and it **weakens the reorder buffer's ordering premise** — `src/vcf_reader.rs::next_atom`
+already flags this:
+
+> "M2b (left-alignment) weakens the `pos >= record_start` premise and must revisit this
+> bound."
+
+Today an atom is safe to emit once `top.pos < frontier` (the read frontier = current
+record's start), because without left-alignment an atom's position is always `>=` its
+record's start. Left-alignment can move an indel's start **below** its record's start, so
+the emit-safety condition must widen by the maximum possible leftward shift.
+
+## Scope
+
+**In:**
+
+- A **reference FASTA (faidx)** input, threaded as a new **required** argument through the
+  conversion entrypoint (`src/orchestrator.rs` and the PyO3 binding). Random-access reads
+  via `rust_htslib::faidx` (htslib is already a dependency).
+- **Left-alignment of anchored indel atoms** in the normalize path: after `atomize_record`
+  produces anchored INS/DEL/SNP atoms, roll each indel leftward while the shift is
+  reference-consistent (classic VCF left-align / trimming roll). SNP atoms never move.
+- **Reorder-buffer bound widening** in `vcf_reader.rs`: introduce a bounded left-shift
+  window `L_MAX` and change the heap emit-safety test to
+  `top.pos < frontier.saturating_sub(L_MAX)`, keeping the position-sorted invariant the
+  Phase-2 merge relies on. Shifts are capped at `L_MAX` (matching bcftools' windowed
+  `--buffer-size` behavior) so memory stays bounded.
+- **Contig-boundary handling**: stop rolling at the contig's first base; never read
+  reference outside `[0, contig_len)`.
+- **Genotype remapping unchanged**: left-alignment mutates an atom's `pos` and its anchor
+  base(s) only; `source_alt_index` and the shared `gt` vector are untouched, so the
+  existing haplotype remap still holds.
+
+**Out:**
+
+- Any change to the encoding, cost model, dense path, on-disk layout, or `max_del`
+  (deletion lengths are invariant under left-alignment — see below).
+- Multi-threaded reference sharing beyond what per-contig conversion already needs (one
+  faidx handle / cached contig sequence per contig worker).
+- Right-alignment, trimming beyond the existing atomize suffix-trim, or reference-mismatch
+  *correction* (a REF that disagrees with the FASTA is an error, not silently fixed).
+
+## Why this stays orthogonal to M5
+
+`max_del` / `overlap_range` bound how far **left of the query start** a spanning deletion
+can begin, via the maximum **deletion length**. Left-alignment changes a deletion's
+*start position* but never its *length* (the number of deleted reference bases is
+invariant). The bound is applied relative to each deletion's own (post-alignment) start,
+so overlap correctness is preserved with no coordination. The only shared concern is that
+M5's `max_del` post-pass should run over the **final left-aligned** output — which it does
+by construction (it is a post-pass over finished streams).
+
+## Design
+
+- **Reference access.** Open the FASTA with `rust_htslib::faidx::Reader` once; per contig
+  worker, fetch the needed reference bases (either a cached full contig sequence when it
+  fits, or windowed `fetch_seq` calls around each indel — **measure**; cache-per-contig is
+  simplest and usually fine for one contig at a time).
+- **Left-align routine** (`normalize.rs`, pure given a reference-byte accessor):
+  `left_align(atom, ref_accessor) -> Atom`. For an anchored indel at `pos` with indel
+  sequence `s` (inserted bases for INS, deleted bases for DEL):
+  roll left while `pos > contig_start`, the shift count `< L_MAX`, and
+  `ref[pos-1] == s[last]` — decrement `pos`, rotate `s`, and update the anchor base from
+  `ref[pos]`. This is the standard "shared-suffix / repeat" roll; validate against a
+  couple of bcftools-normalized fixtures.
+- **Ordering.** Left-align each atom **after** atomization, **before** pushing to the heap
+  in `decompose_current_record`. The heap key stays `atom.pos` (now the aligned pos).
+- **Buffer bound.** Add `L_MAX` (const or config). Update `next_atom`'s emit guard to
+  `top.pos < frontier.saturating_sub(L_MAX)` and update the memory-note comment. Choose
+  `L_MAX` from the empirical short-read indel/STR distribution — **measure**, don't pick by
+  convention (per the project's "measure, don't guess" principle); document the default and
+  the truncation semantics for shifts that would exceed it (atom left partially aligned,
+  as bcftools does at its buffer limit).
+- **Errors.** REF disagreeing with the FASTA at `pos` ⇒ a new `NormalizeError` variant
+  (fail fast). Out-of-contig fetch ⇒ same. Symbolic/breakend/`*`/`.` handling unchanged.
+
+## Files
+
+- **Touch:** `src/normalize.rs` (`left_align`, new error variant), `src/vcf_reader.rs`
+  (faidx handle, call `left_align`, widen `next_atom` bound + comment),
+  `src/orchestrator.rs` (thread the FASTA path), the PyO3 binding (new required arg),
+  `Cargo.toml` (enable `rust-htslib` faidx feature if not already on).
+- **Docs:** update
+  [`data-model.md`](../../roadmap/data-model.md#variant-normalization) and the M2b
+  checkbox per the roadmap working agreement.
+
+## Testing
+
+- **Unit (`normalize.rs`):** `left_align` on hand-built cases — a deletion in a homopolymer
+  run (rolls fully), a deletion at contig start (stops at boundary), an insertion in a
+  tandem repeat, a SNP (no move), and a shift that would exceed `L_MAX` (partial align).
+- **Proptest:** random reference + random indel; assert the aligned variant is
+  reference-equivalent to the original (re-expanding both against the reference yields the
+  same alt sequence) and is genuinely leftmost within `L_MAX`.
+- **bcftools cross-check:** for a small fixture VCF+FASTA, assert atoms match
+  `bcftools norm -a -m- -f ref.fa` positions/alleles (modulo the documented
+  substituted-deletion-anchor deviation already noted in `normalize.rs`).
+- **Reorder invariant:** proptest that emitted atom positions are non-decreasing across
+  chunk boundaries even with left-shifts up to `L_MAX` (the property the widened bound
+  must preserve).
+- **e2e:** convert an un-left-aligned VCF with and without the reference; assert indels
+  move to expected positions and a round-trip still reconstructs the correct haplotypes.
+
+## Open questions
+
+- **`L_MAX` value and units** — a fixed base window vs. tied to the max observed repeat.
+  Measure on representative short-read VCFs; default conservative, document truncation.
+- **Reference caching strategy** — full-contig cache vs. windowed `fetch_seq`. Start with
+  full-contig-per-worker; revisit if peak RAM at cohort scale is a problem.
+- **Making the FASTA optional** — should conversion still allow skipping left-alignment
+  (already-normalized input)? Recommendation: keep the arg **required** for M2b to avoid a
+  silent "not actually normalized" footgun; a future flag can opt out explicitly.

--- a/docs/superpowers/specs/2026-07-02-svar2-m5-max-del-postpass-design.md
+++ b/docs/superpowers/specs/2026-07-02-svar2-m5-max-del-postpass-design.md
@@ -1,0 +1,125 @@
+# SVAR 2.0 — M5 (part 2a): `max_del` standalone post-pass (design)
+
+> Partial spec for roadmap milestone **M5** in
+> [`docs/roadmap/svar-2.md`](../../roadmap/svar-2.md).
+> Supplements: [`data-model.md`](../../roadmap/data-model.md#overlap-queries-and-deletions),
+> [`architecture.md`](../../roadmap/architecture.md#query-path).
+> Branch off `svar-2`, own worktree. **Parallel-safe** with the `(range, sample)` query
+> spec (shares only the frozen `max_del.npy` contract below) and with the M2b
+> left-alignment spec (disjoint files).
+
+## Context
+
+`overlap_range` (M5 part 1, `src/search.rs`) already takes a `max_region_length: u32`
+bound as a **parameter**. Full M5 needs that bound to come from disk. Per
+[`data-model.md`](../../roadmap/data-model.md#overlap-queries-and-deletions) the bound is
+the **maximum deletion length per `(contig, sample, ploid)`**, stored in a per-contig
+`max_del.npy`. This spec covers **producing** that file.
+
+The key enabling fact: a deletion's length is fully recoverable from the finished
+on-disk `var_key/indel` and `dense/indel` streams — a pure DEL encodes its `ilen` as a
+signed-i31 **inside the inline key** (`src/rvk.rs`, `pack_variant`: `bit 31 = 1 → pure
+DEL, bits[31:1] = signed ilen`), so it never spills to the LUT. Computing `max_del` is
+therefore a **pure scan of the already-written `alleles.bin` keys** — no LUT reads, no
+reference genome, and crucially **no coupling to the conversion pipeline**. It runs as a
+standalone pass over a finished SVAR2 directory.
+
+## Scope
+
+**In:**
+
+- A standalone function/binary that, given a finished SVAR2 contig directory, reads the
+  indel key streams and emits the `max_del` artifacts (contract below).
+- Decoding DEL `ilen` from a 32-bit indel key: reuse/expose the existing decode in
+  `src/rvk.rs` rather than re-deriving the bit layout (respect the encoding seam — see
+  [`architecture.md`](../../roadmap/architecture.md#the-encoding-agnostic-seam)). Deletion
+  length `d = -ilen` for `ilen < 0`; `0` for SNP/INS keys.
+- **`var_key/indel`** producer: for each column `c` (flattened `(sample, ploid)`), scan
+  that column's slice of `alleles.bin` (bounded by `offsets.npy[c]..offsets.npy[c+1]`),
+  take `max(d)`; write the `(sample, ploid)` array.
+- **`dense/indel`** producer: the dense indel variant table is **shared across samples**
+  (one position/key list per contig, genotypes selected by the 1-bit matrix), so its
+  overlap search runs once over shared positions → a **single per-contig scalar**
+  `max(d)` over the dense indel keys.
+- Runs after a contig's merge completes; callable per-contig so it composes with the
+  per-contig conversion fan-out (an orchestrator can invoke it as each contig finalizes,
+  or as a batch sweep over an existing directory).
+
+**Out (deferred / other specs):**
+
+- Consuming `max_del.npy` in the query — the `(range, sample)` spec.
+- Any change to the conversion/merge write path. (This is explicitly a *post*-pass; we do
+  not piggyback on the merge, keeping it decoupled from M2b left-alignment which edits the
+  read/normalize side.)
+- `pointer` representation (M11) — no `pointer/indel` stream exists yet; when it lands,
+  its indel keys join the same per-`(sample, ploid)` max.
+
+## The frozen contract (shared with the `(range, sample)` query spec)
+
+Per contig directory `{out}/{contig}/`:
+
+- **`max_del.npy`** — dtype `u32`, shape `(n_samples, ploidy)`. `max_del[s, p]` = the
+  maximum deletion length (in reference bases) over the `var_key/indel` stream for column
+  `(s, p)`, or `0` if that column carries no deletions. The `(s, p)` → flat-column mapping
+  **must match `src/merge.rs`** (`total_columns = num_samples * ploidy`, column index as
+  used to slice `offsets.npy`); the producer derives it from the same convention, and the
+  consumer reshapes identically. A pure-SNP contig still emits an all-zero array (so the
+  consumer never special-cases a missing file).
+- **`dense/max_del.npy`** — dtype `u32`, shape `()` (0-d scalar) or `(1,)`: the single
+  max deletion length over the shared `dense/indel` key table for this contig, `0` if
+  none / no dense indel stream.
+- SNP sub-streams (`var_key/snp`, `dense/snp`) get **no** file — their overlap is a plain
+  half-open range (`max_region_length == 0`), as the query spec relies on.
+
+`overlap_range`'s existing proptest (`overlap_max_region_length_overshoot_is_safe`) proves
+an **over**-estimate is always correct, only looser — so the producer may be conservative,
+but the per-column tight bound keeps the linear sub-scan short.
+
+## Design
+
+- New module, e.g. `src/max_del.rs`. Public entry: `write_max_del(contig_dir: &Path,
+  n_samples: usize, ploidy: usize) -> Result<(), Error>`.
+- Read `var_key/indel/{offsets.npy, alleles.bin}` via mmap (`memmap2`, matching the
+  reader access model). `alleles.bin` is a raw little-endian `u32` array; `offsets.npy` is
+  the `total_columns + 1` prefix-sum from `merge.rs`.
+- Per column, iterate keys in `[offsets[c], offsets[c+1])`, decode `ilen`, accumulate the
+  max deletion length. This is `O(total indel calls)` and embarrassingly parallel across
+  columns (rayon) if needed — but a single pass is likely I/O-bound and fine serial;
+  **measure before parallelizing.**
+- Read `dense/indel/alleles.bin` (if present), single max over all keys → scalar.
+- Write both artifacts with `ndarray-npy::write_npy` (same dependency the merge already
+  uses).
+- Absent `var_key/indel` or `dense/indel` dir ⇒ treat as empty ⇒ zero output (still write
+  `max_del.npy` so the consumer's contract holds; skip `dense/max_del.npy` only if the
+  consumer is specified to default-absent-to-0 — **decide with the query spec**, keep the
+  two symmetric).
+
+## Files
+
+- **New:** `src/max_del.rs` (+ `mod max_del` wiring).
+- **Touch (minimal):** `src/rvk.rs` — expose a `pub fn deletion_len(key: u32) -> u32` (or
+  reuse an existing decoder) so the bit layout stays in one place. `src/layout.rs` — add
+  path helpers `max_del(contig_dir)` and `dense_max_del(contig_dir)`.
+- **Optional:** `src/orchestrator.rs` — invoke `write_max_del` per contig after merge, so
+  a normal conversion produces `max_del.npy` end-to-end. (Can be a follow-up; the pass is
+  usable standalone against any finished directory.)
+
+## Testing
+
+- **Unit:** `deletion_len` decode vs. hand-constructed keys (SNP→0, INS→0, small DEL,
+  large DEL near `MIN_I31`), mirroring the existing `rvk.rs` key-layout tests.
+- **Proptest:** build a small synthetic contig (random atomized variants with known
+  deletion lengths across random columns), run the pass, assert `max_del[s,p]` equals the
+  brute-force per-column max — the same oracle style as `search.rs`.
+- **e2e round-trip:** extend an existing conversion e2e test to assert `max_del.npy`
+  exists, has shape `(n_samples, ploidy)`, and its values match a direct scan of the input
+  VCF's deletions per sample. Feed the produced `max_del` into `overlap_range` on a
+  deletion that spans a query start and assert the deletion is returned (closes the
+  producer↔consumer loop once the query spec lands).
+
+## Open questions
+
+- **`dense/max_del` shape** — 0-d scalar vs `(1,)` vs folding into a length-1 axis of the
+  main file. Pick whatever the query spec finds cleanest to load; keep both specs in sync.
+- **Where the pass is triggered** — per-contig inside `orchestrator.rs` vs. a separate
+  sweep entrypoint. Standalone-first; wire into the orchestrator once green.

--- a/docs/superpowers/specs/2026-07-02-svar2-m5-range-sample-query-design.md
+++ b/docs/superpowers/specs/2026-07-02-svar2-m5-range-sample-query-design.md
@@ -1,0 +1,118 @@
+# SVAR 2.0 — M5 (part 2b): `(range, sample)` query — disk integration (design)
+
+> Partial spec for roadmap milestone **M5** in
+> [`docs/roadmap/svar-2.md`](../../roadmap/svar-2.md).
+> Supplements: [`architecture.md`](../../roadmap/architecture.md#query-path),
+> [`data-model.md`](../../roadmap/data-model.md#overlap-queries-and-deletions).
+> Branch off `svar-2`, own worktree. **Parallel-safe** with the `max_del` post-pass spec
+> (shares only the frozen `max_del.npy` contract) and the M2b spec (disjoint files).
+
+## Context
+
+M5 part 1 shipped the format-independent core (`src/search.rs`: `SearchTree`,
+`overlap_range`), depending only on in-memory `u32` slices. This spec wires that core to a
+**finished SVAR2 contig on disk** to answer a `(range, sample)` query: given a contig, a
+`[q_start, q_end)` region, and a sample, return that sample's variants (both haplotypes)
+overlapping the region.
+
+A single contig spreads a sample's variants across up to four sub-streams today
+(`var_key/{snp,indel}` and `dense/{snp,indel}`; `pointer/*` arrives with M11). Each is
+independently position-sorted. Answering the query means: search each relevant sub-stream,
+combine the hits in position order, and gather the sample's genotype/allele for each.
+
+## Scope
+
+**In:**
+
+- **Sidecar loading** for a contig: mmap `positions.bin` (raw LE `u32` → build
+  `SearchTree`), `alleles.bin` (keys), `offsets.npy` (per-column bounds), `genotypes.bin`
+  (dense), and `max_del.npy` / `dense/max_del.npy` (from the post-pass spec's contract).
+- **Per-sub-stream overlap** using `overlap_range`:
+  - `var_key/*` — per-column `(sample, ploid)`: slice the column via `offsets.npy`, build a
+    `SearchTree` over that column's positions, run `overlap_range` with the column's
+    `max_del[s,p]` (indel) or `0` (snp). Reconstruct `v_ends` from keys via the `rvk`
+    decoder (deletion length), respecting the encoding seam.
+  - `dense/*` — one shared position table per contig: run `overlap_range` once with the
+    per-contig `dense/max_del` (indel) / `0` (snp), then select the sample's carried
+    variants from the 1-bit `(sample, ploid, variant)` matrix (`genotypes.bin`, read via
+    `BitGrid3`/`bits.rs`) within the returned `[s_idx, e_idx)`.
+- **Sorted union** across the sub-streams: each `overlap_range` yields an index range into
+  one sorted stream; merge the referenced `(position, key/genotype)` records into one
+  **position-sorted** result. A k-way merge over ≤4 already-sorted runs
+  (see [`architecture.md`](../../roadmap/architecture.md#python-decode-path) — the
+  union-shaped dual of sorted intersection).
+- **Genotype gather**: assemble the per-`(sample, ploid)` overlapping calls into an
+  **intermediate Rust-side result** — positions, decoded `(ILEN, ALT)` (via the `rvk`
+  decoder + LUT for long alleles), and which haplotype(s) carry each. Shape TBD with M6
+  but must be a plain owned struct, not a Python type.
+- Single-query API first; a thin batched wrapper (many ranges) is a follow-up — SVAR 1.0
+  batches, and the core is single-query.
+
+**Out (deferred):**
+
+- **Producing** `max_del.npy` — the post-pass spec. This spec **consumes** it, developing
+  against a hand-written fixture until that lands.
+- **Python-facing structs/classes** and the `SparseVar2` reader class — **M6**. This spec
+  stops at the intermediate Rust result + (optionally) a minimal PyO3 accessor returning
+  arrays, only if needed to test end-to-end.
+- `pointer` representation (M11): design the union so adding a 5th/6th sub-stream is a list
+  entry, not a rewrite, but do not implement it.
+- Left-alignment (M2b) — orthogonal; this spec reads whatever positions are on disk.
+
+## Design
+
+- New module `src/query.rs` (or extend `search.rs` with a disk-facing submodule; keep the
+  pure core in `search.rs` untouched so its proptests stay valid).
+- **`ContigReader`** — opens a contig dir, mmaps the sidecars, exposes typed views:
+  per-column `var_key` slices, the shared `dense` table + matrix, the LUT, and the loaded
+  `max_del` arrays. Owns lifetimes so the mmaps outlive the query.
+- **`overlap_sample(reader, sample, q_start, q_end) -> QueryResult`**:
+  1. For `p in 0..ploidy`: run `var_key/snp` + `var_key/indel` overlaps for column
+     `(sample, p)`; run `dense/snp` + `dense/indel` overlaps (shared) and filter to
+     variants where the sample/ploid bit is set.
+  2. Decode each hit's `(ILEN, ALT)` and true `v_end` via `rvk` (+ LUT).
+  3. k-way merge the ≤4 runs per haplotype into one position-sorted list.
+  4. Return `QueryResult { per_hap: [Vec<Call>; ploidy] }` (owned; `Call` = position,
+     ILEN, ALT bytes or LUT handle, allele/dosage).
+- **`v_ends` reconstruction** must go through a single `rvk` decoder entry point
+  (`deletion_len` / `decode_key`), not inline bit math — same seam discipline as the core.
+- **Empty/degenerate:** no overlap ⇒ `s_idx == e_idx` ⇒ empty run; a pure-SNP contig ⇒
+  all `max_region_length == 0`; a contig with no dense dir ⇒ skip dense runs.
+
+## Files
+
+- **New:** `src/query.rs` (`ContigReader`, `overlap_sample`, `QueryResult`, `Call`, the
+  k-way sorted union).
+- **Reuse:** `src/search.rs` (`SearchTree`, `overlap_range` — unchanged), `src/rvk.rs`
+  (key decode + LUT), `src/bits.rs`/`BitGrid3` (dense matrix reads), `src/layout.rs`
+  (paths — add sidecar path helpers if missing), `memmap2`.
+- **Fixture:** a small committed SVAR2 dir (or a builder that converts a tiny VCF) plus a
+  hand-written `max_del.npy` for pre-integration testing.
+
+## Testing
+
+- **Unit:** `ContigReader` loads sidecars with correct shapes/dtypes; `v_end`
+  reconstruction from keys matches `rvk` decode.
+- **Oracle proptest:** against a brute-force reference that holds the whole contig in
+  memory and linearly finds every overlapping variant a sample carries — assert
+  `overlap_sample` returns exactly those, in position order, across random contigs
+  (mixed SNP/indel, var_key/dense routing, random deletions, empty and no-overlap
+  queries, deletions spanning `q_start`).
+- **Cross-check the dense/var_key split:** a variant routed to dense vs. var_key must yield
+  identical query results for the carrying sample (routing is an internal storage choice,
+  invisible to the query).
+- **e2e:** convert a small VCF → query a known region for a known sample → assert calls
+  match the VCF. Once the post-pass spec lands, drop the fixture `max_del.npy` and use the
+  produced one; results must be identical.
+
+## Open questions
+
+- **Result shape** — finalize with M6 so the Rust `QueryResult` maps cleanly to the Python
+  struct without a second reshuffle. Keep it array-of-structs vs. struct-of-arrays open
+  until M6's decode needs are known; lean SoA (columnar) since M6 wants a fast sorted union
+  and numpy-friendly output.
+- **Union placement** — do the sorted union in Rust (here) vs. Python (M6)?
+  Recommendation: Rust, since `search.rs` already returns index ranges and the union is
+  cheap over ≤4 runs; M6 then only decodes/boxes. Revisit if M6 needs cross-contig unions.
+- **Batched queries** — single-query now; confirm the batch wrapper shape when M6's access
+  pattern (one region vs. many) is fixed.

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,4 +18,10 @@ pub enum ConversionError {
         #[source]
         source: ndarray_npy::WriteNpyError,
     },
+    #[error("failed to read npy at {path}: {source}")]
+    ReadNpy {
+        path: String,
+        #[source]
+        source: ndarray_npy::ReadNpyError,
+    },
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -78,6 +78,23 @@ pub fn genotypes(dir: &Path) -> PathBuf {
     dir.join("genotypes.bin")
 }
 
+/// Contig-dir-relative path helpers for the standalone `max_del` post-pass. These
+/// take the contig directory (`{out}/{contig}`) directly, unlike the `ContigPaths`
+/// methods which build from `base_out_dir` + `chrom`. Keeping them here preserves
+/// layout.rs as the single source of on-disk paths.
+pub fn var_key_indel_dir(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("var_key").join("indel")
+}
+pub fn dense_indel_dir(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("dense").join("indel")
+}
+pub fn max_del(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("max_del.npy")
+}
+pub fn dense_max_del(contig_dir: &Path) -> PathBuf {
+    contig_dir.join("dense").join("max_del.npy")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -107,6 +124,15 @@ mod tests {
         let p = ContigPaths::new("/out", "chr1");
         assert_eq!(p.dense_snp_dir(), Path::new("/out/chr1/dense/snp"));
         assert_eq!(p.dense_indel_dir(), Path::new("/out/chr1/dense/indel"));
+    }
+
+    #[test]
+    fn test_max_del_postpass_paths() {
+        let c = Path::new("/out/chr1");
+        assert_eq!(var_key_indel_dir(c), Path::new("/out/chr1/var_key/indel"));
+        assert_eq!(dense_indel_dir(c), Path::new("/out/chr1/dense/indel"));
+        assert_eq!(max_del(c), Path::new("/out/chr1/max_del.npy"));
+        assert_eq!(dense_max_del(c), Path::new("/out/chr1/dense/max_del.npy"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod dense_merge;
 pub mod error;
 pub mod executor;
 pub mod layout;
+pub mod max_del;
 pub mod merge;
 pub mod meta;
 pub mod monitor;

--- a/src/max_del.rs
+++ b/src/max_del.rs
@@ -1,0 +1,221 @@
+//! Standalone `max_del` post-pass (SVAR 2.0, M5 part 2a).
+//!
+//! Scans a finished contig's indel key streams and emits the max-deletion-length
+//! artifacts consumed by the `(range, sample)` overlap query. A deletion's length
+//! is recoverable from the inline pure-DEL key alone (see [`crate::rvk::deletion_len`]),
+//! so this is a pure scan of `alleles.bin` — no LUT reads, no reference genome, no
+//! coupling to the conversion/merge write path. Runs after a contig's merge
+//! completes; callable per-contig or as a batch sweep over an existing directory.
+
+use crate::error::ConversionError;
+use crate::layout;
+use crate::rvk::deletion_len;
+use ndarray::{Array1, Array2};
+use ndarray_npy::write_npy;
+use std::path::Path;
+
+/// Emit `{contig_dir}/max_del.npy` (shape `(n_samples, ploidy)`, `u32`) and
+/// `{contig_dir}/dense/max_del.npy` (shape `(1,)`, `u32`). Both are always written
+/// — a contig with no deletions emits all-zero artifacts so the consumer never
+/// special-cases a missing file. `O(total indel calls)`; a single serial pass
+/// (measure before parallelizing — this is I/O-bound).
+pub fn write_max_del(
+    contig_dir: &Path,
+    n_samples: usize,
+    ploidy: usize,
+) -> Result<(), ConversionError> {
+    let var_key = var_key_max_del(contig_dir, n_samples, ploidy)?;
+    let out = layout::max_del(contig_dir);
+    write_npy(&out, &var_key).map_err(|source| ConversionError::Npy {
+        path: out.display().to_string(),
+        source,
+    })?;
+
+    let dense = dense_max_del_scalar(contig_dir)?;
+    let dense_out = layout::dense_max_del(contig_dir);
+    // dense/max_del.npy lives under {contig_dir}/dense, which may not exist for a
+    // contig without any dense stream. Create it so the write (and the contract)
+    // always succeeds.
+    if let Some(parent) = dense_out.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| ConversionError::Io {
+            context: format!("creating {}", parent.display()),
+            source,
+        })?;
+    }
+    let dense_arr = Array1::from_vec(vec![dense]); // shape (1,)
+    write_npy(&dense_out, &dense_arr).map_err(|source| ConversionError::Npy {
+        path: dense_out.display().to_string(),
+        source,
+    })?;
+    Ok(())
+}
+
+/// Per-column max deletion length over the `var_key/indel` stream, reshaped to
+/// `(n_samples, ploidy)`. Absent stream ⇒ all-zero (pure-SNP / no-indel contig).
+fn var_key_max_del(
+    contig_dir: &Path,
+    n_samples: usize,
+    ploidy: usize,
+) -> Result<Array2<u32>, ConversionError> {
+    let total_columns = n_samples * ploidy;
+    let indel_dir = layout::var_key_indel_dir(contig_dir);
+    let offsets_path = layout::offsets(&indel_dir);
+
+    // No offsets file ⇒ the stream was never written ⇒ zero output.
+    if !offsets_path.exists() {
+        return Ok(Array2::zeros((n_samples, ploidy)));
+    }
+
+    let offsets: Array1<u64> =
+        ndarray_npy::read_npy(&offsets_path).map_err(|source| ConversionError::ReadNpy {
+            path: offsets_path.display().to_string(),
+            source,
+        })?;
+    debug_assert_eq!(
+        offsets.len(),
+        total_columns + 1,
+        "offsets.npy length must be total_columns + 1"
+    );
+
+    let keys = read_keys(&layout::alleles(&indel_dir))?;
+
+    let mut per_col = vec![0u32; total_columns];
+    for (c, slot) in per_col.iter_mut().enumerate() {
+        let lo = offsets[c] as usize;
+        let hi = offsets[c + 1] as usize;
+        *slot = keys[lo..hi]
+            .iter()
+            .copied()
+            .map(deletion_len)
+            .max()
+            .unwrap_or(0);
+    }
+
+    // Sample-major columns (c = s*ploidy + p) ⇒ row-major reshape to (n_samples, ploidy).
+    Ok(Array2::from_shape_vec((n_samples, ploidy), per_col)
+        .expect("per_col length == n_samples * ploidy"))
+}
+
+/// Single max deletion length over the shared `dense/indel` key table. Absent
+/// stream ⇒ 0.
+fn dense_max_del_scalar(contig_dir: &Path) -> Result<u32, ConversionError> {
+    let keys = read_keys(&layout::alleles(&layout::dense_indel_dir(contig_dir)))?;
+    Ok(keys.iter().copied().map(deletion_len).max().unwrap_or(0))
+}
+
+/// Read a raw little-endian `u32` key file into a `Vec<u32>`. A missing file is
+/// treated as empty (an absent stream). Alignment-agnostic: `std::fs::read` may
+/// return an unaligned buffer, so decode via `chunks_exact(4)` rather than
+/// `bytemuck::cast_slice`.
+fn read_keys(path: &Path) -> Result<Vec<u32>, ConversionError> {
+    match std::fs::read(path) {
+        Ok(bytes) => Ok(bytes
+            .chunks_exact(4)
+            .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(source) => Err(ConversionError::Io {
+            context: format!("reading {}", path.display()),
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // `use super::*` already brings `Array1`, `Array2`, `Path`, `layout`,
+    // `write_npy`, `deletion_len`, and `write_max_del` into scope.
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Pure-DEL key for a deletion of `d` reference bases (`ilen = -d`), matching
+    /// the pure-DEL lane of `rvk::pack_variant`. `d == 0` yields a non-deletion
+    /// inline key (deletion_len 0). The encoder↔decoder faithfulness itself is
+    /// proven in `rvk`'s `deletion_len` tests; here we only exercise the scan.
+    fn del_key(d: u32) -> u32 {
+        if d == 0 {
+            0 // inline lane, bit 31 clear → not a deletion
+        } else {
+            ((-(d as i32)) << 1) as u32
+        }
+    }
+
+    /// Write a synthetic `var_key/indel` stream: `offsets.npy` (u64 prefix sum,
+    /// len total_columns+1) and `alleles.bin` (raw le u32 keys).
+    fn write_var_key_indel(contig_dir: &Path, offsets: &[u64], keys: &[u32]) {
+        let dir = layout::var_key_indel_dir(contig_dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        write_npy(layout::offsets(&dir), &Array1::from_vec(offsets.to_vec())).unwrap();
+        std::fs::write(layout::alleles(&dir), bytemuck::cast_slice(keys)).unwrap();
+    }
+
+    /// Write a synthetic `dense/indel` stream: just `alleles.bin` (raw le u32 keys).
+    fn write_dense_indel(contig_dir: &Path, keys: &[u32]) {
+        let dir = layout::dense_indel_dir(contig_dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(layout::alleles(&dir), bytemuck::cast_slice(keys)).unwrap();
+    }
+
+    fn read_max_del(contig_dir: &Path) -> Array2<u32> {
+        ndarray_npy::read_npy(layout::max_del(contig_dir)).unwrap()
+    }
+
+    fn read_dense_max_del(contig_dir: &Path) -> Array1<u32> {
+        ndarray_npy::read_npy(layout::dense_max_del(contig_dir)).unwrap()
+    }
+
+    #[test]
+    fn absent_streams_emit_all_zero_artifacts() {
+        // No var_key/indel, no dense/indel dirs at all. Contract still holds:
+        // an all-zero (n_samples, ploidy) file and a [0] dense scalar.
+        let tmp = tempdir().unwrap();
+        let c = tmp.path();
+        write_max_del(c, 2, 2).unwrap();
+        assert_eq!(read_max_del(c), Array2::<u32>::zeros((2, 2)));
+        assert_eq!(read_dense_max_del(c), Array1::from_vec(vec![0u32]));
+    }
+
+    #[test]
+    fn per_column_max_over_var_key_indel() {
+        // np = 4 columns (2 samples x ploidy 2), sample-major c = s*ploidy + p.
+        //   col 0: dels {3, 1}      → 3
+        //   col 1: {} (empty)       → 0
+        //   col 2: SNP/INS only     → 0
+        //   col 3: dels {2}         → 2
+        let tmp = tempdir().unwrap();
+        let c = tmp.path();
+        let keys = vec![
+            del_key(3),
+            del_key(1), // col 0
+            // col 1 empty
+            del_key(0),
+            del_key(0), // col 2: non-deletion inline keys
+            del_key(2), // col 3
+        ];
+        let offsets = vec![0u64, 2, 2, 4, 5];
+        write_var_key_indel(c, &offsets, &keys);
+
+        write_max_del(c, 2, 2).unwrap();
+        let m = read_max_del(c);
+        // row-major reshape: [[col0, col1], [col2, col3]]
+        assert_eq!(m[[0, 0]], 3);
+        assert_eq!(m[[0, 1]], 0);
+        assert_eq!(m[[1, 0]], 0);
+        assert_eq!(m[[1, 1]], 2);
+        // No dense stream → dense scalar is 0.
+        assert_eq!(read_dense_max_del(c), Array1::from_vec(vec![0u32]));
+    }
+
+    #[test]
+    fn dense_scalar_is_single_max_over_shared_keys() {
+        let tmp = tempdir().unwrap();
+        let c = tmp.path();
+        // A pure-SNP var_key side (no deletions) + a dense indel table with dels.
+        write_var_key_indel(c, &[0u64, 0, 0, 0, 0], &[]);
+        write_dense_indel(c, &[del_key(5), del_key(2), del_key(0)]);
+
+        write_max_del(c, 2, 2).unwrap();
+        assert_eq!(read_max_del(c), Array2::<u32>::zeros((2, 2)));
+        assert_eq!(read_dense_max_del(c), Array1::from_vec(vec![5u32]));
+    }
+}

--- a/src/max_del.rs
+++ b/src/max_del.rs
@@ -218,4 +218,58 @@ mod tests {
         assert_eq!(read_max_del(c), Array2::<u32>::zeros((2, 2)));
         assert_eq!(read_dense_max_del(c), Array1::from_vec(vec![5u32]));
     }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        // Random per-column deletion lengths → the produced (n_samples, ploidy)
+        // max_del must equal the brute-force per-column maximum. `0` marks a
+        // non-deletion call (SNP/INS). This is the primary correctness gate for
+        // the scan + column slicing + reshape.
+        #[test]
+        fn prop_var_key_max_del_matches_oracle(
+            n_samples in 1usize..4,
+            ploidy in 1usize..3,
+            // per-column deletion lengths, flattened; sized/chunked below.
+            col_lens in proptest::collection::vec(0usize..6, 0..12),
+            del_seeds in proptest::collection::vec(0u32..1000, 0..64),
+        ) {
+            let total_columns = n_samples * ploidy;
+
+            // Deterministic per-column call counts (0..=5) derived from col_lens.
+            let counts: Vec<usize> =
+                (0..total_columns).map(|c| col_lens.get(c).copied().unwrap_or(0)).collect();
+
+            // Assign deletion lengths to calls from del_seeds (cycled), building
+            // both the key stream and the per-column oracle max in lockstep.
+            let mut keys: Vec<u32> = Vec::new();
+            let mut offsets: Vec<u64> = vec![0u64; total_columns + 1];
+            let mut oracle = vec![0u32; total_columns];
+            let mut seed_i = 0usize;
+            for c in 0..total_columns {
+                let mut col_max = 0u32;
+                for _ in 0..counts[c] {
+                    let d = del_seeds.get(seed_i % del_seeds.len().max(1)).copied().unwrap_or(0);
+                    seed_i += 1;
+                    keys.push(del_key(d));
+                    col_max = col_max.max(d);
+                }
+                offsets[c + 1] = offsets[c] + counts[c] as u64;
+                oracle[c] = col_max;
+            }
+
+            let tmp = tempdir().unwrap();
+            let cdir = tmp.path();
+            write_var_key_indel(cdir, &offsets, &keys);
+            write_max_del(cdir, n_samples, ploidy).unwrap();
+
+            let m = read_max_del(cdir);
+            prop_assert_eq!(m.shape(), &[n_samples, ploidy]);
+            for (c, &want) in oracle.iter().enumerate() {
+                let s = c / ploidy;
+                let p = c % ploidy;
+                prop_assert_eq!(m[[s, p]], want, "col {}", c);
+            }
+        }
+    }
 }

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -251,6 +251,11 @@ pub fn process_chromosome(
         );
     }
 
+    // M5 post-pass: emit max-deletion-length artifacts for the overlap query.
+    // A pure scan of the finished indel key streams — decoupled from the merge.
+    let contig_dir = std::path::Path::new(base_out_dir).join(chrom);
+    crate::max_del::write_max_del(&contig_dir, samples.len(), ploidy)?;
+
     println!("[{}] Pipeline Execution Finished Successfully.", chrom);
 
     Ok(())

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -260,6 +260,33 @@ pub fn pack_variant(ilen: i32, alt_allele: &[u8], bank: &mut LongAlleleTableWrit
     (ilen as u32) << 1
 }
 
+/// Reference-base deletion length encoded in a 32-bit indel `var_key`/`dense` key.
+///
+/// Inverse of the DEL lane of [`pack_variant`]: a pure DEL clears the lookup flag
+/// (`bit 0 == 0`) and sets the top bit (`bit 31 == 1`), storing its signed `ilen`
+/// in `bits[31:1]`; the deletion length is `-ilen`. Inline INS/SNP keys clear the
+/// top bit, and long-INS lookup keys set `bit 0`, so both yield `0`. This is the
+/// single decode site for the deletion length — the bit layout stays co-located
+/// with the encoder (respecting the encoding-agnostic seam).
+#[inline]
+pub fn deletion_len(key: u32) -> u32 {
+    // Long-INS lookup keys set the LSB; they are never deletions. Checked first
+    // because such a key can also have its top bit set (a large row index).
+    if key & 1 == 1 {
+        return 0;
+    }
+    // Inline lane. Pure DEL sets the top bit; INS/SNP clear it.
+    if key & (1 << 31) == 0 {
+        return 0;
+    }
+    let ilen = (key as i32) >> 1; // arithmetic shift recovers the signed i31
+    debug_assert!(
+        ilen < 0,
+        "top-bit-set inline key must be a negative-ilen DEL"
+    );
+    ilen.unsigned_abs()
+}
+
 // The two inline flavors, tagged for stream routing (the encoding-seam output;
 // see architecture.md#the-encoding-agnostic-seam).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -626,6 +653,35 @@ mod tests {
         assert_eq!(((key as i32) >> 1), -3);
         // (-3i32 << 1) = -6 → as u32 = 0xFFFFFFFA
         assert_eq!(key, 0xFFFFFFFAu32);
+    }
+
+    #[test]
+    fn test_deletion_len_snp_and_ins_are_zero() {
+        let mut bank = make_bank();
+        // SNP (ilen 0) and INS (ilen > 0) carry no deletion.
+        let snp = pack_variant(0, b"C", &mut bank);
+        let ins = pack_variant(2, b"ACG", &mut bank);
+        assert_eq!(deletion_len(snp), 0);
+        assert_eq!(deletion_len(ins), 0);
+    }
+
+    #[test]
+    fn test_deletion_len_small_and_large_del() {
+        let mut bank = make_bank();
+        // ref=ACGT alt=A → ilen=-3, deletion of 3 reference bases.
+        let small = pack_variant(-3, b"A", &mut bank);
+        assert_eq!(deletion_len(small), 3);
+        // Largest atomizable deletion: ilen == MIN_I31 → d == 1 << 30.
+        let large = pack_variant(crate::types::MIN_I31, b"A", &mut bank);
+        assert_eq!(deletion_len(large), (1u32 << 30));
+    }
+
+    #[test]
+    fn test_deletion_len_lookup_key_is_zero() {
+        // A long-INS lookup key sets the LSB. Even with the top bit set
+        // (a large row index), the LSB check must win → not a deletion.
+        assert_eq!(deletion_len(0x0000_0003), 0); // LSB set
+        assert_eq!(deletion_len(0xFFFF_FFFF), 0); // LSB set AND top bit set
     }
 
     #[test]

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -10,6 +10,7 @@ mod common;
 use common::{SynthRecord, build_bcf_with_index, read_offsets_npy, read_u32_bin};
 use genoray_core::process_chromosome;
 use genoray_core::rvk::decode_alt_inline;
+use genoray_core::search::{SearchTree, overlap_range};
 use genoray_core::vcf_reader::VcfChunkReader;
 
 use tempfile::tempdir;
@@ -137,6 +138,84 @@ fn test_e2e_normalized_bcf_pipeline() {
     assert!(genoray_core::bits::get_bit(&dindel_geno, 1)); // hap1
     assert!(!genoray_core::bits::get_bit(&dindel_geno, 2));
     assert!(!genoray_core::bits::get_bit(&dindel_geno, 3));
+}
+
+// M5 max_del post-pass, end-to-end. Two deletions with known lengths:
+//   pos=100  ATTT → A  (d=3)  gt=[1,0,0,0]  x=1 → rare → var_key/indel (hap 0)
+//   pos=200  ATT  → A  (d=2)  gt=[1,1,1,0]  x=3 → common → dense/indel (shared)
+// Asserts the produced artifacts, then feeds max_del into overlap_range to prove
+// a deletion that starts left of the query but spans into it is recoverable.
+#[test]
+fn test_e2e_max_del_postpass() {
+    let tmp = tempdir().unwrap();
+    let bcf_path = tmp.path().join("maxdel.bcf");
+    let samples = vec!["S0", "S1"]; // np = 4
+
+    let records = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"ATTT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 0, 0, 0], // hap 0 only → var_key/indel
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"ATT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 1, 0], // haps 0,1,2 → dense/indel
+        },
+    ];
+    build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
+
+    let out_dir = tmp.path().join("out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    process_chromosome(
+        bcf_path.to_str().unwrap(),
+        "chr1",
+        out_dir.to_str().unwrap(),
+        &samples,
+        100,
+        2,
+        1,
+        4096,
+    )
+    .expect("conversion");
+
+    let contig_dir = out_dir.join("chr1");
+
+    // var_key max_del: shape (2, 2); only col 0 (S0_p0) carries the d=3 deletion.
+    let m: ndarray::Array2<u32> = ndarray_npy::read_npy(contig_dir.join("max_del.npy")).unwrap();
+    assert_eq!(m.shape(), &[2, 2]);
+    assert_eq!(m[[0, 0]], 3);
+    assert_eq!(m[[0, 1]], 0);
+    assert_eq!(m[[1, 0]], 0);
+    assert_eq!(m[[1, 1]], 0);
+
+    // dense max_del: shape (1,); single max over the shared indel table = 2.
+    let dm: ndarray::Array1<u32> =
+        ndarray_npy::read_npy(contig_dir.join("dense/max_del.npy")).unwrap();
+    assert_eq!(dm, ndarray::Array1::from_vec(vec![2u32]));
+
+    // Close the producer -> consumer loop: the var_key/indel deletion for hap 0
+    // starts at pos 100 and spans 3 bases (v_end = 100 + 1 + 3 = 104). A query
+    // strictly right of the start but inside the deletion must still find it,
+    // using the produced max_del as max_region_length.
+    let vk_indel = contig_dir.join("var_key/indel");
+    let off = read_offsets_npy(&vk_indel.join("offsets.npy"));
+    let pos = read_u32_bin(&vk_indel.join("positions.bin"));
+    // hap 0 owns exactly the [off[0], off[1]) slice = one call at pos 100.
+    let col0 = &pos[off[0] as usize..off[1] as usize];
+    assert_eq!(col0, &[100u32]);
+
+    let v_starts: Vec<u32> = col0.to_vec();
+    let v_ends: Vec<u32> = vec![100 + 1 + 3]; // start + 1 + d, d = max_del[0,0]
+    let tree = SearchTree::new(&v_starts);
+    let max_region_length = m[[0, 0]];
+    // query [102, 103): starts right of variant start 100 but inside the deletion.
+    assert_eq!(
+        overlap_range(&tree, &v_ends, max_region_length, 102, 103),
+        (0, 1)
+    );
 }
 
 // Dense round-trip: a SNP carried by most of a small cohort must be routed to


### PR DESCRIPTION
## Summary

**SVAR 2.0 — M5 part 2a: `max_del` standalone post-pass (producer).**

Produces, as a standalone post-pass over a finished SVAR2 contig directory, the
per-`(sample, ploid)` and dense max-deletion-length artifacts that the `(range, sample)`
overlap query will consume:

- `max_del.npy` — `u32`, shape `(n_samples, ploidy)`, at `{contig_dir}/max_del.npy`.
- `dense/max_del.npy` — `u32`, shape `(1,)`, at `{contig_dir}/dense/max_del.npy`.

Both are **always written** — a no-deletion contig emits all-zero artifacts, so the
consumer never special-cases a missing file. A deletion's reference-base length is fully
recoverable from the already-written indel key streams (a pure DEL packs its signed
`ilen` inline), so the pass is a decoupled scan of `alleles.bin` — **no LUT reads, no
reference genome, no coupling to the conversion/merge write path.**

### What's in this PR (5 commits + docs)

- `rvk::deletion_len` — the single decoder for a deletion's ref-base length from a 32-bit
  indel key (co-located with the `pack_variant` encoder).
- Four `layout` path helpers for the post-pass (keeps `layout.rs` the single source of
  on-disk paths).
- `src/max_del.rs` — the producer (`write_max_del`): per-column max over `var_key/indel`
  reshaped sample-major to `(n_samples, ploidy)`, plus the dense scalar over
  `dense/indel`; a `ReadNpy` error variant.
- Brute-force per-column **oracle proptest** for the producer.
- Orchestrator wiring (runs after each contig's merge) + an **e2e round-trip** that feeds
  the produced `max_del` into `search::overlap_range` to close the producer↔consumer loop.

### Testing

Full suite green (`pixi run cargo test --no-default-features`): all lib + integration
tests pass, including the new `max_del::` unit tests, the oracle proptest, and
`test_e2e_max_del_postpass`. `cargo fmt` + `cargo clippy --all-targets -- -D warnings`
clean.

### Frozen-contract note

The shapes/dtypes/paths above are the frozen contract shared with the sibling
`(range, sample)` query workstream (they must match, as that branch consumes these files).
The producer was reviewed against `merge.rs`/`streams.rs`/`dense.rs` to confirm the
on-disk assumptions hold.

> Note: `origin/svar-2` is a couple of commits behind the local `svar-2` this branch was
> cut from, so this PR currently also lists two pre-existing `svar-2` commits (gitignore
> chore + the three-parallel-specs doc). They drop out once `svar-2` is pushed.

## SVAR 2.0 roadmap check

- [x] Re-read `svar-2.md`, `data-model.md`, and `architecture.md`.
- [x] Milestone checkboxes/statuses updated to match reality — **M5 stays `[~]`**; the
      "Remaining" note now records the `max_del` **producer** as shipped (part 2a),
      leaving the consumer, sub-stream union, per-`(contig, sample, ploid)` wiring, and
      genotype gather.
- [x] Data-model/architecture reconciled — no change needed: `data-model.md` already
      specifies the `max_del.npy` contract (`(sample, ploid)` `u32`, indel-sub-streams
      only, per-contig `dense/max_del.npy`) exactly as implemented here.
- [x] No new open questions — the deferred scope (consumer, batch-sweep/Python
      entrypoint, `pointer/indel` fold-in) is already tracked in the M5 "Remaining" note
      and the plan's deferred-scope section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
