### PR TITLE
SVAR2 M6.1: query decode core (consumer spine)

### DIFF
--- a/docs/roadmap/architecture.md
+++ b/docs/roadmap/architecture.md
@@ -133,6 +133,11 @@ split into an independent, position-sorted `snp/` and `indel/` sub-stream (up to
 sources) — assembling a result requires a **fast sorted union / merge** of multiple
 sorted streams.
 
+- **M6.1 implementation:** This union is realized by `overlap_batch` (`src/query.rs`) over the
+  reader-free `src/spine.rs` `gather_keys` / `merge_keys`, producing a two-channel result:
+  per-hap `var_key` KeyRefs (with uniform 32-bit keys via `svar2_codec::snp_code_to_key`)
+  + a decode-once `dense` union with per-region ranges and per-hap presence bitmasks.
+  Allele decode is deferred to the consumer via `decode_keyref` / `BatchResult::decode_hap`.
 - This is the union-shaped dual of fast sorted-array **intersection**; the techniques
   in [Doug Turnbull's "Faster intersect"](https://softwaredoug.com/blog/2024/05/05/faster-intersect)
   (branch-light, SIMD-friendly merging of sorted integer arrays) are good inspiration

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -176,14 +176,14 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
     action, still pending (it release-gates M6b's gvl side alongside the `svar-2` PyPI
     release). See
     [`../superpowers/plans/2026-07-02-svar2-codec-crate.md`](../superpowers/plans/2026-07-02-svar2-codec-crate.md).
-  - [ ] **M6.1 consumer spine (now unblocked — next up).** With the codec landed, build the
-    batched multi-region × multi-sample spine: uniform-key SNP re-expansion + the fast
-    sorted **union** across the four `{var_key, dense} × {snp, indel}` sub-streams. This is
-    the MVP critical path — both M6b and M6c fan out from it, so nothing else in the MVP
-    tail can proceed until it lands. (The independent tracks M7–M10 do not touch the query
-    path and can proceed in parallel.)
-  See [`architecture.md`](architecture.md#python-decode-path) and the design spec
-  [`../superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md`](../superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md).
+  - [x] **M6.1 consumer spine (done).** `src/spine.rs` (`KeyRef` / `gather_keys` / `merge_keys`)
+    + `overlap_batch` / `BatchResult` / `decode_hap` in `src/query.rs` deliver the batched
+    two-channel spine; SNPs re-expand via `svar2_codec::snp_code_to_key`; `overlap_sample`
+    re-expressed on the spine (M5 tests are the regression oracle); cross-checked by
+    `tests/test_batch.rs`. See [`architecture.md`](architecture.md#python-decode-path) and
+    the design spec [`../superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md`](../superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md).
+    Remaining for M6: PyO3/numpy exposure of `BatchResult` and dense-window subsetting are
+    **M6b**; `seqpro.rag.Ragged` materialization is **M6c**.
 - [ ] **M6b. gvl Rust variant interface.** *(built first among M6 consumers)* The primary
   consumer. genoray returns a **two-channel** query result — `var_key` gathered per-hap
   inline (no dedup, no barrier) + a shared decode-once `dense` table with per-hap presence

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -167,14 +167,22 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   `(range, sample)` query landed (`overlap_sample` in `src/query.rs`); M6 generalizes it
   into the batched multi-region × multi-sample consumer spine, re-expands SNPs to the
   uniform 32-bit key at query time, and implements the fast sorted **union** across the
-  `{var_key, dense} × {snp, indel}` sub-streams. *Done:* the key ↔ `(ILEN, ALT)` decode
-  seam has already been extracted out of `rvk.rs` into the dependency-light,
-  crates.io publish-ready **`svar2-codec`** workspace crate, so genoray and gvl share one
-  decoder — see
-  [`../superpowers/plans/2026-07-02-svar2-codec-crate.md`](../superpowers/plans/2026-07-02-svar2-codec-crate.md).
-  What remains is the batched consumer spine above, then the two-channel/materialized
-  consumer interfaces, M6b/M6c. See
-  [`architecture.md`](architecture.md#python-decode-path) and the design spec
+  `{var_key, dense} × {snp, indel}` sub-streams.
+  - [x] **M6.0 `svar2-codec` seam crate (done).** The key ↔ `(ILEN, ALT)` encode/decode
+    seam is extracted out of `rvk.rs` into the dependency-light, crates.io publish-ready
+    **`svar2-codec`** workspace crate (std-only, zero runtime deps), so genoray and gvl
+    share one decoder. Verified: 16 codec tests green (PEXT↔SWAR parity, all key-lane
+    round-trips), `cargo publish --dry-run` clean. Publishing to crates.io is a maintainer
+    action, still pending (it release-gates M6b's gvl side alongside the `svar-2` PyPI
+    release). See
+    [`../superpowers/plans/2026-07-02-svar2-codec-crate.md`](../superpowers/plans/2026-07-02-svar2-codec-crate.md).
+  - [ ] **M6.1 consumer spine (now unblocked — next up).** With the codec landed, build the
+    batched multi-region × multi-sample spine: uniform-key SNP re-expansion + the fast
+    sorted **union** across the four `{var_key, dense} × {snp, indel}` sub-streams. This is
+    the MVP critical path — both M6b and M6c fan out from it, so nothing else in the MVP
+    tail can proceed until it lands. (The independent tracks M7–M10 do not touch the query
+    path and can proceed in parallel.)
+  See [`architecture.md`](architecture.md#python-decode-path) and the design spec
   [`../superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md`](../superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md).
 - [ ] **M6b. gvl Rust variant interface.** *(built first among M6 consumers)* The primary
   consumer. genoray returns a **two-channel** query result — `var_key` gathered per-hap

--- a/docs/superpowers/plans/2026-07-02-svar2-m6.1-consumer-spine.md
+++ b/docs/superpowers/plans/2026-07-02-svar2-m6.1-consumer-spine.md
@@ -1,0 +1,1199 @@
+# SVAR2 M6.1 — Query Decode Core (Consumer Spine) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generalize M5's single-sample `overlap_sample` into the batched, uniform-key, two-channel query **spine** (`overlap_batch`) that both SVAR2 consumers (M6b gvl, M6c Python) build on — carrying undecoded uniform 32-bit keys, unioning `snp`+`indel` within each of the `var_key` and `dense` channels, and leaving the final `var_key ⋈ dense` merge + allele decode to the consumer.
+
+**Architecture:** Split M5's fused *overlap+decode* `gather_run` into two layers. A new pure `src/spine.rs` owns the reader-free algorithms — `KeyRef` (an undecoded `(position, key)` pair), `gather_keys` (overlap → `KeyRef`), and `merge_keys` (stable position-sorted n-way merge). `src/query.rs` keeps the disk wiring and grows the batched entry point: SNP sub-streams are re-expanded to the uniform 32-bit key via a new `svar2_codec::snp_code_to_key` (one shift — the `<<25` layout stays in the codec); `var_key` is gathered per `(region, sample, ploid)` (ragged, no dedup); `dense` is built once per query as a shared `snp`+`indel` union with per-region index ranges and per-hap presence bitmasks. `overlap_sample` is re-expressed on top of the same helpers so the existing M5 disk-integration tests become the regression oracle for the refactor.
+
+**Tech Stack:** Rust (edition 2024), Cargo workspace (`genoray` root cdylib + `svar2-codec` rlib), `memmap2` + `ndarray` + `ndarray-npy` (sidecar I/O), `bytemuck` (zero-copy `u32` views), `proptest` + `tempfile` (tests), pixi (`lint` env carries the Rust + clang toolchain), `rust-htslib` (only pulled in by the integration tests via the real converter).
+
+## Global Constraints
+
+- **`svar2-codec` stays pure and leaf.** No `pyo3`, `htslib`, `memmap2`, or any `genoray` dependency; std-only, zero non-std runtime deps; must stay `cargo publish --dry-run -p svar2-codec` clean. The only codec change here is adding `snp_code_to_key` (Task 1).
+- **The encoding seam is co-located in the codec.** Every bit-position of both key layouts lives in `svar2-codec`. `genoray` never re-derives a shift or mask — the SNP→uniform-key `<<25` re-expansion is a codec function, not an inline shift in `query.rs`.
+- **No behavior change to `overlap_sample`.** Its public signature and returned `QueryResult` are byte-for-byte unchanged; the refactor onto the spine is an internal restructure guarded by the existing `tests/test_query.rs` suite (its proptest is the primary oracle).
+- **The spine does not decode alleles.** `overlap_batch` carries uniform `u32` keys and the dense presence bits; the LUT is *referenced* (any key with LSB set), never resolved inside the spine. Decoding happens only in `decode_keyref` / `decode_hap`, which the consumer (or the cross-check test) calls.
+- **Uniform key convention.** A SNP's uniform 32-bit key is `(code << 25)` (`ilen` top-5-bits = 0 → `alt_len = 1`); indel keys are stored uniform already. `decode_key` on a uniform SNP key yields `Inline { alt: [base] }`, `ilen = 0` — identical to M5's `decode_snp_2bit` path.
+- **Edition 2024** for both crates. Conventional-commit messages (`cz`/commitizen runs in prek; hooks already installed in this worktree). Commit only files you created/modified in each task.
+- **Rust test commands** (pixi `lint` env has `rust` + `clangdev`):
+  - Codec only (fast, no htslib): `pixi run -e lint cargo test -p svar2-codec`
+  - Full genoray unit suite (needs `--no-default-features` so pyo3 links libpython instead of building the extension module): `pixi run -e lint cargo test -p genoray --no-default-features`
+  - A single integration binary: append `--test test_query` or `--test test_batch`.
+- **This is an MVP-critical-path milestone; performance is secondary to correctness.** `overlap_batch` is single-threaded here. `rayon` over `(region, sample, ploid)` (the var_key path) and dense-window subsetting are deferred to M6b — noted inline, not implemented.
+- **Working agreement:** the roadmap + supplements are updated in this same branch (Task 6).
+
+---
+
+### Task 1: `snp_code_to_key` — uniform-key re-expansion in `svar2-codec`
+
+**Files:**
+- Modify: `svar2-codec/src/lib.rs` (add `snp_code_to_key` + a round-trip test)
+- Modify: `src/rvk.rs:14-17` (extend the `pub use svar2_codec::{…}` re-export list)
+
+**Interfaces:**
+- Consumes: `svar2_codec::{decode_key, decode_snp_2bit, DecodedKey}` (existing).
+- Produces: `svar2_codec::snp_code_to_key(code: u8) -> u32`, re-exported as `crate::rvk::snp_code_to_key`.
+
+- [ ] **Step 1: Write the failing test in `svar2-codec/src/lib.rs`**
+
+Add to the existing `#[cfg(test)] mod tests` block (do not create a second one):
+
+```rust
+    #[test]
+    fn snp_code_to_key_decodes_to_inline_base() {
+        // Every 2-bit code re-expands to a uniform key whose decode is a 1-base
+        // Inline ALT equal to decode_snp_2bit(code), with ilen 0.
+        for code in 0u8..4 {
+            let key = snp_code_to_key(code);
+            assert_eq!(key & 1, 0, "uniform SNP key must clear the lookup flag");
+            assert_eq!(
+                decode_key(key),
+                DecodedKey::Inline {
+                    alt: vec![decode_snp_2bit(code)]
+                },
+                "code {code} round-trips through the uniform key",
+            );
+        }
+    }
+
+    #[test]
+    fn snp_code_to_key_matches_encode_alt_inline() {
+        // The one-shift re-expansion equals encoding the decoded base inline.
+        for code in 0u8..4 {
+            let base = decode_snp_2bit(code);
+            assert_eq!(snp_code_to_key(code), encode_alt_inline(&[base], 0));
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pixi run -e lint cargo test -p svar2-codec snp_code_to_key`
+Expected: FAIL — `cannot find function snp_code_to_key in this scope`.
+
+- [ ] **Step 3: Add the function to `svar2-codec/src/lib.rs`**
+
+Place it directly after `decode_snp_2bit` (the SNP primitives cluster):
+
+```rust
+/// Re-expand a 2-bit SNP code into the **uniform 32-bit indel key** (`ilen = 0`,
+/// the single ALT base inline at `[26:25]`, lookup flag clear). This is the
+/// pre-M1-split encoding: after re-expansion a query result has one `decode_key`
+/// path for both `snp` and `indel` sub-streams. One shift — the `<< 25` lives
+/// here so no consumer re-derives the layout. Inverse view: `decode_key` on the
+/// result is `Inline { alt: [decode_snp_2bit(code)] }`.
+#[inline]
+pub fn snp_code_to_key(code: u8) -> u32 {
+    ((code & 3) as u32) << 25
+}
+```
+
+- [ ] **Step 4: Run the codec test to verify it passes**
+
+Run: `pixi run -e lint cargo test -p svar2-codec snp_code_to_key`
+Expected: PASS — both `snp_code_to_key_*` tests green.
+
+- [ ] **Step 5: Re-export through `rvk` so `crate::rvk::snp_code_to_key` resolves**
+
+In `src/rvk.rs`, add `snp_code_to_key` to the existing re-export list (keep it sorted):
+
+```rust
+pub use svar2_codec::{
+    DecodedKey, decode_alt_inline, decode_key, decode_snp_2bit, deletion_len, encode_snp_2bit,
+    pack_snp_keys, snp_code_to_key, unpack_snp_key_at, unpack_snp_keys,
+};
+```
+
+- [ ] **Step 6: Verify the full unit suite still builds**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features`
+Expected: PASS — unchanged test count (nothing consumes `snp_code_to_key` yet; this only proves the re-export compiles).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add svar2-codec/src/lib.rs src/rvk.rs
+git commit -m "feat(svar2-codec): add snp_code_to_key uniform-key re-expansion"
+```
+
+---
+
+### Task 2: `src/spine.rs` — `KeyRef`, `gather_keys`, `merge_keys`
+
+**Files:**
+- Create: `src/spine.rs`
+- Modify: `src/lib.rs:22` (register `pub mod spine;` — keep the module list alphabetical: after `search`, before `streams`)
+
+**Interfaces:**
+- Consumes: `crate::search::{SearchTree, overlap_range}` (existing).
+- Produces:
+  - `spine::KeyRef { position: u32, key: u32 }` — `#[derive(Debug, Clone, Copy, PartialEq, Eq)]`.
+  - `spine::gather_keys(positions: &[u32], max_region_length: u32, q_start: u32, q_end: u32, del_len: impl Fn(usize) -> u32, carried: impl Fn(usize) -> bool, to_key: impl Fn(usize) -> u32, out: &mut Vec<KeyRef>)` — overlap-filters `positions` against `[q_start, q_end)` (deletion-aware via `del_len` + `max_region_length`), keeps carried elements, and pushes `KeyRef { position, key: to_key(i) }`.
+  - `spine::merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef>` — stable position-sorted n-way merge (earlier run wins ties).
+
+- [ ] **Step 1: Create `src/spine.rs` with the failing tests only**
+
+This is the reader-free algorithm layer M5 lacked — `gather_run`/`kway_merge` currently live fused in `query.rs`; Task 3 deletes them. Write the module with a doc header, the `KeyRef` type, empty stubs, and the ported tests:
+
+```rust
+//! Reader-free spine algorithms for the SVAR2 query decode core (M6.1).
+//!
+//! `gather_keys` and `merge_keys` are the pure half of what M5's `query.rs`
+//! did inline: overlap-resolve a position run into undecoded `(position, key)`
+//! pairs, and merge already-sorted runs. They carry **uniform 32-bit keys** and
+//! never touch alleles or the LUT — decoding is the consumer's job. Splitting
+//! them out lets both `overlap_sample` and the batched `overlap_batch` share one
+//! gather/merge and one uniform-key convention.
+
+use crate::search::{SearchTree, overlap_range};
+
+/// An undecoded variant reference: a genomic start plus its **uniform 32-bit
+/// key** (SNPs re-expanded via [`crate::rvk::snp_code_to_key`]; indel keys
+/// stored uniform already). A key with LSB set references the long-allele LUT,
+/// resolved downstream — never here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyRef {
+    pub position: u32,
+    pub key: u32,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gather_keys(
+    _positions: &[u32],
+    _max_region_length: u32,
+    _q_start: u32,
+    _q_end: u32,
+    _del_len: impl Fn(usize) -> u32,
+    _carried: impl Fn(usize) -> bool,
+    _to_key: impl Fn(usize) -> u32,
+    _out: &mut Vec<KeyRef>,
+) {
+    unimplemented!()
+}
+
+pub fn merge_keys(_runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kr(position: u32, key: u32) -> KeyRef {
+        KeyRef { position, key }
+    }
+
+    #[test]
+    fn test_gather_keys_snp_half_open() {
+        // positions [10, 20, 30], v_end = pos + 1, max_del 0; query [15, 25):
+        // only index 1 (pos 20) overlaps. to_key(i) = i as a marker key.
+        let positions = [10u32, 20, 30];
+        let mut out = Vec::new();
+        gather_keys(
+            &positions, 0, 15, 25,
+            |_| 0, |_| true, |i| i as u32, &mut out,
+        );
+        assert_eq!(out, vec![kr(20, 1)]);
+    }
+
+    #[test]
+    fn test_gather_keys_deletion_spans_query_start() {
+        // v0 start 2 deletes 6 bases -> v_end 9; v1 SNP at 10. query [5, 7):
+        // only v0 (2..9) spans it. max_region_length 6 covers the deletion.
+        let positions = [2u32, 10];
+        let dels = [6u32, 0];
+        let mut out = Vec::new();
+        gather_keys(
+            &positions, 6, 5, 7,
+            |i| dels[i], |_| true, |i| 100 + i as u32, &mut out,
+        );
+        assert_eq!(out, vec![kr(2, 100)]);
+    }
+
+    #[test]
+    fn test_gather_keys_carried_filter() {
+        // Only even indices carried; query covers all.
+        let positions = [10u32, 20, 30, 40];
+        let mut out = Vec::new();
+        gather_keys(
+            &positions, 0, 0, 100,
+            |_| 0, |i| i % 2 == 0, |i| i as u32, &mut out,
+        );
+        assert_eq!(out, vec![kr(10, 0), kr(30, 2)]);
+    }
+
+    #[test]
+    fn test_gather_keys_empty_positions() {
+        let mut out = Vec::new();
+        gather_keys(&[], 0, 0, 100, |_| 0, |_| true, |_| 0, &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_merge_keys_orders_by_position() {
+        let runs = vec![
+            vec![kr(10, 0), kr(30, 2)],
+            vec![kr(20, 1)],
+            vec![],
+            vec![kr(25, 9)],
+        ];
+        let merged = merge_keys(runs);
+        let positions: Vec<u32> = merged.iter().map(|k| k.position).collect();
+        assert_eq!(positions, vec![10, 20, 25, 30]);
+    }
+
+    #[test]
+    fn test_merge_keys_ties_keep_earlier_run_first() {
+        let runs = vec![vec![kr(50, 111)], vec![kr(50, 222)]];
+        assert_eq!(merge_keys(runs), vec![kr(50, 111), kr(50, 222)]);
+    }
+}
+```
+
+- [ ] **Step 2: Register the module and run the tests to verify they fail**
+
+In `src/lib.rs`, add between `pub mod search;` and `pub mod streams;`:
+
+```rust
+pub mod spine;
+```
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features spine::`
+Expected: FAIL — the tests panic with `not implemented` (`unimplemented!()`).
+
+- [ ] **Step 3: Implement `gather_keys` and `merge_keys`**
+
+Replace the two stub bodies:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub fn gather_keys(
+    positions: &[u32],
+    max_region_length: u32,
+    q_start: u32,
+    q_end: u32,
+    del_len: impl Fn(usize) -> u32,
+    carried: impl Fn(usize) -> bool,
+    to_key: impl Fn(usize) -> u32,
+    out: &mut Vec<KeyRef>,
+) {
+    if positions.is_empty() {
+        return;
+    }
+    let v_ends: Vec<u32> = positions
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| p + 1 + del_len(i))
+        .collect();
+    let tree = SearchTree::new(positions);
+    let (s_idx, e_idx) = overlap_range(&tree, &v_ends, max_region_length, q_start, q_end);
+    for (i, &position) in positions.iter().enumerate().take(e_idx).skip(s_idx) {
+        if carried(i) {
+            out.push(KeyRef {
+                position,
+                key: to_key(i),
+            });
+        }
+    }
+}
+
+/// K-way merge of already position-sorted runs into one position-sorted list.
+/// Stable across ties (earlier run wins). `O(total × n_runs)` with `n_runs`
+/// small (2 within a channel; more only if M11 adds a `pointer` sub-stream).
+pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
+    let total: usize = runs.iter().map(|r| r.len()).sum();
+    let mut heads = vec![0usize; runs.len()];
+    let mut out = Vec::with_capacity(total);
+    for _ in 0..total {
+        let mut best: Option<usize> = None;
+        for r in 0..runs.len() {
+            if heads[r] >= runs[r].len() {
+                continue;
+            }
+            match best {
+                // Keep `best` on ties so the earlier run emits first (stable).
+                Some(b) if runs[b][heads[b]].position <= runs[r][heads[r]].position => {}
+                _ => best = Some(r),
+            }
+        }
+        let b = best.expect("total accounts for every remaining element");
+        out.push(runs[b][heads[b]]);
+        heads[b] += 1;
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run the spine tests to verify they pass**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features spine::`
+Expected: PASS — all six `test_gather_keys_*` / `test_merge_keys_*` green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib.rs src/spine.rs
+git commit -m "feat(spine): add reader-free KeyRef gather + merge algorithms"
+```
+
+---
+
+### Task 3: Refactor `query.rs` onto the spine (uniform keys, single decode site)
+
+**Files:**
+- Modify: `src/query.rs` — delete `gather_run` (`:82-113`), `kway_merge` (`:119-140`), `decode_indel_hit` (`:314-325`); add `decode_keyref`, `ContigReader::vk_slice`, `DenseUnion` + `ContigReader::dense_union`/`DenseUnion::overlap`/`ContigReader::dense_carried`; rewrite `overlap_sample` (`:329-443`) on top of them; move the deleted functions' unit tests out (they now live in `spine.rs` from Task 2 — delete the `test_gather_run_*` / `test_kway_merge_*` cases here).
+
+**Interfaces:**
+- Consumes: `spine::{KeyRef, gather_keys, merge_keys}`; `rvk::{decode_key, DecodedKey, deletion_len, snp_code_to_key, unpack_snp_key_at}`; `crate::nrvk::LongAlleleReader`; the existing `ContigReader` fields, `SubStreamView`, `DenseView`, `as_u32`, `as_bytes`.
+- Produces (all crate-internal except `overlap_sample`, whose public contract is unchanged):
+  - `fn decode_keyref(kr: KeyRef, lut: Option<&LongAlleleReader>) -> Call` — single decode site; SNP/INS → `Inline`, DEL → `PureDel`, long-INS → LUT `Lookup`.
+  - `ContigReader::vk_slice(&self, col: usize, sample: usize, p: usize, q_start: u32, q_end: u32) -> Vec<KeyRef>` — one hap-column's `var_key` `snp`+`indel` union, uniform keys, position-sorted.
+  - `struct DenseUnion { refs: Vec<KeyRef>, src: Vec<(bool, usize)>, positions: Vec<u32>, v_ends: Vec<u32>, max_del: u32 }` where `src[i] = (is_indel, col)`.
+  - `ContigReader::dense_union(&self) -> DenseUnion` — region-independent `snp`+`indel` union over the whole contig.
+  - `DenseUnion::overlap(&self, q_start: u32, q_end: u32) -> (usize, usize)` — `[s, e)` into `refs`/`src`.
+  - `ContigReader::dense_carried(&self, union: &DenseUnion, hap: usize, s: usize, e: usize) -> Vec<KeyRef>`.
+
+- [ ] **Step 1: Confirm the existing M5 tests pass (baseline for the regression guard)**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features --test test_query`
+Expected: PASS — this is the oracle the refactor must preserve. If it does not pass before you start, stop and investigate; the branch is broken.
+
+- [ ] **Step 2: Update the `query.rs` imports**
+
+Replace the `use crate::rvk::{self, DecodedKey};` line and add the spine + search imports. The head of `query.rs` `use` block becomes:
+
+```rust
+use crate::bits;
+use crate::layout::{self, ContigPaths};
+use crate::nrvk::LongAlleleReader;
+use crate::rvk::{self, DecodedKey};
+use crate::search::{SearchTree, overlap_range};
+use crate::spine::{self, KeyRef};
+```
+
+(`SearchTree`/`overlap_range` were already imported for `gather_run`; keep them — `DenseUnion::overlap` uses them. `gather_run`'s own use of them goes away when it is deleted.)
+
+- [ ] **Step 3: Delete `gather_run`, `kway_merge`, `decode_indel_hit` and their unit tests**
+
+Remove:
+- `gather_run` (the `#[allow(clippy::too_many_arguments)] fn gather_run(...)` and its doc comment).
+- `kway_merge` (fn + doc comment).
+- `decode_indel_hit` (fn + doc comment).
+- In `#[cfg(test)] mod tests`: the `test_gather_run_snp_half_open`, `test_gather_run_deletion_spans_query_start`, `test_gather_run_carried_filter`, `test_gather_run_empty_positions`, `test_kway_merge_orders_by_position`, `test_kway_merge_ties_keep_earlier_run_first` cases and the `fn call(...)` helper they use. **Keep** `test_mmap_u32_roundtrip` and `test_mmap_missing_and_empty_are_none`.
+
+(`Call`, `HapCalls`, `QueryResult`, `SubStreamView`, `DenseView`, `as_u32`, `as_bytes`, the loader fns, and `ContigReader`/`open` all stay.)
+
+- [ ] **Step 4: Add `decode_keyref` — the single decode site**
+
+Place after the `Call` struct definition:
+
+```rust
+/// Decode one uniform `KeyRef` into a `Call`, resolving long-INS lookups through
+/// the LUT. The single place a query result touches alleles: SNP/INS decode
+/// inline (`Inline`), a pure DEL yields an empty ALT (`PureDel`), a long INS
+/// resolves via the bank (`Lookup`). `ilen = alt.len() - 1` for the inline lanes
+/// matches M5's `decode_snp_2bit`/`decode_indel_hit` contract exactly.
+fn decode_keyref(kr: KeyRef, lut: Option<&LongAlleleReader>) -> Call {
+    match rvk::decode_key(kr.key) {
+        DecodedKey::Inline { alt } => Call {
+            position: kr.position,
+            ilen: alt.len() as i32 - 1,
+            alt,
+        },
+        DecodedKey::PureDel { ilen } => Call {
+            position: kr.position,
+            ilen,
+            alt: Vec::new(),
+        },
+        DecodedKey::Lookup { row } => {
+            let alt = lut
+                .expect("indel lookup key requires a long-allele LUT")
+                .get_allele(row);
+            Call {
+                position: kr.position,
+                ilen: alt.len() as i32 - 1,
+                alt,
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Add the reader-facing spine helpers (`vk_slice`, `dense_union`, `overlap`, `dense_carried`)**
+
+Add an `impl ContigReader` block (below the existing one) plus the `DenseUnion` struct:
+
+```rust
+/// The per-contig dense table unioned across `snp`+`indel`, position-sorted,
+/// carrying uniform keys plus the `(is_indel, col)` needed to test carriage.
+/// Region-independent — built once per query; `overlap` derives each region's
+/// index range from it. `src[i] = (is_indel, col)` addresses the original dense
+/// class table for the genotype-bit test.
+struct DenseUnion {
+    refs: Vec<KeyRef>,
+    src: Vec<(bool, usize)>,
+    positions: Vec<u32>,
+    v_ends: Vec<u32>,
+    max_del: u32,
+}
+
+impl DenseUnion {
+    /// `[s, e)` into `refs`/`src` for `[q_start, q_end)`, deletion-aware. Builds a
+    /// fresh search tree over `positions` (cheap; one per region in a batch).
+    fn overlap(&self, q_start: u32, q_end: u32) -> (usize, usize) {
+        if self.refs.is_empty() {
+            return (0, 0);
+        }
+        let tree = SearchTree::new(&self.positions);
+        overlap_range(&tree, &self.v_ends, self.max_del, q_start, q_end)
+    }
+}
+
+impl ContigReader {
+    /// `var_key` channel for one flat hap-column over one region: `snp`+`indel`
+    /// unioned, uniform keys (SNP re-expanded via `snp_code_to_key`), sorted.
+    fn vk_slice(
+        &self,
+        col: usize,
+        sample: usize,
+        p: usize,
+        q_start: u32,
+        q_end: u32,
+    ) -> Vec<KeyRef> {
+        let mut runs: Vec<Vec<KeyRef>> = Vec::with_capacity(2);
+
+        // var_key/snp: 2-bit codes, absolute index o0 + i into the packed buffer.
+        {
+            let (o0, o1) = self.vk_snp.column(col);
+            let positions = &self.vk_snp.positions()[o0..o1];
+            let keys = as_bytes(&self.vk_snp.keys);
+            let mut run = Vec::new();
+            spine::gather_keys(
+                positions,
+                0,
+                q_start,
+                q_end,
+                |_| 0,
+                |_| true,
+                |i| rvk::snp_code_to_key(rvk::unpack_snp_key_at(keys, o0 + i)),
+                &mut run,
+            );
+            runs.push(run);
+        }
+
+        // var_key/indel: uniform u32 keys, per-column max_del bound.
+        {
+            let (o0, o1) = self.vk_indel.column(col);
+            let positions = &self.vk_indel.positions()[o0..o1];
+            let keys = &as_u32(&self.vk_indel.keys)[o0..o1];
+            let max_del = self.vk_indel_max_del[[sample, p]];
+            let mut run = Vec::new();
+            spine::gather_keys(
+                positions,
+                max_del,
+                q_start,
+                q_end,
+                |i| rvk::deletion_len(keys[i]),
+                |_| true,
+                |i| keys[i],
+                &mut run,
+            );
+            runs.push(run);
+        }
+
+        spine::merge_keys(runs)
+    }
+
+    /// Build the region-independent dense `snp`+`indel` union (see `DenseUnion`).
+    /// SNP codes re-expand to uniform keys; the max_region_length bound is the
+    /// per-contig dense/indel max (SNP contributes 0).
+    fn dense_union(&self) -> DenseUnion {
+        // (position, key, del_len, is_indel, col), snp pushed before indel so a
+        // stable sort keeps snp-before-indel on any shared position.
+        let mut items: Vec<(u32, u32, u32, bool, usize)> = Vec::new();
+        if let Some(d) = &self.dense_snp {
+            let positions = d.positions();
+            let keys = as_bytes(&d.keys);
+            for col in 0..positions.len() {
+                let key = rvk::snp_code_to_key(rvk::unpack_snp_key_at(keys, col));
+                items.push((positions[col], key, 0, false, col));
+            }
+        }
+        if let Some(d) = &self.dense_indel {
+            let positions = d.positions();
+            let keys = as_u32(&d.keys);
+            for col in 0..positions.len() {
+                items.push((positions[col], keys[col], rvk::deletion_len(keys[col]), true, col));
+            }
+        }
+        items.sort_by_key(|it| it.0);
+
+        let refs = items.iter().map(|it| KeyRef { position: it.0, key: it.1 }).collect();
+        let positions = items.iter().map(|it| it.0).collect();
+        let v_ends = items.iter().map(|it| it.0 + 1 + it.2).collect();
+        let src = items.iter().map(|it| (it.3, it.4)).collect();
+        DenseUnion {
+            refs,
+            src,
+            positions,
+            v_ends,
+            max_del: self.dense_indel_max_del,
+        }
+    }
+
+    /// The dense variants in `union[s..e]` that `hap` carries, as uniform KeyRefs.
+    fn dense_carried(&self, union: &DenseUnion, hap: usize, s: usize, e: usize) -> Vec<KeyRef> {
+        let mut out = Vec::new();
+        for j in s..e {
+            let (is_indel, col) = union.src[j];
+            let carried = if is_indel {
+                self.dense_indel.as_ref().expect("indel src implies table").carried(hap, col)
+            } else {
+                self.dense_snp.as_ref().expect("snp src implies table").carried(hap, col)
+            };
+            if carried {
+                out.push(union.refs[j]);
+            }
+        }
+        out
+    }
+}
+```
+
+- [ ] **Step 6: Rewrite `overlap_sample` on top of the spine**
+
+Replace the whole `overlap_sample` body (signature unchanged):
+
+```rust
+/// Return every variant that `sample` carries overlapping `[q_start, q_end)`, per
+/// haplotype, position-sorted, unioning the var_key and dense sub-streams. M5's
+/// public contract, re-expressed on the M6.1 spine: gather uniform KeyRefs, do
+/// the final `var_key ⋈ dense` 2-way merge, then decode.
+pub fn overlap_sample(
+    reader: &ContigReader,
+    sample: usize,
+    q_start: u32,
+    q_end: u32,
+) -> QueryResult {
+    let ploidy = reader.ploidy;
+    let lut = reader.lut.as_ref();
+    let dense = reader.dense_union();
+    let (ds, de) = dense.overlap(q_start, q_end);
+
+    let mut per_hap = Vec::with_capacity(ploidy);
+    for p in 0..ploidy {
+        let col = sample * ploidy + p; // flat column
+        let hap = col; // sample-major hap index == flat column
+        let vk = reader.vk_slice(col, sample, p, q_start, q_end);
+        let dn = reader.dense_carried(&dense, hap, ds, de);
+        let merged = spine::merge_keys(vec![vk, dn]);
+
+        let mut hc = HapCalls::default();
+        for kr in merged {
+            let c = decode_keyref(kr, lut);
+            hc.positions.push(c.position);
+            hc.ilens.push(c.ilen);
+            hc.alts.push(c.alt);
+        }
+        per_hap.push(hc);
+    }
+    QueryResult { per_hap }
+}
+```
+
+- [ ] **Step 7: Run the unit + M5 integration suites (the regression gate)**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features`
+Expected: PASS — including the spine unit tests and, crucially, every `tests/test_query.rs` case (`test_overlap_sample_known_contig`, the nonzero-CSR-offset regression, the routing invariant, the pure-SNP contig, and `prop_overlap_sample_matches_oracle`). Identical results prove the spine reproduces M5 byte-for-byte.
+
+If any `test_query` case fails, the refactor changed behavior — debug against that case (superpowers:systematic-debugging) before proceeding. Do not adjust the test to match new output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/query.rs
+git commit -m "refactor(query): re-express overlap_sample on the uniform-key spine"
+```
+
+---
+
+### Task 4: `overlap_batch` + `BatchResult` (batched two-channel spine)
+
+**Files:**
+- Modify: `src/query.rs` — add `n_samples` to `ContigReader` (field + `open`); add `BatchResult`, `overlap_batch`, and `BatchResult::decode_hap`.
+
+**Interfaces:**
+- Consumes: `ContigReader::{vk_slice, dense_union, dense_carried}` and `DenseUnion::overlap` (Task 3); `spine::{KeyRef, merge_keys}`; `decode_keyref` (Task 3); `crate::bits::{set_bit, get_bit}`.
+- Produces:
+  - Public field `ContigReader.n_samples: usize`.
+  - `pub struct BatchResult { pub n_regions: usize, pub n_samples: usize, pub ploidy: usize, pub vk: Vec<KeyRef>, pub vk_off: Vec<usize>, pub dense: Vec<KeyRef>, pub dense_range: Vec<(usize, usize)>, pub dense_present: Vec<u8>, pub dense_present_off: Vec<usize> }`.
+    - `vk`/`vk_off`: flat `var_key` channel, ragged over `H = n_regions * n_samples * ploidy` slices in **region-major** order `h = (r * n_samples + s) * ploidy + p`; `vk_off` is CSR (len `H + 1`).
+    - `dense`: the shared per-contig `snp`+`indel` union (uniform keys, position-sorted); `dense_range[r] = [s, e)` into it for region `r`.
+    - `dense_present`/`dense_present_off`: per-`(region, sample, ploid)` presence bitmask over that region's `dense[s..e]` slice, LSB-first, concatenated; `dense_present_off` (len `H + 1`) holds **bit** offsets.
+  - `pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult`.
+  - `pub fn BatchResult::decode_hap(&self, reader: &ContigReader, r: usize, s: usize, p: usize) -> HapCalls` — merge this hap's `var_key` slice ⋈ its dense-carried refs and decode (the M6c materialization primitive and the Task 5 cross-check oracle).
+
+- [ ] **Step 1: Add `n_samples` to `ContigReader`**
+
+In the `ContigReader` struct, add a field (below `ploidy`):
+
+```rust
+    ploidy: usize,
+    n_samples: usize,
+```
+
+In `open`, set it in the returned `Self { … }` (it is already a parameter):
+
+```rust
+        Ok(Self {
+            ploidy,
+            n_samples,
+            vk_snp,
+            vk_indel,
+            dense_snp,
+            dense_indel,
+            vk_indel_max_del,
+            dense_indel_max_del,
+            lut,
+        })
+```
+
+- [ ] **Step 2: Write the failing unit test for the batch shape**
+
+Add to `query.rs`'s `#[cfg(test)] mod tests` a pure-shape test that does not need a real contig — it builds a tiny in-memory `BatchResult` invariant check via `overlap_batch` on an empty contig dir is awkward, so instead assert the **offset invariants** with a constructed value. Add:
+
+```rust
+    #[test]
+    fn test_batch_result_offsets_are_consistent() {
+        // A hand-built BatchResult: 1 region, 2 samples, ploidy 2 -> H = 4.
+        // vk_off / dense_present_off must be non-decreasing, length H+1, and
+        // bound the flat buffers.
+        let br = BatchResult {
+            n_regions: 1,
+            n_samples: 2,
+            ploidy: 2,
+            vk: vec![KeyRef { position: 10, key: 1 << 25 }],
+            vk_off: vec![0, 1, 1, 1, 1],
+            dense: vec![],
+            dense_range: vec![(0, 0)],
+            dense_present: vec![],
+            dense_present_off: vec![0, 0, 0, 0, 0],
+        };
+        let h = br.n_regions * br.n_samples * br.ploidy;
+        assert_eq!(br.vk_off.len(), h + 1);
+        assert_eq!(br.dense_present_off.len(), h + 1);
+        assert_eq!(*br.vk_off.last().unwrap(), br.vk.len());
+        assert!(br.vk_off.windows(2).all(|w| w[0] <= w[1]));
+        assert!(br.dense_present_off.windows(2).all(|w| w[0] <= w[1]));
+    }
+```
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features test_batch_result_offsets`
+Expected: FAIL — `cannot find type BatchResult in this scope`.
+
+- [ ] **Step 3: Add `BatchResult`, `overlap_batch`, and `decode_hap`**
+
+Place after `overlap_sample`:
+
+```rust
+/// The batched, two-channel query spine result for one contig (M6.1). Carries
+/// undecoded uniform keys; consumers (gvl M6b / Python M6c) do the final
+/// `var_key ⋈ dense` merge and allele decode. `H = n_regions * n_samples *
+/// ploidy` hap-slices in region-major order `h = (r * n_samples + s) * ploidy + p`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BatchResult {
+    pub n_regions: usize,
+    pub n_samples: usize,
+    pub ploidy: usize,
+    /// Flat var_key channel; `vk_off` (len H+1, CSR) slices it per hap.
+    pub vk: Vec<KeyRef>,
+    pub vk_off: Vec<usize>,
+    /// Shared dense union (uniform keys, position-sorted); decode-once.
+    pub dense: Vec<KeyRef>,
+    /// `[s, e)` into `dense` per region (len n_regions).
+    pub dense_range: Vec<(usize, usize)>,
+    /// Per-hap dense presence bitmask over that region's `dense[s..e]`, LSB-first,
+    /// concatenated; `dense_present_off` (len H+1) holds BIT offsets.
+    pub dense_present: Vec<u8>,
+    pub dense_present_off: Vec<usize>,
+}
+
+/// Batched multi-region × whole-cohort query. `regions` is a list of half-open
+/// `[q_start, q_end)`. Single-threaded; `rayon` over the H hap-slices and dense-
+/// window subsetting are M6b concerns (see the design spec's open questions).
+pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
+    let ploidy = reader.ploidy;
+    let n_samples = reader.n_samples;
+    let n_regions = regions.len();
+
+    let dense = reader.dense_union();
+    // Per-region dense index ranges — shared across all samples in the region.
+    let ranges: Vec<(usize, usize)> = regions.iter().map(|&(qs, qe)| dense.overlap(qs, qe)).collect();
+
+    let mut vk: Vec<KeyRef> = Vec::new();
+    let mut vk_off: Vec<usize> = vec![0];
+    let mut dense_present: Vec<u8> = Vec::new();
+    let mut dense_present_off: Vec<usize> = vec![0];
+
+    for (r, &(qs, qe)) in regions.iter().enumerate() {
+        let (ds, de) = ranges[r];
+        for s in 0..n_samples {
+            for p in 0..ploidy {
+                let col = s * ploidy + p;
+                let hap = col;
+
+                // var_key channel slice for (region r, sample s, ploid p).
+                let slice = reader.vk_slice(col, s, p, qs, qe);
+                vk.extend_from_slice(&slice);
+                vk_off.push(vk.len());
+
+                // dense presence bits over dense[ds..de].
+                let nbits = de - ds;
+                let bit_base = *dense_present_off.last().unwrap();
+                let need_bytes = (bit_base + nbits).div_ceil(8);
+                if dense_present.len() < need_bytes {
+                    dense_present.resize(need_bytes, 0);
+                }
+                for (k, j) in (ds..de).enumerate() {
+                    let (is_indel, dcol) = dense.src[j];
+                    let carried = if is_indel {
+                        reader.dense_indel.as_ref().expect("indel src implies table").carried(hap, dcol)
+                    } else {
+                        reader.dense_snp.as_ref().expect("snp src implies table").carried(hap, dcol)
+                    };
+                    if carried {
+                        bits::set_bit(&mut dense_present, bit_base + k);
+                    }
+                }
+                dense_present_off.push(bit_base + nbits);
+            }
+        }
+    }
+
+    BatchResult {
+        n_regions,
+        n_samples,
+        ploidy,
+        vk,
+        vk_off,
+        dense: dense.refs,
+        dense_range: ranges,
+        dense_present,
+        dense_present_off,
+    }
+}
+
+impl BatchResult {
+    /// Decode the merged `var_key ⋈ dense` variants that `(sample s, ploid p)`
+    /// carries in region `r` — position-sorted `(position, ilen, alt)`, identical
+    /// to `overlap_sample(sample=s, region=r).per_hap[p]`. The M6c materialization
+    /// primitive; here also the Task 5 cross-check oracle. Needs `reader` for the
+    /// LUT (long-INS allele bytes).
+    pub fn decode_hap(&self, reader: &ContigReader, r: usize, s: usize, p: usize) -> HapCalls {
+        let h = (r * self.n_samples + s) * self.ploidy + p;
+        let vk_slice = self.vk[self.vk_off[h]..self.vk_off[h + 1]].to_vec();
+
+        let (ds, de) = self.dense_range[r];
+        let bit0 = self.dense_present_off[h];
+        let mut dn: Vec<KeyRef> = Vec::new();
+        for (k, j) in (ds..de).enumerate() {
+            if bits::get_bit(&self.dense_present, bit0 + k) {
+                dn.push(self.dense[j]);
+            }
+        }
+
+        let merged = spine::merge_keys(vec![vk_slice, dn]);
+        let lut = reader.lut.as_ref();
+        let mut hc = HapCalls::default();
+        for kr in merged {
+            let c = decode_keyref(kr, lut);
+            hc.positions.push(c.position);
+            hc.ilens.push(c.ilen);
+            hc.alts.push(c.alt);
+        }
+        hc
+    }
+}
+```
+
+- [ ] **Step 4: Run the unit test to verify it passes**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features test_batch_result_offsets`
+Expected: PASS.
+
+Run the full unit suite too: `pixi run -e lint cargo test -p genoray --no-default-features`
+Expected: PASS — `overlap_sample` and all M5 integration tests unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/query.rs
+git commit -m "feat(query): add batched two-channel overlap_batch spine"
+```
+
+---
+
+### Task 5: Disk-integration test — `overlap_batch` ≡ `overlap_sample`, and decode-free counts
+
+**Files:**
+- Create: `tests/test_batch.rs`
+
+**Interfaces:**
+- Consumes: `genoray_core::query::{ContigReader, overlap_sample, overlap_batch}`; `genoray_core::process_chromosome`; `common::{SynthRecord, build_bcf_with_index, build_fasta_with_index}`.
+- Produces: nothing (test-only).
+
+- [ ] **Step 1: Write the failing cross-check test**
+
+`overlap_batch` decoded per hap must equal `overlap_sample` for every `(region, sample, ploid)` — reusing M5's already-oracle-tested `overlap_sample` as the reference makes this transitively correct. The `decode_hap` merge also proves the two-channel form re-composes to the materialized form (the "two-channel ≡ materialized" check in the spec). Create `tests/test_batch.rs`:
+
+```rust
+//! Disk-integration tests for the batched M6.1 spine (`overlap_batch`). Builds
+//! finished SVAR2 contigs via the real converter, then cross-checks the two-
+//! channel batch result against the M5 single-sample `overlap_sample` — the
+//! already-oracle-tested reference — for every (region, sample, ploid), plus a
+//! decode-free dense-count sanity check.
+
+mod common;
+
+use common::{SynthRecord, build_bcf_with_index, build_fasta_with_index};
+use genoray_core::process_chromosome;
+use genoray_core::query::{ContigReader, overlap_batch, overlap_sample};
+use ndarray::{Array1, Array2};
+use std::path::Path;
+use tempfile::tempdir;
+
+/// Deletion length implied by a record's ref/alt lengths (`max(0, -ilen)`).
+fn del_len_of(rec: &SynthRecord) -> u32 {
+    let ilen = rec.alts[0].len() as i32 - rec.ref_allele.len() as i32;
+    if ilen < 0 { (-ilen) as u32 } else { 0 }
+}
+
+/// Conservative `max_del` fixture (overshoot-safe; mirrors `tests/test_query.rs`).
+fn write_max_del_fixture(contig_dir: &Path, n_samples: usize, ploidy: usize, records: &[SynthRecord]) {
+    let columns = n_samples * ploidy;
+    let mut per_col = vec![0u32; columns];
+    let mut global = 0u32;
+    for rec in records {
+        let d = del_len_of(rec);
+        global = global.max(d);
+        for (hap, &g) in rec.gt.iter().enumerate() {
+            if g == 1 {
+                per_col[hap] = per_col[hap].max(d);
+            }
+        }
+    }
+    let arr = Array2::from_shape_vec((n_samples, ploidy), per_col).unwrap();
+    ndarray_npy::write_npy(contig_dir.join("max_del.npy"), &arr).unwrap();
+    std::fs::create_dir_all(contig_dir.join("dense")).unwrap();
+    let dense = Array1::from_vec(vec![global]);
+    ndarray_npy::write_npy(contig_dir.join("dense").join("max_del.npy"), &dense).unwrap();
+}
+
+/// Convert `records` to a finished contig under `out/{chrom}` + write max_del.
+fn build_contig(out: &Path, chrom: &str, samples: &[&str], ploidy: usize, records: &[SynthRecord]) {
+    let bcf = out.join("in.bcf");
+    let fasta = out.join("in.fa");
+    build_bcf_with_index(&bcf, chrom, 1_000_000, samples, records);
+    build_fasta_with_index(&fasta, chrom, 1_000_000, records);
+    process_chromosome(
+        bcf.to_str().unwrap(),
+        fasta.to_str().unwrap(),
+        chrom,
+        out.to_str().unwrap(),
+        samples,
+        1000, // chunk_size
+        ploidy,
+        1,    // htslib_threads
+        4096, // long_allele_capacity
+    )
+    .expect("process_chromosome should succeed");
+    write_max_del_fixture(&out.join(chrom), samples.len(), ploidy, records);
+}
+
+#[test]
+fn test_overlap_batch_matches_overlap_sample() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let samples = ["S0", "S1"];
+    let records = vec![
+        SynthRecord { pos: 100, ref_allele: b"A", alts: vec![&b"C"[..]], gt: vec![1, 0, 1, 1] },
+        SynthRecord { pos: 200, ref_allele: b"A", alts: vec![&b"AT"[..]], gt: vec![0, 1, 0, 0] },
+        SynthRecord { pos: 300, ref_allele: b"AT", alts: vec![&b"A"[..]], gt: vec![1, 1, 0, 0] },
+    ];
+    build_contig(&out, "chr1", &samples, 2, &records);
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap();
+
+    // Two regions: one whole-contig, one that a deletion spans into.
+    let regions = [(0u32, 1000u32), (301u32, 302u32)];
+    let batch = overlap_batch(&reader, &regions);
+
+    assert_eq!(batch.n_regions, 2);
+    assert_eq!(batch.n_samples, 2);
+    assert_eq!(batch.ploidy, 2);
+
+    for (r, &(qs, qe)) in regions.iter().enumerate() {
+        for s in 0..2usize {
+            let single = overlap_sample(&reader, s, qs, qe);
+            for p in 0..2usize {
+                let got = batch.decode_hap(&reader, r, s, p);
+                assert_eq!(got, single.per_hap[p], "r={r} s={s} p={p}");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features --test test_batch`
+Expected: FAIL to compile if Task 4 was skipped (`unresolved import overlap_batch`); otherwise it should already PASS if Tasks 3–4 are correct. If it PASSES immediately, that is fine — it is a regression/parity test, not a red-first unit; note the pass and continue. (Keep the TDD discipline for the counting test below.)
+
+- [ ] **Step 3: Add the decode-free dense-count parity test**
+
+Append to `tests/test_batch.rs`. A common deletion carried by most samples routes to `dense/indel`; the per-hap `dense_present` popcount must equal the number of dense variants that hap actually carries (which decode-free counting in M6c will rely on):
+
+```rust
+/// popcount of a hap's dense presence bitmask == the dense variants that hap
+/// carries in that region (the decode-free count M6c is built on).
+fn dense_popcount(batch: &genoray_core::query::BatchResult, r: usize, s: usize, p: usize) -> usize {
+    let h = (r * batch.n_samples + s) * batch.ploidy + p;
+    let (bit0, bit1) = (batch.dense_present_off[h], batch.dense_present_off[h + 1]);
+    (bit0..bit1)
+        .filter(|&b| (batch.dense_present[b >> 3] >> (b & 7)) & 1 != 0)
+        .count()
+}
+
+#[test]
+fn test_dense_present_popcount_counts_dense_carriers() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    // 6 samples; a 4-base DEL carried by nearly everyone -> dense/indel.
+    let samples = ["S0", "S1", "S2", "S3", "S4", "S5"];
+    let records = vec![SynthRecord {
+        pos: 500,
+        ref_allele: b"ATATC",
+        alts: vec![&b"A"[..]],
+        gt: vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], // S5 carries neither hap
+    }];
+    build_contig(&out, "chr1", &samples, 2, &records);
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 6, 2).unwrap();
+
+    let regions = [(0u32, 1000u32)];
+    let batch = overlap_batch(&reader, &regions);
+
+    // The DEL is dense, so it sits in the dense channel: carriers see popcount 1,
+    // S5 (gt 0,0) sees 0. Cross-check against decode_hap's length.
+    for s in 0..6usize {
+        for p in 0..2usize {
+            let want = batch.decode_hap(&reader, 0, s, p).positions.len();
+            assert_eq!(dense_popcount(&batch, 0, s, p), want, "s={s} p={p}");
+        }
+    }
+    // Explicit: S5 carries nothing here.
+    assert_eq!(dense_popcount(&batch, 0, 5, 0), 0);
+    assert_eq!(dense_popcount(&batch, 0, 5, 1), 0);
+}
+```
+
+> Note: this test asserts `dense_popcount == decode_hap(...).len()` **only because this fixture has no `var_key` variants** — every carried variant is the dense DEL. In the general case `decode_hap` length is `var_key + dense` carriers; the equality here isolates the dense count. Keep the fixture single-DEL so the invariant holds.
+
+- [ ] **Step 4: Run both batch tests to verify they pass**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features --test test_batch`
+Expected: PASS — `test_overlap_batch_matches_overlap_sample` and `test_dense_present_popcount_counts_dense_carriers`.
+
+- [ ] **Step 5: Add the randomized cross-check proptest**
+
+Append to `tests/test_batch.rs`. Reuse the M5 random-contig generator shape (owned records, gaps ≥ 17 so positions stay left-canonical), build a contig, query several random regions, and assert `overlap_batch` ≡ `overlap_sample` for every `(region, sample, ploid)`:
+
+```rust
+use proptest::prelude::*;
+
+/// Owned atomized record (proptest values must outlive the borrow).
+#[derive(Clone, Debug)]
+struct OwnedRecord {
+    pos: i64,
+    ref_allele: Vec<u8>,
+    alt: Vec<u8>,
+    gt: Vec<i32>,
+}
+
+/// Random atomized contig (SNP/INS/DEL), strictly increasing positions with gaps
+/// >= 17 so REF stamps never touch and M2b never left-shifts. Mirrors
+/// `tests/test_query.rs::arb_records`.
+fn arb_records(n_haps: usize) -> impl Strategy<Value = Vec<OwnedRecord>> {
+    proptest::collection::vec(
+        (
+            0u8..3u8,
+            0usize..4,
+            0usize..4,
+            proptest::collection::vec(0usize..4, 1..16),
+            proptest::collection::vec(0i32..2, n_haps..=n_haps),
+            17u32..40u32,
+        ),
+        1..8,
+    )
+    .prop_map(move |specs| {
+        const BASES: [u8; 4] = [b'A', b'C', b'T', b'G'];
+        let mut pos: i64 = 100;
+        let mut out = Vec::new();
+        for (kind, anchor, snp_alt, tail, gt, gap) in specs {
+            pos += gap as i64;
+            let b0 = BASES[anchor];
+            let mut tail = tail;
+            if tail.last() == Some(&anchor) {
+                *tail.last_mut().unwrap() = (anchor + 1) % 4;
+            }
+            let (ref_allele, alt) = match kind {
+                0 => {
+                    let alt_idx = if snp_alt == anchor { (anchor + 1) % 4 } else { snp_alt };
+                    (vec![b0], vec![BASES[alt_idx]])
+                }
+                1 => {
+                    let mut a = vec![b0];
+                    a.extend(tail.iter().map(|&x| BASES[x]));
+                    (vec![b0], a)
+                }
+                _ => {
+                    let mut r = vec![b0];
+                    r.extend(tail.iter().map(|&x| BASES[x]));
+                    (r, vec![b0])
+                }
+            };
+            out.push(OwnedRecord { pos, ref_allele, alt, gt });
+        }
+        out
+    })
+}
+
+proptest! {
+    // Heavy: each case runs the full converter. Low case count on purpose.
+    #![proptest_config(ProptestConfig::with_cases(16))]
+
+    #[test]
+    fn prop_overlap_batch_matches_overlap_sample(
+        records in arb_records(6), // 3 samples, diploid
+        starts in proptest::collection::vec(0u32..1200, 1..4),
+        q_len in 1u32..300,
+    ) {
+        let n_samples = 3usize;
+        let ploidy = 2usize;
+        let sample_names = ["S0", "S1", "S2"];
+
+        let synth: Vec<SynthRecord> = records
+            .iter()
+            .map(|r| SynthRecord {
+                pos: r.pos,
+                ref_allele: &r.ref_allele,
+                alts: vec![&r.alt[..]],
+                gt: r.gt.clone(),
+            })
+            .collect();
+
+        let tmp = tempdir().unwrap();
+        let out = tmp.path().join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        build_contig(&out, "chr1", &sample_names, ploidy, &synth);
+        let reader = ContigReader::open(out.to_str().unwrap(), "chr1", n_samples, ploidy).unwrap();
+
+        let regions: Vec<(u32, u32)> = starts.iter().map(|&s| (s, s + q_len)).collect();
+        let batch = overlap_batch(&reader, &regions);
+
+        for (r, &(qs, qe)) in regions.iter().enumerate() {
+            for s in 0..n_samples {
+                let single = overlap_sample(&reader, s, qs, qe);
+                for p in 0..ploidy {
+                    prop_assert_eq!(
+                        batch.decode_hap(&reader, r, s, p),
+                        single.per_hap[p].clone(),
+                        "r={} s={} p={}", r, s, p
+                    );
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run the full integration suite**
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features --test test_batch`
+Expected: PASS — all three tests including `prop_overlap_batch_matches_overlap_sample`.
+
+Then the whole suite once more: `pixi run -e lint cargo test -p genoray --no-default-features`
+Expected: PASS — nothing regressed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_batch.rs
+git commit -m "test(query): cross-check overlap_batch against overlap_sample"
+```
+
+---
+
+### Task 6: Reconcile roadmap + supplements
+
+**Files:**
+- Modify: `docs/roadmap/svar-2.md` (mark M6.1 done; note the spine + `overlap_batch`)
+- Modify: `docs/roadmap/architecture.md` (the "Python decode path" / union hot-loop section names `overlap_batch` + the two-channel spine)
+- Modify: `docs/superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md` (tick the "Shared spine (M6)" items this plan delivered)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: docs consistent with the shipped spine (the working agreement requires this in the same branch).
+
+- [ ] **Step 1: Mark M6.1 done in `docs/roadmap/svar-2.md`**
+
+Change the `- [ ] **M6.1 consumer spine (now unblocked — next up).**` checkbox to `- [x] **M6.1 consumer spine (done).**` and replace its body with a *Done* note: `src/spine.rs` (`KeyRef`/`gather_keys`/`merge_keys`) + `overlap_batch`/`BatchResult`/`decode_hap` in `src/query.rs` deliver the batched two-channel spine; SNPs re-expand via `svar2_codec::snp_code_to_key`; `overlap_sample` re-expressed on the spine (M5 tests are the regression oracle); cross-checked by `tests/test_batch.rs`. Point to this plan. Note what remains under M6: the PyO3/numpy exposure of `BatchResult` and dense-window subsetting are **M6b**, and the `seqpro.rag.Ragged` materialization is **M6c**.
+
+- [ ] **Step 2: Name the spine in `docs/roadmap/architecture.md`**
+
+In the "Python decode path" section (the sorted-union hot loop referenced by the design spec), add a sentence: the union is realized by `overlap_batch` (`src/query.rs`) over the reader-free `src/spine.rs` `gather_keys`/`merge_keys`, producing a two-channel result (per-hap `var_key` KeyRefs + a decode-once `dense` union with per-region ranges and presence bitmasks); allele decode is deferred to the consumer via `decode_keyref`/`BatchResult::decode_hap`.
+
+- [ ] **Step 3: Tick the delivered spine items in the M6 design spec**
+
+In `2026-07-02-svar2-m6-consumer-interfaces-design.md` under "Shared spine (M6)", annotate items 3 (uniform in-memory key) and 4 (sorted union) as delivered by M6.1 (`overlap_batch` + `snp_code_to_key`), and note item 1 (finish M5 disk integration) landed with M5's `overlap_sample`. Leave items marked for M6b/M6c untouched.
+
+- [ ] **Step 4: Verify docs and run the whole suite once more**
+
+Run: `git diff --stat docs/`
+Expected: three files changed.
+
+Run: `pixi run -e lint cargo test -p genoray --no-default-features && pixi run -e lint cargo test -p svar2-codec`
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/roadmap/svar-2.md docs/roadmap/architecture.md docs/superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md
+git commit -m "docs(svar-2): mark M6.1 consumer spine done"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `2026-07-02-svar2-m6-consumer-interfaces-design.md`, "Shared spine (M6)"):
+- Item 1 (finish M5 disk integration) — landed with M5; `overlap_sample` re-expressed on the spine (Task 3), regression-guarded.
+- Item 2 (`svar2-codec` crate) — done pre-plan (M6.0); this plan only adds `snp_code_to_key` (Task 1) for the uniform-key re-expansion, keeping the `<<25` layout in the codec.
+- Item 3 (uniform in-memory key) — `snp_code_to_key` + `KeyRef` carries uniform 32-bit keys; SNP sub-streams re-expanded in `vk_slice`/`dense_union` (Tasks 1–4).
+- Item 4 (sorted union) — `merge_keys` unions `snp`+`indel` within `var_key` (per hap) and within `dense` (shared); the final `var_key ⋈ dense` merge is left to the consumer, exercised by `decode_hap` (Tasks 2–4).
+- Two-channel result shape (`vk`/`vk_off`, `dense`/`dense_range`, `dense_present`/`dense_present_off`) — `BatchResult` (Task 4), matching the M6b spec's channels in Rust-native form (PyO3 exposure is M6b).
+- Verification: "two-channel ≡ materialized" and "count shortcut" from the spec's Verification section → `test_overlap_batch_matches_overlap_sample` + `test_dense_present_popcount_counts_dense_carriers` + the proptest (Task 5). Codec parity for the new primitive → Task 1 tests.
+- Explicitly deferred, called out in-plan: `rayon` over haps, dense-window subsetting, and the PyO3/numpy + `seqpro.rag.Ragged` materialization (M6b/M6c; spec open questions).
+
+**Placeholder scan:** none — every step carries real code or an exact command with expected output. The `arb_records` generator and `build_contig`/`write_max_del_fixture` are reproduced verbatim from `tests/test_query.rs` (the plan repeats them so Task 5 is self-contained rather than referencing "similar to test_query").
+
+**Type consistency:**
+- `KeyRef { position: u32, key: u32 }` (Copy) — defined Task 2, consumed identically in Tasks 3–5.
+- `snp_code_to_key(u8) -> u32` — Task 1; called in `vk_slice` and `dense_union` (Task 3) via the `rvk` re-export.
+- `gather_keys(positions, max_region_length, q_start, q_end, del_len, carried, to_key, out)` and `merge_keys(Vec<Vec<KeyRef>>) -> Vec<KeyRef>` — Task 2 signatures; call sites in Tasks 3–4 match argument order and arity.
+- `decode_keyref(KeyRef, Option<&LongAlleleReader>) -> Call` — Task 3; reused by `decode_hap` (Task 4).
+- `BatchResult` fields and the region-major index `h = (r * n_samples + s) * ploidy + p` are used identically in `overlap_batch`, `decode_hap`, and the Task 5 `dense_popcount` helper.
+- `ContigReader.n_samples` added in Task 4 and read by `overlap_batch`; `open`'s existing `n_samples` parameter feeds it.

--- a/docs/superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-02-svar2-m6-consumer-interfaces-design.md
@@ -80,7 +80,7 @@ two-channel sparse, fused decode    materialized seqpro Ragged record
 
 ### Shared spine (M6)
 
-1. **Finish M5 disk integration.** Turn a `(contig, ranges, samples)` query into index
+1. **Finish M5 disk integration** *(M5).* Turn a `(contig, ranges, samples)` query into index
    ranges per `(sample, ploid)` per sub-stream: consume `max_del.npy` for the `indel/`
    leftward bound, read the on-disk sidecars (`positions.bin`, `offsets.npy`, dense
    `genotypes.bin`), and resolve `[s_idx, e_idx)` via the existing `overlap_range`
@@ -101,18 +101,19 @@ two-channel sparse, fused decode    materialized seqpro Ragged record
    allele buffer crossing FFI. Track re-align calls only `ilen`/`deletion_len` — zero
    allele materialization.
 
-3. **Uniform in-memory key.** On disk stays split (`snp/` 2-bit-packed, `indel/` 32-bit)
+3. **Uniform in-memory key** *(M6.1).* On disk stays split (`snp/` 2-bit-packed, `indel/` 32-bit)
    for space. A query result **re-expands SNPs into the uniform 32-bit key** (`ILEN=0`,
-   ALT base inline — the pre-M1-split encoding). Consumers then have a single
-   `decode(u32, lut)` path, and gvl's per-hap merge drops from 3-way (snp/indel/dense)
-   to 2-way (var_key/dense). Cost: one shift per SNP in genoray (the 2-bit code is
-   already unpacked at read time).
+   ALT base inline — the pre-M1-split encoding) via `svar2_codec::snp_code_to_key`.
+   Consumers then have a single `decode(u32, lut)` path, and gvl's per-hap merge drops from
+   3-way (snp/indel/dense) to 2-way (var_key/dense). Cost: one shift per SNP in genoray
+   (the 2-bit code is already unpacked at read time).
 
-4. **Sorted union.** Branch-light merge of position-sorted sub-streams (the query hot
+4. **Sorted union** *(M6.1).* Branch-light merge of position-sorted sub-streams (the query hot
    loop flagged in [`architecture.md`](../../roadmap/architecture.md#python-decode-path)).
-   genoray pre-unions `snp` + `indel` *within* `var_key` (into one per-hap stream) and
-   *within* `dense` (into one shared table). The final `var_key ⋈ dense` merge is done by
-   the consumer, interleaved with its own work (splice / materialize).
+   `overlap_batch` + `merge_keys` in `src/spine.rs` pre-union `snp` + `indel` *within*
+   `var_key` (into one per-hap stream) and *within* `dense` (into one shared table).
+   The final `var_key ⋈ dense` merge is done by the consumer, interleaved with its own work
+   (splice / materialize).
 
 ### M6b — gvl Rust variant interface (two-channel, built first)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod orchestrator;
 pub mod query;
 pub mod rvk;
 pub mod search;
+pub mod spine;
 pub mod streams;
 pub mod types;
 pub mod vcf_reader;

--- a/src/query.rs
+++ b/src/query.rs
@@ -186,6 +186,7 @@ fn open_dense(dir: &Path) -> std::io::Result<Option<DenseView>> {
 /// lifetime of queries against it.
 pub struct ContigReader {
     ploidy: usize,
+    n_samples: usize,
     vk_snp: SubStreamView,
     vk_indel: SubStreamView,
     dense_snp: Option<DenseView>,
@@ -240,6 +241,7 @@ impl ContigReader {
 
         Ok(Self {
             ploidy,
+            n_samples,
             vk_snp,
             vk_indel,
             dense_snp,
@@ -449,10 +451,167 @@ pub fn overlap_sample(
     QueryResult { per_hap }
 }
 
+/// The batched, two-channel query spine result for one contig (M6.1). Carries
+/// undecoded uniform keys; consumers (gvl M6b / Python M6c) do the final
+/// `var_key ⋈ dense` merge and allele decode. `H = n_regions * n_samples *
+/// ploidy` hap-slices in region-major order `h = (r * n_samples + s) * ploidy + p`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BatchResult {
+    pub n_regions: usize,
+    pub n_samples: usize,
+    pub ploidy: usize,
+    /// Flat var_key channel; `vk_off` (len H+1, CSR) slices it per hap.
+    pub vk: Vec<KeyRef>,
+    pub vk_off: Vec<usize>,
+    /// Shared dense union (uniform keys, position-sorted); decode-once.
+    pub dense: Vec<KeyRef>,
+    /// `[s, e)` into `dense` per region (len n_regions).
+    pub dense_range: Vec<(usize, usize)>,
+    /// Per-hap dense presence bitmask over that region's `dense[s..e]`, LSB-first,
+    /// concatenated; `dense_present_off` (len H+1) holds BIT offsets.
+    pub dense_present: Vec<u8>,
+    pub dense_present_off: Vec<usize>,
+}
+
+/// Batched multi-region × whole-cohort query. `regions` is a list of half-open
+/// `[q_start, q_end)`. Single-threaded; `rayon` over the H hap-slices and dense-
+/// window subsetting are M6b concerns (see the design spec's open questions).
+pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
+    let ploidy = reader.ploidy;
+    let n_samples = reader.n_samples;
+    let n_regions = regions.len();
+
+    let dense = reader.dense_union();
+    // Per-region dense index ranges — shared across all samples in the region.
+    let ranges: Vec<(usize, usize)> = regions
+        .iter()
+        .map(|&(qs, qe)| dense.overlap(qs, qe))
+        .collect();
+
+    let mut vk: Vec<KeyRef> = Vec::new();
+    let mut vk_off: Vec<usize> = vec![0];
+    let mut dense_present: Vec<u8> = Vec::new();
+    let mut dense_present_off: Vec<usize> = vec![0];
+
+    for (r, &(qs, qe)) in regions.iter().enumerate() {
+        let (ds, de) = ranges[r];
+        for s in 0..n_samples {
+            for p in 0..ploidy {
+                let col = s * ploidy + p;
+                let hap = col;
+
+                // var_key channel slice for (region r, sample s, ploid p).
+                let slice = reader.vk_slice(col, s, p, qs, qe);
+                vk.extend_from_slice(&slice);
+                vk_off.push(vk.len());
+
+                // dense presence bits over dense[ds..de].
+                let nbits = de - ds;
+                let bit_base = *dense_present_off.last().unwrap();
+                let need_bytes = (bit_base + nbits).div_ceil(8);
+                if dense_present.len() < need_bytes {
+                    dense_present.resize(need_bytes, 0);
+                }
+                for (k, j) in (ds..de).enumerate() {
+                    let (is_indel, dcol) = dense.src[j];
+                    let carried = if is_indel {
+                        reader
+                            .dense_indel
+                            .as_ref()
+                            .expect("indel src implies table")
+                            .carried(hap, dcol)
+                    } else {
+                        reader
+                            .dense_snp
+                            .as_ref()
+                            .expect("snp src implies table")
+                            .carried(hap, dcol)
+                    };
+                    if carried {
+                        bits::set_bit(&mut dense_present, bit_base + k);
+                    }
+                }
+                dense_present_off.push(bit_base + nbits);
+            }
+        }
+    }
+
+    BatchResult {
+        n_regions,
+        n_samples,
+        ploidy,
+        vk,
+        vk_off,
+        dense: dense.refs,
+        dense_range: ranges,
+        dense_present,
+        dense_present_off,
+    }
+}
+
+impl BatchResult {
+    /// Decode the merged `var_key ⋈ dense` variants that `(sample s, ploid p)`
+    /// carries in region `r` — position-sorted `(position, ilen, alt)`, identical
+    /// to `overlap_sample(sample=s, region=r).per_hap[p]`. The M6c materialization
+    /// primitive; here also the Task 5 cross-check oracle. Needs `reader` for the
+    /// LUT (long-INS allele bytes).
+    pub fn decode_hap(&self, reader: &ContigReader, r: usize, s: usize, p: usize) -> HapCalls {
+        let h = (r * self.n_samples + s) * self.ploidy + p;
+        let vk_slice = self.vk[self.vk_off[h]..self.vk_off[h + 1]].to_vec();
+
+        let (ds, de) = self.dense_range[r];
+        let bit0 = self.dense_present_off[h];
+        let mut dn: Vec<KeyRef> = Vec::new();
+        for (k, j) in (ds..de).enumerate() {
+            if bits::get_bit(&self.dense_present, bit0 + k) {
+                dn.push(self.dense[j]);
+            }
+        }
+
+        let merged = spine::merge_keys(vec![vk_slice, dn]);
+        let lut = reader.lut.as_ref();
+        let mut hc = HapCalls::default();
+        for kr in merged {
+            let c = decode_keyref(kr, lut);
+            hc.positions.push(c.position);
+            hc.ilens.push(c.ilen);
+            hc.alts.push(c.alt);
+        }
+        hc
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn test_batch_result_offsets_are_consistent() {
+        // A hand-built BatchResult: 1 region, 2 samples, ploidy 2 -> H = 4.
+        // vk_off / dense_present_off must be non-decreasing, length H+1, and
+        // bound the flat buffers.
+        let br = BatchResult {
+            n_regions: 1,
+            n_samples: 2,
+            ploidy: 2,
+            vk: vec![KeyRef {
+                position: 10,
+                key: 1 << 25,
+            }],
+            vk_off: vec![0, 1, 1, 1, 1],
+            dense: vec![],
+            dense_range: vec![(0, 0)],
+            dense_present: vec![],
+            dense_present_off: vec![0, 0, 0, 0, 0],
+        };
+        let h = br.n_regions * br.n_samples * br.ploidy;
+        assert_eq!(br.vk_off.len(), h + 1);
+        assert_eq!(br.dense_present_off.len(), h + 1);
+        assert_eq!(*br.vk_off.last().unwrap(), br.vk.len());
+        assert!(br.vk_off.windows(2).all(|w| w[0] <= w[1]));
+        assert!(br.dense_present_off.windows(2).all(|w| w[0] <= w[1]));
+    }
 
     #[test]
     fn test_mmap_u32_roundtrip() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -15,6 +15,7 @@ use crate::layout::{self, ContigPaths};
 use crate::nrvk::LongAlleleReader;
 use crate::rvk::{self, DecodedKey};
 use crate::search::{SearchTree, overlap_range};
+use crate::spine::{self, KeyRef};
 
 /// mmap a file into memory, returning `None` for a missing or zero-length file
 /// (memmap2 rejects empty maps; an absent sidecar means an empty sub-stream).
@@ -66,77 +67,34 @@ pub struct Call {
     pub alt: Vec<u8>,
 }
 
-/// Gather one sub-stream's overlapping, sample-carried calls into `out`.
-///
-/// * `positions` — ascending variant starts for this run (a var_key column slice,
-///   or a whole dense-class table).
-/// * `max_region_length` — the run's max deletion bound (`max_del`), `0` for SNP.
-/// * `del_len(i)` — deletion length of run element `i` (for the exclusive end
-///   `positions[i] + 1 + del_len(i)`); `0` for SNP runs.
-/// * `carried(i)` — whether the queried `(sample, ploid)` carries element `i`
-///   (always `true` for var_key columns; a genotype-bit test for dense).
-/// * `decode_hit(i)` — `(ilen, alt)` for a carried, overlapping element `i`.
-// The 8-argument shape is the task's locked interface (per-sub-stream decode
-// callbacks passed positionally); bundling them into a struct would obscure
-// the call sites more than it helps.
-#[allow(clippy::too_many_arguments)]
-fn gather_run(
-    positions: &[u32],
-    max_region_length: u32,
-    q_start: u32,
-    q_end: u32,
-    del_len: impl Fn(usize) -> u32,
-    carried: impl Fn(usize) -> bool,
-    decode_hit: impl Fn(usize) -> (i32, Vec<u8>),
-    out: &mut Vec<Call>,
-) {
-    if positions.is_empty() {
-        return;
-    }
-    let v_ends: Vec<u32> = positions
-        .iter()
-        .enumerate()
-        .map(|(i, &p)| p + 1 + del_len(i))
-        .collect();
-    let tree = SearchTree::new(positions);
-    let (s_idx, e_idx) = overlap_range(&tree, &v_ends, max_region_length, q_start, q_end);
-    for (i, &position) in positions.iter().enumerate().take(e_idx).skip(s_idx) {
-        if carried(i) {
-            let (ilen, alt) = decode_hit(i);
-            out.push(Call {
-                position,
-                ilen,
+/// Decode one uniform `KeyRef` into a `Call`, resolving long-INS lookups through
+/// the LUT. The single place a query result touches alleles: SNP/INS decode
+/// inline (`Inline`), a pure DEL yields an empty ALT (`PureDel`), a long INS
+/// resolves via the bank (`Lookup`). `ilen = alt.len() - 1` for the inline lanes
+/// matches M5's `decode_snp_2bit`/`decode_indel_hit` contract exactly.
+fn decode_keyref(kr: KeyRef, lut: Option<&LongAlleleReader>) -> Call {
+    match rvk::decode_key(kr.key) {
+        DecodedKey::Inline { alt } => Call {
+            position: kr.position,
+            ilen: alt.len() as i32 - 1,
+            alt,
+        },
+        DecodedKey::PureDel { ilen } => Call {
+            position: kr.position,
+            ilen,
+            alt: Vec::new(),
+        },
+        DecodedKey::Lookup { row } => {
+            let alt = lut
+                .expect("indel lookup key requires a long-allele LUT")
+                .get_allele(row);
+            Call {
+                position: kr.position,
+                ilen: alt.len() as i32 - 1,
                 alt,
-            });
-        }
-    }
-}
-
-/// K-way merge of already position-sorted runs into one position-sorted list.
-/// The union-shaped dual of sorted intersection; a 5th/6th sub-stream (M11
-/// `pointer/*`) is one more entry. Stable across ties (earlier run wins).
-/// `O(total_calls × n_runs)` with `n_runs ≤ 4`.
-fn kway_merge(runs: Vec<Vec<Call>>) -> Vec<Call> {
-    let total: usize = runs.iter().map(|r| r.len()).sum();
-    let mut heads = vec![0usize; runs.len()];
-    let mut out = Vec::with_capacity(total);
-    for _ in 0..total {
-        let mut best: Option<usize> = None;
-        for r in 0..runs.len() {
-            if heads[r] >= runs[r].len() {
-                continue;
-            }
-            match best {
-                // Keep `best` on ties so the earlier run emits first (stable).
-                Some(b) if runs[b][heads[b]].position <= runs[r][heads[r]].position => {}
-                _ => best = Some(r),
             }
         }
-        let b = best.expect("total accounts for every remaining element");
-        out.push(runs[b][heads[b]].clone());
-        heads[b] += 1;
     }
-    out
 }
 
 /// A var_key sub-stream (snp or indel): mmap'd `positions.bin` + `alleles.bin`
@@ -293,6 +251,153 @@ impl ContigReader {
     }
 }
 
+/// The per-contig dense table unioned across `snp`+`indel`, position-sorted,
+/// carrying uniform keys plus the `(is_indel, col)` needed to test carriage.
+/// Region-independent — built once per query; `overlap` derives each region's
+/// index range from it. `src[i] = (is_indel, col)` addresses the original dense
+/// class table for the genotype-bit test.
+struct DenseUnion {
+    refs: Vec<KeyRef>,
+    src: Vec<(bool, usize)>,
+    positions: Vec<u32>,
+    v_ends: Vec<u32>,
+    max_del: u32,
+}
+
+impl DenseUnion {
+    /// `[s, e)` into `refs`/`src` for `[q_start, q_end)`, deletion-aware. Builds a
+    /// fresh search tree over `positions` (cheap; one per region in a batch).
+    fn overlap(&self, q_start: u32, q_end: u32) -> (usize, usize) {
+        if self.refs.is_empty() {
+            return (0, 0);
+        }
+        let tree = SearchTree::new(&self.positions);
+        overlap_range(&tree, &self.v_ends, self.max_del, q_start, q_end)
+    }
+}
+
+impl ContigReader {
+    /// `var_key` channel for one flat hap-column over one region: `snp`+`indel`
+    /// unioned, uniform keys (SNP re-expanded via `snp_code_to_key`), sorted.
+    fn vk_slice(
+        &self,
+        col: usize,
+        sample: usize,
+        p: usize,
+        q_start: u32,
+        q_end: u32,
+    ) -> Vec<KeyRef> {
+        let mut runs: Vec<Vec<KeyRef>> = Vec::with_capacity(2);
+
+        // var_key/snp: 2-bit codes, absolute index o0 + i into the packed buffer.
+        {
+            let (o0, o1) = self.vk_snp.column(col);
+            let positions = &self.vk_snp.positions()[o0..o1];
+            let keys = as_bytes(&self.vk_snp.keys);
+            let mut run = Vec::new();
+            spine::gather_keys(
+                positions,
+                0,
+                q_start,
+                q_end,
+                |_| 0,
+                |_| true,
+                |i| rvk::snp_code_to_key(rvk::unpack_snp_key_at(keys, o0 + i)),
+                &mut run,
+            );
+            runs.push(run);
+        }
+
+        // var_key/indel: uniform u32 keys, per-column max_del bound.
+        {
+            let (o0, o1) = self.vk_indel.column(col);
+            let positions = &self.vk_indel.positions()[o0..o1];
+            let keys = &as_u32(&self.vk_indel.keys)[o0..o1];
+            let max_del = self.vk_indel_max_del[[sample, p]];
+            let mut run = Vec::new();
+            spine::gather_keys(
+                positions,
+                max_del,
+                q_start,
+                q_end,
+                |i| rvk::deletion_len(keys[i]),
+                |_| true,
+                |i| keys[i],
+                &mut run,
+            );
+            runs.push(run);
+        }
+
+        spine::merge_keys(runs)
+    }
+
+    /// Build the region-independent dense `snp`+`indel` union (see `DenseUnion`).
+    /// SNP codes re-expand to uniform keys; the max_region_length bound is the
+    /// per-contig dense/indel max (SNP contributes 0).
+    fn dense_union(&self) -> DenseUnion {
+        // (position, key, del_len, is_indel, col), snp pushed before indel so a
+        // stable sort keeps snp-before-indel on any shared position.
+        let mut items: Vec<(u32, u32, u32, bool, usize)> = Vec::new();
+        if let Some(d) = &self.dense_snp {
+            let positions = d.positions();
+            let keys = as_bytes(&d.keys);
+            for (col, &pos) in positions.iter().enumerate() {
+                let key = rvk::snp_code_to_key(rvk::unpack_snp_key_at(keys, col));
+                items.push((pos, key, 0, false, col));
+            }
+        }
+        if let Some(d) = &self.dense_indel {
+            let positions = d.positions();
+            let keys = as_u32(&d.keys);
+            for (col, (&pos, &key)) in positions.iter().zip(keys.iter()).enumerate() {
+                items.push((pos, key, rvk::deletion_len(key), true, col));
+            }
+        }
+        items.sort_by_key(|it| it.0);
+
+        let refs = items
+            .iter()
+            .map(|it| KeyRef {
+                position: it.0,
+                key: it.1,
+            })
+            .collect();
+        let positions = items.iter().map(|it| it.0).collect();
+        let v_ends = items.iter().map(|it| it.0 + 1 + it.2).collect();
+        let src = items.iter().map(|it| (it.3, it.4)).collect();
+        DenseUnion {
+            refs,
+            src,
+            positions,
+            v_ends,
+            max_del: self.dense_indel_max_del,
+        }
+    }
+
+    /// The dense variants in `union[s..e]` that `hap` carries, as uniform KeyRefs.
+    fn dense_carried(&self, union: &DenseUnion, hap: usize, s: usize, e: usize) -> Vec<KeyRef> {
+        let mut out = Vec::new();
+        for j in s..e {
+            let (is_indel, col) = union.src[j];
+            let carried = if is_indel {
+                self.dense_indel
+                    .as_ref()
+                    .expect("indel src implies table")
+                    .carried(hap, col)
+            } else {
+                self.dense_snp
+                    .as_ref()
+                    .expect("snp src implies table")
+                    .carried(hap, col)
+            };
+            if carried {
+                out.push(union.refs[j]);
+            }
+        }
+        out
+    }
+}
+
 /// Per-haplotype overlapping calls, position-sorted. Struct-of-arrays for a
 /// numpy-friendly M6 hand-off.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -309,23 +414,10 @@ pub struct QueryResult {
     pub per_hap: Vec<HapCalls>,
 }
 
-/// Decode an indel key into `(ilen, alt)` for a hit, resolving long-INS lookups
-/// through the LUT. `alt` is empty for a pure DEL.
-fn decode_indel_hit(key: u32, lut: Option<&LongAlleleReader>) -> (i32, Vec<u8>) {
-    match rvk::decode_key(key) {
-        DecodedKey::Inline { alt } => (alt.len() as i32 - 1, alt),
-        DecodedKey::PureDel { ilen } => (ilen, Vec::new()),
-        DecodedKey::Lookup { row } => {
-            let alt = lut
-                .expect("indel lookup key requires a long-allele LUT")
-                .get_allele(row);
-            (alt.len() as i32 - 1, alt)
-        }
-    }
-}
-
 /// Return every variant that `sample` carries overlapping `[q_start, q_end)`, per
-/// haplotype, position-sorted, unioning the var_key and dense sub-streams.
+/// haplotype, position-sorted, unioning the var_key and dense sub-streams. M5's
+/// public contract, re-expressed on the M6.1 spine: gather uniform KeyRefs, do
+/// the final `var_key ⋈ dense` 2-way merge, then decode.
 pub fn overlap_sample(
     reader: &ContigReader,
     sample: usize,
@@ -333,112 +425,27 @@ pub fn overlap_sample(
     q_end: u32,
 ) -> QueryResult {
     let ploidy = reader.ploidy;
-    let mut per_hap = Vec::with_capacity(ploidy);
+    let lut = reader.lut.as_ref();
+    let dense = reader.dense_union();
+    let (ds, de) = dense.overlap(q_start, q_end);
 
+    let mut per_hap = Vec::with_capacity(ploidy);
     for p in 0..ploidy {
         let col = sample * ploidy + p; // flat column
         let hap = col; // sample-major hap index == flat column
-        let mut runs: Vec<Vec<Call>> = Vec::with_capacity(4);
+        let vk = reader.vk_slice(col, sample, p, q_start, q_end);
+        let dn = reader.dense_carried(&dense, hap, ds, de);
+        let merged = spine::merge_keys(vec![vk, dn]);
 
-        // --- var_key/snp column ---
-        {
-            let (o0, o1) = reader.vk_snp.column(col);
-            let positions = &reader.vk_snp.positions()[o0..o1];
-            let keys = as_bytes(&reader.vk_snp.keys);
-            let mut run = Vec::new();
-            gather_run(
-                positions,
-                0,
-                q_start,
-                q_end,
-                |_| 0,
-                |_| true,
-                |i| {
-                    (
-                        0,
-                        vec![rvk::decode_snp_2bit(rvk::unpack_snp_key_at(keys, o0 + i))],
-                    )
-                },
-                &mut run,
-            );
-            runs.push(run);
-        }
-
-        // --- var_key/indel column ---
-        {
-            let (o0, o1) = reader.vk_indel.column(col);
-            let positions = &reader.vk_indel.positions()[o0..o1];
-            let all_keys = as_u32(&reader.vk_indel.keys);
-            let keys = &all_keys[o0..o1];
-            let max_del = reader.vk_indel_max_del[[sample, p]];
-            let lut = reader.lut.as_ref();
-            let mut run = Vec::new();
-            gather_run(
-                positions,
-                max_del,
-                q_start,
-                q_end,
-                |i| rvk::deletion_len(keys[i]),
-                |_| true,
-                |i| decode_indel_hit(keys[i], lut),
-                &mut run,
-            );
-            runs.push(run);
-        }
-
-        // --- dense/snp (shared table, genotype-filtered) ---
-        if let Some(dense) = &reader.dense_snp {
-            let positions = dense.positions();
-            let keys = as_bytes(&dense.keys);
-            let mut run = Vec::new();
-            gather_run(
-                positions,
-                0,
-                q_start,
-                q_end,
-                |_| 0,
-                |col_d| dense.carried(hap, col_d),
-                |col_d| {
-                    (
-                        0,
-                        vec![rvk::decode_snp_2bit(rvk::unpack_snp_key_at(keys, col_d))],
-                    )
-                },
-                &mut run,
-            );
-            runs.push(run);
-        }
-
-        // --- dense/indel (shared table, genotype-filtered) ---
-        if let Some(dense) = &reader.dense_indel {
-            let positions = dense.positions();
-            let keys = as_u32(&dense.keys);
-            let max_del = reader.dense_indel_max_del;
-            let lut = reader.lut.as_ref();
-            let mut run = Vec::new();
-            gather_run(
-                positions,
-                max_del,
-                q_start,
-                q_end,
-                |i| rvk::deletion_len(keys[i]),
-                |col_d| dense.carried(hap, col_d),
-                |i| decode_indel_hit(keys[i], lut),
-                &mut run,
-            );
-            runs.push(run);
-        }
-
-        let merged = kway_merge(runs);
         let mut hc = HapCalls::default();
-        for c in merged {
+        for kr in merged {
+            let c = decode_keyref(kr, lut);
             hc.positions.push(c.position);
             hc.ilens.push(c.ilen);
             hc.alts.push(c.alt);
         }
         per_hap.push(hc);
     }
-
     QueryResult { per_hap }
 }
 
@@ -469,98 +476,5 @@ mod tests {
 
         assert_eq!(as_u32(&None), &[] as &[u32]);
         assert_eq!(as_bytes(&None), &[] as &[u8]);
-    }
-
-    fn call(position: u32, ilen: i32, alt: &[u8]) -> Call {
-        Call {
-            position,
-            ilen,
-            alt: alt.to_vec(),
-        }
-    }
-
-    #[test]
-    fn test_gather_run_snp_half_open() {
-        // Pure-SNP run: positions [10, 20, 30], v_end = pos + 1, max_del 0.
-        let positions = [10u32, 20, 30];
-        let mut out = Vec::new();
-        gather_run(
-            &positions,
-            0,
-            15,
-            25, // query [15, 25): only 20 overlaps
-            |_| 0,
-            |_| true,
-            |i| (0, vec![b'A' + i as u8]),
-            &mut out,
-        );
-        assert_eq!(out, vec![call(20, 0, b"B")]);
-    }
-
-    #[test]
-    fn test_gather_run_deletion_spans_query_start() {
-        // v0 start 2 deletes 6 bases -> v_end 9; v1 SNP at 10.
-        let positions = [2u32, 10];
-        let dels = [6u32, 0];
-        let mut out = Vec::new();
-        gather_run(
-            &positions,
-            6, // max_region_length covers the 6-base deletion
-            5,
-            7, // query [5, 7): only v0 (2..9) spans it
-            |i| dels[i],
-            |_| true,
-            |_| (-6, Vec::new()),
-            &mut out,
-        );
-        assert_eq!(out, vec![call(2, -6, b"")]);
-    }
-
-    #[test]
-    fn test_gather_run_carried_filter() {
-        // Dense-style: only even indices are carried by the sample.
-        let positions = [10u32, 20, 30, 40];
-        let mut out = Vec::new();
-        gather_run(
-            &positions,
-            0,
-            0,
-            100,
-            |_| 0,
-            |i| i % 2 == 0,
-            |i| (0, vec![b'A' + i as u8]),
-            &mut out,
-        );
-        assert_eq!(out, vec![call(10, 0, b"A"), call(30, 0, b"C")]);
-    }
-
-    #[test]
-    fn test_gather_run_empty_positions() {
-        let mut out = Vec::new();
-        gather_run(&[], 0, 0, 100, |_| 0, |_| true, |_| (0, vec![]), &mut out);
-        assert!(out.is_empty());
-    }
-
-    #[test]
-    fn test_kway_merge_orders_by_position() {
-        let runs = vec![
-            vec![call(10, 0, b"A"), call(30, 0, b"C")],
-            vec![call(20, 1, b"AT")],
-            vec![],
-            vec![call(25, -2, b"")],
-        ];
-        let merged = kway_merge(runs);
-        let positions: Vec<u32> = merged.iter().map(|c| c.position).collect();
-        assert_eq!(positions, vec![10, 20, 25, 30]);
-    }
-
-    #[test]
-    fn test_kway_merge_ties_keep_earlier_run_first() {
-        let runs = vec![
-            vec![call(50, 0, b"A")],  // run 0
-            vec![call(50, 1, b"AT")], // run 1, same position
-        ];
-        let merged = kway_merge(runs);
-        assert_eq!(merged, vec![call(50, 0, b"A"), call(50, 1, b"AT")]);
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -351,6 +351,10 @@ impl ContigReader {
         if let Some(d) = &self.dense_indel {
             let positions = d.positions();
             let keys = as_u32(&d.keys);
+            // Fail fast on a corrupt sidecar: `zip` would otherwise silently
+            // truncate to the shorter of the two instead of panicking like the
+            // pre-refactor indexed loop did.
+            debug_assert_eq!(positions.len(), keys.len());
             for (col, (&pos, &key)) in positions.iter().zip(keys.iter()).enumerate() {
                 items.push((pos, key, rvk::deletion_len(key), true, col));
             }
@@ -376,10 +380,24 @@ impl ContigReader {
         }
     }
 
-    /// The dense variants in `union[s..e]` that `hap` carries, as uniform KeyRefs.
-    fn dense_carried(&self, union: &DenseUnion, hap: usize, s: usize, e: usize) -> Vec<KeyRef> {
+    /// The dense variants in `union[s..e]` that `hap` carries and that TRULY
+    /// overlap `[q_start, q_end)` (exact left-overlap `q_start < v_end`; the
+    /// right half is guaranteed by `union.overlap`'s window — see
+    /// `spine::gather_keys`'s doc comment for why the per-element check is
+    /// still needed within a carried window).
+    fn dense_carried(
+        &self,
+        union: &DenseUnion,
+        hap: usize,
+        s: usize,
+        e: usize,
+        q_start: u32,
+    ) -> Vec<KeyRef> {
         let mut out = Vec::new();
         for j in s..e {
+            if union.v_ends[j] <= q_start {
+                continue;
+            }
             let (is_indel, col) = union.src[j];
             let carried = if is_indel {
                 self.dense_indel
@@ -436,7 +454,7 @@ pub fn overlap_sample(
         let col = sample * ploidy + p; // flat column
         let hap = col; // sample-major hap index == flat column
         let vk = reader.vk_slice(col, sample, p, q_start, q_end);
-        let dn = reader.dense_carried(&dense, hap, ds, de);
+        let dn = reader.dense_carried(&dense, hap, ds, de, q_start);
         let merged = spine::merge_keys(vec![vk, dn]);
 
         let mut hc = HapCalls::default();
@@ -498,7 +516,7 @@ pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResu
         for s in 0..n_samples {
             for p in 0..ploidy {
                 let col = s * ploidy + p;
-                let hap = col;
+                let hap = col; // sample-major hap index == flat column
 
                 // var_key channel slice for (region r, sample s, ploid p).
                 let slice = reader.vk_slice(col, s, p, qs, qe);
@@ -527,7 +545,7 @@ pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResu
                             .expect("snp src implies table")
                             .carried(hap, dcol)
                     };
-                    if carried {
+                    if carried && dense.v_ends[j] > qs {
                         bits::set_bit(&mut dense_present, bit_base + k);
                     }
                 }

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 // (query.rs, max_del.rs, tests) resolve.
 pub use svar2_codec::{
     DecodedKey, decode_alt_inline, decode_key, decode_snp_2bit, deletion_len, encode_snp_2bit,
-    pack_snp_keys, unpack_snp_key_at, unpack_snp_keys,
+    pack_snp_keys, snp_code_to_key, unpack_snp_key_at, unpack_snp_keys,
 };
 
 // Post-merge pass for the SNP stream: read the merged `alleles.bin` (one

--- a/src/spine.rs
+++ b/src/spine.rs
@@ -1,0 +1,169 @@
+//! Reader-free spine algorithms for the SVAR2 query decode core (M6.1).
+//!
+//! `gather_keys` and `merge_keys` are the pure half of what M5's `query.rs`
+//! did inline: overlap-resolve a position run into undecoded `(position, key)`
+//! pairs, and merge already-sorted runs. They carry **uniform 32-bit keys** and
+//! never touch alleles or the LUT — decoding is the consumer's job. Splitting
+//! them out lets both `overlap_sample` and the batched `overlap_batch` share one
+//! gather/merge and one uniform-key convention.
+
+use crate::search::{SearchTree, overlap_range};
+
+/// An undecoded variant reference: a genomic start plus its **uniform 32-bit
+/// key** (SNPs re-expanded via [`crate::rvk::snp_code_to_key`]; indel keys
+/// stored uniform already). A key with LSB set references the long-allele LUT,
+/// resolved downstream — never here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyRef {
+    pub position: u32,
+    pub key: u32,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gather_keys(
+    positions: &[u32],
+    max_region_length: u32,
+    q_start: u32,
+    q_end: u32,
+    del_len: impl Fn(usize) -> u32,
+    carried: impl Fn(usize) -> bool,
+    to_key: impl Fn(usize) -> u32,
+    out: &mut Vec<KeyRef>,
+) {
+    if positions.is_empty() {
+        return;
+    }
+    let v_ends: Vec<u32> = positions
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| p + 1 + del_len(i))
+        .collect();
+    let tree = SearchTree::new(positions);
+    let (s_idx, e_idx) = overlap_range(&tree, &v_ends, max_region_length, q_start, q_end);
+    for (i, &position) in positions.iter().enumerate().take(e_idx).skip(s_idx) {
+        if carried(i) {
+            out.push(KeyRef {
+                position,
+                key: to_key(i),
+            });
+        }
+    }
+}
+
+/// K-way merge of already position-sorted runs into one position-sorted list.
+/// Stable across ties (earlier run wins). `O(total × n_runs)` with `n_runs`
+/// small (2 within a channel; more only if M11 adds a `pointer` sub-stream).
+pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
+    let total: usize = runs.iter().map(|r| r.len()).sum();
+    let mut heads = vec![0usize; runs.len()];
+    let mut out = Vec::with_capacity(total);
+    for _ in 0..total {
+        let mut best: Option<usize> = None;
+        for r in 0..runs.len() {
+            if heads[r] >= runs[r].len() {
+                continue;
+            }
+            match best {
+                // Keep `best` on ties so the earlier run emits first (stable).
+                Some(b) if runs[b][heads[b]].position <= runs[r][heads[r]].position => {}
+                _ => best = Some(r),
+            }
+        }
+        let b = best.expect("total accounts for every remaining element");
+        out.push(runs[b][heads[b]]);
+        heads[b] += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kr(position: u32, key: u32) -> KeyRef {
+        KeyRef { position, key }
+    }
+
+    #[test]
+    fn test_gather_keys_snp_half_open() {
+        // positions [10, 20, 30], v_end = pos + 1, max_del 0; query [15, 25):
+        // only index 1 (pos 20) overlaps. to_key(i) = i as a marker key.
+        let positions = [10u32, 20, 30];
+        let mut out = Vec::new();
+        gather_keys(
+            &positions,
+            0,
+            15,
+            25,
+            |_| 0,
+            |_| true,
+            |i| i as u32,
+            &mut out,
+        );
+        assert_eq!(out, vec![kr(20, 1)]);
+    }
+
+    #[test]
+    fn test_gather_keys_deletion_spans_query_start() {
+        // v0 start 2 deletes 6 bases -> v_end 9; v1 SNP at 10. query [5, 7):
+        // only v0 (2..9) spans it. max_region_length 6 covers the deletion.
+        let positions = [2u32, 10];
+        let dels = [6u32, 0];
+        let mut out = Vec::new();
+        gather_keys(
+            &positions,
+            6,
+            5,
+            7,
+            |i| dels[i],
+            |_| true,
+            |i| 100 + i as u32,
+            &mut out,
+        );
+        assert_eq!(out, vec![kr(2, 100)]);
+    }
+
+    #[test]
+    fn test_gather_keys_carried_filter() {
+        // Only even indices carried; query covers all.
+        let positions = [10u32, 20, 30, 40];
+        let mut out = Vec::new();
+        gather_keys(
+            &positions,
+            0,
+            0,
+            100,
+            |_| 0,
+            |i| i % 2 == 0,
+            |i| i as u32,
+            &mut out,
+        );
+        assert_eq!(out, vec![kr(10, 0), kr(30, 2)]);
+    }
+
+    #[test]
+    fn test_gather_keys_empty_positions() {
+        let mut out = Vec::new();
+        gather_keys(&[], 0, 0, 100, |_| 0, |_| true, |_| 0, &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_merge_keys_orders_by_position() {
+        let runs = vec![
+            vec![kr(10, 0), kr(30, 2)],
+            vec![kr(20, 1)],
+            vec![],
+            vec![kr(25, 9)],
+        ];
+        let merged = merge_keys(runs);
+        let positions: Vec<u32> = merged.iter().map(|k| k.position).collect();
+        assert_eq!(positions, vec![10, 20, 25, 30]);
+    }
+
+    #[test]
+    fn test_merge_keys_ties_keep_earlier_run_first() {
+        let runs = vec![vec![kr(50, 111)], vec![kr(50, 222)]];
+        assert_eq!(merge_keys(runs), vec![kr(50, 111), kr(50, 222)]);
+    }
+}

--- a/src/spine.rs
+++ b/src/spine.rs
@@ -19,6 +19,13 @@ pub struct KeyRef {
     pub key: u32,
 }
 
+/// Gathers `(position, key)` pairs from `positions` that TRULY overlap
+/// `[q_start, q_end)` (exact overlap: `pos < q_end && q_start < v_end`), among
+/// those `carried`. `overlap_range` only guarantees the right half (`pos <
+/// q_end`) of that predicate for every candidate in its window — a spanning
+/// deletion earlier in the run can widen the window's left bound and pull in
+/// later elements whose `v_end <= q_start` (they end before the query
+/// starts), so this checks the left half (`q_start < v_end`) per element.
 #[allow(clippy::too_many_arguments)]
 pub fn gather_keys(
     positions: &[u32],
@@ -41,7 +48,7 @@ pub fn gather_keys(
     let tree = SearchTree::new(positions);
     let (s_idx, e_idx) = overlap_range(&tree, &v_ends, max_region_length, q_start, q_end);
     for (i, &position) in positions.iter().enumerate().take(e_idx).skip(s_idx) {
-        if carried(i) {
+        if carried(i) && q_start < v_ends[i] {
             out.push(KeyRef {
                 position,
                 key: to_key(i),
@@ -139,6 +146,30 @@ mod tests {
             &mut out,
         );
         assert_eq!(out, vec![kr(10, 0), kr(30, 2)]);
+    }
+
+    #[test]
+    fn test_gather_keys_excludes_interior_non_overlap_behind_spanning_deletion() {
+        // v0: DEL@100, del_len 20 -> v_end 121 (widens the window's left bound).
+        // v1: SNP@105 -> v_end 106 (ends before q_start=110: NOT a true overlap,
+        // but interior to overlap_range's carried window because v0 pulled the
+        // window's start left of 105).
+        // v2: SNP@112 -> v_end 113 (truly overlaps [110, 115)).
+        // All carried; max_region_length 20 covers the deletion.
+        let positions = [100u32, 105, 112];
+        let del_len = [20u32, 0, 0];
+        let mut out = Vec::new();
+        gather_keys(
+            &positions,
+            20,
+            110,
+            115,
+            |i| del_len[i],
+            |_| true,
+            |i| i as u32,
+            &mut out,
+        );
+        assert_eq!(out, vec![kr(100, 0), kr(112, 2)]);
     }
 
     #[test]

--- a/svar2-codec/src/lib.rs
+++ b/svar2-codec/src/lib.rs
@@ -35,6 +35,17 @@ pub fn decode_snp_2bit(code: u8) -> u8 {
     BASES[(code & 3) as usize]
 }
 
+/// Re-expand a 2-bit SNP code into the **uniform 32-bit indel key** (`ilen = 0`,
+/// the single ALT base inline at `[26:25]`, lookup flag clear). This is the
+/// pre-M1-split encoding: after re-expansion a query result has one `decode_key`
+/// path for both `snp` and `indel` sub-streams. One shift — the `<< 25` lives
+/// here so no consumer re-derives the layout. Inverse view: `decode_key` on the
+/// result is `Inline { alt: [decode_snp_2bit(code)] }`.
+#[inline]
+pub fn snp_code_to_key(code: u8) -> u32 {
+    ((code & 3) as u32) << 25
+}
+
 /// Pack 2-bit SNP codes 4-per-byte, little-pair-first: code `i` occupies bits
 /// `[(i&3)*2 + 1 : (i&3)*2]` of byte `i >> 2`. The final byte is zero-padded when
 /// `codes.len()` is not a multiple of 4. Offsets index CALLS, not bytes.
@@ -288,6 +299,32 @@ mod tests {
         for &b in b"ACGT" {
             let code = encode_snp_2bit(b);
             assert_eq!(decode_snp_2bit(code), b, "base {} round-trips", b as char);
+        }
+    }
+
+    #[test]
+    fn snp_code_to_key_decodes_to_inline_base() {
+        // Every 2-bit code re-expands to a uniform key whose decode is a 1-base
+        // Inline ALT equal to decode_snp_2bit(code), with ilen 0.
+        for code in 0u8..4 {
+            let key = snp_code_to_key(code);
+            assert_eq!(key & 1, 0, "uniform SNP key must clear the lookup flag");
+            assert_eq!(
+                decode_key(key),
+                DecodedKey::Inline {
+                    alt: vec![decode_snp_2bit(code)]
+                },
+                "code {code} round-trips through the uniform key",
+            );
+        }
+    }
+
+    #[test]
+    fn snp_code_to_key_matches_encode_alt_inline() {
+        // The one-shift re-expansion equals encoding the decoded base inline.
+        for code in 0u8..4 {
+            let base = decode_snp_2bit(code);
+            assert_eq!(snp_code_to_key(code), encode_alt_inline(&[base], 0));
         }
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,9 @@
 // Shared BCF test harness: synthetic record builder and binary I/O helpers
 // for E2E pipeline testing.
 
+use genoray_core::process_chromosome;
+use ndarray::{Array1, Array2};
+use proptest::prelude::*;
 use rust_htslib::bcf::record::GenotypeAllele;
 use rust_htslib::bcf::{Format, Header, Writer};
 
@@ -111,4 +114,150 @@ pub fn read_u32_bin(path: &Path) -> Vec<u32> {
 pub fn read_offsets_npy(path: &Path) -> Vec<u64> {
     let arr: ndarray::Array1<u64> = ndarray_npy::read_npy(path).expect("read offsets npy");
     arr.to_vec()
+}
+
+/// Deletion length implied by a record's ref/alt lengths (`max(0, -ilen)`).
+#[allow(dead_code)]
+pub fn del_len_of(rec: &SynthRecord) -> u32 {
+    let ilen = rec.alts[0].len() as i32 - rec.ref_allele.len() as i32;
+    if ilen < 0 { (-ilen) as u32 } else { 0 }
+}
+
+/// Write the `max_del` sidecars for a finished contig. Conservative per-column
+/// bound: each `(sample, ploid)` column's max over ALL deletions it carries (an
+/// over-estimate vs. the var_key-only contract, but `overlap_range`'s overshoot
+/// is proven safe — see `search.rs` `overlap_max_region_length_overshoot_is_safe`),
+/// and the global max for `dense/max_del`. This exercises per-column indexing in
+/// the consumer while remaining independent of the producer's tight per-column bound.
+#[allow(dead_code)]
+pub fn write_max_del_fixture(
+    contig_dir: &Path,
+    n_samples: usize,
+    ploidy: usize,
+    records: &[SynthRecord],
+) {
+    let columns = n_samples * ploidy;
+    let mut per_col = vec![0u32; columns];
+    let mut global = 0u32;
+    for rec in records {
+        let d = del_len_of(rec);
+        global = global.max(d);
+        for (hap, &g) in rec.gt.iter().enumerate() {
+            if g == 1 {
+                per_col[hap] = per_col[hap].max(d);
+            }
+        }
+    }
+    let arr = Array2::from_shape_vec((n_samples, ploidy), per_col).unwrap();
+    ndarray_npy::write_npy(contig_dir.join("max_del.npy"), &arr).unwrap();
+
+    std::fs::create_dir_all(contig_dir.join("dense")).unwrap();
+    let dense = Array1::from_vec(vec![global]);
+    ndarray_npy::write_npy(contig_dir.join("dense").join("max_del.npy"), &dense).unwrap();
+}
+
+/// Convert `records` to a finished SVAR2 contig under `out/{chrom}` and write the
+/// `max_del` fixture. `out` must already exist.
+#[allow(dead_code)]
+pub fn build_contig(
+    out: &Path,
+    chrom: &str,
+    samples: &[&str],
+    ploidy: usize,
+    records: &[SynthRecord],
+) {
+    let bcf = out.join("in.bcf");
+    let fasta = out.join("in.fa");
+    build_bcf_with_index(&bcf, chrom, 1_000_000, samples, records);
+    // M2b: the reader validates REF and left-aligns against a reference FASTA.
+    // Stamp each record's REF into an 'N'-filler contig; 'N' never satisfies the
+    // left-align repeat condition, so positions stay put and the oracle holds.
+    build_fasta_with_index(&fasta, chrom, 1_000_000, records);
+    process_chromosome(
+        bcf.to_str().unwrap(),
+        fasta.to_str().unwrap(),
+        chrom,
+        out.to_str().unwrap(),
+        samples,
+        1000, // chunk_size
+        ploidy,
+        1,    // htslib_threads
+        4096, // long_allele_capacity
+    )
+    .expect("process_chromosome should succeed");
+    write_max_del_fixture(&out.join(chrom), samples.len(), ploidy, records);
+}
+
+/// Owned analogue of `SynthRecord` (proptest needs values that outlive the
+/// borrow). One atomized bi-allelic variant.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct OwnedRecord {
+    pub pos: i64,
+    pub ref_allele: Vec<u8>,
+    pub alt: Vec<u8>,
+    pub gt: Vec<i32>, // len == n_haps
+}
+
+/// Random atomized contig: strictly increasing positions, each variant a SNP,
+/// INS (alt = anchor + tail), or DEL (ref = anchor + tail), with random per-hap
+/// genotypes. INS tails reach 15 bases so some insertions spill to the LUT.
+#[allow(dead_code)]
+pub fn arb_records(n_haps: usize) -> impl Strategy<Value = Vec<OwnedRecord>> {
+    proptest::collection::vec(
+        (
+            0u8..3u8,                                            // kind: 0 SNP, 1 INS, 2 DEL
+            0usize..4,                                           // anchor base index
+            0usize..4,                                           // SNP alt base index
+            proptest::collection::vec(0usize..4, 1..16),         // INS/DEL tail (>= 1 base)
+            proptest::collection::vec(0i32..2, n_haps..=n_haps), // genotypes
+            17u32..40u32, // position gap: >= 17 keeps an 'N' between records' REF
+                          // stamps (max REF span is 16), so no overlap and M2b never left-shifts
+        ),
+        1..8, // 1..7 records; empty contigs are covered by the degenerate tests
+    )
+    .prop_map(move |specs| {
+        const BASES: [u8; 4] = [b'A', b'C', b'T', b'G'];
+        let mut pos: i64 = 100;
+        let mut out = Vec::new();
+        for (kind, anchor, snp_alt, tail, gt, gap) in specs {
+            pos += gap as i64;
+            let b0 = BASES[anchor];
+            // M2b left-aligns any indel whose anchor base repeats at the allele's
+            // end (roll condition: anchor == tail's last base). Force them distinct
+            // so generated records are already left-canonical and the converter
+            // leaves positions put — keeping the brute-force oracle valid.
+            let mut tail = tail;
+            if tail.last() == Some(&anchor) {
+                *tail.last_mut().unwrap() = (anchor + 1) % 4;
+            }
+            let (ref_allele, alt) = match kind {
+                0 => {
+                    let alt_idx = if snp_alt == anchor {
+                        (anchor + 1) % 4
+                    } else {
+                        snp_alt
+                    };
+                    (vec![b0], vec![BASES[alt_idx]])
+                }
+                1 => {
+                    let mut a = vec![b0];
+                    a.extend(tail.iter().map(|&x| BASES[x]));
+                    (vec![b0], a)
+                }
+                _ => {
+                    let mut r = vec![b0];
+                    r.extend(tail.iter().map(|&x| BASES[x]));
+                    (r, vec![b0])
+                }
+            };
+            out.push(OwnedRecord {
+                pos,
+                ref_allele,
+                alt,
+                gt,
+            });
+        }
+        out
+    })
 }

--- a/tests/test_batch.rs
+++ b/tests/test_batch.rs
@@ -103,6 +103,120 @@ fn test_dense_present_popcount_counts_dense_carriers() {
     assert_eq!(dense_popcount(&batch, 0, 5, 1), 0);
 }
 
+/// Regression for the spanning-deletion overlap bug: `overlap_range`'s window
+/// endpoints truly overlap the query, but a spanning deletion earlier in the
+/// run can widen the window's left bound and pull in a later variant whose
+/// `v_end <= q_start` (it ends before the query starts). This builds a contig
+/// where a 20-base DEL@100 (v_end 121) spans a SNP@105 (v_end 106, ends before
+/// q_start=110 — must be EXCLUDED) and a SNP@112 (v_end 113, truly overlaps
+/// [110, 115) — must be INCLUDED), all common enough to route to the dense
+/// channel, and checks both `overlap_sample` and `overlap_batch`/`decode_hap`
+/// exclude the spurious SNP@105.
+#[test]
+fn test_dense_channel_excludes_interior_non_overlap_behind_spanning_deletion() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    // DEL@100: anchor 'A' + 20-base tail, alt = anchor only -> ilen -20, v_end
+    // 121. Non-repetitive tail bases (all 'C' except two positions that must
+    // agree with the SNPs' REF below) so the converter's left-alignment never
+    // rolls the deletion: `left_align` only rolls while
+    // `ref_seq[pos] == ref_seq[pos + ndel]`, and anchor 'A' != tail's last
+    // base 'C' (pos 120), so the roll check fails immediately regardless of
+    // the interior bytes.
+    let mut tail = vec![b'C'; 20];
+    tail[4] = b'G'; // offset 5 -> pos 105, must match SNP_A's REF below
+    tail[11] = b'T'; // offset 12 -> pos 112, must match SNP_B's REF below
+    let mut del_ref = vec![b'A'];
+    del_ref.extend_from_slice(&tail);
+
+    // All four haps (2 samples, diploid) carry every variant here: x=4 makes
+    // both SNP (dense 34+4=38 < var_key 34*4=136) and DEL (dense
+    // 32+32+4=68 < var_key 64*4=256) strictly cheaper as dense
+    // (`cost_model::choose_representation`), so all three route to the dense
+    // channel and this exercises the `dense_carried`/`overlap_batch`
+    // presence-bit fix, not the var_key fix (that's covered by
+    // `spine::tests::test_gather_keys_excludes_interior_non_overlap_behind_spanning_deletion`).
+    let samples = ["S0", "S1"];
+    let records = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: &del_ref,
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 1, 1],
+        },
+        SynthRecord {
+            pos: 105,
+            ref_allele: b"G",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 1, 1],
+        },
+        SynthRecord {
+            pos: 112,
+            ref_allele: b"T",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 1, 1, 1],
+        },
+    ];
+    build_contig(&out, "chr1", &samples, 2, &records);
+
+    // Confirm all three actually routed to dense (not var_key) so this test
+    // exercises the channel it claims to.
+    let dense_snp_positions = common::read_u32_bin(
+        &out.join("chr1")
+            .join("dense")
+            .join("snp")
+            .join("positions.bin"),
+    );
+    assert_eq!(
+        dense_snp_positions,
+        vec![105, 112],
+        "expected both SNPs to route to dense/snp"
+    );
+    let dense_indel_positions = common::read_u32_bin(
+        &out.join("chr1")
+            .join("dense")
+            .join("indel")
+            .join("positions.bin"),
+    );
+    assert_eq!(
+        dense_indel_positions,
+        vec![100],
+        "expected the DEL to route to dense/indel"
+    );
+
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap();
+
+    // overlap_sample: query [110, 115) spans SNP@105 (excluded) and truly
+    // overlaps DEL@100 and SNP@112 (included).
+    let r = overlap_sample(&reader, 0, 110, 115);
+    for (p, hc) in r.per_hap.iter().enumerate() {
+        assert_eq!(hc.positions, vec![100, 112], "hap {p} positions");
+        assert_eq!(hc.ilens, vec![-20, 0], "hap {p} ilens");
+        assert_eq!(
+            hc.alts,
+            vec![Vec::<u8>::new(), b"C".to_vec()],
+            "hap {p} alts"
+        );
+    }
+
+    // overlap_batch/decode_hap must agree.
+    let batch = genoray_core::query::overlap_batch(&reader, &[(110u32, 115u32)]);
+    for s in 0..2usize {
+        for p in 0..2usize {
+            let got = batch.decode_hap(&reader, 0, s, p);
+            assert_eq!(got.positions, vec![100, 112], "s={s} p={p} positions");
+            assert_eq!(got.ilens, vec![-20, 0], "s={s} p={p} ilens");
+            assert_eq!(
+                got.alts,
+                vec![Vec::<u8>::new(), b"C".to_vec()],
+                "s={s} p={p} alts"
+            );
+        }
+    }
+}
+
 proptest! {
     // Heavy: each case runs the full converter. Low case count on purpose.
     #![proptest_config(ProptestConfig::with_cases(16))]

--- a/tests/test_batch.rs
+++ b/tests/test_batch.rs
@@ -1,0 +1,152 @@
+//! Disk-integration tests for the batched M6.1 spine (`overlap_batch`). Builds
+//! finished SVAR2 contigs via the real converter, then cross-checks the two-
+//! channel batch result against the M5 single-sample `overlap_sample` — the
+//! already-oracle-tested reference — for every (region, sample, ploid), plus a
+//! decode-free dense-count sanity check.
+
+mod common;
+
+use common::{OwnedRecord, SynthRecord, arb_records, build_contig};
+use genoray_core::query::{ContigReader, overlap_batch, overlap_sample};
+use proptest::prelude::*;
+use tempfile::tempdir;
+
+#[test]
+fn test_overlap_batch_matches_overlap_sample() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let samples = ["S0", "S1"];
+    let records = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0, 1, 1],
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: vec![0, 1, 0, 0],
+        },
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"AT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 0, 0],
+        },
+    ];
+    build_contig(&out, "chr1", &samples, 2, &records);
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap();
+
+    // Two regions: one whole-contig, one that a deletion spans into.
+    let regions = [(0u32, 1000u32), (301u32, 302u32)];
+    let batch = overlap_batch(&reader, &regions);
+
+    assert_eq!(batch.n_regions, 2);
+    assert_eq!(batch.n_samples, 2);
+    assert_eq!(batch.ploidy, 2);
+
+    for (r, &(qs, qe)) in regions.iter().enumerate() {
+        for s in 0..2usize {
+            let single = overlap_sample(&reader, s, qs, qe);
+            for p in 0..2usize {
+                let got = batch.decode_hap(&reader, r, s, p);
+                assert_eq!(got, single.per_hap[p], "r={r} s={s} p={p}");
+            }
+        }
+    }
+}
+
+/// popcount of a hap's dense presence bitmask == the dense variants that hap
+/// carries in that region (the decode-free count M6c is built on).
+fn dense_popcount(batch: &genoray_core::query::BatchResult, r: usize, s: usize, p: usize) -> usize {
+    let h = (r * batch.n_samples + s) * batch.ploidy + p;
+    let (bit0, bit1) = (batch.dense_present_off[h], batch.dense_present_off[h + 1]);
+    (bit0..bit1)
+        .filter(|&b| (batch.dense_present[b >> 3] >> (b & 7)) & 1 != 0)
+        .count()
+}
+
+#[test]
+fn test_dense_present_popcount_counts_dense_carriers() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    // 6 samples; a 4-base DEL carried by nearly everyone -> dense/indel.
+    let samples = ["S0", "S1", "S2", "S3", "S4", "S5"];
+    let records = vec![SynthRecord {
+        pos: 500,
+        ref_allele: b"ATATC",
+        alts: vec![&b"A"[..]],
+        gt: vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0], // S5 carries neither hap
+    }];
+    build_contig(&out, "chr1", &samples, 2, &records);
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 6, 2).unwrap();
+
+    let regions = [(0u32, 1000u32)];
+    let batch = overlap_batch(&reader, &regions);
+
+    // The DEL is dense, so it sits in the dense channel: carriers see popcount 1,
+    // S5 (gt 0,0) sees 0. Cross-check against decode_hap's length.
+    for s in 0..6usize {
+        for p in 0..2usize {
+            let want = batch.decode_hap(&reader, 0, s, p).positions.len();
+            assert_eq!(dense_popcount(&batch, 0, s, p), want, "s={s} p={p}");
+        }
+    }
+    // Explicit: S5 carries nothing here.
+    assert_eq!(dense_popcount(&batch, 0, 5, 0), 0);
+    assert_eq!(dense_popcount(&batch, 0, 5, 1), 0);
+}
+
+proptest! {
+    // Heavy: each case runs the full converter. Low case count on purpose.
+    #![proptest_config(ProptestConfig::with_cases(16))]
+
+    #[test]
+    fn prop_overlap_batch_matches_overlap_sample(
+        records in arb_records(6), // 3 samples, diploid
+        starts in proptest::collection::vec(0u32..1200, 1..4),
+        q_len in 1u32..300,
+    ) {
+        let n_samples = 3usize;
+        let ploidy = 2usize;
+        let sample_names = ["S0", "S1", "S2"];
+
+        let synth: Vec<SynthRecord> = records
+            .iter()
+            .map(|r: &OwnedRecord| SynthRecord {
+                pos: r.pos,
+                ref_allele: &r.ref_allele,
+                alts: vec![&r.alt[..]],
+                gt: r.gt.clone(),
+            })
+            .collect();
+
+        let tmp = tempdir().unwrap();
+        let out = tmp.path().join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        build_contig(&out, "chr1", &sample_names, ploidy, &synth);
+        let reader = ContigReader::open(out.to_str().unwrap(), "chr1", n_samples, ploidy).unwrap();
+
+        let regions: Vec<(u32, u32)> = starts.iter().map(|&s| (s, s + q_len)).collect();
+        let batch = overlap_batch(&reader, &regions);
+
+        for (r, &(qs, qe)) in regions.iter().enumerate() {
+            for s in 0..n_samples {
+                let single = overlap_sample(&reader, s, qs, qe);
+                for p in 0..ploidy {
+                    prop_assert_eq!(
+                        batch.decode_hap(&reader, r, s, p),
+                        single.per_hap[p].clone(),
+                        "r={} s={} p={}", r, s, p
+                    );
+                }
+            }
+        }
+    }
+}

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -8,76 +8,10 @@ mod common;
 
 use proptest::prelude::*;
 
-use common::{SynthRecord, build_bcf_with_index, build_fasta_with_index};
-use genoray_core::process_chromosome;
+use common::{OwnedRecord, SynthRecord, arb_records, build_contig};
 use genoray_core::query::ContigReader;
 use genoray_core::query::overlap_sample;
-use ndarray::{Array1, Array2};
-use std::path::Path;
 use tempfile::tempdir;
-
-/// Deletion length implied by a record's ref/alt lengths (`max(0, -ilen)`).
-fn del_len_of(rec: &SynthRecord) -> u32 {
-    let ilen = rec.alts[0].len() as i32 - rec.ref_allele.len() as i32;
-    if ilen < 0 { (-ilen) as u32 } else { 0 }
-}
-
-/// Write the `max_del` sidecars for a finished contig. Conservative per-column
-/// bound: each `(sample, ploid)` column's max over ALL deletions it carries (an
-/// over-estimate vs. the var_key-only contract, but `overlap_range`'s overshoot
-/// is proven safe — see `search.rs` `overlap_max_region_length_overshoot_is_safe`),
-/// and the global max for `dense/max_del`. This exercises per-column indexing in
-/// the consumer while remaining independent of the producer's tight per-column bound.
-fn write_max_del_fixture(
-    contig_dir: &Path,
-    n_samples: usize,
-    ploidy: usize,
-    records: &[SynthRecord],
-) {
-    let columns = n_samples * ploidy;
-    let mut per_col = vec![0u32; columns];
-    let mut global = 0u32;
-    for rec in records {
-        let d = del_len_of(rec);
-        global = global.max(d);
-        for (hap, &g) in rec.gt.iter().enumerate() {
-            if g == 1 {
-                per_col[hap] = per_col[hap].max(d);
-            }
-        }
-    }
-    let arr = Array2::from_shape_vec((n_samples, ploidy), per_col).unwrap();
-    ndarray_npy::write_npy(contig_dir.join("max_del.npy"), &arr).unwrap();
-
-    std::fs::create_dir_all(contig_dir.join("dense")).unwrap();
-    let dense = Array1::from_vec(vec![global]);
-    ndarray_npy::write_npy(contig_dir.join("dense").join("max_del.npy"), &dense).unwrap();
-}
-
-/// Convert `records` to a finished SVAR2 contig under `out/{chrom}` and write the
-/// `max_del` fixture. `out` must already exist.
-fn build_contig(out: &Path, chrom: &str, samples: &[&str], ploidy: usize, records: &[SynthRecord]) {
-    let bcf = out.join("in.bcf");
-    let fasta = out.join("in.fa");
-    build_bcf_with_index(&bcf, chrom, 1_000_000, samples, records);
-    // M2b: the reader validates REF and left-aligns against a reference FASTA.
-    // Stamp each record's REF into an 'N'-filler contig; 'N' never satisfies the
-    // left-align repeat condition, so positions stay put and the oracle holds.
-    build_fasta_with_index(&fasta, chrom, 1_000_000, records);
-    process_chromosome(
-        bcf.to_str().unwrap(),
-        fasta.to_str().unwrap(),
-        chrom,
-        out.to_str().unwrap(),
-        samples,
-        1000, // chunk_size
-        ploidy,
-        1,    // htslib_threads
-        4096, // long_allele_capacity
-    )
-    .expect("process_chromosome should succeed");
-    write_max_del_fixture(&out.join(chrom), samples.len(), ploidy, records);
-}
 
 #[test]
 fn test_open_ok_and_missing_dirs_tolerated() {
@@ -350,78 +284,6 @@ fn test_pure_snp_contig_and_no_overlap() {
     assert!(left.per_hap[0].positions.is_empty());
     let right = overlap_sample(&reader, 0, 900, 1000);
     assert!(right.per_hap[0].positions.is_empty());
-}
-
-/// Owned analogue of `SynthRecord` (proptest needs values that outlive the
-/// borrow). One atomized bi-allelic variant.
-#[derive(Clone, Debug)]
-struct OwnedRecord {
-    pos: i64,
-    ref_allele: Vec<u8>,
-    alt: Vec<u8>,
-    gt: Vec<i32>, // len == n_haps
-}
-
-/// Random atomized contig: strictly increasing positions, each variant a SNP,
-/// INS (alt = anchor + tail), or DEL (ref = anchor + tail), with random per-hap
-/// genotypes. INS tails reach 15 bases so some insertions spill to the LUT.
-fn arb_records(n_haps: usize) -> impl Strategy<Value = Vec<OwnedRecord>> {
-    proptest::collection::vec(
-        (
-            0u8..3u8,                                            // kind: 0 SNP, 1 INS, 2 DEL
-            0usize..4,                                           // anchor base index
-            0usize..4,                                           // SNP alt base index
-            proptest::collection::vec(0usize..4, 1..16),         // INS/DEL tail (>= 1 base)
-            proptest::collection::vec(0i32..2, n_haps..=n_haps), // genotypes
-            17u32..40u32, // position gap: >= 17 keeps an 'N' between records' REF
-                          // stamps (max REF span is 16), so no overlap and M2b never left-shifts
-        ),
-        1..8, // 1..7 records; empty contigs are covered by the degenerate tests
-    )
-    .prop_map(move |specs| {
-        const BASES: [u8; 4] = [b'A', b'C', b'T', b'G'];
-        let mut pos: i64 = 100;
-        let mut out = Vec::new();
-        for (kind, anchor, snp_alt, tail, gt, gap) in specs {
-            pos += gap as i64;
-            let b0 = BASES[anchor];
-            // M2b left-aligns any indel whose anchor base repeats at the allele's
-            // end (roll condition: anchor == tail's last base). Force them distinct
-            // so generated records are already left-canonical and the converter
-            // leaves positions put — keeping the brute-force oracle valid.
-            let mut tail = tail;
-            if tail.last() == Some(&anchor) {
-                *tail.last_mut().unwrap() = (anchor + 1) % 4;
-            }
-            let (ref_allele, alt) = match kind {
-                0 => {
-                    let alt_idx = if snp_alt == anchor {
-                        (anchor + 1) % 4
-                    } else {
-                        snp_alt
-                    };
-                    (vec![b0], vec![BASES[alt_idx]])
-                }
-                1 => {
-                    let mut a = vec![b0];
-                    a.extend(tail.iter().map(|&x| BASES[x]));
-                    (vec![b0], a)
-                }
-                _ => {
-                    let mut r = vec![b0];
-                    r.extend(tail.iter().map(|&x| BASES[x]));
-                    (r, vec![b0])
-                }
-            };
-            out.push(OwnedRecord {
-                pos,
-                ref_allele,
-                alt,
-                gt,
-            });
-        }
-        out
-    })
 }
 
 /// Brute-force reference: for `sample`, per hap, the carried variants overlapping


### PR DESCRIPTION
## SVAR2 M6.1 — Query Decode Core (Consumer Spine)

Generalizes M5's single-sample `overlap_sample` into the batched, uniform-key, two-channel query **spine** (`overlap_batch`) that both SVAR2 consumers (gvl M6b, Python M6c) will build on. The spine carries **undecoded** uniform 32-bit keys, unions `snp`+`indel` within each of the `var_key` and `dense` channels, and leaves the final `var_key ⋈ dense` merge + allele decode to the consumer.

Plan: `docs/superpowers/plans/2026-07-02-svar2-m6.1-consumer-spine.md`

### What landed
- **`svar2_codec::snp_code_to_key`** — re-expands a 2-bit SNP code into the uniform 32-bit indel key (`code << 25`); the layout/shift stays in the codec crate (no inline shift in `genoray`). Codec stays pure/leaf/std-only and publish-dry-run clean.
- **`src/spine.rs`** — reader-free algorithm layer: `KeyRef` (undecoded `(position, key)`), `gather_keys` (overlap-filter a position run → `KeyRef`s, deletion-aware), `merge_keys` (stable position-sorted n-way merge).
- **`src/query.rs` refactor** — `overlap_sample` re-expressed on the spine with a single decode site (`decode_keyref`) and reader helpers (`vk_slice`, `dense_union`/`DenseUnion`, `dense_carried`). Public signature and `QueryResult` unchanged; guarded byte-for-byte by the unmodified M5 oracle `tests/test_query.rs`.
- **`overlap_batch` + `BatchResult` + `decode_hap`** — batched multi-region × whole-cohort query. Two channels: per-hap `var_key` CSR (`vk`/`vk_off`), a shared decode-once `dense` union (`dense`/`dense_range`) with per-hap presence bitmasks (`dense_present`/`dense_present_off`). Single-threaded here; rayon + dense-window subsetting are deferred to M6b.
- **`tests/test_batch.rs`** — cross-checks `overlap_batch` decoded per hap ≡ `overlap_sample` for every `(region, sample, ploid)` on real disk contigs (fixed fixture + decode-free dense-popcount parity + randomized proptest). Shared contig/record test helpers hoisted into `tests/common/mod.rs` (DRY).
- **Docs** — roadmap + M6 design spec reconciled; PyO3/numpy exposure (M6b), `seqpro.rag.Ragged` materialization (M6c), and rayon are explicitly marked as remaining.

### Correctness note (found + fixed in review)
The whole-branch review caught a latent bug: `search::overlap_range` only guarantees its window *endpoints* overlap, so a spanning deletion could pull later, non-overlapping variants into the result. This pre-existed for indels in M5 but was masked by the proptest generator's position gaps. Fixed in **both** channels by applying the exact left-overlap predicate `q_start < v_end` per element inside the already-iterated window (`gather_keys`, `dense_carried`, and `overlap_batch`'s presence loop; `decode_hap` inherits it). This aligns the implementation with the oracle's own `pos < q_end && q_start < v_end` definition and makes `BatchResult`'s dense channel self-consistent for consumers (which receive no `v_end`). New spine unit + disk regression tests lock it.

### Testing
- Full genoray suite green (129 lib unit + integration incl. M5 oracle `test_query.rs` 6/6 and `test_batch.rs`), `svar2-codec` 18/18.
- `clippy --tests -D warnings` + `rustfmt` clean; `cargo publish --dry-run -p svar2-codec` clean.

### Process
Executed via subagent-driven development: each task got an implementer + spec/quality review pass; a whole-branch review (Opus) preceded merge. A handful of non-blocking Minor findings (e.g. a `dense_carried` bool-branch DRY helper, a stale doc comment) are deferred — noted in `.superpowers/sdd/progress.md`.

### PR composition
Targets `svar-2`. Local `svar-2` was 1 commit ahead of the remote, so this PR includes 2 pre-existing docs commits (`mark M6.0 done`, the M6.1 plan) plus the 7 M6.1 implementation commits — all belong on the `svar-2` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
