### PR TITLE
feat(svar-2): M2b — left-alignment during conversion

### DIFF
--- a/docs/roadmap/data-model.md
+++ b/docs/roadmap/data-model.md
@@ -276,14 +276,18 @@ always normalized:
   anchored INS / anchored DEL), mirroring bcftools `_atomize_allele`.
 - **Biallelic split (M2)** — split multi-allelic sites into separate biallelic records,
   remapping genotypes by original ALT index.
-- **Left-alignment (M2b, deferred)** — shift indels to their leftmost equivalent
-  position. Deferred because it is the only step requiring a reference genome.
+- **Left-alignment (M2b)** — shift each anchored indel to its leftmost reference-equivalent
+  position (classic VCF repeat roll, matching `bcftools norm -a -m- -f`), capped at a
+  bounded window `L_MAX` (default 1000 bases; indels inside a longer repeat are left
+  partially aligned, as bcftools does at its `--buffer-size` limit). Requires a reference
+  FASTA (faidx), threaded as a required conversion argument. Deletion length is invariant,
+  so overlap/`max_del` semantics are unaffected.
 
 This keeps `ILEN`/ALT semantics simple and makes the inline encoding well-defined.
-Because atomization spreads atom positions rightward (and, once M2b lands,
-left-alignment shifts them leftward), the reader emits atoms through a position-keyed
-reorder buffer so each per-`(sample, ploid)` stream stays position-sorted for the
-interleaving merge.
+Because atomization spreads atom positions rightward (and left-alignment shifts them
+leftward by up to `L_MAX`), the reader emits atoms through a position-keyed reorder buffer
+whose emit bound is relaxed by `L_MAX`, so each per-`(sample, ploid)` stream stays
+position-sorted for the interleaving merge.
 
 ## Overlap queries and deletions
 

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -82,11 +82,16 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   each haplotype's integer allele index to the atom's source ALT index. The former
   "input must be normalized" asserts are gone; symbolic/breakend ALTs are rejected and
   `*`/`.` alleles are skipped.
-- [ ] **M2b. Left-alignment during conversion.** Shift indels to their leftmost
+- [x] **M2b. Left-alignment during conversion.** Shift indels to their leftmost
   equivalent position. Deferred from M2 because it is the only normalization step that
   needs a reference genome (FASTA/faidx) and a new required conversion argument, and it
   widens the reorder-buffer bound (leftward shifts). See
   [`data-model.md`](data-model.md#variant-normalization).
+  *Done:* `normalize::left_align` rolls anchored indels leftward (repeat-slide, capped at
+  `L_MAX`), validated against `bcftools norm -a -m- -f`; `validate_ref` fails fast on
+  REF/FASTA disagreement; the reference FASTA threads through `process_chromosome` and the
+  PyO3 entry point as a required argument; and `vcf_reader::next_atom`'s emit bound is
+  widened by `L_MAX` to keep emission position-sorted.
 - [x] **M3. Per-contig split + sidecar positions + format finalization.** Partition the
   SVAR2 directory by contig; keep positions as sidecar arrays; finalize the on-disk
   format. See [`architecture.md`](architecture.md#on-disk-layout).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,11 @@ pub use orchestrator::process_chromosome;
 //The Python Wrapper and resource allocator
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (vcf_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608))]
+#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608))]
 fn run_conversion_pipeline(
     py: Python,
     vcf_path: String,
+    reference_path: String,
     chroms: Vec<String>, // now taking a vector
     output_dir: String,
     samples: Vec<String>,
@@ -94,6 +95,7 @@ fn run_conversion_pipeline(
                     println!("==> Processing {}", chrom);
                     orchestrator::process_chromosome(
                         &vcf_path,
+                        &reference_path,
                         chrom,
                         &output_dir,
                         &sample_refs,

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -6,7 +6,31 @@
 pub enum NormalizeError {
     #[error("symbolic/breakend ALT '{alt}' at pos {pos} is out of scope (short-read only)")]
     SymbolicAllele { pos: u32, alt: String },
+    #[error("REF '{expected}' at pos {pos} disagrees with reference FASTA ('{found}')")]
+    RefMismatch {
+        pos: u32,
+        expected: String,
+        found: String,
+    },
+    #[error(
+        "REF at pos {pos} needs reference bases up to {needed_end} but contig is only \
+         {contig_len} long"
+    )]
+    RefOutOfContig {
+        pos: u32,
+        needed_end: usize,
+        contig_len: usize,
+    },
 }
+
+/// Maximum leftward shift (in reference bases) applied during left-alignment, and the
+/// matching width by which the reorder buffer's emit bound is relaxed (see
+/// `crate::vcf_reader::VcfChunkReader::next_atom`). Left-alignment never moves an atom
+/// more than `L_MAX` bases; an indel inside a repeat longer than `L_MAX` is left
+/// *partially* aligned — the same truncation `bcftools` applies at its `--buffer-size`
+/// limit. Conservative default pending measurement on representative short-read VCFs (the
+/// M2b spec's open question); real short-read indel/STR shifts are far below this.
+pub const L_MAX: u32 = 1000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Atom {
@@ -41,6 +65,31 @@ pub fn atomize_record(
             });
         }
         atomize_biallelic(pos, ref_allele, alt, src, out);
+    }
+    Ok(())
+}
+
+/// Fail-fast check that a record's REF allele matches the reference FASTA. Left-alignment
+/// rolls an indel against the reference, so a REF that disagrees with the FASTA would
+/// silently corrupt positions; reject it instead (a mismatch is an error, never silently
+/// "corrected"). Comparison is ASCII-case-insensitive so soft-masked (lowercase)
+/// reference bases match uppercase VCF alleles. `ref_seq` is the full 0-based contig.
+pub fn validate_ref(pos: u32, ref_allele: &[u8], ref_seq: &[u8]) -> Result<(), NormalizeError> {
+    let start = pos as usize;
+    let needed_end = start + ref_allele.len();
+    if needed_end > ref_seq.len() {
+        return Err(NormalizeError::RefOutOfContig {
+            pos,
+            needed_end,
+            contig_len: ref_seq.len(),
+        });
+    }
+    if !ref_seq[start..needed_end].eq_ignore_ascii_case(ref_allele) {
+        return Err(NormalizeError::RefMismatch {
+            pos,
+            expected: String::from_utf8_lossy(ref_allele).into_owned(),
+            found: String::from_utf8_lossy(&ref_seq[start..needed_end]).into_owned(),
+        });
     }
     Ok(())
 }
@@ -241,6 +290,43 @@ mod tests {
         assert!(matches!(
             atomize_record(100, b"A", &[b"A[chr2:321[".as_slice()], &mut out),
             Err(NormalizeError::SymbolicAllele { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_ref_accepts_matching_ref() {
+        // ref_seq (0-based): A C G T A C
+        let ref_seq = b"ACGTAC";
+        assert_eq!(validate_ref(2, b"GT", ref_seq), Ok(()));
+        assert_eq!(validate_ref(0, b"A", ref_seq), Ok(()));
+    }
+
+    #[test]
+    fn validate_ref_is_case_insensitive() {
+        // Soft-masked (lowercase) reference bases must still match uppercase VCF REF.
+        let ref_seq = b"acgtac";
+        assert_eq!(validate_ref(2, b"GT", ref_seq), Ok(()));
+    }
+
+    #[test]
+    fn validate_ref_rejects_mismatch() {
+        let ref_seq = b"ACGTAC";
+        assert!(matches!(
+            validate_ref(2, b"AA", ref_seq),
+            Err(NormalizeError::RefMismatch { pos: 2, .. })
+        ));
+    }
+
+    #[test]
+    fn validate_ref_rejects_out_of_contig() {
+        let ref_seq = b"ACGT";
+        assert!(matches!(
+            validate_ref(3, b"TAC", ref_seq),
+            Err(NormalizeError::RefOutOfContig {
+                pos: 3,
+                needed_end: 6,
+                contig_len: 4
+            })
         ));
     }
 

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -94,6 +94,54 @@ pub fn validate_ref(pos: u32, ref_allele: &[u8], ref_seq: &[u8]) -> Result<(), N
     Ok(())
 }
 
+/// Shift an anchored indel atom to its leftmost reference-equivalent position (classic VCF
+/// left-alignment / repeat roll), capped at `l_max` leftward bases. SNP atoms and
+/// substituted-anchor insertions never move. `ref_seq` is the full 0-based contig
+/// (uppercased); the caller must have run `validate_ref` on the source record first, so
+/// every reference read here is in-bounds. Only `pos` and the anchor base(s) in `alt`
+/// change — `ilen` (and thus deletion length) and `source_alt_index` are invariant.
+pub fn left_align(mut atom: Atom, ref_seq: &[u8], l_max: u32) -> Atom {
+    use std::cmp::Ordering;
+    match atom.ilen.cmp(&0) {
+        Ordering::Equal => atom, // SNP: never moves.
+        Ordering::Less => {
+            // Deletion: anchor at `pos`, `ndel` deleted bases at ref_seq[pos+1 ..= pos+ndel].
+            // Roll while the anchor base equals the last deleted base.
+            let ndel = (-atom.ilen) as usize;
+            let mut pos = atom.pos as usize;
+            let mut shifts = 0u32;
+            while pos > 0 && shifts < l_max && ref_seq[pos] == ref_seq[pos + ndel] {
+                pos -= 1;
+                shifts += 1;
+            }
+            atom.pos = pos as u32;
+            atom.alt = vec![ref_seq[pos]]; // pure DEL: alt is the (new) anchor base.
+            atom
+        }
+        Ordering::Greater => {
+            // Insertion: alt = [anchor] ++ inserted. Roll only a clean anchor; a
+            // substituted anchor is SNP+INS and stays put.
+            let mut pos = atom.pos as usize;
+            if ref_seq[pos] != atom.alt[0] {
+                return atom;
+            }
+            let mut inserted: Vec<u8> = atom.alt[1..].to_vec();
+            let mut shifts = 0u32;
+            while pos > 0 && shifts < l_max && ref_seq[pos] == *inserted.last().unwrap() {
+                inserted.rotate_right(1);
+                pos -= 1;
+                shifts += 1;
+            }
+            let mut alt = Vec::with_capacity(1 + inserted.len());
+            alt.push(ref_seq[pos]);
+            alt.extend_from_slice(&inserted);
+            atom.pos = pos as u32;
+            atom.alt = alt;
+            atom
+        }
+    }
+}
+
 #[inline]
 fn is_symbolic(alt: &[u8]) -> bool {
     alt.first() == Some(&b'<') || alt.contains(&b'[') || alt.contains(&b']')
@@ -328,6 +376,125 @@ mod tests {
                 contig_len: 4
             })
         ));
+    }
+
+    // Reference used across left_align tests (0-based indices):
+    //  0:C 1:A 2:A 3:A 4:A 5:T 6:C 7:A 8:G 9:A 10:G 11:T
+    const LA_REF: &[u8] = b"CAAAATCAGAGT";
+
+    #[test]
+    fn left_align_deletion_rolls_through_homopolymer() {
+        // AA>A anchored at pos 3 (delete one A) → bcftools: pos 0, REF "CA" ALT "C".
+        let a = atom(3, -1, b"A", 1);
+        assert_eq!(left_align(a, LA_REF, L_MAX), atom(0, -1, b"C", 1));
+    }
+
+    #[test]
+    fn left_align_deletion_stops_at_contig_start() {
+        // The homopolymer roll above lands exactly on pos 0 (contig start) and stops
+        // there without reading ref_seq[-1].
+        let a = atom(3, -1, b"A", 1);
+        assert_eq!(left_align(a, LA_REF, L_MAX).pos, 0);
+    }
+
+    #[test]
+    fn left_align_insertion_rolls_through_homopolymer() {
+        // A>AA anchored at pos 3 (insert one A) → bcftools: pos 0, REF "C" ALT "CA".
+        let a = atom(3, 1, b"AA", 1);
+        assert_eq!(left_align(a, LA_REF, L_MAX), atom(0, 1, b"CA", 1));
+    }
+
+    #[test]
+    fn left_align_dinucleotide_deletion_rolls_repeat() {
+        // GAG>G anchored at pos 8 (delete "AG" from the AGAG repeat) → bcftools:
+        // pos 6, REF "CAG" ALT "C".
+        let a = atom(8, -2, b"G", 1);
+        assert_eq!(left_align(a, LA_REF, L_MAX), atom(6, -2, b"C", 1));
+    }
+
+    #[test]
+    fn left_align_snp_never_moves() {
+        let a = atom(3, 0, b"T", 1);
+        assert_eq!(left_align(a, LA_REF, L_MAX), atom(3, 0, b"T", 1));
+    }
+
+    #[test]
+    fn left_align_substituted_anchor_insertion_stays_put() {
+        // alt[0]='G' but ref_seq[3]='A' → substituted anchor (SNP+INS), not a pure
+        // insertion. Must not roll.
+        let a = atom(3, 1, b"GT", 1);
+        assert_eq!(left_align(a, LA_REF, L_MAX), atom(3, 1, b"GT", 1));
+    }
+
+    #[test]
+    fn left_align_respects_l_max_partial_align() {
+        // Same homopolymer deletion, but l_max = 2 caps the roll: pos 3 → 1 (two shifts),
+        // not all the way to 0.
+        let a = atom(3, -1, b"A", 1);
+        let out = left_align(a, LA_REF, 2);
+        assert_eq!(out.pos, 1);
+        assert_eq!(out.alt, b"A".to_vec()); // ref_seq[1] == 'A'
+    }
+
+    // Apply a (clean) indel atom to a copy of the reference, returning the alt haplotype.
+    // DEL removes ref_seq[pos+1 ..= pos+ndel]; INS splices alt[1..] in after `pos`.
+    fn apply_edit(atom: &Atom, ref_seq: &[u8]) -> Vec<u8> {
+        let pos = atom.pos as usize;
+        let mut out = ref_seq[..=pos].to_vec();
+        if atom.ilen > 0 {
+            out.extend_from_slice(&atom.alt[1..]);
+            out.extend_from_slice(&ref_seq[pos + 1..]);
+        } else {
+            let ndel = (-atom.ilen) as usize;
+            out.extend_from_slice(&ref_seq[pos + 1 + ndel..]);
+        }
+        out
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2000))]
+
+        // Left-alignment preserves the alt haplotype (reference-equivalent) and produces a
+        // representation that cannot shift further left within L_MAX.
+        #[test]
+        fn left_align_is_reference_equivalent_and_leftmost(
+            reference in proptest::collection::vec(
+                prop_oneof![Just(b'A'), Just(b'C'), Just(b'G'), Just(b'T')], 2..40),
+            anchor in 0usize..38,
+            is_del in any::<bool>(),
+            unit in proptest::collection::vec(
+                prop_oneof![Just(b'A'), Just(b'C'), Just(b'G'), Just(b'T')], 1..4),
+        ) {
+            let n = reference.len();
+            let pos = anchor % (n - 1); // leave room for >= 1 base to the right
+
+            let atom = if is_del {
+                // Clean DEL: delete up to `unit.len()` bases starting at pos+1.
+                let ndel = unit.len().min(n - pos - 1);
+                if ndel == 0 { return Ok(()); }
+                Atom { pos: pos as u32, ilen: -(ndel as i32),
+                       alt: vec![reference[pos]], source_alt_index: 1 }
+            } else {
+                // Clean INS: anchor is the true reference base, insert `unit`.
+                let mut alt = vec![reference[pos]];
+                alt.extend_from_slice(&unit);
+                Atom { pos: pos as u32, ilen: unit.len() as i32,
+                       alt, source_alt_index: 1 }
+            };
+
+            let aligned = left_align(atom.clone(), &reference, L_MAX);
+
+            // 1. Reference-equivalent: same alt haplotype.
+            prop_assert_eq!(apply_edit(&atom, &reference), apply_edit(&aligned, &reference));
+
+            // 2. Length invariant.
+            prop_assert_eq!(aligned.ilen, atom.ilen);
+
+            // 3. Leftmost within L_MAX: applying left_align again is a fixpoint.
+            let again = left_align(aligned.clone(), &reference, L_MAX);
+            prop_assert_eq!(&again.pos, &aligned.pos);
+            prop_assert_eq!(&again.alt, &aligned.alt);
+        }
     }
 
     proptest! {

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -43,6 +43,7 @@ parallel memory architecture.
 #[allow(clippy::too_many_arguments)]
 pub fn process_chromosome(
     vcf_path: &str,
+    fasta_path: &str,
     chrom: &str,
     base_out_dir: &str,
     samples: &[&str],
@@ -118,6 +119,7 @@ pub fn process_chromosome(
         .name(format!("read-{}", chrom))
         .spawn({
             let vcf = vcf_path.to_string();
+            let fasta = fasta_path.to_string();
             let chr = chrom.to_string();
             // Convert references into owned Strings that can safely live forever in the thread
             let s_owned: Vec<String> = samples.iter().map(|&s| s.to_string()).collect();
@@ -125,7 +127,8 @@ pub fn process_chromosome(
             move || {
                 // passing the thread budget down to HTSLib
                 let s_refs: Vec<&str> = s_owned.iter().map(|s| s.as_str()).collect();
-                let mut reader = VcfChunkReader::new(&vcf, &chr, &s_refs, htslib_threads, ploidy);
+                let mut reader =
+                    VcfChunkReader::new(&vcf, &fasta, &chr, &s_refs, htslib_threads, ploidy);
                 let mut chunk_id = 0;
                 while let Some(dense_chunk) = reader.read_next_chunk(chunk_size, chunk_id) {
                     tx_dense.send(dense_chunk).unwrap();

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -92,7 +92,15 @@ impl VcfChunkReader {
         // soft-masked (lowercase) reference bases compare equal to uppercase VCF alleles.
         let fasta = rust_htslib::faidx::Reader::from_path(fasta_path)
             .expect("Failed to open reference FASTA (is there a .fai?)");
-        let contig_len = fasta.fetch_seq_len(chrom) as usize;
+        // htslib's faidx_seq_len returns -1 for an unknown contig, which fetch_seq_len
+        // (via rust-htslib) surfaces as u64::MAX rather than 0 — check for it explicitly
+        // so a missing contig fails fast with a clear message instead of the generic
+        // "Failed to fetch contig" panic below.
+        let contig_len_raw = fasta.fetch_seq_len(chrom);
+        if contig_len_raw == u64::MAX {
+            panic!("Contig '{chrom}' not found in reference FASTA");
+        }
+        let contig_len = contig_len_raw as usize;
         let mut ref_seq = if contig_len == 0 {
             Vec::new()
         } else {
@@ -187,8 +195,10 @@ impl VcfChunkReader {
     //
     // Memory note: the heap holds every atom with pos >= frontier - L_MAX until a later
     // record advances the frontier past that window (or EOF). For coordinate-sorted input
-    // this is bounded by the atoms within an `L_MAX`-wide window of the frontier; shifts
-    // are capped at `L_MAX` so the window — and thus memory — stays bounded.
+    // this is bounded by the atoms within an `L_MAX`-wide window of the frontier, plus
+    // atoms sharing a single start position — a run of many records all starting at the
+    // same pos never advances the frontier, so the heap can still grow unboundedly in
+    // that (pre-existing) pathological case.
     fn next_atom(&mut self) -> Option<PendingAtom> {
         loop {
             if let Some(Reverse(top)) = self.heap.peek() {

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -39,9 +39,8 @@ pub struct VcfChunkReader {
     num_samples: usize,
     ploidy: usize,
     sample_indices: Vec<usize>,
-    // full 0-based contig sequence, uppercased. Cached now so `new`'s signature and
-    // loading are stable; consumed by `validate_ref`/`left_align` starting M2b Task 4.
-    #[allow(dead_code)]
+    // full 0-based contig sequence, uppercased. Consumed by `validate_ref`/`left_align`
+    // in `decompose_current_record`.
     ref_seq: Vec<u8>,
 
     // Reorder state, persisted across read_next_chunk calls.
@@ -152,12 +151,20 @@ impl VcfChunkReader {
         }
         let gt = Rc::new(gt);
 
+        // Fail fast if the record's REF disagrees with the reference FASTA — left-alignment
+        // rolls against the reference, so a mismatch would silently corrupt positions.
+        crate::normalize::validate_ref(pos, &ref_allele, &self.ref_seq)
+            .expect("REF disagrees with reference FASTA");
+
         let alt_refs: Vec<&[u8]> = alts_owned.iter().map(|a| a.as_slice()).collect();
         let mut atoms = Vec::new();
         atomize_record(pos, &ref_allele, &alt_refs, &mut atoms)
             .expect("symbolic/breakend ALT is out of scope for SVAR2 (short-read only)");
 
         for atom in atoms {
+            // Left-align each anchored indel to its leftmost equivalent position (SNPs and
+            // substituted-anchor insertions are returned unchanged).
+            let atom = crate::normalize::left_align(atom, &self.ref_seq, crate::normalize::L_MAX);
             let seq = self.next_seq;
             self.next_seq += 1;
             self.heap.push(Reverse(PendingAtom {

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -39,6 +39,10 @@ pub struct VcfChunkReader {
     num_samples: usize,
     ploidy: usize,
     sample_indices: Vec<usize>,
+    // full 0-based contig sequence, uppercased. Cached now so `new`'s signature and
+    // loading are stable; consumed by `validate_ref`/`left_align` starting M2b Task 4.
+    #[allow(dead_code)]
+    ref_seq: Vec<u8>,
 
     // Reorder state, persisted across read_next_chunk calls.
     record: Record,
@@ -52,6 +56,7 @@ impl VcfChunkReader {
     // opens the file, applies the sample filter at the C-level, and jumps to the chromosome.
     pub fn new(
         vcf_path: &str,
+        fasta_path: &str,
         chrom: &str,
         samples: &[&str],
         htslib_threads: usize,
@@ -83,6 +88,21 @@ impl VcfChunkReader {
             })
             .collect();
 
+        // Cache the full contig once per worker (simplest; one contig per worker at a
+        // time). fetch_seq's `end` is inclusive, so [0, contig_len-1]. Uppercase so
+        // soft-masked (lowercase) reference bases compare equal to uppercase VCF alleles.
+        let fasta = rust_htslib::faidx::Reader::from_path(fasta_path)
+            .expect("Failed to open reference FASTA (is there a .fai?)");
+        let contig_len = fasta.fetch_seq_len(chrom) as usize;
+        let mut ref_seq = if contig_len == 0 {
+            Vec::new()
+        } else {
+            fasta
+                .fetch_seq(chrom, 0, contig_len - 1)
+                .expect("Failed to fetch contig from reference FASTA")
+        };
+        ref_seq.make_ascii_uppercase();
+
         let record = reader.empty_record();
 
         Self {
@@ -90,6 +110,7 @@ impl VcfChunkReader {
             num_samples: samples.len(),
             ploidy,
             sample_indices,
+            ref_seq,
             record,
             heap: BinaryHeap::new(),
             frontier: 0,
@@ -151,19 +172,20 @@ impl VcfChunkReader {
     }
 
     // Yield the next atom in global position order, reading and decomposing more
-    // records as needed. An atom is safe to emit once its position is strictly below
-    // the read frontier (no future atom can precede the frontier, since there is no
-    // left-alignment) or once the input is exhausted.
+    // records as needed. Left-alignment (M2b) can move an atom up to `L_MAX` bases below
+    // its record's start, so a future record at start `frontier` may still produce an atom
+    // as low as `frontier - L_MAX`. An atom is therefore safe to emit only once its
+    // position is strictly below `frontier - L_MAX` (saturating), or the input is
+    // exhausted — this preserves the position-sorted invariant the Phase-2 merge relies on.
     //
-    // Memory note: the heap holds every atom whose pos == frontier until a record with a
-    // strictly greater start pos advances the frontier (or EOF). For coordinate-sorted
-    // input this is bounded by the atoms at a single position; a pathological run of many
-    // records sharing one start pos would grow it. M2b (left-alignment) weakens the
-    // `pos >= record_start` premise and must revisit this bound.
+    // Memory note: the heap holds every atom with pos >= frontier - L_MAX until a later
+    // record advances the frontier past that window (or EOF). For coordinate-sorted input
+    // this is bounded by the atoms within an `L_MAX`-wide window of the frontier; shifts
+    // are capped at `L_MAX` so the window — and thus memory — stays bounded.
     fn next_atom(&mut self) -> Option<PendingAtom> {
         loop {
             if let Some(Reverse(top)) = self.heap.peek() {
-                if self.eof || top.pos < self.frontier {
+                if self.eof || top.pos < self.frontier.saturating_sub(crate::normalize::L_MAX) {
                     return Some(self.heap.pop().unwrap().0);
                 }
             } else if self.eof {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -64,6 +64,33 @@ pub fn build_bcf_with_index(
         .expect("build BCF index");
 }
 
+/// Build a FASTA (+ `.fai`) whose single contig is `chrom_len` bases of 'N' filler with
+/// each record's REF allele stamped at its 0-based `pos`, so it agrees with the records
+/// pushed into the companion BCF. 'N' filler never satisfies the left-align repeat
+/// condition, so records that should not move don't. Overlapping records must agree on
+/// their shared bases (real VCFs are reference-consistent).
+#[allow(dead_code)]
+pub fn build_fasta_with_index(
+    fasta_path: &Path,
+    chrom: &str,
+    chrom_len: usize,
+    records: &[SynthRecord],
+) {
+    use std::io::Write;
+    let mut seq = vec![b'N'; chrom_len];
+    for rec in records {
+        let start = rec.pos as usize;
+        seq[start..start + rec.ref_allele.len()].copy_from_slice(rec.ref_allele);
+    }
+    {
+        let mut f = std::fs::File::create(fasta_path).expect("create fasta");
+        writeln!(f, ">{}", chrom).expect("write header");
+        f.write_all(&seq).expect("write seq");
+        writeln!(f).expect("write newline");
+    }
+    rust_htslib::faidx::build(fasta_path).expect("build .fai");
+}
+
 // Not every integration-test binary that pulls in this shared `mod common;` calls
 // every helper (e.g. test_atomize_e2e.rs never reads on-disk binary output). Each
 // test file is its own compilation unit, so clippy's dead-code pass is per-binary;

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -2,7 +2,7 @@
 // reader emits correctly split, atomized, and globally position-sorted DenseChunks.
 mod common;
 
-use common::{SynthRecord, build_bcf_with_index};
+use common::{SynthRecord, build_bcf_with_index, build_fasta_with_index};
 use genoray_core::vcf_reader::VcfChunkReader;
 use std::path::Path;
 use tempfile::tempdir;
@@ -16,7 +16,17 @@ fn drain_reader(
     ploidy: usize,
     chunk_size: usize,
 ) -> Vec<(u32, i32, Vec<bool>)> {
-    let mut reader = VcfChunkReader::new(bcf_path.to_str().unwrap(), chrom, samples, 1, ploidy);
+    // Each test builds `bcf_path.with_extension("fa")` from its records *before* calling
+    // drain_reader (see the per-test edit below); here we just point the reader at it.
+    let fasta_path = bcf_path.with_extension("fa");
+    let mut reader = VcfChunkReader::new(
+        bcf_path.to_str().unwrap(),
+        fasta_path.to_str().unwrap(),
+        chrom,
+        samples,
+        1,
+        ploidy,
+    );
     let columns = samples.len() * ploidy;
     let mut out = Vec::new();
     let mut chunk_id = 0;
@@ -47,6 +57,7 @@ fn multiallelic_site_splits_and_remaps_genotypes() {
         gt: vec![1, 2],
     }];
     build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf.with_extension("fa"), "chr1", 10_000, &records);
 
     let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
     // Two SNP atoms at pos 100: ALT C carried on hap0 only, ALT G on hap1 only.
@@ -70,6 +81,7 @@ fn mnp_atomizes_to_snps_shared_presence() {
         gt: vec![1, 1],
     }];
     build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf.with_extension("fa"), "chr1", 10_000, &records);
 
     let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
     // Two SNP atoms (A>G@100, C>T@101), both carried on both haps.
@@ -97,12 +109,13 @@ fn atoms_are_globally_position_sorted_across_records() {
         },
         SynthRecord {
             pos: 102,
-            ref_allele: b"A",
+            ref_allele: b"G",
             alts: vec![&b"T"[..]],
             gt: vec![1, 0],
         },
     ];
     build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf.with_extension("fa"), "chr1", 10_000, &records);
 
     // chunk_size = 1 → every atom lands in its own chunk; emission order must still
     // be globally sorted.
@@ -131,6 +144,7 @@ fn complex_deletion_with_substituted_anchor() {
         gt: vec![1, 1],
     }];
     build_bcf_with_index(&bcf, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf.with_extension("fa"), "chr1", 10_000, &records);
 
     let atoms = drain_reader(&bcf, "chr1", &samples, 2, 100);
     assert_eq!(atoms.len(), 2);

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -7,7 +7,9 @@
 
 mod common;
 
-use common::{SynthRecord, build_bcf_with_index, read_offsets_npy, read_u32_bin};
+use common::{
+    SynthRecord, build_bcf_with_index, build_fasta_with_index, read_offsets_npy, read_u32_bin,
+};
 use genoray_core::process_chromosome;
 use genoray_core::rvk::decode_alt_inline;
 use genoray_core::vcf_reader::VcfChunkReader;
@@ -79,12 +81,14 @@ fn test_e2e_normalized_bcf_pipeline() {
     ];
 
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
     let out_dir = tmp.path().join("out");
     std::fs::create_dir_all(&out_dir).unwrap();
 
     process_chromosome(
         bcf_path.to_str().unwrap(),
+        bcf_path.with_extension("fa").to_str().unwrap(),
         "chr1",
         out_dir.to_str().unwrap(),
         &samples,
@@ -156,11 +160,13 @@ fn test_e2e_dense_snp_roundtrip() {
         gt: vec![1, 1, 1, 1, 1, 0], // S0(1,1) S1(1,1) S2(1,0)
     }];
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
     let out_dir = tmp.path().join("out");
     std::fs::create_dir_all(&out_dir).unwrap();
     process_chromosome(
         bcf_path.to_str().unwrap(),
+        bcf_path.with_extension("fa").to_str().unwrap(),
         "chr1",
         out_dir.to_str().unwrap(),
         &samples,
@@ -223,12 +229,14 @@ fn test_e2e_mutation_conservation() {
         .sum();
 
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
     let out_dir = tmp.path().join("out");
     std::fs::create_dir_all(&out_dir).unwrap();
 
     process_chromosome(
         bcf_path.to_str().unwrap(),
+        bcf_path.with_extension("fa").to_str().unwrap(),
         "chr1",
         out_dir.to_str().unwrap(),
         &samples,
@@ -282,8 +290,16 @@ fn test_reader_accepts_pure_del() {
         gt: vec![1, 1],
     }];
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
-    let mut reader = VcfChunkReader::new(bcf_path.to_str().unwrap(), "chr1", &samples, 1, 2);
+    let mut reader = VcfChunkReader::new(
+        bcf_path.to_str().unwrap(),
+        bcf_path.with_extension("fa").to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+    );
     let chunk = reader
         .read_next_chunk(100, 0)
         .expect("chunk should succeed");
@@ -308,12 +324,14 @@ fn test_missing_chrom_returns_err() {
         gt: vec![1, 0],
     }];
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
+    build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
     let out_dir = tmp.path().join("out");
     std::fs::create_dir_all(&out_dir).unwrap();
 
     let res = genoray_core::orchestrator::process_chromosome(
         bcf_path.to_str().unwrap(),
+        bcf_path.with_extension("fa").to_str().unwrap(),
         "chrZ",
         out_dir.to_str().unwrap(),
         &["s0"],

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -1,0 +1,202 @@
+// End-to-end left-alignment: feed un-left-aligned indels against a repeat-containing
+// reference and assert the reader emits atoms left-aligned to the positions bcftools
+// produces (`bcftools norm -a -m- -f`).
+mod common;
+
+use common::{SynthRecord, build_bcf_with_index};
+use genoray_core::vcf_reader::VcfChunkReader;
+use std::io::Write;
+use std::path::Path;
+use tempfile::tempdir;
+
+// Reference: 0:C 1:A 2:A 3:A 4:A 5:T 6:C 7:A 8:G 9:A 10:G 11:T
+const REF_SEQ: &[u8] = b"CAAAATCAGAGT";
+
+fn write_ref(fasta_path: &Path, chrom: &str, seq: &[u8]) {
+    {
+        let mut f = std::fs::File::create(fasta_path).unwrap();
+        writeln!(f, ">{}", chrom).unwrap();
+        f.write_all(seq).unwrap();
+        writeln!(f).unwrap();
+    }
+    rust_htslib::faidx::build(fasta_path).unwrap();
+}
+
+fn drain(bcf: &Path, fasta: &Path, chrom: &str, samples: &[&str]) -> Vec<(u32, i32)> {
+    let mut reader = VcfChunkReader::new(
+        bcf.to_str().unwrap(),
+        fasta.to_str().unwrap(),
+        chrom,
+        samples,
+        1,
+        2,
+    );
+    let mut out = Vec::new();
+    let mut cid = 0;
+    while let Some(chunk) = reader.read_next_chunk(100, cid) {
+        for i in 0..chunk.pos.len() {
+            out.push((chunk.pos[i], chunk.ilens[i]));
+        }
+        cid += 1;
+    }
+    out
+}
+
+#[test]
+fn indels_left_align_to_bcftools_positions() {
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("la.bcf");
+    let fasta = tmp.path().join("la.fa");
+    write_ref(&fasta, "chr1", REF_SEQ);
+
+    let samples = vec!["S0"];
+    // AA>A @3 (del one A), A>AA @3 (ins one A), GAG>G @8 (del "AG").
+    let records = vec![
+        SynthRecord {
+            pos: 3,
+            ref_allele: b"AA",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 0],
+        },
+        SynthRecord {
+            pos: 3,
+            ref_allele: b"A",
+            alts: vec![&b"AA"[..]],
+            gt: vec![0, 1],
+        },
+        SynthRecord {
+            pos: 8,
+            ref_allele: b"GAG",
+            alts: vec![&b"G"[..]],
+            gt: vec![1, 1],
+        },
+    ];
+    build_bcf_with_index(&bcf, "chr1", 12, &samples, &records);
+
+    let atoms = drain(&bcf, &fasta, "chr1", &samples);
+    // bcftools norm -a -m- -f: DEL→pos0 ilen-1, INS→pos0 ilen+1, DEL→pos6 ilen-2.
+    // Emission is globally position-sorted, so pos 0 atoms come first (order between the
+    // two pos-0 atoms is the reorder heap's stable seq tiebreak: del then ins).
+    let mut sorted = atoms.clone();
+    sorted.sort();
+    assert_eq!(atoms, sorted, "emitted positions must be globally sorted");
+    assert!(atoms.contains(&(0, -1)), "homopolymer DEL → pos 0");
+    assert!(atoms.contains(&(0, 1)), "homopolymer INS → pos 0");
+    assert!(atoms.contains(&(6, -2)), "AGAG DEL → pos 6");
+}
+
+#[test]
+fn ref_mismatch_panics() {
+    // FASTA says pos 3 is 'A' but the record claims REF "GG" → validate_ref fails, and
+    // the reader (which .expect()s it) panics.
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("mm.bcf");
+    let fasta = tmp.path().join("mm.fa");
+    write_ref(&fasta, "chr1", REF_SEQ);
+
+    let samples = vec!["S0"];
+    let records = vec![SynthRecord {
+        pos: 3,
+        ref_allele: b"GG",
+        alts: vec![&b"G"[..]],
+        gt: vec![1, 0],
+    }];
+    build_bcf_with_index(&bcf, "chr1", 12, &samples, &records);
+
+    let res = std::panic::catch_unwind(|| drain(&bcf, &fasta, "chr1", &samples));
+    assert!(res.is_err(), "REF/FASTA mismatch must panic");
+}
+
+use std::process::Command;
+
+// Build a plain-text VCF (bgzip-free is fine for `bcftools norm`, which reads text VCF).
+fn write_vcf(path: &Path, chrom: &str, chrom_len: usize, records: &[(u32, &[u8], &[u8])]) {
+    let mut f = std::fs::File::create(path).unwrap();
+    writeln!(f, "##fileformat=VCFv4.2").unwrap();
+    writeln!(f, "##contig=<ID={},length={}>", chrom, chrom_len).unwrap();
+    writeln!(
+        f,
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"
+    )
+    .unwrap();
+    writeln!(
+        f,
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0"
+    )
+    .unwrap();
+    for &(pos0, r, a) in records {
+        // VCF POS is 1-based.
+        writeln!(
+            f,
+            "{}\t{}\t.\t{}\t{}\t.\t.\t.\tGT\t1|0",
+            chrom,
+            pos0 + 1,
+            std::str::from_utf8(r).unwrap(),
+            std::str::from_utf8(a).unwrap()
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn reader_matches_bcftools_norm() {
+    let tmp = tempdir().unwrap();
+    let fasta = tmp.path().join("x.fa");
+    write_ref(&fasta, "chr1", REF_SEQ);
+    let vcf = tmp.path().join("x.vcf");
+    let records: &[(u32, &[u8], &[u8])] = &[(3, b"AA", b"A"), (3, b"A", b"AA"), (8, b"GAG", b"G")];
+    write_vcf(&vcf, "chr1", REF_SEQ.len(), records);
+
+    let out = Command::new("bcftools")
+        .args(["norm", "-a", "-m-", "-f"])
+        .arg(&fasta)
+        .arg(&vcf)
+        .output()
+        .expect("bcftools must be on PATH (run under `pixi run -e default`)");
+    assert!(out.status.success(), "bcftools norm failed: {:?}", out);
+    // Parse (pos0, ilen) from bcftools' left-aligned biallelic records.
+    let mut expected: Vec<(u32, i32)> = String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.starts_with('#'))
+        .map(|l| {
+            let c: Vec<&str> = l.split('\t').collect();
+            let pos0 = c[1].parse::<u32>().unwrap() - 1;
+            let ilen = c[4].len() as i32 - c[3].len() as i32;
+            (pos0, ilen)
+        })
+        .collect();
+    expected.sort();
+
+    // Drive the reader over an equivalent BCF.
+    let bcf = tmp.path().join("x.bcf");
+    let samples = vec!["S0"];
+    let synth = vec![
+        SynthRecord {
+            pos: 3,
+            ref_allele: b"AA",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 0],
+        },
+        SynthRecord {
+            pos: 3,
+            ref_allele: b"A",
+            alts: vec![&b"AA"[..]],
+            gt: vec![1, 0],
+        },
+        SynthRecord {
+            pos: 8,
+            ref_allele: b"GAG",
+            alts: vec![&b"G"[..]],
+            gt: vec![1, 0],
+        },
+    ];
+    build_bcf_with_index(&bcf, "chr1", REF_SEQ.len() as u64, &samples, &synth);
+    let mut got = drain(&bcf, &fasta, "chr1", &samples);
+    got.sort();
+
+    assert_eq!(
+        got, expected,
+        "reader atoms must match `bcftools norm -a -m-`"
+    );
+}

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -5,6 +5,7 @@ mod common;
 
 use common::{SynthRecord, build_bcf_with_index};
 use genoray_core::vcf_reader::VcfChunkReader;
+use proptest::prelude::*;
 use std::io::Write;
 use std::path::Path;
 use tempfile::tempdir;
@@ -199,4 +200,117 @@ fn reader_matches_bcftools_norm() {
         got, expected,
         "reader atoms must match `bcftools norm -a -m-`"
     );
+}
+
+#[test]
+fn left_shifts_stay_sorted_across_chunk_boundaries() {
+    // A later record's indel left-aligns to a position *below* an earlier-emitted record's
+    // start. With chunk_size = 1, ordering must still hold across chunks.
+    // Reference: index 6:C 7:A 8:G 9:A 10:G 11:T — a SNP at 7, then GAG>G @8 which rolls
+    // to pos 6. The reorder buffer (widened by L_MAX) must emit pos 6 before pos 7.
+    let tmp = tempdir().unwrap();
+    let bcf = tmp.path().join("order.bcf");
+    let fasta = tmp.path().join("order.fa");
+    write_ref(&fasta, "chr1", REF_SEQ);
+
+    let samples = vec!["S0"];
+    let records = vec![
+        SynthRecord {
+            pos: 7,
+            ref_allele: b"A",
+            alts: vec![&b"T"[..]],
+            gt: vec![1, 0],
+        },
+        SynthRecord {
+            pos: 8,
+            ref_allele: b"GAG",
+            alts: vec![&b"G"[..]],
+            gt: vec![1, 0],
+        },
+    ];
+    build_bcf_with_index(&bcf, "chr1", REF_SEQ.len() as u64, &samples, &records);
+
+    // chunk_size = 1 forces every atom into its own chunk.
+    let mut reader = VcfChunkReader::new(
+        bcf.to_str().unwrap(),
+        fasta.to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+    );
+    let mut positions = Vec::new();
+    let mut cid = 0;
+    while let Some(chunk) = reader.read_next_chunk(1, cid) {
+        positions.extend_from_slice(&chunk.pos);
+        cid += 1;
+    }
+    // GAG>G rolls to pos 6, SNP stays at 7 → sorted [6, 7].
+    assert_eq!(positions, vec![6, 7]);
+    let mut sorted = positions.clone();
+    sorted.sort();
+    assert_eq!(
+        positions, sorted,
+        "emitted positions must be non-decreasing"
+    );
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    // Random homopolymer/repeat reference + random indels: whatever the reader emits is
+    // globally position-sorted, even with left-shifts and chunk_size = 1.
+    #[test]
+    fn emitted_positions_are_sorted_under_random_left_shifts(
+        seed in proptest::collection::vec(
+            prop_oneof![Just(b'A'), Just(b'C'), Just(b'G'), Just(b'T')], 20..60),
+        anchors in proptest::collection::vec(2usize..18, 1..6),
+    ) {
+        let tmp = tempdir().unwrap();
+        let bcf = tmp.path().join("p.bcf");
+        let fasta = tmp.path().join("p.fa");
+        write_ref(&fasta, "chr1", &seed);
+
+        // Build clean single-base deletions at sorted, distinct anchor positions (each
+        // deletes the base to its right, so REF is [ref, ref+1]).
+        let mut sorted_anchors: Vec<usize> = anchors.clone();
+        sorted_anchors.sort_unstable();
+        sorted_anchors.dedup();
+        let refs: Vec<(usize, Vec<u8>, Vec<u8>)> = sorted_anchors
+            .iter()
+            .filter(|&&p| p + 1 < seed.len())
+            .map(|&p| (p, vec![seed[p], seed[p + 1]], vec![seed[p]]))
+            .collect();
+        prop_assume!(!refs.is_empty());
+
+        let samples = vec!["S0"];
+        let synth: Vec<SynthRecord> = refs
+            .iter()
+            .map(|(p, r, a)| SynthRecord {
+                pos: *p as i64,
+                ref_allele: r.as_slice(),
+                alts: vec![a.as_slice()],
+                gt: vec![1, 0],
+            })
+            .collect();
+        build_bcf_with_index(&bcf, "chr1", seed.len() as u64, &samples, &synth);
+
+        let mut reader = VcfChunkReader::new(
+            bcf.to_str().unwrap(),
+            fasta.to_str().unwrap(),
+            "chr1",
+            &samples,
+            1,
+            2,
+        );
+        let mut positions = Vec::new();
+        let mut cid = 0;
+        while let Some(chunk) = reader.read_next_chunk(1, cid) {
+            positions.extend_from_slice(&chunk.pos);
+            cid += 1;
+        }
+        let mut sorted = positions.clone();
+        sorted.sort();
+        prop_assert_eq!(positions, sorted);
+    }
 }


### PR DESCRIPTION
## Summary

Implements **M2b — left-alignment during conversion**: anchored indel atoms are now
left-aligned against a reference FASTA during VCF→SVAR2 conversion, matching
`bcftools norm -a -m- -f`, and the reorder buffer's emit bound is widened so leftward
shifts cannot break the position-sorted invariant the Phase-2 merge relies on.

**What changed (`src/`):**
- `normalize.rs`: `pub const L_MAX: u32 = 1000` (caps the shift *and* widens the reorder
  bound — single source); `NormalizeError::{RefMismatch, RefOutOfContig}`; `validate_ref`
  (fail-fast REF/FASTA agreement, ASCII-case-insensitive for soft-masked bases); and
  `left_align` (the classic DEL/INS repeat roll, capped at `L_MAX`, SNPs and
  substituted-anchor insertions never move).
- Reference FASTA threaded as a **required** argument (2nd param) through
  `VcfChunkReader::new` → `orchestrator::process_chromosome` → PyO3
  `run_conversion_pipeline`. The full contig is cached once per worker via
  `rust_htslib::faidx` and uppercased; a missing contig now fails fast with a message
  naming the contig.
- `vcf_reader::decompose_current_record` validates REF then left-aligns each atom before
  the heap push; `next_atom`'s emit guard widened to
  `frontier.saturating_sub(L_MAX)`. Only `pos`/`alt` change — `ilen`,
  `source_alt_index`, and the shared `gt` vector are invariant, keeping M5's `max_del`
  and the genotype remap valid.

**Tests (all green, 132):**
- Unit + a 2000-case reference-equivalence/leftmost-fixpoint proptest for `left_align`.
- `tests/test_left_align_e2e.rs`: bcftools-validated fixtures, a **live**
  `bcftools norm -a -m-` cross-check (parses real output, not baked constants), a
  REF-mismatch fail-fast test, a deterministic cross-chunk ordering regression test, and
  a randomized reorder-invariant proptest.

Reviewed task-by-task plus a whole-branch review; the one soundness-critical piece — the
widened emit bound vs `L_MAX`-capped leftward shifts (strict `<`) — was verified correct.

`L_MAX = 1000` is a conservative default pending measurement on representative short-read
VCFs (recorded as an open question in-code and in the roadmap); indels inside a longer
repeat are left *partially* aligned, matching bcftools' `--buffer-size` truncation.

## SVAR 2.0 roadmap check

- [x] Re-read `svar-2.md`, `data-model.md`, and `architecture.md`. (architecture.md
      unchanged — M2b introduces no architectural change.)
- [x] Milestone checkboxes/statuses updated to match reality — M2b `[ ]` → `[x]` with a
      `*Done:*` note.
- [x] Data-model change reconciled **in this PR**: `data-model.md` left-alignment bullet
      and the reorder-buffer paragraph now describe the shipped `L_MAX`-relaxed bound.
- [x] Open question recorded: `L_MAX` default pending measurement (noted in
      `normalize.rs` and the roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
