### PR TITLE
SP-3: Rust panics → typed Python exceptions

### DIFF
--- a/docs/superpowers/plans/2026-07-09-sp3-rust-typed-errors.md
+++ b/docs/superpowers/plans/2026-07-09-sp3-rust-typed-errors.md
@@ -1,0 +1,1284 @@
+# SP-3 — Rust panics → typed errors: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `panic!`/`.expect()`/`.unwrap()` on I/O and user-input conditions in the Rust conversion and query paths with propagated typed errors, so Python callers get a meaningful exception type and message instead of a context-free `WorkerPanicked` or a process abort.
+
+**Architecture:** Extend `ConversionError` with `Input`/`MissingFile` categories and a `From<NormalizeError>` bridge; add `impl From<ConversionError> for PyErr` mapping each category to a Python builtin. Thread `Result` through the reader → writer → merge worker paths and surface it at the orchestrator's thread joins. Thread `io::Result` through the query sidecar loaders (rides the existing `ContigReader::open -> io::Result -> PyOSError` seam). Make the `bundle_from_dict` FFI parser fallible.
+
+**Tech Stack:** Rust (pyo3, thiserror, rayon, ndarray-npy, rust-htslib), Python (pytest), Pixi.
+
+## Global Constraints
+
+- Panics are retained **only** for genuine invariants (proptested internal contracts). After SP-3, a Rust panic reaching Python means "genoray bug," never "bad VCF/args."
+- **Python exception surface is builtins-only** — no new public Python names. Mapping: user-input content → `ValueError`; missing required file → `FileNotFoundError`; corrupt/failed disk I/O → `OSError`; genuine panic → `RuntimeError`.
+- Rust tests MUST run with `pixi run bash -lc 'cargo test --no-default-features <args>'` — the default features build a pyo3 test binary that fails to link (`undefined symbol: _Py_Dealloc`).
+- Behavior-preserving on the happy path; the only intended change is panics/aborts → typed exceptions.
+- `ConversionError` must stay `Send` (rayon `try_for_each` requires it): only `String`/`std::io::Error`/`ndarray_npy` sources, all `Send`.
+- The full suite (`pixi run test`) and `cargo test --no-default-features` stay green after every commit.
+- Commit messages follow Conventional Commits (`feat:`/`fix:`/`refactor:`). End each with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+- Branch: `sp3-rust-typed-errors` (already checked out). prek hooks are installed; let them run.
+
+---
+
+## File Structure
+
+- `src/error.rs` — extend `ConversionError` (new variants + `From<NormalizeError>` + `From<ConversionError> for PyErr`).
+- `src/lib.rs` — `run_conversion_pipeline` result loop uses `?` via the new `PyErr` conversion.
+- `src/vcf_reader.rs` — `new`, `decompose_current_record`, `next_atom`, `read_next_chunk` return `Result<_, ConversionError>`.
+- `src/writer.rs` — `run_io_writer`, `run_long_allele_writer`, `write_bin` return `Result<(), ConversionError>`.
+- `src/orchestrator.rs` — reader/writer thread closures return `Result`; three-way join surfacing; `?` at merge/pack call sites.
+- `src/merge.rs`, `src/dense_merge.rs` — `merge_mini_sc` / `merge_dense_class` return `Result<(), ConversionError>`.
+- `src/rvk.rs` — `pack_snp_key_file` returns `Result<(), ConversionError>`.
+- `src/streams.rs` — `post_merge` hook type gains a `Result` return.
+- `src/query/sidecar.rs` — `load_offsets`/`load_max_del`/`load_dense_max_del` return `io::Result`.
+- `src/nrvk.rs` — `LongAlleleReader::new` returns `io::Result`.
+- `src/query/reader.rs`, `src/query/decode.rs` — propagate the loader/`new` `io::Result`.
+- `src/py_query_ranges.rs` — `bundle_from_dict` returns `PyResult<RangesBundle>`.
+- `tests/test_svar2_errors.py` — NEW pytest asserting exception types/messages.
+- `tests/test_svar2_from_vcf.py` — tighten the existing `raises(Exception)` symbolic test to `raises(ValueError)`.
+- `skills/genoray-api/SKILL.md` — add an **Errors** subsection.
+
+---
+
+## Commit 1 — Taxonomy foundation
+
+### Task 1: Extend `ConversionError` and add the Python mapping
+
+**Files:**
+- Modify: `src/error.rs`
+- Modify: `src/lib.rs:182-185`
+- Test: `src/error.rs` (`#[cfg(test)]` module)
+
+**Interfaces:**
+- Produces: `ConversionError::Input(String)`, `ConversionError::MissingFile { path: String }`, `impl From<NormalizeError> for ConversionError`, `impl From<ConversionError> for pyo3::PyErr`. Later tasks construct `Input`/`MissingFile`/`Io` and rely on the `PyErr` mapping.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the bottom of `src/error.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::normalize::NormalizeError;
+
+    #[test]
+    fn normalize_error_maps_to_input_with_message() {
+        let ne = NormalizeError::RefMismatch {
+            pos: 7,
+            expected: "A".into(),
+            found: "C".into(),
+        };
+        let expected_msg = ne.to_string();
+        let ce: ConversionError = ne.into();
+        match ce {
+            ConversionError::Input(msg) => {
+                assert_eq!(msg, expected_msg);
+                assert!(msg.contains("disagrees"));
+            }
+            other => panic!("expected Input, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_file_message_includes_path() {
+        let ce = ConversionError::MissingFile {
+            path: "/x/in.vcf.gz.tbi".into(),
+        };
+        assert!(ce.to_string().contains("/x/in.vcf.gz.tbi"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features error::tests'`
+Expected: FAIL — `Input`/`MissingFile` variants and `From<NormalizeError>` do not exist (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Replace the enum in `src/error.rs` (keep the module docstring) with:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ConversionError {
+    /// User-recoverable *content* error: bad contig/sample name, symbolic ALT,
+    /// REF/FASTA mismatch, missing index. The message is the whole error.
+    #[error("{0}")]
+    Input(String),
+    /// A required input file (index, FASTA) is absent.
+    #[error("required file not found: {path}")]
+    MissingFile { path: String },
+    #[error("I/O error at {context}: {source}")]
+    Io {
+        context: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("worker thread '{thread}' panicked")]
+    WorkerPanicked { thread: String },
+    #[error("failed to write npy at {path}: {source}")]
+    Npy {
+        path: String,
+        #[source]
+        source: ndarray_npy::WriteNpyError,
+    },
+    #[error("failed to read npy at {path}: {source}")]
+    ReadNpy {
+        path: String,
+        #[source]
+        source: ndarray_npy::ReadNpyError,
+    },
+}
+
+impl From<crate::normalize::NormalizeError> for ConversionError {
+    fn from(e: crate::normalize::NormalizeError) -> Self {
+        ConversionError::Input(e.to_string())
+    }
+}
+
+impl From<ConversionError> for pyo3::PyErr {
+    fn from(e: ConversionError) -> Self {
+        use pyo3::exceptions::{
+            PyFileNotFoundError, PyOSError, PyRuntimeError, PyValueError,
+        };
+        let msg = e.to_string();
+        match e {
+            ConversionError::Input(_) => PyValueError::new_err(msg),
+            ConversionError::MissingFile { .. } => PyFileNotFoundError::new_err(msg),
+            ConversionError::Io { .. }
+            | ConversionError::Npy { .. }
+            | ConversionError::ReadNpy { .. } => PyOSError::new_err(msg),
+            ConversionError::WorkerPanicked { .. } => PyRuntimeError::new_err(msg),
+        }
+    }
+}
+```
+
+Also update the module docstring's stale note (lines 1-3) — the "worker-thread hot loops still panic (converting them is a follow-up)" clause is now inaccurate; change it to: `//! Boundary-level typed errors for the conversion pipeline. Categories map to`
+`//! Python builtins via \`impl From<ConversionError> for PyErr\`.`
+
+- [ ] **Step 4: Update the `lib.rs` mapping to use the new conversion**
+
+In `src/lib.rs`, replace lines 182-185:
+
+```rust
+    let mut total_dropped: u64 = 0;
+    for r in results {
+        total_dropped += r.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+    }
+```
+
+with:
+
+```rust
+    let mut total_dropped: u64 = 0;
+    for r in results {
+        total_dropped += r?; // ConversionError -> PyErr via From (category-aware)
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features error::tests'`
+Expected: PASS (2 tests).
+
+Run: `pixi run bash -lc 'cargo build --no-default-features'`
+Expected: builds clean (the `?` in `lib.rs` resolves via the new `From`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/error.rs src/lib.rs
+git commit -m "feat(error): add Input/MissingFile categories and PyErr mapping
+
+Adds user-input vs. internal categories to ConversionError, a From<NormalizeError>
+bridge, and a category-aware From<ConversionError> for PyErr (Input->ValueError,
+MissingFile->FileNotFoundError, Io/Npy->OSError, WorkerPanicked->RuntimeError).
+run_conversion_pipeline now propagates via ? instead of flattening to RuntimeError.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Commit 2 — Conversion workers → typed errors
+
+### Task 2: Reader path → typed errors, surfaced at the join
+
+This is the crown-jewel task: it turns swallowed `WorkerPanicked`s (bad contig/sample/REF/symbolic ALT) into real `ValueError`s. It is independently shippable and tested end-to-end from Python.
+
+**Files:**
+- Modify: `src/vcf_reader.rs:153-233` (`new`), `:242-323` (`decompose_current_record`), `:338-357` (`next_atom`), `:363-378+` (`read_next_chunk`)
+- Modify: `src/orchestrator.rs:137-166` (reader closure), `:208-217` (reader join surfacing)
+- Test: `tests/test_svar2_errors.py` (NEW)
+
+**Interfaces:**
+- Consumes: `ConversionError::{Input, MissingFile, Io}`, `From<NormalizeError>` (Task 1).
+- Produces: `VcfChunkReader::new(...) -> Result<Self, ConversionError>`; `read_next_chunk(...) -> Result<Option<DenseChunk>, ConversionError>`. The reader closure returns `Result<u64, ConversionError>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_svar2_errors.py`:
+
+```python
+"""SP-3: conversion errors surface as typed Python exceptions, not RuntimeError."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from genoray import SparseVar2
+
+_REF = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"
+
+
+def _write_ref(d: Path) -> Path:
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+    return ref
+
+
+def _write_vcf(d: Path, body_rows: str, *, contig_len: int = 40) -> Path:
+    body = (
+        "##fileformat=VCFv4.2\n"
+        f"##contig=<ID=chr1,length={contig_len}>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+        + body_rows
+    )
+    plain = d / "in.vcf"
+    plain.write_text(body)
+    gz = d / "in.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+    return gz
+
+
+def test_symbolic_alt_raises_value_error(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, "chr1\t20\t.\tT\t<DEL>\t.\t.\t.\tGT\t0|1\t0|0\n")
+    with pytest.raises(ValueError, match="symbolic"):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=1)
+
+
+def test_ref_mismatch_raises_value_error(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    # POS 3 (1-based) in _REF is 'A'; claim REF='G' to force a mismatch.
+    vcf = _write_vcf(tmp_path, "chr1\t3\t.\tG\tT\t.\t.\t.\tGT\t0|1\t0|0\n")
+    with pytest.raises(ValueError, match="disagrees"):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=1)
+
+
+def test_missing_reference_raises_file_not_found(tmp_path: Path):
+    vcf = _write_vcf(tmp_path, "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n")
+    with pytest.raises(FileNotFoundError):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, tmp_path / "nope.fa", threads=1)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar2_errors.py -v`
+Expected: FAIL — the pipeline currently panics, surfacing as `RuntimeError` (or a `pyo3_runtime.PanicException`), not `ValueError`.
+
+- [ ] **Step 3: Convert `VcfChunkReader::new`**
+
+In `src/vcf_reader.rs`, change the signature at line 161 from `) -> Self {` to `) -> Result<Self, ConversionError> {` and rewrite the body's fallible sites. Add `use crate::error::ConversionError;` to the file's imports if not present. Replacement body:
+
+```rust
+        let mut reader = IndexedReader::from_path(vcf_path).map_err(|e| {
+            ConversionError::Input(format!(
+                "Failed to open VCF/BCF index for '{vcf_path}' \
+                 (is there a .tbi or .csi file?): {e}"
+            ))
+        })?;
+
+        reader.set_threads(htslib_threads).map_err(|e| ConversionError::Io {
+            context: format!("allocating {htslib_threads} HTSlib background threads"),
+            source: std::io::Error::other(e.to_string()),
+        })?;
+
+        let header = reader.header().clone();
+
+        let rid = header.name2rid(chrom.as_bytes()).map_err(|_| {
+            ConversionError::Input(format!("Chromosome '{chrom}' not found in VCF header"))
+        })?;
+
+        reader.fetch(rid, 0, None).map_err(|e| ConversionError::Io {
+            context: format!("fetching region for chromosome '{chrom}'"),
+            source: std::io::Error::other(e.to_string()),
+        })?;
+
+        let sample_indices: Vec<usize> = samples
+            .iter()
+            .map(|name| {
+                header.sample_id(name.as_bytes()).ok_or_else(|| {
+                    ConversionError::Input(format!("Sample '{name}' not found in VCF"))
+                })
+            })
+            .collect::<Result<_, _>>()?;
+
+        // Reference is optional. With a FASTA, cache the full uppercased contig for
+        // validate_ref/left_align; without one, leave it empty and skip both.
+        let (ref_seq, has_reference) = match fasta_path {
+            Some(path) => {
+                // A wrong reference path reaches Rust unchecked (Python does not
+                // validate it), so surface it as FileNotFoundError specifically.
+                if !std::path::Path::new(path).exists() {
+                    return Err(ConversionError::MissingFile { path: path.to_string() });
+                }
+                let fasta = rust_htslib::faidx::Reader::from_path(path).map_err(|e| {
+                    ConversionError::Input(format!(
+                        "Failed to open reference FASTA '{path}' (is there a .fai?): {e}"
+                    ))
+                })?;
+                // htslib's faidx_seq_len returns -1 for an unknown contig, surfaced
+                // via rust-htslib as u64::MAX — check explicitly for a clear message.
+                let contig_len_raw = fasta.fetch_seq_len(chrom);
+                if contig_len_raw == u64::MAX {
+                    return Err(ConversionError::Input(format!(
+                        "Contig '{chrom}' not found in reference FASTA"
+                    )));
+                }
+                let contig_len = contig_len_raw as usize;
+                let mut ref_seq = if contig_len == 0 {
+                    Vec::new()
+                } else {
+                    fasta.fetch_seq(chrom, 0, contig_len - 1).map_err(|e| {
+                        ConversionError::Io {
+                            context: format!("fetching contig '{chrom}' from reference FASTA"),
+                            source: std::io::Error::other(e.to_string()),
+                        }
+                    })?
+                };
+                ref_seq.make_ascii_uppercase();
+                (ref_seq, true)
+            }
+            None => (Vec::new(), false),
+        };
+
+        let record = reader.empty_record();
+
+        Ok(Self {
+            inner_reader: reader,
+            num_samples: samples.len(),
+            ploidy,
+            sample_indices,
+            ref_seq,
+            has_reference,
+            skip_out_of_scope,
+            dropped_out_of_scope: 0,
+            record,
+            heap: BinaryHeap::new(),
+            frontier: 0,
+            eof: false,
+            next_seq: 0,
+        })
+```
+
+- [ ] **Step 4: Convert `decompose_current_record` and `next_atom`**
+
+Change `fn decompose_current_record(&mut self) {` (line 242) to `fn decompose_current_record(&mut self) -> Result<(), ConversionError> {`. Inside it:
+
+Replace the GT-read `.expect(...)` (line 266-270) with:
+```rust
+            let gts = self
+                .record
+                .format(b"GT")
+                .integer()
+                .map_err(|e| ConversionError::Input(format!(
+                    "Failed to read GT format at pos {pos}: {e}"
+                )))?;
+```
+
+Replace the `validate_ref(...).expect(...)` (lines 288-289) with:
+```rust
+            crate::normalize::validate_ref(pos, &ref_allele, &self.ref_seq)?;
+```
+
+Replace the `atomize_record(...).expect(...)` (lines 294-301) with:
+```rust
+        let dropped = atomize_record(pos, &ref_allele, &alt_refs, &mut atoms, self.skip_out_of_scope)?;
+```
+
+Add `Ok(())` as the final line of the function (after the `for atom in atoms { ... }` loop).
+
+Change `fn next_atom(&mut self) -> Option<PendingAtom> {` (line 338) to `fn next_atom(&mut self) -> Result<Option<PendingAtom>, ConversionError> {`. In its body: change `return Some(...)` → `return Ok(Some(...))`; change `return None` → `return Ok(None)`; change the `self.decompose_current_record();` call to `self.decompose_current_record()?;`; and replace `Some(Err(e)) => panic!("VCF Read Error: {}", e),` with:
+```rust
+                Some(Err(e)) => {
+                    return Err(ConversionError::Io {
+                        context: "reading next VCF record".to_string(),
+                        source: std::io::Error::other(e.to_string()),
+                    })
+                }
+```
+
+- [ ] **Step 5: Convert `read_next_chunk`**
+
+Change the signature (line 363-368) return type from `-> Option<DenseChunk> {` to `-> Result<Option<DenseChunk>, ConversionError> {`. Change the gather loop (lines 370-378):
+
+```rust
+        let mut atoms: Vec<PendingAtom> = Vec::with_capacity(chunk_size);
+        while atoms.len() < chunk_size {
+            match self.next_atom()? {
+                Some(a) => atoms.push(a),
+                None => break,
+            }
+        }
+        if atoms.is_empty() {
+            return Ok(None);
+        }
+```
+
+At the end of the function, wrap the returned `DenseChunk` in `Ok(Some(...))` (find the final `Some(DenseChunk { ... })` or `DenseChunk { ... }` return and make it `Ok(Some(DenseChunk { ... }))`).
+
+- [ ] **Step 6: Update the reader thread closure + join in `orchestrator.rs`**
+
+Replace the closure body (lines 147-166, the `move || { ... }` block) with a `Result`-returning closure:
+
+```rust
+            move || -> Result<u64, ConversionError> {
+                // passing the thread budget down to HTSLib
+                let s_refs: Vec<&str> = s_owned.iter().map(|s| s.as_str()).collect();
+                let mut reader = VcfChunkReader::new(
+                    &vcf,
+                    fasta.as_deref(),
+                    &chr,
+                    &s_refs,
+                    htslib_threads,
+                    ploidy,
+                    skip_out_of_scope,
+                )?;
+                let mut chunk_id = 0;
+                while let Some(dense_chunk) =
+                    reader.read_next_chunk(chunk_size, chunk_id, Some(&pool))?
+                {
+                    tx_dense.send(dense_chunk).unwrap();
+                    chunk_id += 1;
+                }
+                Ok(reader.dropped_out_of_scope())
+            }
+```
+
+Replace the reader-join surfacing (lines 215-217):
+
+```rust
+    let dropped = match reader_res {
+        Ok(r) => r?, // ConversionError propagates with its real message
+        Err(_) => {
+            return Err(ConversionError::WorkerPanicked {
+                thread: format!("read-{}", chrom),
+            })
+        }
+    };
+```
+
+(Leave the sampler/executor/writer joins at 218-234 unchanged for now — Task 3/4 update the writer ones.)
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo build --no-default-features'`
+Expected: builds clean.
+
+Run: `pixi run pytest tests/test_svar2_errors.py -v`
+Expected: PASS (3 tests) — symbolic + REF-mismatch raise `ValueError`, missing reference raises `FileNotFoundError`.
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: PASS (existing Rust tests unaffected).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/vcf_reader.rs src/orchestrator.rs tests/test_svar2_errors.py
+git commit -m "fix(vcf): surface reader errors as typed ValueError instead of WorkerPanicked
+
+Threads Result through VcfChunkReader (new/decompose/next_atom/read_next_chunk)
+and the orchestrator reader thread, so bad contig, missing sample, REF mismatch,
+and symbolic ALT reach Python as ValueError with the real message.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 3: Writer threads → typed errors
+
+**Files:**
+- Modify: `src/writer.rs:14-77` (`run_io_writer`, `run_long_allele_writer`, `write_bin`)
+- Modify: `src/orchestrator.rs:186-201` (writer closures), `:229-234` (writer joins)
+- Test: `src/writer.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `ConversionError::Io` (Task 1).
+- Produces: `run_io_writer(...) -> Result<(), ConversionError>`, `run_long_allele_writer(...) -> Result<(), ConversionError>`, `write_bin(...) -> Result<(), ConversionError>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/writer.rs`'s test module:
+
+```rust
+    #[test]
+    fn write_bin_returns_io_error_on_unwritable_path() {
+        // A path whose parent dir does not exist cannot be created.
+        let bad = std::path::Path::new("/nonexistent-sp3-dir/child/out.bin");
+        let err = write_bin(bad, &[1u8, 2, 3]).unwrap_err();
+        match err {
+            crate::error::ConversionError::Io { context, .. } => {
+                assert!(context.contains("out.bin"));
+            }
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features writer::tests::write_bin_returns_io_error'`
+Expected: FAIL — `write_bin` returns `()` and panics (compile error on `.unwrap_err()`).
+
+- [ ] **Step 3: Convert `write_bin`, `run_io_writer`, `run_long_allele_writer`**
+
+Add `use crate::error::ConversionError;` to `src/writer.rs`. Replace the three functions:
+
+```rust
+pub fn run_io_writer(
+    rx_sparse: Receiver<SparseChunk>,
+    dirs: StreamMap<PathBuf>,
+    dense_dirs: DenseMap<PathBuf>,
+) -> Result<(), ConversionError> {
+    while let Ok(chunk) = rx_sparse.recv() {
+        let id = chunk.chunk_id;
+
+        for (tag, sub) in chunk.streams.iter() {
+            let dir = dirs.get(tag);
+            write_bin(
+                &layout::chunk_pos(dir, id),
+                bytemuck::cast_slice(&sub.call_positions),
+            )?;
+            write_bin(&layout::chunk_key(dir, id), &sub.call_keys)?;
+        }
+
+        for spec in &DENSE_REGISTRY {
+            let sub = chunk.dense.get(spec.class);
+            if sub.n_dense_variants == 0 {
+                continue;
+            }
+            let dir = dense_dirs.get(spec.class);
+            write_bin(&layout::chunk_pos(dir, id), bytemuck::cast_slice(&sub.positions))?;
+            write_bin(&layout::chunk_key(dir, id), &sub.keys)?;
+            write_bin(&layout::chunk_geno(dir, id), &sub.geno_bits)?;
+        }
+    }
+
+    println!("Writer Thread: Channel closed. All chunks safely committed to SSD.");
+    Ok(())
+}
+
+pub fn run_long_allele_writer(
+    rx_long: Receiver<Vec<u8>>,
+    out_path: &Path,
+    chrom_label: &str,
+) -> Result<(), ConversionError> {
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(out_path)
+        .map_err(|e| ConversionError::Io {
+            context: format!("creating {}", out_path.display()),
+            source: e,
+        })?;
+    let mut disk_writer = BufWriter::with_capacity(1024 * 1024, file);
+    while let Ok(buffer) = rx_long.recv() {
+        disk_writer.write_all(&buffer).map_err(|e| ConversionError::Io {
+            context: format!("writing long alleles to {}", out_path.display()),
+            source: e,
+        })?;
+    }
+    disk_writer.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", out_path.display()),
+        source: e,
+    })?;
+    println!(
+        "[{}] Long Allele Writer: All buffer data safely committed.",
+        chrom_label
+    );
+    Ok(())
+}
+
+fn write_bin(path: &Path, bytes: &[u8]) -> Result<(), ConversionError> {
+    let f = File::create(path).map_err(|e| ConversionError::Io {
+        context: format!("creating {}", path.display()),
+        source: e,
+    })?;
+    let mut f = BufWriter::new(f);
+    f.write_all(bytes).map_err(|e| ConversionError::Io {
+        context: format!("writing {}", path.display()),
+        source: e,
+    })?;
+    f.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", path.display()),
+        source: e,
+    })?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Update the writer closures + joins in `orchestrator.rs`**
+
+The chunk-writer closure (line 200) is `move || writer::run_io_writer(...)` — it now returns `Result`, no change to the closure text. Same for the long-allele writer closure (line 199). Update the two joins (lines 229-234):
+
+```rust
+    match chunk_writer_res {
+        Ok(r) => r?,
+        Err(_) => {
+            return Err(ConversionError::WorkerPanicked {
+                thread: format!("cw-{}", chrom),
+            })
+        }
+    }
+    match long_allele_writer_res {
+        Ok(r) => r?,
+        Err(_) => {
+            return Err(ConversionError::WorkerPanicked {
+                thread: format!("lw-{}", chrom),
+            })
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features writer::tests'`
+Expected: PASS (existing writer test + the new one).
+
+Run: `pixi run bash -lc 'cargo build --no-default-features'`
+Expected: builds clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/writer.rs src/orchestrator.rs
+git commit -m "fix(writer): return ConversionError::Io from writer threads
+
+run_io_writer/run_long_allele_writer/write_bin propagate I/O failures as typed
+Io errors; the orchestrator surfaces them at the writer joins instead of aborting.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 4: Merge / dense-merge / pack → typed errors
+
+**Files:**
+- Modify: `src/merge.rs:24-31` (signature) + all I/O `.expect()`/`panic!` sites in `merge_mini_sc`
+- Modify: `src/dense_merge.rs` (`merge_dense_class` signature + I/O sites)
+- Modify: `src/rvk.rs:23-56` (`pack_snp_key_file`)
+- Modify: `src/streams.rs:31` (hook type)
+- Modify: `src/orchestrator.rs:256-266`, `:276-284` (merge/pack call sites use `?`)
+- Test: `src/rvk.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `ConversionError::{Io, Npy}` (Task 1).
+- Produces: `merge_mini_sc(...) -> Result<(), ConversionError>`, `merge_dense_class(...) -> Result<(), ConversionError>`, `pack_snp_key_file(&Path) -> Result<(), ConversionError>`; `StreamSpec::post_merge: Option<fn(&Path) -> Result<(), ConversionError>>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/rvk.rs`'s test module (create a `#[cfg(test)] mod tests` if absent, with `use super::*;`):
+
+```rust
+    #[test]
+    fn pack_snp_key_file_errors_on_missing_dir() {
+        let missing = std::path::Path::new("/nonexistent-sp3-pack/dir");
+        let err = pack_snp_key_file(missing).unwrap_err();
+        match err {
+            crate::error::ConversionError::Io { .. } => {}
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features rvk::tests::pack_snp_key_file_errors'`
+Expected: FAIL — `pack_snp_key_file` returns `()` and panics (compile error on `.unwrap_err()`).
+
+- [ ] **Step 3: Convert `pack_snp_key_file`**
+
+In `src/rvk.rs`, add `use crate::error::ConversionError;`. Change the signature (line 23) to `pub fn pack_snp_key_file(dir: &Path) -> Result<(), ConversionError> {` and replace every `.expect(...)` with a mapped `?`:
+
+```rust
+    let src = layout::alleles(dir);
+    let tmp = dir.join("alleles.packed.tmp");
+
+    let mut reader = BufReader::new(File::open(&src).map_err(|e| ConversionError::Io {
+        context: format!("opening {}", src.display()),
+        source: e,
+    })?);
+    let mut writer = BufWriter::new(File::create(&tmp).map_err(|e| ConversionError::Io {
+        context: format!("creating {}", tmp.display()),
+        source: e,
+    })?);
+
+    const BLOCK: usize = 4 * 1024 * 1024; // multiple of 4
+    let mut buf = vec![0u8; BLOCK];
+    loop {
+        let mut filled = 0usize;
+        while filled < BLOCK {
+            let n = reader.read(&mut buf[filled..]).map_err(|e| ConversionError::Io {
+                context: format!("reading {}", src.display()),
+                source: e,
+            })?;
+            match n {
+                0 => break,
+                n => filled += n,
+            }
+        }
+        if filled == 0 {
+            break;
+        }
+        let packed = pack_snp_keys(&buf[..filled]);
+        writer.write_all(&packed).map_err(|e| ConversionError::Io {
+            context: format!("writing {}", tmp.display()),
+            source: e,
+        })?;
+        if filled < BLOCK {
+            break;
+        }
+    }
+    writer.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", tmp.display()),
+        source: e,
+    })?;
+    drop(writer);
+    drop(reader);
+
+    std::fs::rename(&tmp, &src).map_err(|e| ConversionError::Io {
+        context: format!("renaming {} -> {}", tmp.display(), src.display()),
+        source: e,
+    })?;
+    Ok(())
+```
+
+- [ ] **Step 4: Update the `post_merge` hook type in `streams.rs`**
+
+In `src/streams.rs`, change line 31 from:
+```rust
+    pub post_merge: Option<fn(&Path)>,
+```
+to:
+```rust
+    pub post_merge: Option<fn(&Path) -> Result<(), crate::error::ConversionError>>,
+```
+The `REGISTRY` entry `Some(pack_snp_key_file)` (line 40) now type-checks against the new signature — no change to that line. The `test_only_snp_has_post_merge` test (lines 94-102) still passes (it only checks `is_some()`/`is_none()`).
+
+- [ ] **Step 5: Convert `merge_mini_sc`**
+
+In `src/merge.rs`, add `use crate::error::ConversionError;`. Change the signature (line 31) `) {` → `) -> Result<(), ConversionError> {`. Convert the sequential I/O sites:
+
+- `write_npy(layout::offsets(...), &offsets_array).expect("Failed to write final offsets");` →
+  ```rust
+  write_npy(layout::offsets(output_dir_path), &offsets_array).map_err(|source| {
+      ConversionError::Npy {
+          path: layout::offsets(output_dir_path).to_string_lossy().into_owned(),
+          source,
+      }
+  })?;
+  ```
+- The `File::create(...).expect("Failed to create positions.bin")` + `.set_len(...).expect("Failed to size positions.bin")` and the `alleles.bin` pair → map each to `ConversionError::Io { context, source }` with a `?`, e.g.:
+  ```rust
+  let final_pos_file = File::create(layout::positions(output_dir_path)).map_err(|e| ConversionError::Io {
+      context: "creating positions.bin".to_string(),
+      source: e,
+  })?;
+  final_pos_file.set_len(pos_total_bytes).map_err(|e| ConversionError::Io {
+      context: "sizing positions.bin".to_string(),
+      source: e,
+  })?;
+  let final_key_file = File::create(layout::alleles(output_dir_path)).map_err(|e| ConversionError::Io {
+      context: "creating alleles.bin".to_string(),
+      source: e,
+  })?;
+  final_key_file.set_len(key_total_bytes).map_err(|e| ConversionError::Io {
+      context: "sizing alleles.bin".to_string(),
+      source: e,
+  })?;
+  ```
+- The `chunk_files` builder (the `.map(|c| { ... panic!(...) })` closure) → collect into a `Result`:
+  ```rust
+  let chunk_files: Vec<(File, File)> = (0..num_chunks)
+      .map(|c| -> Result<(File, File), ConversionError> {
+          let pf = File::open(layout::chunk_pos(output_dir_path, c)).map_err(|e| ConversionError::Io {
+              context: format!("opening chunk_{c}_pos.bin"),
+              source: e,
+          })?;
+          let kf = File::open(layout::chunk_key(output_dir_path, c)).map_err(|e| ConversionError::Io {
+              context: format!("opening chunk_{c}_key.bin"),
+              source: e,
+          })?;
+          Ok((pf, kf))
+      })
+      .collect::<Result<_, _>>()?;
+  ```
+
+- Convert the parallel gather from `tile_starts.par_iter().for_each(|&tile_start_col| { ... });` to `try_for_each` returning `Result`, and map the four inner `.expect()` I/O sites. The closure's early `return;` (empty tile) becomes `return Ok(());`, and add `Ok(())` at the closure's end:
+  ```rust
+  tile_starts.par_iter().try_for_each(|&tile_start_col| -> Result<(), ConversionError> {
+      // ... unchanged setup ...
+      if tile_total_items == 0 {
+          return Ok(());
+      }
+      // ... unchanged buffer/gather setup ...
+      // Inside the `for chunk_id in 0..num_chunks` loop, the two preads:
+      chunk_files_ref[chunk_id].0.read_exact_at(&mut chunk_pos_bytes, pos_byte_offset)
+          .map_err(|e| ConversionError::Io { context: "pread chunk pos".into(), source: e })?;
+      chunk_files_ref[chunk_id].1.read_exact_at(&mut chunk_key_bytes, key_byte_offset)
+          .map_err(|e| ConversionError::Io { context: "pread chunk key".into(), source: e })?;
+      // ... unchanged stitch loop ...
+      // The two final pwrites:
+      final_pos_ref.write_all_at(tile_pos_bytes, tile_pos_byte_offset)
+          .map_err(|e| ConversionError::Io { context: "pwrite positions.bin".into(), source: e })?;
+      final_key_ref.write_all_at(&tile_key_buffer, tile_key_byte_offset)
+          .map_err(|e| ConversionError::Io { context: "pwrite alleles.bin".into(), source: e })?;
+      Ok(())
+  })?;
+  ```
+
+- After the parallel block, the temp-file cleanup loop and the `println!` finalize stay as-is. Add `Ok(())` as the function's final expression. If any remaining `.expect()` on cleanup `remove_file` exists, leave it (best-effort cleanup on genoray's own temp files is an acceptable invariant) — but if the reviewer prefers, map to `Io` too.
+
+- [ ] **Step 6: Convert `merge_dense_class`**
+
+`src/dense_merge.rs`'s `merge_dense_class` mirrors `merge_mini_sc`'s I/O shape (create/set_len the final files, open chunk files, parallel pread/pwrite, write offsets npy). Apply the identical mapping rule: add `use crate::error::ConversionError;`, change the signature's `) {` → `) -> Result<(), ConversionError> {`, and convert each I/O `.expect(...)`/`panic!(...)` site to a `.map_err(|e| ConversionError::Io { context: "<describe the op>".into(), source: e })?` (use `ConversionError::Npy` for the `write_npy` site, as in Step 5). Convert any `par_iter().for_each` to `try_for_each` returning `Result<(), ConversionError>` exactly as shown in Step 5. Discover the exact sites with:
+
+Run: `grep -n 'expect\|unwrap()\|panic!' src/dense_merge.rs`
+
+and convert each I/O one (leave any genuine-invariant `unwrap` on in-memory data, e.g. `.last().unwrap()` on a known-nonempty vec). End the function with `Ok(())`.
+
+- [ ] **Step 7: Update the merge/pack call sites in `orchestrator.rs`**
+
+Replace the `merge_mini_sc(...)` call + hook (lines 256-266):
+```rust
+        merge::merge_mini_sc(
+            spec.key_bytes,
+            num_chunks,
+            samples.len(),
+            ploidy,
+            dir.to_str().unwrap(),
+            ledger,
+        )?;
+        if let Some(hook) = spec.post_merge {
+            hook(&dir)?;
+        }
+```
+
+Replace the `merge_dense_class(...)` call (lines 276-284) — append `?` after the closing `);`:
+```rust
+        crate::dense_merge::merge_dense_class(
+            num_chunks,
+            samples.len(),
+            ploidy,
+            spec.key_bytes,
+            spec.pack_snp,
+            dir.to_str().unwrap(),
+            ledger,
+        )?;
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: PASS (rvk pack test + all existing merge/dense_merge tests green).
+
+Run: `pixi run pytest tests/test_svar2_from_vcf.py tests/test_svar2.py -q`
+Expected: PASS (happy-path conversion unchanged).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/merge.rs src/dense_merge.rs src/rvk.rs src/streams.rs src/orchestrator.rs
+git commit -m "fix(merge): return ConversionError from merge/dense-merge/pack paths
+
+merge_mini_sc, merge_dense_class, and pack_snp_key_file propagate I/O failures as
+typed errors (parallel tiles via try_for_each); the post_merge hook signature and
+orchestrator call sites thread the Result through.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 5: Tighten the existing symbolic-ALT test
+
+**Files:**
+- Modify: `tests/test_svar2_from_vcf.py:96-100`
+
+- [ ] **Step 1: Replace the loose assertion**
+
+The existing `test_from_vcf_symbolic_errors_without_skip` uses `pytest.raises(Exception)`. Now that symbolic ALT raises a typed `ValueError`, tighten it. Replace:
+
+```python
+    with pytest.raises(Exception):
+        SparseVar2.from_vcf(tmp_path / "store_err", vcf, ref, threads=1)
+```
+
+with:
+
+```python
+    with pytest.raises(ValueError, match="symbolic"):
+        SparseVar2.from_vcf(tmp_path / "store_err", vcf, ref, threads=1)
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `pixi run pytest tests/test_svar2_from_vcf.py::test_from_vcf_symbolic_errors_without_skip -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_svar2_from_vcf.py
+git commit -m "test(svar2): assert symbolic ALT raises ValueError, not bare Exception
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Commit 3 — Query sidecar + FFI
+
+### Task 6: Query sidecar loaders → `io::Result`
+
+**Scope boundary:** convert the setup-time loaders (`load_offsets`/`load_max_del`/`load_dense_max_del`) and `LongAlleleReader::new`, all of which are reached through `ContigReader::open -> io::Result` and surface as `PyOSError`. The per-call `LongAlleleReader::get_allele`/`all_bytes` preads stay `.expect()` — they run in the decode hot path on genoray's own finished files; making them fallible would ripple `Result` through the entire decode/gather chain for a can't-happen I/O fault with no user-facing benefit.
+
+**Files:**
+- Modify: `src/query/sidecar.rs:94-121` (three loaders)
+- Modify: `src/nrvk.rs:105-119` (`LongAlleleReader::new`)
+- Modify: `src/query/reader.rs` (callers of the loaders + `LongAlleleReader::new`)
+- Test: `src/query/sidecar.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Produces: `load_offsets(path, columns) -> std::io::Result<Vec<u64>>`, `load_max_del(path, n, p) -> std::io::Result<Array2<u32>>`, `load_dense_max_del(path) -> std::io::Result<u32>`, `LongAlleleReader::new(dir, chrom) -> std::io::Result<Self>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/query/sidecar.rs` (create a `#[cfg(test)] mod tests { use super::*; ... }` if absent):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_offsets_missing_file_is_empty_prefix_sum() {
+        let p = std::path::Path::new("/nonexistent-sp3/offsets.npy");
+        let v = load_offsets(p, 3).unwrap();
+        assert_eq!(v, vec![0u64; 4]);
+    }
+
+    #[test]
+    fn load_offsets_corrupt_file_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("offsets.npy");
+        std::fs::write(&p, b"not a valid npy header").unwrap();
+        assert!(load_offsets(&p, 3).is_err());
+    }
+}
+```
+
+(If `tempfile` is not already a dev-dependency, it is — the writer tests use `tempfile::tempdir`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features query::sidecar::tests'`
+Expected: FAIL — `load_offsets` returns `Vec<u64>` and `.expect()`s on corrupt input (compile error on `.unwrap()`/`.is_err()`).
+
+- [ ] **Step 3: Convert the three loaders**
+
+In `src/query/sidecar.rs`, replace lines 94-121:
+
+```rust
+/// Load a CSR `offsets.npy` (len `columns + 1`); a missing file means an empty
+/// stream — return an all-zero prefix-sum so every column is empty.
+pub(crate) fn load_offsets(path: &Path, columns: usize) -> std::io::Result<Vec<u64>> {
+    if path.exists() {
+        let a: Array1<u64> = ndarray_npy::read_npy(path)
+            .map_err(|e| std::io::Error::other(format!("read {}: {e}", path.display())))?;
+        Ok(a.to_vec())
+    } else {
+        Ok(vec![0u64; columns + 1])
+    }
+}
+
+/// Load `max_del.npy` (`u32`, shape `(n_samples, ploidy)`); a missing file
+/// (pure-SNP contig, or predating the post-pass) defaults to all-zero.
+pub(crate) fn load_max_del(
+    path: &Path,
+    n_samples: usize,
+    ploidy: usize,
+) -> std::io::Result<Array2<u32>> {
+    if path.exists() {
+        ndarray_npy::read_npy(path)
+            .map_err(|e| std::io::Error::other(format!("read {}: {e}", path.display())))
+    } else {
+        Ok(Array2::zeros((n_samples, ploidy)))
+    }
+}
+
+/// Load `dense/max_del.npy` (`u32`, shape `(1,)`); missing defaults to `0`.
+pub(crate) fn load_dense_max_del(path: &Path) -> std::io::Result<u32> {
+    if path.exists() {
+        let a: Array1<u32> = ndarray_npy::read_npy(path)
+            .map_err(|e| std::io::Error::other(format!("read {}: {e}", path.display())))?;
+        Ok(a.into_iter().next().unwrap_or(0))
+    } else {
+        Ok(0)
+    }
+}
+```
+
+- [ ] **Step 4: Convert `LongAlleleReader::new`**
+
+In `src/nrvk.rs`, change `pub fn new(output_dir: &str, chrom: &str) -> Self {` (line 106) to `-> std::io::Result<Self> {` and rewrite:
+
+```rust
+    pub fn new(output_dir: &str, chrom: &str) -> std::io::Result<Self> {
+        let paths = ContigPaths::new(output_dir, chrom);
+        let file = File::open(paths.long_alleles_bin())?;
+        let offsets_array: ndarray::Array1<u64> = ndarray_npy::read_npy(paths.long_allele_offsets())
+            .map_err(|e| std::io::Error::other(format!("read long_allele_offsets.npy: {e}")))?;
+        Ok(Self {
+            file,
+            offsets: offsets_array.into_raw_vec_and_offset().0,
+        })
+    }
+```
+
+Also remove the stale `// TODO: Decide which will call this ...` comment above it (the caller is now `ContigReader::open`).
+
+- [ ] **Step 5: Propagate at the callers in `query/reader.rs`**
+
+`ContigReader::open` already returns `io::Result`. Update its loader/`new` call sites to `?`:
+
+- The `load_offsets(...)` / `load_max_del(...)` / `load_dense_max_del(...)` calls each gain a `?` (they now return `io::Result`).
+- The LUT construction at `src/query/reader.rs:75` — `Some(LongAlleleReader::new(base_out_dir, chrom))` — becomes `Some(LongAlleleReader::new(base_out_dir, chrom)?)`. Confirm the surrounding expression is inside the `-> io::Result<...>` `open` body; if the `Some(...)` is produced by an `if`/`match` arm, keep the arm shape and only add `?` inside `Some(...)`.
+
+Discover any loader call sites you may have missed with:
+
+Run: `grep -rn 'load_offsets\|load_max_del\|load_dense_max_del\|LongAlleleReader::new' src/query/`
+
+and add `?` to each (all are inside `open`, which returns `io::Result`).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: PASS (new sidecar tests + all existing query/decode tests green).
+
+Run: `pixi run pytest tests/test_svar2_ranges.py tests/test_svar2_decode.py -q`
+Expected: PASS (query happy path unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/query/sidecar.rs src/nrvk.rs src/query/reader.rs
+git commit -m "fix(query): thread io::Result through sidecar loaders and LUT open
+
+load_offsets/load_max_del/load_dense_max_del and LongAlleleReader::new return
+io::Result; ContigReader::open surfaces a corrupt/truncated sidecar as PyOSError
+instead of aborting. Per-call get_allele/all_bytes preads stay panics by design.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 7: `bundle_from_dict` → `PyResult`
+
+**Files:**
+- Modify: `src/py_query_ranges.rs:139-201` (`bundle_from_dict`) + its call sites (`read_ranges`/`gather_ranges`)
+- Test: `tests/test_svar2_errors.py` (extend)
+
+**Interfaces:**
+- Produces: `bundle_from_dict(d) -> PyResult<RangesBundle>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_svar2_errors.py`:
+
+```python
+def test_gather_ranges_malformed_bundle_raises_keyerror(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(
+        tmp_path,
+        "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n",
+    )
+    out = tmp_path / "store"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv = SparseVar2(out)
+
+    bundle = sv.find_ranges("chr1", [0], [40])
+    del bundle["sample_cols"]  # drop a required key
+    with pytest.raises(KeyError, match="sample_cols"):
+        sv.gather_ranges("chr1", bundle)
+```
+
+(If `SparseVar2(out)` is not the opening idiom, mirror how `tests/test_svar2_ranges.py` opens a store for querying and adapt the two query calls accordingly.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar2_errors.py::test_gather_ranges_malformed_bundle_raises_keyerror -v`
+Expected: FAIL — the missing key currently triggers a Rust `unwrap` panic (`PanicException`/abort), not a clean `KeyError`.
+
+- [ ] **Step 3: Convert `bundle_from_dict`**
+
+In `src/py_query_ranges.rs`, add the imports (near the existing pyo3 imports): `use pyo3::exceptions::{PyKeyError, PyTypeError};`. Replace the function (lines 139-201):
+
+```rust
+/// Inverse of `bundle_to_dict`: read a `find_ranges` dict back into a
+/// `RangesBundle` for `gather_ranges`. Fallible: a missing key or wrong
+/// dtype/shape becomes a Python KeyError/TypeError rather than a Rust panic.
+fn bundle_from_dict(d: &Bound<'_, PyDict>) -> PyResult<RangesBundle> {
+    let require = |k: &str| -> PyResult<Bound<'_, PyAny>> {
+        d.get_item(k)?
+            .ok_or_else(|| PyKeyError::new_err(format!("bundle missing key '{k}'")))
+    };
+    let get_i32 = |k: &str| -> PyResult<Vec<i32>> {
+        let obj = require(k)?;
+        let arr = obj
+            .cast::<PyArray1<i32>>()
+            .map_err(|_| PyTypeError::new_err(format!("bundle key '{k}' must be an int32 1D array")))?;
+        Ok(arr.readonly().as_slice()?.to_vec())
+    };
+    let get_i64 = |k: &str| -> PyResult<Vec<i64>> {
+        let obj = require(k)?;
+        let arr = obj
+            .cast::<PyArray1<i64>>()
+            .map_err(|_| PyTypeError::new_err(format!("bundle key '{k}' must be an int64 1D array")))?;
+        Ok(arr.readonly().as_slice()?.to_vec())
+    };
+    let get_i32_pairs = |k: &str| -> PyResult<Vec<Range<usize>>> {
+        let obj = require(k)?;
+        let arr = obj
+            .cast::<PyArray2<i32>>()
+            .map_err(|_| PyTypeError::new_err(format!("bundle key '{k}' must be an int32 (N,2) array")))?
+            .readonly();
+        Ok(arr
+            .as_array()
+            .rows()
+            .into_iter()
+            .map(|row| (row[0] as usize)..(row[1] as usize))
+            .collect())
+    };
+    let get_i64_pairs = |k: &str| -> PyResult<Vec<Range<usize>>> {
+        let obj = require(k)?;
+        let arr = obj
+            .cast::<PyArray2<i64>>()
+            .map_err(|_| PyTypeError::new_err(format!("bundle key '{k}' must be an int64 (N,2) array")))?
+            .readonly();
+        Ok(arr
+            .as_array()
+            .rows()
+            .into_iter()
+            .map(|row| (row[0] as usize)..(row[1] as usize))
+            .collect())
+    };
+    let get_usize = |k: &str| -> PyResult<usize> { require(k)?.extract() };
+
+    Ok(RangesBundle {
+        n_regions: get_usize("n_regions")?,
+        n_samples: get_usize("n_samples")?,
+        ploidy: get_usize("ploidy")?,
+        region_starts: get_i32("region_starts")?
+            .into_iter()
+            .map(|x| x as u32)
+            .collect(),
+        dense_range: get_i32_pairs("dense_range")?,
+        sample_cols: get_i64("sample_cols")?
+            .into_iter()
+            .map(|x| x as usize)
+            .collect(),
+        vk_snp_range: get_i64_pairs("vk_snp_range")?,
+        vk_indel_range: get_i64_pairs("vk_indel_range")?,
+        dense_snp_range: get_i32_pairs("dense_snp_range")?,
+        dense_indel_range: get_i32_pairs("dense_indel_range")?,
+    })
+}
+```
+
+- [ ] **Step 4: Propagate at the call sites**
+
+Find the `bundle_from_dict(...)` call(s) inside the `#[pymethods]` (`gather_ranges`, and any other consumer). Each is inside a `-> PyResult<...>` method, so add `?`:
+
+Run: `grep -n 'bundle_from_dict' src/py_query_ranges.rs`
+
+Change each `let rb = bundle_from_dict(&d);` (or inline use) to `let rb = bundle_from_dict(&d)?;`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo build --no-default-features'`
+Expected: builds clean.
+
+Run: `pixi run pytest tests/test_svar2_errors.py -v`
+Expected: PASS (all error tests, including the new KeyError case).
+
+Run: `pixi run pytest tests/test_svar2_ranges.py -q`
+Expected: PASS (valid bundles still round-trip).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/py_query_ranges.rs tests/test_svar2_errors.py
+git commit -m "fix(ffi): make bundle_from_dict fallible (KeyError/TypeError not panic)
+
+A malformed find_ranges bundle (missing key, wrong dtype) now raises a clean
+Python KeyError/TypeError at the FFI boundary instead of aborting via unwrap.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+### Task 8: Document the exception contract in SKILL.md
+
+**Files:**
+- Modify: `skills/genoray-api/SKILL.md`
+
+- [ ] **Step 1: Add an Errors subsection**
+
+Add a short subsection (place it near the SparseVar2 conversion/query docs; match the file's existing heading style):
+
+```markdown
+### Errors
+
+genoray raises standard Python builtins, by category:
+
+- `ValueError` — bad input content: contig/sample not found, REF disagrees with
+  the reference FASTA, or a symbolic/breakend ALT with `skip_out_of_scope=False`.
+- `FileNotFoundError` — a required input file is missing.
+- `OSError` — a corrupt/truncated store sidecar or an underlying disk I/O failure.
+- `RuntimeError` — an internal genoray bug (a worker thread panicked); please
+  report it.
+```
+
+- [ ] **Step 2: Verify the suite is fully green**
+
+Run: `pixi run test`
+Expected: PASS (full Python suite).
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: PASS (full Rust suite).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/genoray-api/SKILL.md
+git commit -m "docs(skill): document the genoray exception-type contract
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes (for the executor)
+
+- **Every `cargo test` invocation MUST use** `pixi run bash -lc 'cargo test --no-default-features ...'` — a bare `cargo test` fails to link the pyo3 test binary.
+- If `cargo clippy` (a prek hook) flags the new `try_for_each` closure's `ConversionError` not being `Send`, re-check that no variant carries a non-`Send` source — all current variants are `Send`.
+- Tasks 2, 6, and 7 each add observable Python behavior with a dedicated pytest; Tasks 3 and 4 are I/O-on-own-files conversions verified by a Rust unit test plus the suite staying green.
+- The `dense_merge.rs` (Task 6, step 6) and call-site (`grep`) steps intentionally use discovery commands because the sites are a mechanical repeat of the fully-shown `merge_mini_sc` pattern — apply the identical `.map_err(|e| ConversionError::Io { context, source: e })?` rule to each.

--- a/docs/superpowers/specs/2026-07-09-sp3-rust-typed-errors-design.md
+++ b/docs/superpowers/specs/2026-07-09-sp3-rust-typed-errors-design.md
@@ -1,0 +1,156 @@
+# SP-3 — Rust panics → typed errors
+
+**Date:** 2026-07-09
+**Roadmap item:** SP-3 (`docs/roadmap/clean-code-audit.md`), size L, risk low (behavior improves)
+**Findings source:** `docs/roadmap/audit-findings/05-rust-query.md`,
+`docs/roadmap/audit-findings/06-rust-rest.md`
+**Depends on:** SP-2 (merged — `query.rs` is now the `query/` package; sidecar loaders
+live in `src/query/sidecar.rs`).
+
+## Goal
+
+Replace `panic!` / `.expect()` / `.unwrap()` on **I/O and user-input** conditions in the
+Rust worker and FFI paths with propagated typed errors, so a Python caller sees the real
+message and a meaningful exception type instead of a context-free `WorkerPanicked` or a
+process-level abort.
+
+**Guiding principle:** panics are retained *only* for genuine invariants (proptested
+internal contracts). After SP-3, a Rust panic reaching Python means "genoray bug," never
+"your VCF/args were wrong."
+
+## Background — current state
+
+- `ConversionError` (`src/error.rs`) has `Io`, `WorkerPanicked`, `Npy`, `ReadNpy`. Every
+  conversion error surfaces to Python as a flat `PyRuntimeError::new_err(e.to_string())`
+  at `src/lib.rs:184` — no category distinction.
+- `src/normalize.rs` **already** defines a typed `NormalizeError`
+  (`SymbolicAllele`, `RefMismatch`, `RefOutOfContig`), but `src/vcf_reader.rs:289,301`
+  discards it with `.expect()`.
+- The reader-thread closure panics internally; `orchestrator.rs` `join()` catches the
+  panic and flattens it to `WorkerPanicked { thread }`, discarding the message.
+- **Query path:** the sidecar npy loaders and the `nrvk::LongAlleleReader` random-access
+  path `.expect()` on I/O. `ContigReader::open` already returns `io::Result` and is mapped
+  to `PyOSError` in `src/py_query.rs:23` — so threading a `Result` through the loaders
+  simply lights up that existing surface.
+- `rvk::pack_snp_key_file` is a conversion-time `post_merge` hook (`fn(&Path)` in the
+  `streams.rs` registry), not a direct Python call; it `.expect()`s on every I/O op.
+- **FFI parser:** `bundle_from_dict` (`src/py_query_ranges.rs:139`) panics per field; it is
+  called by `read_ranges` / `gather_ranges`, which already return `PyResult`.
+
+## Design
+
+### 1. Rust error taxonomy (two enums, one Python mapping)
+
+The conversion pipeline and the query path are separate lifecycles with separate pyo3
+entry points, so they keep separate error types, but both map to Python builtins through
+one convention. **No new public Python names** (decision: builtins-only surface).
+
+**`ConversionError`** — extend `src/error.rs` with two category variants:
+
+- `Input(String)` — user-recoverable *content* errors: missing contig in VCF header,
+  missing sample, symbolic/breakend ALT out of scope, REF/FASTA mismatch, contig absent
+  from FASTA.
+- `MissingFile { path }` — missing `.tbi` / `.csi` / `.fai`.
+- Keep `Io`, `Npy`, `ReadNpy` (failed/corrupt disk I/O on genoray's own files) and
+  `WorkerPanicked` (now reserved for *genuine* panics only).
+- Add `impl From<NormalizeError> for ConversionError` → `Input`, reusing the already-typed
+  `RefMismatch` / `SymbolicAllele` / `RefOutOfContig` that `vcf_reader.rs` currently
+  `.expect()`s away.
+
+**Query path** — no new enum. The sidecar loaders live inside `ContigReader::open ->
+io::Result`. Thread `io::Result` through `load_offsets` / `load_max_del` /
+`load_dense_max_del` and the `nrvk::LongAlleleReader` npy/pread calls, wrapping
+`ndarray_npy::ReadNpyError` via `std::io::Error::other(..)`. Rides the existing
+`open` → `PyOSError` mapping (`py_query.rs:23`).
+
+**Python mapping** — replace the flat `PyRuntimeError` at `src/lib.rs:184` with
+`impl From<ConversionError> for PyErr`:
+
+| `ConversionError` variant | Python exception       |
+| ------------------------- | ---------------------- |
+| `Input`                   | `PyValueError`         |
+| `MissingFile`             | `PyFileNotFoundError`  |
+| `Io` / `Npy` / `ReadNpy`  | `PyOSError`            |
+| `WorkerPanicked`          | `PyRuntimeError`       |
+
+### 2. Threading Results through the conversion workers
+
+- `VcfChunkReader::new` (`vcf_reader.rs:153`) → `Result<Self, ConversionError>` (index
+  open, header contig lookup, sample lookup, FASTA open/contig lookup).
+- `read_next_chunk` (`vcf_reader.rs:363`) → `Result<Option<DenseChunk>, ConversionError>`;
+  the reader-thread loop becomes `while let Some(c) = reader.read_next_chunk(...)? { ... }`.
+- The reader-thread closure returns `Result<u64, ConversionError>`. The **orchestrator
+  join** (`orchestrator.rs:208–232`) gains a three-way match per thread:
+  - `Ok(Ok(v))` → value,
+  - `Ok(Err(e))` → **surface `e`** (the fix),
+  - `Err(_)` → `WorkerPanicked` (genuine panic only).
+
+  Applied to the reader, executor (nrvk/rvk), and writer threads.
+- **Phase-2 merges** (`merge_mini_sc`, `merge_dense_class`) run on the orchestrator thread,
+  not spawned — so `merge.rs` / `dense_merge.rs` worker fns return `Result` and propagate
+  with plain `?` at `orchestrator.rs:256/276`. No join plumbing.
+- `pack_snp_key_file` (`rvk.rs:23`) → `Result<(), ConversionError>`; the `post_merge` hook
+  type in `streams.rs:31` becomes `Option<fn(&Path) -> Result<(), ConversionError>>`,
+  propagated where `merge_mini_sc` invokes it.
+
+Convert only **I/O and user-input** panics. Genuine internal invariants stay panics — in
+particular the `push_long_allele` 31-bit capacity `assert!` (`nrvk.rs:40`) is a bug-guard,
+not user input, and is left as-is (its message-typo fix is an SP-0 item, out of scope
+here).
+
+### 3. FFI dict parser
+
+`bundle_from_dict` (`py_query_ranges.rs:139`) → `PyResult<RangesBundle>`. The per-field
+closures map: missing key → `PyKeyError(key)`, wrong dtype/cast → `PyTypeError`, bad shape
+→ `PyValueError`. Callers `read_ranges` / `gather_ranges` already return `PyResult`, so
+they add `?`.
+
+### 4. Out of scope (deferred to other sub-projects)
+
+Everything else in findings 05/06: DRY gather-loop extraction, `DenseMap`/`StreamMap`
+unification, `(bool,usize)` → `DenseClass`, the three parallel SNP/indel enums, `unsafe`
+SAFETY comments (SP-2 follow-ups / SP-5). The `push_long_allele` assert-message typo is
+SP-0. This spec touches error handling only.
+
+## Commit / PR structure
+
+One branch, three ordered commits, each independently gated green (keeps the roadmap's
+"small, reviewable PRs — no god-branch" invariant):
+
+1. **Taxonomy foundation** — extend `ConversionError` (`Input`, `MissingFile`),
+   `From<NormalizeError>`, `From<ConversionError> for PyErr`, update the `lib.rs` mapping.
+   Mapping change only; the happy path is unchanged.
+2. **Conversion workers → Result** — `vcf_reader`, executor/nrvk-writer, `merge` /
+   `dense_merge`, `pack_snp_key_file`, and the orchestrator join surfacing.
+3. **Query sidecar + FFI** — sidecar / `LongAlleleReader` `io::Result`,
+   `bundle_from_dict → PyResult`.
+
+## Testing
+
+New regression tests asserting the exception **type and message** Python sees (not merely
+"it raises"):
+
+- bad contig name → `ValueError`
+- missing sample → `ValueError`
+- REF/FASTA mismatch → `ValueError`
+- symbolic/breakend ALT → `ValueError`
+- missing `.tbi`/`.csi` → `FileNotFoundError`
+- truncated / corrupt sidecar npy → `OSError`
+- malformed `bundle` dict (missing key) → `KeyError`
+
+The full existing suite (`pixi run test`) and `cargo test --no-default-features` (per the
+pyo3-link requirement) stay green — behavior-preserving on the happy path.
+
+## Public-surface / SKILL update
+
+Builtins-only adds **no new public names**, but "bad sample now raises `ValueError`, not
+`RuntimeError`" is an observable contract change. Add a short **Errors** subsection to
+`skills/genoray-api/SKILL.md` documenting the exception-type contract (per the CLAUDE.md
+public-behavior rule). No `docs/source/api.md` autodoc change is required.
+
+## Invariants (per roadmap)
+
+1. Behavior-preserving on the happy path; the only intended behavior change is
+   panics/aborts → typed exceptions with real messages.
+2. No new public Python names; the exception-contract change is reflected in `SKILL.md`.
+3. Small, reviewable commits (three, above).

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -279,6 +279,17 @@ two-channel `BatchResult` → numpy dict (`vk_pos`/`vk_key`/`vk_off`, `dense_*`,
   gather_ranges(find_ranges(...))`. `find_ranges(out=...)` streams the bundle into
   caller-preallocated arrays.
 
+### Errors
+
+genoray raises standard Python builtins, by category:
+
+- `ValueError` — bad input content: contig/sample not found, REF disagrees with
+  the reference FASTA, or a symbolic/breakend ALT with `skip_out_of_scope=False`.
+- `FileNotFoundError` — a required input file is missing.
+- `OSError` — a corrupt/truncated store sidecar or an underlying disk I/O failure.
+- `RuntimeError` — an internal genoray bug (a worker thread panicked); please
+  report it.
+
 ## CLI (`genoray write`)
 
 `genoray write` **defaults to SVAR2**; `genoray write svar1` runs the previous

--- a/src/dense_merge.rs
+++ b/src/dense_merge.rs
@@ -5,6 +5,7 @@
 //! non-trivial step is the per-hap bit concatenation across chunks.
 
 use crate::bits::copy_bits;
+use crate::error::ConversionError;
 use crate::layout;
 use crate::rvk::pack_snp_keys;
 use std::fs;
@@ -21,7 +22,7 @@ pub fn merge_dense_class(
     pack_snp: bool,
     output_dir: &str,
     dense_ledger: Vec<u32>,
-) {
+) -> Result<(), ConversionError> {
     debug_assert_eq!(
         dense_ledger.len(),
         num_chunks,
@@ -38,16 +39,24 @@ pub fn merge_dense_class(
         if count == 0 {
             continue;
         }
-        positions.extend_from_slice(&fs::read(layout::chunk_pos(dir, c)).expect("read dense pos"));
-        keys.extend_from_slice(&fs::read(layout::chunk_key(dir, c)).expect("read dense key"));
+        let pos_path = layout::chunk_pos(dir, c);
+        positions.extend_from_slice(&fs::read(&pos_path).map_err(|e| ConversionError::Io {
+            context: format!("reading {}", pos_path.display()),
+            source: e,
+        })?);
+        let key_path = layout::chunk_key(dir, c);
+        keys.extend_from_slice(&fs::read(&key_path).map_err(|e| ConversionError::Io {
+            context: format!("reading {}", key_path.display()),
+            source: e,
+        })?);
     }
-    write_all(&layout::positions(dir), &positions);
+    write_all(&layout::positions(dir), &positions)?;
     let final_key_bytes = if pack_snp {
         pack_snp_keys(&keys) // keys are one raw 2-bit code per variant
     } else {
         keys
     };
-    write_all(&layout::alleles(dir), &final_key_bytes);
+    write_all(&layout::alleles(dir), &final_key_bytes)?;
 
     // ---- genotypes: per-hap bit concatenation across chunks ----
     // output bit (hap h, global col g) at flat index h * v_total + g.
@@ -65,7 +74,11 @@ pub fn merge_dense_class(
         if v_c == 0 {
             continue;
         }
-        let block = fs::read(layout::chunk_geno(dir, c)).expect("read dense geno");
+        let geno_path = layout::chunk_geno(dir, c);
+        let block = fs::read(&geno_path).map_err(|e| ConversionError::Io {
+            context: format!("reading {}", geno_path.display()),
+            source: e,
+        })?;
         // block bit (hap h, local col d) at h*v_c + d.
         for h in 0..np {
             let src_bit = h * v_c;
@@ -73,7 +86,7 @@ pub fn merge_dense_class(
             copy_bits(&mut out, dst_bit, &block, src_bit, v_c);
         }
     }
-    write_all(&layout::genotypes(dir), &out);
+    write_all(&layout::genotypes(dir), &out)?;
 
     // ---- cleanup per-chunk temp files ----
     for c in 0..num_chunks {
@@ -81,13 +94,23 @@ pub fn merge_dense_class(
         let _ = fs::remove_file(layout::chunk_key(dir, c));
         let _ = fs::remove_file(layout::chunk_geno(dir, c));
     }
+    Ok(())
 }
 
-fn write_all(path: &Path, bytes: &[u8]) {
-    let mut f =
-        fs::File::create(path).unwrap_or_else(|e| panic!("create {}: {}", path.display(), e));
-    f.write_all(bytes).expect("write dense final");
-    f.flush().expect("flush dense final");
+fn write_all(path: &Path, bytes: &[u8]) -> Result<(), ConversionError> {
+    let mut f = fs::File::create(path).map_err(|e| ConversionError::Io {
+        context: format!("creating {}", path.display()),
+        source: e,
+    })?;
+    f.write_all(bytes).map_err(|e| ConversionError::Io {
+        context: format!("writing {}", path.display()),
+        source: e,
+    })?;
+    f.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", path.display()),
+        source: e,
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -109,9 +132,9 @@ mod tests {
                 }
             }
         }
-        write_all(&layout::chunk_pos(dir, c), bytemuck::cast_slice(positions));
-        write_all(&layout::chunk_key(dir, c), keys);
-        write_all(&layout::chunk_geno(dir, c), &block);
+        write_all(&layout::chunk_pos(dir, c), bytemuck::cast_slice(positions)).unwrap();
+        write_all(&layout::chunk_key(dir, c), keys).unwrap();
+        write_all(&layout::chunk_geno(dir, c), &block).unwrap();
     }
 
     fn read_u32(path: &Path) -> Vec<u32> {
@@ -144,7 +167,8 @@ mod tests {
             /*pack_snp=*/ false,
             dir.to_str().unwrap(),
             vec![2, 1],
-        );
+        )
+        .unwrap();
 
         // positions concat in chunk order
         assert_eq!(read_u32(&layout::positions(dir)), vec![100, 200, 300]);
@@ -172,7 +196,7 @@ mod tests {
     fn test_merge_dense_empty() {
         let tmp = tempdir().unwrap();
         let dir = tmp.path();
-        merge_dense_class(1, 2, 2, 1, true, dir.to_str().unwrap(), vec![0]);
+        merge_dense_class(1, 2, 2, 1, true, dir.to_str().unwrap(), vec![0]).unwrap();
         assert_eq!(fs::read(layout::positions(dir)).unwrap().len(), 0);
         assert_eq!(fs::read(layout::genotypes(dir)).unwrap().len(), 0);
     }
@@ -190,7 +214,7 @@ mod tests {
             &[1u8, 2, 3, 0, 1],
             &[vec![true, true, true, true, true]],
         );
-        merge_dense_class(1, 1, 1, 1, true, dir.to_str().unwrap(), vec![5]);
+        merge_dense_class(1, 1, 1, 1, true, dir.to_str().unwrap(), vec![5]).unwrap();
         // pack_snp_keys([1,2,3,0,1]) == [0x39, 0x01] (see rvk.rs test)
         assert_eq!(fs::read(layout::alleles(dir)).unwrap(), vec![0x39u8, 0x01]);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,15 @@
-//! Typed errors for the conversion pipeline. Boundary-level: the orchestrator and
-//! pyo3 entry point return these; worker-thread hot loops still panic (converting
-//! them is a follow-up).
+//! Boundary-level typed errors for the conversion pipeline. Categories map to
+//! Python builtins via `impl From<ConversionError> for PyErr`.
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConversionError {
+    /// User-recoverable *content* error: bad contig/sample name, symbolic ALT,
+    /// REF/FASTA mismatch, missing index. The message is the whole error.
+    #[error("{0}")]
+    Input(String),
+    /// A required input file (index, FASTA) is absent.
+    #[error("required file not found: {path}")]
+    MissingFile { path: String },
     #[error("I/O error at {context}: {source}")]
     Io {
         context: String,
@@ -24,4 +30,60 @@ pub enum ConversionError {
         #[source]
         source: ndarray_npy::ReadNpyError,
     },
+}
+
+#[cfg(feature = "conversion")]
+impl From<crate::normalize::NormalizeError> for ConversionError {
+    fn from(e: crate::normalize::NormalizeError) -> Self {
+        ConversionError::Input(e.to_string())
+    }
+}
+
+impl From<ConversionError> for pyo3::PyErr {
+    fn from(e: ConversionError) -> Self {
+        use pyo3::exceptions::{PyFileNotFoundError, PyOSError, PyRuntimeError, PyValueError};
+        let msg = e.to_string();
+        match e {
+            ConversionError::Input(_) => PyValueError::new_err(msg),
+            ConversionError::MissingFile { .. } => PyFileNotFoundError::new_err(msg),
+            ConversionError::Io { .. }
+            | ConversionError::Npy { .. }
+            | ConversionError::ReadNpy { .. } => PyOSError::new_err(msg),
+            ConversionError::WorkerPanicked { .. } => PyRuntimeError::new_err(msg),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "conversion")]
+    use crate::normalize::NormalizeError;
+
+    #[cfg(feature = "conversion")]
+    #[test]
+    fn normalize_error_maps_to_input_with_message() {
+        let ne = NormalizeError::RefMismatch {
+            pos: 7,
+            expected: "A".into(),
+            found: "C".into(),
+        };
+        let expected_msg = ne.to_string();
+        let ce: ConversionError = ne.into();
+        match ce {
+            ConversionError::Input(msg) => {
+                assert_eq!(msg, expected_msg);
+                assert!(msg.contains("disagrees"));
+            }
+            other => panic!("expected Input, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_file_message_includes_path() {
+        let ce = ConversionError::MissingFile {
+            path: "/x/in.vcf.gz.tbi".into(),
+        };
+        assert!(ce.to_string().contains("/x/in.vcf.gz.tbi"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,9 +192,7 @@ fn run_conversion_pipeline(
         &chroms,
         ploidy,
     )
-    .map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("failed to write meta.json: {e}"))
-    })?;
+    .map_err(|e| pyo3::exceptions::PyOSError::new_err(format!("failed to write meta.json: {e}")))?;
 
     Ok(total_dropped as usize)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ fn run_conversion_pipeline(
 
     let mut total_dropped: u64 = 0;
     for r in results {
-        total_dropped += r.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        total_dropped += r?; // ConversionError -> PyErr via From (category-aware)
     }
 
     // All contigs converted — write the top-level meta.json describing the cohort.

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,3 +1,4 @@
+use crate::error::ConversionError;
 use crate::layout;
 use bytemuck;
 use ndarray::Array1;
@@ -28,7 +29,7 @@ pub fn merge_mini_sc(
     ploidy: usize,
     output_dir: &str,
     ram_ledger: Vec<Vec<u32>>,
-) {
+) -> Result<(), ConversionError> {
     let output_dir_path = Path::new(output_dir);
     let total_columns = num_samples * ploidy;
     let pos_size = std::mem::size_of::<u32>(); // positions are always u32
@@ -52,8 +53,14 @@ pub fn merge_mini_sc(
 
     // save the global offsets array immediately
     let offsets_array = Array1::from_vec(final_offsets.clone());
-    write_npy(layout::offsets(output_dir_path), &offsets_array)
-        .expect("Failed to write final offsets");
+    write_npy(layout::offsets(output_dir_path), &offsets_array).map_err(|source| {
+        ConversionError::Npy {
+            path: layout::offsets(output_dir_path)
+                .to_string_lossy()
+                .into_owned(),
+            source,
+        }
+    })?;
 
     let total_items: u64 = final_offsets[total_columns];
     let pos_total_bytes: u64 = total_items * pos_size as u64;
@@ -65,27 +72,47 @@ pub fn merge_mini_sc(
     // disjoint byte ranges. set_len doesn't allocate disk space (sparse file)
     // until each tile actually writes.
     let final_pos_file =
-        File::create(layout::positions(output_dir_path)).expect("Failed to create positions.bin");
+        File::create(layout::positions(output_dir_path)).map_err(|e| ConversionError::Io {
+            context: "creating positions.bin".to_string(),
+            source: e,
+        })?;
     final_pos_file
         .set_len(pos_total_bytes)
-        .expect("Failed to size positions.bin");
+        .map_err(|e| ConversionError::Io {
+            context: "sizing positions.bin".to_string(),
+            source: e,
+        })?;
     let final_key_file =
-        File::create(layout::alleles(output_dir_path)).expect("Failed to create alleles.bin");
+        File::create(layout::alleles(output_dir_path)).map_err(|e| ConversionError::Io {
+            context: "creating alleles.bin".to_string(),
+            source: e,
+        })?;
     final_key_file
         .set_len(key_total_bytes)
-        .expect("Failed to size alleles.bin");
+        .map_err(|e| ConversionError::Io {
+            context: "sizing alleles.bin".to_string(),
+            source: e,
+        })?;
 
     // Open every chunk's pos/key file exactly once; pread() is stateless and
     // safe to call concurrently from multiple rayon workers.
     let chunk_files: Vec<(File, File)> = (0..num_chunks)
-        .map(|c| {
-            let pf = File::open(layout::chunk_pos(output_dir_path, c))
-                .unwrap_or_else(|e| panic!("Failed to open chunk_{}_pos.bin: {}", c, e));
-            let kf = File::open(layout::chunk_key(output_dir_path, c))
-                .unwrap_or_else(|e| panic!("Failed to open chunk_{}_key.bin: {}", c, e));
-            (pf, kf)
+        .map(|c| -> Result<(File, File), ConversionError> {
+            let pf = File::open(layout::chunk_pos(output_dir_path, c)).map_err(|e| {
+                ConversionError::Io {
+                    context: format!("opening chunk_{c}_pos.bin"),
+                    source: e,
+                }
+            })?;
+            let kf = File::open(layout::chunk_key(output_dir_path, c)).map_err(|e| {
+                ConversionError::Io {
+                    context: format!("opening chunk_{c}_key.bin"),
+                    source: e,
+                }
+            })?;
+            Ok((pf, kf))
         })
-        .collect();
+        .collect::<Result<_, _>>()?;
 
     // Adaptive tile size: target TILE_RAM_BUDGET per tile.
     // pos buffer (u32) + key buffer (key_bytes-wide) → (pos_size + key_bytes) bytes per item.
@@ -117,100 +144,115 @@ pub fn merge_mini_sc(
     let final_pos_ref = &final_pos_file;
     let final_key_ref = &final_key_file;
 
-    tile_starts.par_iter().for_each(|&tile_start_col| {
-        let tile_end_col = std::cmp::min(tile_start_col + columns_per_tile, total_columns);
-        let tile_n_cols = tile_end_col - tile_start_col;
-        let tile_start_item = final_offsets_ref[tile_start_col] as usize;
-        let tile_end_item = final_offsets_ref[tile_end_col] as usize;
-        let tile_total_items = tile_end_item - tile_start_item;
+    tile_starts
+        .par_iter()
+        .try_for_each(|&tile_start_col| -> Result<(), ConversionError> {
+            let tile_end_col = std::cmp::min(tile_start_col + columns_per_tile, total_columns);
+            let tile_n_cols = tile_end_col - tile_start_col;
+            let tile_start_item = final_offsets_ref[tile_start_col] as usize;
+            let tile_end_item = final_offsets_ref[tile_end_col] as usize;
+            let tile_total_items = tile_end_item - tile_start_item;
 
-        if tile_total_items == 0 {
-            return;
-        }
-
-        let mut tile_pos_buffer = vec![0u32; tile_total_items];
-        let mut tile_key_buffer = vec![0u8; tile_total_items * key_bytes];
-
-        // per-column write head (offset within this tile buffer)
-        let mut tile_write_heads = vec![0usize; tile_n_cols];
-        // index loop: `i` indexes tile_write_heads while `col` offsets into the global ledger.
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..tile_n_cols {
-            let col = tile_start_col + i;
-            tile_write_heads[i] = (final_offsets_ref[col] as usize) - tile_start_item;
-        }
-
-        // gather from chunks
-        for chunk_id in 0..num_chunks {
-            let chunk_start_item = chunk_offsets_ref[chunk_id][tile_start_col] as usize;
-            let chunk_end_item = chunk_offsets_ref[chunk_id][tile_end_col] as usize;
-            let chunk_items_to_read = chunk_end_item - chunk_start_item;
-
-            if chunk_items_to_read == 0 {
-                continue;
+            if tile_total_items == 0 {
+                return Ok(());
             }
 
-            // Stateless positional reads — multiple workers can read the same File
-            // concurrently without locking or seek-state contention.
-            let mut chunk_pos_bytes = vec![0u8; chunk_items_to_read * pos_size];
-            let mut chunk_key_bytes = vec![0u8; chunk_items_to_read * key_bytes];
-            let pos_byte_offset = (chunk_start_item * pos_size) as u64;
-            let key_byte_offset = (chunk_start_item * key_bytes) as u64;
-            chunk_files_ref[chunk_id]
-                .0
-                .read_exact_at(&mut chunk_pos_bytes, pos_byte_offset)
-                .expect("Failed to pread chunk pos");
-            chunk_files_ref[chunk_id]
-                .1
-                .read_exact_at(&mut chunk_key_bytes, key_byte_offset)
-                .expect("Failed to pread chunk key");
+            let mut tile_pos_buffer = vec![0u32; tile_total_items];
+            let mut tile_key_buffer = vec![0u8; tile_total_items * key_bytes];
 
-            // zero-copy cast back to typed slice (positions only — keys stay raw bytes)
-            let chunk_pos_u32: &[u32] = bytemuck::cast_slice(&chunk_pos_bytes);
-
-            // stitch this chunk's block into the main Tile buffer
-            let mut local_chunk_cursor = 0usize;
-            // index loop: `i` indexes tile-local write heads while `col` offsets the ledger.
+            // per-column write head (offset within this tile buffer)
+            let mut tile_write_heads = vec![0usize; tile_n_cols];
+            // index loop: `i` indexes tile_write_heads while `col` offsets into the global ledger.
             #[allow(clippy::needless_range_loop)]
             for i in 0..tile_n_cols {
                 let col = tile_start_col + i;
-                let calls = ram_ledger_ref[chunk_id][col] as usize;
-                if calls == 0 {
+                tile_write_heads[i] = (final_offsets_ref[col] as usize) - tile_start_item;
+            }
+
+            // gather from chunks
+            for chunk_id in 0..num_chunks {
+                let chunk_start_item = chunk_offsets_ref[chunk_id][tile_start_col] as usize;
+                let chunk_end_item = chunk_offsets_ref[chunk_id][tile_end_col] as usize;
+                let chunk_items_to_read = chunk_end_item - chunk_start_item;
+
+                if chunk_items_to_read == 0 {
                     continue;
                 }
 
-                let dest_start = tile_write_heads[i];
-                let dest_end = dest_start + calls;
+                // Stateless positional reads — multiple workers can read the same File
+                // concurrently without locking or seek-state contention.
+                let mut chunk_pos_bytes = vec![0u8; chunk_items_to_read * pos_size];
+                let mut chunk_key_bytes = vec![0u8; chunk_items_to_read * key_bytes];
+                let pos_byte_offset = (chunk_start_item * pos_size) as u64;
+                let key_byte_offset = (chunk_start_item * key_bytes) as u64;
+                chunk_files_ref[chunk_id]
+                    .0
+                    .read_exact_at(&mut chunk_pos_bytes, pos_byte_offset)
+                    .map_err(|e| ConversionError::Io {
+                        context: "pread chunk pos".into(),
+                        source: e,
+                    })?;
+                chunk_files_ref[chunk_id]
+                    .1
+                    .read_exact_at(&mut chunk_key_bytes, key_byte_offset)
+                    .map_err(|e| ConversionError::Io {
+                        context: "pread chunk key".into(),
+                        source: e,
+                    })?;
 
-                tile_pos_buffer[dest_start..dest_end].copy_from_slice(
-                    &chunk_pos_u32[local_chunk_cursor..local_chunk_cursor + calls],
-                );
+                // zero-copy cast back to typed slice (positions only — keys stay raw bytes)
+                let chunk_pos_u32: &[u32] = bytemuck::cast_slice(&chunk_pos_bytes);
 
-                let key_dest_start = dest_start * key_bytes;
-                let key_src_start = local_chunk_cursor * key_bytes;
-                tile_key_buffer[key_dest_start..key_dest_start + calls * key_bytes]
-                    .copy_from_slice(
-                        &chunk_key_bytes[key_src_start..key_src_start + calls * key_bytes],
+                // stitch this chunk's block into the main Tile buffer
+                let mut local_chunk_cursor = 0usize;
+                // index loop: `i` indexes tile-local write heads while `col` offsets the ledger.
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..tile_n_cols {
+                    let col = tile_start_col + i;
+                    let calls = ram_ledger_ref[chunk_id][col] as usize;
+                    if calls == 0 {
+                        continue;
+                    }
+
+                    let dest_start = tile_write_heads[i];
+                    let dest_end = dest_start + calls;
+
+                    tile_pos_buffer[dest_start..dest_end].copy_from_slice(
+                        &chunk_pos_u32[local_chunk_cursor..local_chunk_cursor + calls],
                     );
 
-                tile_write_heads[i] += calls;
-                local_chunk_cursor += calls;
-            }
-        }
+                    let key_dest_start = dest_start * key_bytes;
+                    let key_src_start = local_chunk_cursor * key_bytes;
+                    tile_key_buffer[key_dest_start..key_dest_start + calls * key_bytes]
+                        .copy_from_slice(
+                            &chunk_key_bytes[key_src_start..key_src_start + calls * key_bytes],
+                        );
 
-        // pwrite the assembled tile to its known byte range in the final files.
-        // Tiles are disjoint by construction (final_offsets is monotonically increasing),
-        // so concurrent write_all_at calls touch non-overlapping regions.
-        let tile_pos_byte_offset = (tile_start_item * pos_size) as u64;
-        let tile_key_byte_offset = (tile_start_item * key_bytes) as u64;
-        let tile_pos_bytes: &[u8] = bytemuck::cast_slice(&tile_pos_buffer);
-        final_pos_ref
-            .write_all_at(tile_pos_bytes, tile_pos_byte_offset)
-            .expect("Failed to pwrite tile to positions.bin");
-        final_key_ref
-            .write_all_at(&tile_key_buffer, tile_key_byte_offset)
-            .expect("Failed to pwrite tile to alleles.bin");
-    });
+                    tile_write_heads[i] += calls;
+                    local_chunk_cursor += calls;
+                }
+            }
+
+            // pwrite the assembled tile to its known byte range in the final files.
+            // Tiles are disjoint by construction (final_offsets is monotonically increasing),
+            // so concurrent write_all_at calls touch non-overlapping regions.
+            let tile_pos_byte_offset = (tile_start_item * pos_size) as u64;
+            let tile_key_byte_offset = (tile_start_item * key_bytes) as u64;
+            let tile_pos_bytes: &[u8] = bytemuck::cast_slice(&tile_pos_buffer);
+            final_pos_ref
+                .write_all_at(tile_pos_bytes, tile_pos_byte_offset)
+                .map_err(|e| ConversionError::Io {
+                    context: "pwrite positions.bin".into(),
+                    source: e,
+                })?;
+            final_key_ref
+                .write_all_at(&tile_key_buffer, tile_key_byte_offset)
+                .map_err(|e| ConversionError::Io {
+                    context: "pwrite alleles.bin".into(),
+                    source: e,
+                })?;
+            Ok(())
+        })?;
 
     // Drop file handles to flush metadata before cleanup
     drop(chunk_files);
@@ -224,6 +266,7 @@ pub fn merge_mini_sc(
     }
 
     println!("Merge Complete.");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -275,7 +318,7 @@ mod tests {
         let key: Vec<u32> = vec![10, 20, 30, 40, 50, 60];
         write_chunk_files(dir, 0, &pos, &key);
 
-        merge_mini_sc(4, 1, 2, 2, dir.to_str().unwrap(), ram_ledger);
+        merge_mini_sc(4, 1, 2, 2, dir.to_str().unwrap(), ram_ledger).unwrap();
 
         let final_pos = read_u32_bin(&dir.join("positions.bin"));
         let final_key = read_u32_bin(&dir.join("alleles.bin"));
@@ -304,7 +347,7 @@ mod tests {
         write_chunk_files(dir, 0, &[100, 200, 300], &[1, 2, 3]);
         write_chunk_files(dir, 1, &[400, 500, 600], &[4, 5, 6]);
 
-        merge_mini_sc(4, 2, 2, 1, dir.to_str().unwrap(), ram_ledger);
+        merge_mini_sc(4, 2, 2, 1, dir.to_str().unwrap(), ram_ledger).unwrap();
 
         let final_pos = read_u32_bin(&dir.join("positions.bin"));
         let final_key = read_u32_bin(&dir.join("alleles.bin"));
@@ -324,7 +367,7 @@ mod tests {
         let ram_ledger = vec![vec![0u32; 4]];
         write_chunk_files(dir, 0, &[], &[]);
 
-        merge_mini_sc(4, 1, 2, 2, dir.to_str().unwrap(), ram_ledger);
+        merge_mini_sc(4, 1, 2, 2, dir.to_str().unwrap(), ram_ledger).unwrap();
 
         let final_pos = read_u32_bin(&dir.join("positions.bin"));
         let final_off = read_offsets_npy(&dir.join("offsets.npy"));
@@ -344,7 +387,7 @@ mod tests {
         write_chunk_files(dir, 0, &[], &[]);
         write_chunk_files(dir, 1, &[10, 20, 30, 40, 50], &[1, 2, 3, 4, 5]);
 
-        merge_mini_sc(4, 2, 2, 1, dir.to_str().unwrap(), ram_ledger);
+        merge_mini_sc(4, 2, 2, 1, dir.to_str().unwrap(), ram_ledger).unwrap();
 
         let final_pos = read_u32_bin(&dir.join("positions.bin"));
         let final_off = read_offsets_npy(&dir.join("offsets.npy"));
@@ -381,7 +424,7 @@ mod tests {
             kf.write_all(&[4u8, 5, 6]).unwrap();
         }
 
-        merge_mini_sc(1, 2, 2, 1, dir.to_str().unwrap(), ram_ledger);
+        merge_mini_sc(1, 2, 2, 1, dir.to_str().unwrap(), ram_ledger).unwrap();
 
         let final_pos = read_u32_bin(&dir.join("positions.bin"));
         let final_key = read_u8_bin(&dir.join("alleles.bin"));
@@ -447,7 +490,7 @@ mod tests {
                 write_chunk_files(dir, chunk_id, &pos_buf, &key_buf);
             }
 
-            merge_mini_sc(4, num_chunks, num_samples, ploidy, dir.to_str().unwrap(), ram_ledger.clone());
+            merge_mini_sc(4, num_chunks, num_samples, ploidy, dir.to_str().unwrap(), ram_ledger.clone()).unwrap();
 
             let final_pos = read_u32_bin(&dir.join("positions.bin"));
             let final_key = read_u32_bin(&dir.join("alleles.bin"));

--- a/src/nrvk.rs
+++ b/src/nrvk.rs
@@ -102,20 +102,17 @@ pub struct LongAlleleReader {
 }
 
 impl LongAlleleReader {
-    // TODO: Decide which will call this (or create this instance)
-    pub fn new(output_dir: &str, chrom: &str) -> Self {
+    pub fn new(output_dir: &str, chrom: &str) -> std::io::Result<Self> {
         // Layout matches the writer: {output_dir}/{chrom}/indel/{long_alleles.bin, long_allele_offsets.npy}
         let paths = ContigPaths::new(output_dir, chrom);
-
-        let file = File::open(paths.long_alleles_bin()).expect("Failed to open long_alleles.bin");
-
+        let file = File::open(paths.long_alleles_bin())?;
         let offsets_array: ndarray::Array1<u64> =
-            ndarray_npy::read_npy(paths.long_allele_offsets()).expect("Failed to load offsets npy");
-
-        Self {
+            ndarray_npy::read_npy(paths.long_allele_offsets())
+                .map_err(|e| std::io::Error::other(format!("read long_allele_offsets.npy: {e}")))?;
+        Ok(Self {
             file,
             offsets: offsets_array.into_raw_vec_and_offset().0,
-        }
+        })
     }
 
     // Fetches the exact DNA string from the disk using the 31-bit row index.
@@ -195,7 +192,7 @@ mod tests {
         let offsets = ndarray::Array1::from_vec(vec![0u64, 4, 6]);
         ndarray_npy::write_npy(dir.join("long_allele_offsets.npy"), &offsets).unwrap();
 
-        let reader = LongAlleleReader::new(tmp.path().to_str().unwrap(), "chr1");
+        let reader = LongAlleleReader::new(tmp.path().to_str().unwrap(), "chr1").unwrap();
         // &self: two immutable calls, no &mut needed
         assert_eq!(reader.get_allele(0), b"AAAA".to_vec());
         assert_eq!(reader.get_allele(1), b"CC".to_vec());
@@ -212,7 +209,7 @@ mod tests {
         let offsets = ndarray::Array1::from_vec(vec![0u64, 4, 6]);
         ndarray_npy::write_npy(dir.join("long_allele_offsets.npy"), &offsets).unwrap();
 
-        let reader = LongAlleleReader::new(tmp.path().to_str().unwrap(), "chr1");
+        let reader = LongAlleleReader::new(tmp.path().to_str().unwrap(), "chr1").unwrap();
         assert_eq!(reader.offsets(), &[0u64, 4, 6]);
         assert_eq!(reader.all_bytes(), b"AAAACC".to_vec());
     }

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -275,9 +275,9 @@ pub fn process_chromosome(
             ploidy,
             dir.to_str().unwrap(),
             ledger,
-        );
+        )?;
         if let Some(hook) = spec.post_merge {
-            hook(&dir);
+            hook(&dir)?;
         }
     }
 
@@ -296,7 +296,7 @@ pub fn process_chromosome(
             spec.pack_snp,
             dir.to_str().unwrap(),
             ledger,
-        );
+        )?;
     }
 
     // M5 post-pass: emit max-deletion-length artifacts for the overlap query.

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -231,12 +231,22 @@ pub fn process_chromosome(
         dense_ledgers,
         long_allele_offsets,
     } = phase1;
-    chunk_writer_res.map_err(|_| ConversionError::WorkerPanicked {
-        thread: format!("cw-{}", chrom),
-    })?;
-    long_allele_writer_res.map_err(|_| ConversionError::WorkerPanicked {
-        thread: format!("lw-{}", chrom),
-    })?;
+    match chunk_writer_res {
+        Ok(r) => r?,
+        Err(_) => {
+            return Err(ConversionError::WorkerPanicked {
+                thread: format!("cw-{}", chrom),
+            });
+        }
+    }
+    match long_allele_writer_res {
+        Ok(r) => r?,
+        Err(_) => {
+            return Err(ConversionError::WorkerPanicked {
+                thread: format!("lw-{}", chrom),
+            });
+        }
+    }
 
     println!(
         "[{}] Phase 1 Complete. Triggering Phase 2 In-Memory Merge...",

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -144,7 +144,7 @@ pub fn process_chromosome(
             let s_owned: Vec<String> = samples.iter().map(|&s| s.to_string()).collect();
             let pool = Arc::clone(&processing_pool);
 
-            move || {
+            move || -> Result<u64, ConversionError> {
                 // passing the thread budget down to HTSLib
                 let s_refs: Vec<&str> = s_owned.iter().map(|s| s.as_str()).collect();
                 let mut reader = VcfChunkReader::new(
@@ -155,15 +155,15 @@ pub fn process_chromosome(
                     htslib_threads,
                     ploidy,
                     skip_out_of_scope,
-                );
+                )?;
                 let mut chunk_id = 0;
                 while let Some(dense_chunk) =
-                    reader.read_next_chunk(chunk_size, chunk_id, Some(&pool))
+                    reader.read_next_chunk(chunk_size, chunk_id, Some(&pool))?
                 {
                     tx_dense.send(dense_chunk).unwrap();
                     chunk_id += 1;
                 }
-                reader.dropped_out_of_scope()
+                Ok(reader.dropped_out_of_scope())
             }
         })
         .expect("spawn reader");
@@ -212,9 +212,14 @@ pub fn process_chromosome(
     let chunk_writer_res = chunk_writer_thread.join();
     let long_allele_writer_res = long_allele_writer_thread.join();
 
-    let dropped = reader_res.map_err(|_| ConversionError::WorkerPanicked {
-        thread: format!("read-{}", chrom),
-    })?;
+    let dropped = match reader_res {
+        Ok(r) => r?, // ConversionError propagates with its real message
+        Err(_) => {
+            return Err(ConversionError::WorkerPanicked {
+                thread: format!("read-{}", chrom),
+            });
+        }
+    };
     sampler_res.map_err(|_| ConversionError::WorkerPanicked {
         thread: format!("samp-{}", chrom),
     })?;

--- a/src/py_query.rs
+++ b/src/py_query.rs
@@ -19,8 +19,7 @@ impl PyContigReader {
     // plain Rust constructor; pyo3 keeps `#[new]` methods callable from Rust.
     #[new]
     pub fn new(base_out_dir: &str, chrom: &str, n_samples: usize, ploidy: usize) -> PyResult<Self> {
-        let inner = ContigReader::open(base_out_dir, chrom, n_samples, ploidy)
-            .map_err(|e| pyo3::exceptions::PyOSError::new_err(e.to_string()))?;
+        let inner = ContigReader::open(base_out_dir, chrom, n_samples, ploidy)?;
         Ok(Self { inner })
     }
 }

--- a/src/py_query_ranges.rs
+++ b/src/py_query_ranges.rs
@@ -17,6 +17,7 @@ use std::ops::Range;
 
 use ndarray::Array2;
 use numpy::{PyArray1, PyArray2, PyArrayMethods, ToPyArray};
+use pyo3::exceptions::{PyKeyError, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyDictMethods};
 
@@ -135,71 +136,77 @@ fn bundle_to_dict<'py>(py: Python<'py>, rb: &RangesBundle) -> PyResult<Bound<'py
 }
 
 /// Inverse of `bundle_to_dict`: read a `find_ranges` dict back into a
-/// `RangesBundle` for `gather_ranges`.
-fn bundle_from_dict(d: &Bound<'_, PyDict>) -> RangesBundle {
-    let get_i32 = |k: &str| -> Vec<i32> {
-        d.get_item(k)
-            .unwrap()
-            .unwrap()
-            .cast::<PyArray1<i32>>()
-            .unwrap()
-            .readonly()
-            .as_slice()
-            .unwrap()
-            .to_vec()
+/// `RangesBundle` for `gather_ranges`. Fallible: a missing key or wrong
+/// dtype/shape becomes a Python KeyError/TypeError rather than a Rust panic.
+fn bundle_from_dict(d: &Bound<'_, PyDict>) -> PyResult<RangesBundle> {
+    let require = |k: &str| -> PyResult<Bound<'_, PyAny>> {
+        d.get_item(k)?
+            .ok_or_else(|| PyKeyError::new_err(format!("bundle missing key '{k}'")))
     };
-    let get_i64 = |k: &str| -> Vec<i64> {
-        d.get_item(k)
-            .unwrap()
-            .unwrap()
-            .cast::<PyArray1<i64>>()
-            .unwrap()
-            .readonly()
-            .as_slice()
-            .unwrap()
-            .to_vec()
+    let get_i32 = |k: &str| -> PyResult<Vec<i32>> {
+        let obj = require(k)?;
+        let arr = obj.cast::<PyArray1<i32>>().map_err(|_| {
+            PyTypeError::new_err(format!("bundle key '{k}' must be an int32 1D array"))
+        })?;
+        Ok(arr.readonly().as_slice()?.to_vec())
     };
-    let get_i32_pairs = |k: &str| -> Vec<Range<usize>> {
-        let obj = d.get_item(k).unwrap().unwrap();
-        let arr = obj.cast::<PyArray2<i32>>().unwrap().readonly();
-        arr.as_array()
+    let get_i64 = |k: &str| -> PyResult<Vec<i64>> {
+        let obj = require(k)?;
+        let arr = obj.cast::<PyArray1<i64>>().map_err(|_| {
+            PyTypeError::new_err(format!("bundle key '{k}' must be an int64 1D array"))
+        })?;
+        Ok(arr.readonly().as_slice()?.to_vec())
+    };
+    let get_i32_pairs = |k: &str| -> PyResult<Vec<Range<usize>>> {
+        let obj = require(k)?;
+        let arr = obj
+            .cast::<PyArray2<i32>>()
+            .map_err(|_| {
+                PyTypeError::new_err(format!("bundle key '{k}' must be an int32 (N,2) array"))
+            })?
+            .readonly();
+        Ok(arr
+            .as_array()
             .rows()
             .into_iter()
             .map(|row| (row[0] as usize)..(row[1] as usize))
-            .collect()
+            .collect())
     };
-    let get_i64_pairs = |k: &str| -> Vec<Range<usize>> {
-        let obj = d.get_item(k).unwrap().unwrap();
-        let arr = obj.cast::<PyArray2<i64>>().unwrap().readonly();
-        arr.as_array()
+    let get_i64_pairs = |k: &str| -> PyResult<Vec<Range<usize>>> {
+        let obj = require(k)?;
+        let arr = obj
+            .cast::<PyArray2<i64>>()
+            .map_err(|_| {
+                PyTypeError::new_err(format!("bundle key '{k}' must be an int64 (N,2) array"))
+            })?
+            .readonly();
+        Ok(arr
+            .as_array()
             .rows()
             .into_iter()
             .map(|row| (row[0] as usize)..(row[1] as usize))
-            .collect()
+            .collect())
     };
+    let get_usize = |k: &str| -> PyResult<usize> { require(k)?.extract() };
 
-    let n_regions: usize = d.get_item("n_regions").unwrap().unwrap().extract().unwrap();
-    let n_samples: usize = d.get_item("n_samples").unwrap().unwrap().extract().unwrap();
-    let ploidy: usize = d.get_item("ploidy").unwrap().unwrap().extract().unwrap();
-
-    RangesBundle {
-        n_regions,
-        n_samples,
-        ploidy,
-        region_starts: get_i32("region_starts")
+    Ok(RangesBundle {
+        n_regions: get_usize("n_regions")?,
+        n_samples: get_usize("n_samples")?,
+        ploidy: get_usize("ploidy")?,
+        region_starts: get_i32("region_starts")?
             .into_iter()
             .map(|x| x as u32)
             .collect(),
-        dense_range: get_i32_pairs("dense_range"),
-        sample_cols: get_i64("sample_cols")
+        dense_range: get_i32_pairs("dense_range")?,
+        sample_cols: get_i64("sample_cols")?
             .into_iter()
             .map(|x| x as usize)
             .collect(),
-        vk_snp_range: get_i64_pairs("vk_snp_range"),
-        vk_indel_range: get_i64_pairs("vk_indel_range"),
-        dense_snp_range: get_i32_pairs("dense_snp_range"),
-        dense_indel_range: get_i32_pairs("dense_indel_range"),
-    }
+        vk_snp_range: get_i64_pairs("vk_snp_range")?,
+        vk_indel_range: get_i64_pairs("vk_indel_range")?,
+        dense_snp_range: get_i32_pairs("dense_snp_range")?,
+        dense_indel_range: get_i32_pairs("dense_indel_range")?,
+    })
 }
 
 #[pymethods]
@@ -239,7 +246,7 @@ impl PyContigReader {
         py: Python<'py>,
         bundle: Bound<'py, PyDict>,
     ) -> PyResult<Bound<'py, PyDict>> {
-        let rb = bundle_from_dict(&bundle);
+        let rb = bundle_from_dict(&bundle)?;
         let br = gather_ranges(&self.inner, &rb);
         batch_result_to_dict(py, self.inner.lut_arrays(), &br)
     }

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -57,22 +57,22 @@ impl ContigReader {
         let vk_snp = SubStreamView {
             positions: mmap_file(&layout::positions(&vk_snp_dir))?,
             keys: mmap_file(&layout::alleles(&vk_snp_dir))?,
-            offsets: load_offsets(&layout::offsets(&vk_snp_dir), columns),
+            offsets: load_offsets(&layout::offsets(&vk_snp_dir), columns)?,
         };
         let vk_indel = SubStreamView {
             positions: mmap_file(&layout::positions(&vk_indel_dir))?,
             keys: mmap_file(&layout::alleles(&vk_indel_dir))?,
-            offsets: load_offsets(&layout::offsets(&vk_indel_dir), columns),
+            offsets: load_offsets(&layout::offsets(&vk_indel_dir), columns)?,
         };
 
         let dense_snp = open_dense(&paths.dense_snp_dir())?;
         let dense_indel = open_dense(&paths.dense_indel_dir())?;
 
-        let vk_indel_max_del = load_max_del(&layout::max_del(&contig_dir), n_samples, ploidy);
-        let dense_indel_max_del = load_dense_max_del(&layout::dense_max_del(&contig_dir));
+        let vk_indel_max_del = load_max_del(&layout::max_del(&contig_dir), n_samples, ploidy)?;
+        let dense_indel_max_del = load_dense_max_del(&layout::dense_max_del(&contig_dir))?;
 
         let lut = if paths.long_alleles_bin().exists() {
-            Some(LongAlleleReader::new(base_out_dir, chrom))
+            Some(LongAlleleReader::new(base_out_dir, chrom)?)
         } else {
             None
         };

--- a/src/query/sidecar.rs
+++ b/src/query/sidecar.rs
@@ -91,32 +91,39 @@ impl DenseView {
 
 /// Load a CSR `offsets.npy` (len `columns + 1`); a missing file means an empty
 /// stream — return an all-zero prefix-sum so every column is empty.
-pub(crate) fn load_offsets(path: &Path, columns: usize) -> Vec<u64> {
+pub(crate) fn load_offsets(path: &Path, columns: usize) -> std::io::Result<Vec<u64>> {
     if path.exists() {
-        let a: Array1<u64> = ndarray_npy::read_npy(path).expect("read offsets.npy");
-        a.to_vec()
+        let a: Array1<u64> = ndarray_npy::read_npy(path)
+            .map_err(|e| std::io::Error::other(format!("read {}: {e}", path.display())))?;
+        Ok(a.to_vec())
     } else {
-        vec![0u64; columns + 1]
+        Ok(vec![0u64; columns + 1])
     }
 }
 
 /// Load `max_del.npy` (`u32`, shape `(n_samples, ploidy)`); a missing file
 /// (pure-SNP contig, or predating the post-pass) defaults to all-zero.
-pub(crate) fn load_max_del(path: &Path, n_samples: usize, ploidy: usize) -> Array2<u32> {
+pub(crate) fn load_max_del(
+    path: &Path,
+    n_samples: usize,
+    ploidy: usize,
+) -> std::io::Result<Array2<u32>> {
     if path.exists() {
-        ndarray_npy::read_npy(path).expect("read max_del.npy")
+        ndarray_npy::read_npy(path)
+            .map_err(|e| std::io::Error::other(format!("read {}: {e}", path.display())))
     } else {
-        Array2::zeros((n_samples, ploidy))
+        Ok(Array2::zeros((n_samples, ploidy)))
     }
 }
 
 /// Load `dense/max_del.npy` (`u32`, shape `(1,)`); missing defaults to `0`.
-pub(crate) fn load_dense_max_del(path: &Path) -> u32 {
+pub(crate) fn load_dense_max_del(path: &Path) -> std::io::Result<u32> {
     if path.exists() {
-        let a: Array1<u32> = ndarray_npy::read_npy(path).expect("read dense/max_del.npy");
-        a.into_iter().next().unwrap_or(0)
+        let a: Array1<u32> = ndarray_npy::read_npy(path)
+            .map_err(|e| std::io::Error::other(format!("read {}: {e}", path.display())))?;
+        Ok(a.into_iter().next().unwrap_or(0))
     } else {
-        0
+        Ok(0)
     }
 }
 
@@ -134,4 +141,24 @@ pub(crate) fn open_dense(dir: &Path) -> std::io::Result<Option<DenseView>> {
         positions,
         n_dense_variants,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_offsets_missing_file_is_empty_prefix_sum() {
+        let p = std::path::Path::new("/nonexistent-sp3/offsets.npy");
+        let v = load_offsets(p, 3).unwrap();
+        assert_eq!(v, vec![0u64; 4]);
+    }
+
+    #[test]
+    fn load_offsets_corrupt_file_returns_err() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("offsets.npy");
+        std::fs::write(&p, b"not a valid npy header").unwrap();
+        assert!(load_offsets(&p, 3).is_err());
+    }
 }

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -1,5 +1,6 @@
 use crate::cost_model::{Class, Representation, choose_representation};
 use crate::dense::{DenseClass, DenseMap};
+use crate::error::ConversionError;
 use crate::layout;
 use crate::nrvk::LongAlleleTableWriter;
 use crate::streams::StreamTag;
@@ -20,12 +21,18 @@ pub use svar2_codec::{
 // u8 code per call) and rewrite it 2-bit packed (4 calls/byte). Streams in
 // 4-MiB blocks (a multiple of 4, so no pack straddles a block boundary except
 // the genuine EOF tail). Offsets are call-indexed and need no change.
-pub fn pack_snp_key_file(dir: &Path) {
+pub fn pack_snp_key_file(dir: &Path) -> Result<(), ConversionError> {
     let src = layout::alleles(dir);
     let tmp = dir.join("alleles.packed.tmp");
 
-    let mut reader = BufReader::new(File::open(&src).expect("open snp alleles.bin"));
-    let mut writer = BufWriter::new(File::create(&tmp).expect("create packed tmp"));
+    let mut reader = BufReader::new(File::open(&src).map_err(|e| ConversionError::Io {
+        context: format!("opening {}", src.display()),
+        source: e,
+    })?);
+    let mut writer = BufWriter::new(File::create(&tmp).map_err(|e| ConversionError::Io {
+        context: format!("creating {}", tmp.display()),
+        source: e,
+    })?);
 
     const BLOCK: usize = 4 * 1024 * 1024; // multiple of 4
     let mut buf = vec![0u8; BLOCK];
@@ -34,7 +41,13 @@ pub fn pack_snp_key_file(dir: &Path) {
         // multiple of 4 and pack cleanly byte-aligned).
         let mut filled = 0usize;
         while filled < BLOCK {
-            match reader.read(&mut buf[filled..]).expect("read snp keys") {
+            let n = reader
+                .read(&mut buf[filled..])
+                .map_err(|e| ConversionError::Io {
+                    context: format!("reading {}", src.display()),
+                    source: e,
+                })?;
+            match n {
                 0 => break,
                 n => filled += n,
             }
@@ -43,16 +56,26 @@ pub fn pack_snp_key_file(dir: &Path) {
             break;
         }
         let packed = pack_snp_keys(&buf[..filled]);
-        writer.write_all(&packed).expect("write packed snp keys");
+        writer.write_all(&packed).map_err(|e| ConversionError::Io {
+            context: format!("writing {}", tmp.display()),
+            source: e,
+        })?;
         if filled < BLOCK {
             break; // EOF tail handled
         }
     }
-    writer.flush().expect("flush packed snp keys");
+    writer.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", tmp.display()),
+        source: e,
+    })?;
     drop(writer);
     drop(reader);
 
-    std::fs::rename(&tmp, &src).expect("replace snp alleles.bin with packed");
+    std::fs::rename(&tmp, &src).map_err(|e| ConversionError::Io {
+        context: format!("renaming {} -> {}", tmp.display(), src.display()),
+        source: e,
+    })?;
+    Ok(())
 }
 
 // Pack a single variant into its 32-bit key.
@@ -250,6 +273,16 @@ mod tests {
     use crate::types::{BitGrid3, MIN_I31};
     use crossbeam_channel::bounded;
     use proptest::prelude::*;
+
+    #[test]
+    fn pack_snp_key_file_errors_on_missing_dir() {
+        let missing = std::path::Path::new("/nonexistent-sp3-pack/dir");
+        let err = pack_snp_key_file(missing).unwrap_err();
+        match err {
+            crate::error::ConversionError::Io { .. } => {}
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
 
     // Big-capacity bank so push_long_allele never flushes during tests.
     fn make_bank() -> LongAlleleTableWriter {

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -23,12 +23,15 @@ impl StreamTag {
     }
 }
 
+/// Post-merge rewrite hook applied to a stream's final files (e.g. 2-bit packing).
+pub type PostMergeHook = fn(&Path) -> Result<(), crate::error::ConversionError>;
+
 pub struct StreamSpec {
     pub tag: StreamTag,
     pub subdir: &'static str,
     pub key_bytes: usize,
     /// Post-merge rewrite hook applied to the stream's final files (e.g. 2-bit packing).
-    pub post_merge: Option<fn(&Path)>,
+    pub post_merge: Option<PostMergeHook>,
 }
 
 /// One entry per active on-disk sub-stream. Order matches `StreamTag as usize`.

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -160,6 +160,14 @@ impl VcfChunkReader {
         ploidy: usize,
         skip_out_of_scope: bool,
     ) -> Result<Self, ConversionError> {
+        // A wrong VCF path reaches Rust when the file was removed after Python's
+        // upstream indexing/open; surface it as FileNotFoundError, not a ".tbi?" Input.
+        if !std::path::Path::new(vcf_path).exists() {
+            return Err(ConversionError::MissingFile {
+                path: vcf_path.to_string(),
+            });
+        }
+
         let mut reader = IndexedReader::from_path(vcf_path).map_err(|e| {
             ConversionError::Input(format!(
                 "Failed to open VCF/BCF index for '{vcf_path}' \

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -1,3 +1,4 @@
+use crate::error::ConversionError;
 use crate::normalize::atomize_record;
 use crate::types::{BitGrid3, DenseChunk};
 use rayon::prelude::*;
@@ -158,46 +159,66 @@ impl VcfChunkReader {
         htslib_threads: usize,
         ploidy: usize,
         skip_out_of_scope: bool,
-    ) -> Self {
-        let mut reader = IndexedReader::from_path(vcf_path)
-            .expect("Failed to open VCF/BCF index. Is there a .tbi or .csi file?");
+    ) -> Result<Self, ConversionError> {
+        let mut reader = IndexedReader::from_path(vcf_path).map_err(|e| {
+            ConversionError::Input(format!(
+                "Failed to open VCF/BCF index for '{vcf_path}' \
+                 (is there a .tbi or .csi file?): {e}"
+            ))
+        })?;
 
         reader
             .set_threads(htslib_threads)
-            .expect("Failed to allocate HTSlib background threads");
+            .map_err(|e| ConversionError::Io {
+                context: format!("allocating {htslib_threads} HTSlib background threads"),
+                source: std::io::Error::other(e.to_string()),
+            })?;
 
         let header = reader.header().clone();
 
-        let rid = header
-            .name2rid(chrom.as_bytes())
-            .expect("Chromosome not found in VCF header");
+        let rid = header.name2rid(chrom.as_bytes()).map_err(|_| {
+            ConversionError::Input(format!("Chromosome '{chrom}' not found in VCF header"))
+        })?;
 
         reader
             .fetch(rid, 0, None)
-            .expect("Failed to fetch chromosome region");
+            .map_err(|e| ConversionError::Io {
+                context: format!("fetching region for chromosome '{chrom}'"),
+                source: std::io::Error::other(e.to_string()),
+            })?;
 
         let sample_indices: Vec<usize> = samples
             .iter()
             .map(|name| {
-                header
-                    .sample_id(name.as_bytes())
-                    .unwrap_or_else(|| panic!("Sample {} not found in VCF", name))
+                header.sample_id(name.as_bytes()).ok_or_else(|| {
+                    ConversionError::Input(format!("Sample '{name}' not found in VCF"))
+                })
             })
-            .collect();
+            .collect::<Result<_, _>>()?;
 
         // Reference is optional. With a FASTA, cache the full uppercased contig for
         // validate_ref/left_align; without one, leave it empty and skip both.
         let (ref_seq, has_reference) = match fasta_path {
             Some(path) => {
-                let fasta = rust_htslib::faidx::Reader::from_path(path)
-                    .expect("Failed to open reference FASTA (is there a .fai?)");
-                // htslib's faidx_seq_len returns -1 for an unknown contig, which
-                // fetch_seq_len (via rust-htslib) surfaces as u64::MAX rather than 0 —
-                // check for it explicitly so a missing contig fails fast with a clear
-                // message instead of the generic "Failed to fetch contig" panic below.
+                // A wrong reference path reaches Rust unchecked (Python does not
+                // validate it), so surface it as FileNotFoundError specifically.
+                if !std::path::Path::new(path).exists() {
+                    return Err(ConversionError::MissingFile {
+                        path: path.to_string(),
+                    });
+                }
+                let fasta = rust_htslib::faidx::Reader::from_path(path).map_err(|e| {
+                    ConversionError::Input(format!(
+                        "Failed to open reference FASTA '{path}' (is there a .fai?): {e}"
+                    ))
+                })?;
+                // htslib's faidx_seq_len returns -1 for an unknown contig, surfaced
+                // via rust-htslib as u64::MAX — check explicitly for a clear message.
                 let contig_len_raw = fasta.fetch_seq_len(chrom);
                 if contig_len_raw == u64::MAX {
-                    panic!("Contig '{chrom}' not found in reference FASTA");
+                    return Err(ConversionError::Input(format!(
+                        "Contig '{chrom}' not found in reference FASTA"
+                    )));
                 }
                 let contig_len = contig_len_raw as usize;
                 let mut ref_seq = if contig_len == 0 {
@@ -205,7 +226,10 @@ impl VcfChunkReader {
                 } else {
                     fasta
                         .fetch_seq(chrom, 0, contig_len - 1)
-                        .expect("Failed to fetch contig from reference FASTA")
+                        .map_err(|e| ConversionError::Io {
+                            context: format!("fetching contig '{chrom}' from reference FASTA"),
+                            source: std::io::Error::other(e.to_string()),
+                        })?
                 };
                 ref_seq.make_ascii_uppercase();
                 (ref_seq, true)
@@ -215,7 +239,7 @@ impl VcfChunkReader {
 
         let record = reader.empty_record();
 
-        Self {
+        Ok(Self {
             inner_reader: reader,
             num_samples: samples.len(),
             ploidy,
@@ -229,7 +253,7 @@ impl VcfChunkReader {
             frontier: 0,
             eof: false,
             next_seq: 0,
-        }
+        })
     }
 
     /// Total out-of-scope ALTs dropped so far (valid after the read loop drains).
@@ -239,7 +263,7 @@ impl VcfChunkReader {
 
     // Decompose `self.record` into atoms and push them onto the reorder heap, sharing
     // one decoded genotype vector across all atoms of the record.
-    fn decompose_current_record(&mut self) {
+    fn decompose_current_record(&mut self) -> Result<(), ConversionError> {
         let pos = self.record.pos() as u32;
 
         // Own the alleles so the record borrow is released before we mutate self.
@@ -263,11 +287,9 @@ impl VcfChunkReader {
             // `(e >> 1) - 1`; `e` of 0/1 is missing and `i32::MIN` is vector-end
             // padding — both `< 2`, so a single `e >= 2` test reproduces the
             // `GenotypeAllele::index()` semantics exactly.
-            let gts = self
-                .record
-                .format(b"GT")
-                .integer()
-                .expect("Failed to read GT format");
+            let gts = self.record.format(b"GT").integer().map_err(|e| {
+                ConversionError::Input(format!("Failed to read GT format at pos {pos}: {e}"))
+            })?;
             let ploidy = self.ploidy;
             for (s_idx, &vcf_idx) in self.sample_indices.iter().enumerate() {
                 let raw = gts[vcf_idx];
@@ -285,8 +307,7 @@ impl VcfChunkReader {
         // Fail fast only when a reference is available; without one we trust the
         // input is already normalized/left-aligned.
         if self.has_reference {
-            crate::normalize::validate_ref(pos, &ref_allele, &self.ref_seq)
-                .expect("REF disagrees with reference FASTA");
+            crate::normalize::validate_ref(pos, &ref_allele, &self.ref_seq)?;
         }
 
         let alt_refs: Vec<&[u8]> = alts_owned.iter().map(|a| a.as_slice()).collect();
@@ -297,8 +318,7 @@ impl VcfChunkReader {
             &alt_refs,
             &mut atoms,
             self.skip_out_of_scope,
-        )
-        .expect("symbolic/breakend ALT is out of scope for SVAR2 (short-read only)");
+        )?;
         self.dropped_out_of_scope += dropped as u64;
 
         for atom in atoms {
@@ -320,6 +340,7 @@ impl VcfChunkReader {
                 seq,
             }));
         }
+        Ok(())
     }
 
     // Yield the next atom in global position order, reading and decomposing more
@@ -335,22 +356,27 @@ impl VcfChunkReader {
     // atoms sharing a single start position — a run of many records all starting at the
     // same pos never advances the frontier, so the heap can still grow unboundedly in
     // that (pre-existing) pathological case.
-    fn next_atom(&mut self) -> Option<PendingAtom> {
+    fn next_atom(&mut self) -> Result<Option<PendingAtom>, ConversionError> {
         loop {
             if let Some(Reverse(top)) = self.heap.peek() {
                 if self.eof || top.pos < self.frontier.saturating_sub(crate::normalize::L_MAX) {
-                    return Some(self.heap.pop().unwrap().0);
+                    return Ok(Some(self.heap.pop().unwrap().0));
                 }
             } else if self.eof {
-                return None;
+                return Ok(None);
             }
 
             match self.inner_reader.read(&mut self.record) {
                 Some(Ok(())) => {
                     self.frontier = self.record.pos() as u32;
-                    self.decompose_current_record();
+                    self.decompose_current_record()?;
                 }
-                Some(Err(e)) => panic!("VCF Read Error: {}", e),
+                Some(Err(e)) => {
+                    return Err(ConversionError::Io {
+                        context: "reading next VCF record".to_string(),
+                        source: std::io::Error::other(e.to_string()),
+                    });
+                }
                 None => self.eof = true,
             }
         }
@@ -365,16 +391,16 @@ impl VcfChunkReader {
         chunk_size: usize,
         chunk_id: usize,
         pool: Option<&rayon::ThreadPool>,
-    ) -> Option<DenseChunk> {
+    ) -> Result<Option<DenseChunk>, ConversionError> {
         let mut atoms: Vec<PendingAtom> = Vec::with_capacity(chunk_size);
         while atoms.len() < chunk_size {
-            match self.next_atom() {
+            match self.next_atom()? {
                 Some(a) => atoms.push(a),
                 None => break,
             }
         }
         if atoms.is_empty() {
-            return None;
+            return Ok(None);
         }
 
         let v = atoms.len();
@@ -408,14 +434,14 @@ impl VcfChunkReader {
             pack_presence_seq(&mut genos.words, &atoms, columns);
         }
 
-        Some(DenseChunk {
+        Ok(Some(DenseChunk {
             chunk_id,
             pos,
             ilens,
             alt,
             alt_offsets,
             genos,
-        })
+        }))
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,4 +1,5 @@
 use crate::dense::{DENSE_REGISTRY, DenseMap};
+use crate::error::ConversionError;
 use crate::layout;
 use crate::streams::StreamMap;
 use crate::types::SparseChunk;
@@ -15,7 +16,7 @@ pub fn run_io_writer(
     rx_sparse: Receiver<SparseChunk>,
     dirs: StreamMap<PathBuf>,
     dense_dirs: DenseMap<PathBuf>,
-) {
+) -> Result<(), ConversionError> {
     while let Ok(chunk) = rx_sparse.recv() {
         let id = chunk.chunk_id;
 
@@ -25,8 +26,8 @@ pub fn run_io_writer(
             write_bin(
                 &layout::chunk_pos(dir, id),
                 bytemuck::cast_slice(&sub.call_positions),
-            );
-            write_bin(&layout::chunk_key(dir, id), &sub.call_keys); // already bytes
+            )?;
+            write_bin(&layout::chunk_key(dir, id), &sub.call_keys)?; // already bytes
         }
 
         // dense per-class matrix + table (only classes with dense variants)
@@ -39,41 +40,65 @@ pub fn run_io_writer(
             write_bin(
                 &layout::chunk_pos(dir, id),
                 bytemuck::cast_slice(&sub.positions),
-            );
-            write_bin(&layout::chunk_key(dir, id), &sub.keys);
-            write_bin(&layout::chunk_geno(dir, id), &sub.geno_bits);
+            )?;
+            write_bin(&layout::chunk_key(dir, id), &sub.keys)?;
+            write_bin(&layout::chunk_geno(dir, id), &sub.geno_bits)?;
         }
     }
 
     println!("Writer Thread: Channel closed. All chunks safely committed to SSD.");
+    Ok(())
 }
 
-pub fn run_long_allele_writer(rx_long: Receiver<Vec<u8>>, out_path: &Path, chrom_label: &str) {
+pub fn run_long_allele_writer(
+    rx_long: Receiver<Vec<u8>>,
+    out_path: &Path,
+    chrom_label: &str,
+) -> Result<(), ConversionError> {
     let file = OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
         .open(out_path)
-        .unwrap();
+        .map_err(|e| ConversionError::Io {
+            context: format!("creating {}", out_path.display()),
+            source: e,
+        })?;
     let mut disk_writer = BufWriter::with_capacity(1024 * 1024, file);
     while let Ok(buffer) = rx_long.recv() {
         disk_writer
             .write_all(&buffer)
-            .expect("Failed to write long alleles");
+            .map_err(|e| ConversionError::Io {
+                context: format!("writing long alleles to {}", out_path.display()),
+                source: e,
+            })?;
     }
-    disk_writer.flush().unwrap();
+    disk_writer.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", out_path.display()),
+        source: e,
+    })?;
     println!(
         "[{}] Long Allele Writer: All buffer data safely committed.",
         chrom_label
     );
+    Ok(())
 }
 
-fn write_bin(path: &Path, bytes: &[u8]) {
-    let mut f = BufWriter::new(
-        File::create(path).unwrap_or_else(|e| panic!("create {}: {}", path.display(), e)),
-    );
-    f.write_all(bytes).expect("write chunk bytes");
-    f.flush().expect("flush chunk bytes");
+fn write_bin(path: &Path, bytes: &[u8]) -> Result<(), ConversionError> {
+    let f = File::create(path).map_err(|e| ConversionError::Io {
+        context: format!("creating {}", path.display()),
+        source: e,
+    })?;
+    let mut f = BufWriter::new(f);
+    f.write_all(bytes).map_err(|e| ConversionError::Io {
+        context: format!("writing {}", path.display()),
+        source: e,
+    })?;
+    f.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", path.display()),
+        source: e,
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -84,6 +109,19 @@ mod tests {
     use crate::types::{DenseSubChunk, SparseChunk, SparseSubStream};
     use crossbeam_channel::bounded;
     use tempfile::tempdir;
+
+    #[test]
+    fn write_bin_returns_io_error_on_unwritable_path() {
+        // A path whose parent dir does not exist cannot be created.
+        let bad = std::path::Path::new("/nonexistent-sp3-dir/child/out.bin");
+        let err = write_bin(bad, &[1u8, 2, 3]).unwrap_err();
+        match err {
+            crate::error::ConversionError::Io { context, .. } => {
+                assert!(context.contains("out.bin"));
+            }
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_writer_persists_dense_chunk_files() {
@@ -132,7 +170,7 @@ mod tests {
             DenseClass::Indel => indel_dir.clone(),
         });
 
-        run_io_writer(rx, dirs, dense_dirs);
+        run_io_writer(rx, dirs, dense_dirs).unwrap();
 
         // dense snp chunk files exist with the right bytes
         let pos = std::fs::read(snp_dir.join("chunk_0_pos.bin")).unwrap();

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -27,11 +27,12 @@ fn drain_reader(
         1,
         ploidy,
         false,
-    );
+    )
+    .unwrap();
     let columns = samples.len() * ploidy;
     let mut out = Vec::new();
     let mut chunk_id = 0;
-    while let Some(chunk) = reader.read_next_chunk(chunk_size, chunk_id, None) {
+    while let Some(chunk) = reader.read_next_chunk(chunk_size, chunk_id, None).unwrap() {
         let v = chunk.pos.len();
         for i in 0..v {
             let mut presence = Vec::with_capacity(columns);

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -389,18 +389,21 @@ fn test_reader_accepts_pure_del() {
         1,
         2,
         false,
-    );
+    )
+    .unwrap();
     let chunk = reader
         .read_next_chunk(100, 0, None)
+        .expect("chunk should succeed")
         .expect("chunk should succeed");
     assert_eq!(chunk.ilens.len(), 1);
     assert_eq!(chunk.ilens, vec![-2]);
 }
 
 // Boundary error-handling: a chromosome absent from the VCF header must surface
-// as a typed `ConversionError::WorkerPanicked` (the reader thread panics on
-// `name2rid`, and `process_chromosome` converts the join panic into an Err)
-// rather than unwinding the calling thread.
+// as a typed `ConversionError::Input` (SP-3: `VcfChunkReader::new` now returns
+// `Result` instead of panicking on `name2rid`, so the reader thread's closure
+// propagates it and the join surfaces the real error, not a swallowed
+// `WorkerPanicked`).
 #[test]
 fn test_missing_chrom_returns_err() {
     let tmp = tempdir().unwrap();
@@ -435,6 +438,6 @@ fn test_missing_chrom_returns_err() {
 
     assert!(matches!(
         res,
-        Err(genoray_core::error::ConversionError::WorkerPanicked { .. })
+        Err(genoray_core::error::ConversionError::Input(_))
     ));
 }

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -441,3 +441,27 @@ fn test_missing_chrom_returns_err() {
         Err(genoray_core::error::ConversionError::Input(_))
     ));
 }
+
+// Boundary error-handling: a VCF/BCF path that does not exist on disk must
+// surface as a typed `ConversionError::MissingFile`, symmetric with the FASTA
+// missing-file check (SP-3 final review, M2).
+#[test]
+fn test_missing_vcf_returns_missing_file() {
+    let tmp = tempdir().unwrap();
+    let missing_path = tmp.path().join("does_not_exist.vcf.gz");
+
+    let res = VcfChunkReader::new(
+        missing_path.to_str().unwrap(),
+        None,
+        "chr1",
+        &["s0"],
+        1,
+        2,
+        false,
+    );
+
+    assert!(matches!(
+        res,
+        Err(genoray_core::error::ConversionError::MissingFile { .. })
+    ));
+}

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -32,10 +32,11 @@ fn drain(bcf: &Path, fasta: &Path, chrom: &str, samples: &[&str]) -> Vec<(u32, i
         1,
         2,
         false,
-    );
+    )
+    .unwrap();
     let mut out = Vec::new();
     let mut cid = 0;
-    while let Some(chunk) = reader.read_next_chunk(100, cid, None) {
+    while let Some(chunk) = reader.read_next_chunk(100, cid, None).unwrap() {
         for i in 0..chunk.pos.len() {
             out.push((chunk.pos[i], chunk.ilens[i]));
         }
@@ -89,8 +90,8 @@ fn indels_left_align_to_bcftools_positions() {
 
 #[test]
 fn ref_mismatch_panics() {
-    // FASTA says pos 3 is 'A' but the record claims REF "GG" → validate_ref fails, and
-    // the reader (which .expect()s it) panics.
+    // FASTA says pos 3 is 'A' but the record claims REF "GG" → validate_ref fails,
+    // read_next_chunk returns Err, and `drain`'s `.unwrap()` turns that into a panic.
     let tmp = tempdir().unwrap();
     let bcf = tmp.path().join("mm.bcf");
     let fasta = tmp.path().join("mm.fa");
@@ -240,10 +241,11 @@ fn left_shifts_stay_sorted_across_chunk_boundaries() {
         1,
         2,
         false,
-    );
+    )
+    .unwrap();
     let mut positions = Vec::new();
     let mut cid = 0;
-    while let Some(chunk) = reader.read_next_chunk(1, cid, None) {
+    while let Some(chunk) = reader.read_next_chunk(1, cid, None).unwrap() {
         positions.extend_from_slice(&chunk.pos);
         cid += 1;
     }
@@ -305,10 +307,11 @@ proptest! {
             1,
             2,
             false,
-        );
+        )
+        .unwrap();
         let mut positions = Vec::new();
         let mut cid = 0;
-        while let Some(chunk) = reader.read_next_chunk(1, cid, None) {
+        while let Some(chunk) = reader.read_next_chunk(1, cid, None).unwrap() {
             positions.extend_from_slice(&chunk.pos);
             cid += 1;
         }

--- a/tests/test_svar2_errors.py
+++ b/tests/test_svar2_errors.py
@@ -1,0 +1,56 @@
+"""SP-3: conversion errors surface as typed Python exceptions, not RuntimeError."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from genoray import SparseVar2
+
+_REF = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"
+
+
+def _write_ref(d: Path) -> Path:
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+    return ref
+
+
+def _write_vcf(d: Path, body_rows: str, *, contig_len: int = 40) -> Path:
+    body = (
+        "##fileformat=VCFv4.2\n"
+        f"##contig=<ID=chr1,length={contig_len}>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n" + body_rows
+    )
+    plain = d / "in.vcf"
+    plain.write_text(body)
+    gz = d / "in.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+    return gz
+
+
+def test_symbolic_alt_raises_value_error(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, "chr1\t20\t.\tT\t<DEL>\t.\t.\t.\tGT\t0|1\t0|0\n")
+    with pytest.raises(ValueError, match="symbolic"):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=1)
+
+
+def test_ref_mismatch_raises_value_error(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    # POS 3 (1-based) in _REF is 'A'; claim REF='G' to force a mismatch.
+    vcf = _write_vcf(tmp_path, "chr1\t3\t.\tG\tT\t.\t.\t.\tGT\t0|1\t0|0\n")
+    with pytest.raises(ValueError, match="disagrees"):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=1)
+
+
+def test_missing_reference_raises_file_not_found(tmp_path: Path):
+    vcf = _write_vcf(tmp_path, "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n")
+    with pytest.raises(FileNotFoundError):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, tmp_path / "nope.fa", threads=1)

--- a/tests/test_svar2_errors.py
+++ b/tests/test_svar2_errors.py
@@ -54,3 +54,20 @@ def test_missing_reference_raises_file_not_found(tmp_path: Path):
     vcf = _write_vcf(tmp_path, "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n")
     with pytest.raises(FileNotFoundError):
         SparseVar2.from_vcf(tmp_path / "store", vcf, tmp_path / "nope.fa", threads=1)
+
+
+def test_gather_ranges_malformed_bundle_raises_keyerror(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(
+        tmp_path,
+        "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n",
+    )
+    out = tmp_path / "store"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv = SparseVar2(out)
+
+    bundle = sv.find_ranges("chr1", [0], [40])
+    del bundle["sample_cols"]  # drop a required key
+    with pytest.raises(KeyError, match="sample_cols"):
+        sv.gather_ranges("chr1", bundle)

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -96,7 +96,7 @@ def test_from_vcf_skip_out_of_scope_counts(tmp_path: Path):
 def test_from_vcf_symbolic_errors_without_skip(tmp_path: Path):
     ref = _write_ref(tmp_path)
     vcf = _write_vcf(tmp_path, symbolic=True, indexed=True)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="symbolic"):
         SparseVar2.from_vcf(tmp_path / "store_err", vcf, ref, threads=1)
 
 


### PR DESCRIPTION
## SP-3 — Rust panics → typed errors

Replaces `panic!`/`.expect()`/`.unwrap()` on **I/O and user-input conditions** in the Rust conversion and query paths with propagated **typed errors**, so Python callers get a meaningful exception type and message instead of a context-free `WorkerPanicked` or a process abort.

**Contract (now documented in `skills/genoray-api/SKILL.md`):** after this PR, a Rust panic reaching Python means "genoray bug," never "bad VCF/args."

| Python exception | Condition |
|---|---|
| `ValueError` | bad input content — contig/sample not found, REF disagrees with the reference FASTA, symbolic/breakend ALT with `skip_out_of_scope=False`, malformed query bundle |
| `FileNotFoundError` | a required input file is missing (reference FASTA, input VCF) |
| `OSError` | a corrupt/truncated store sidecar or an underlying disk I/O failure |
| `RuntimeError` | an internal genoray bug (a worker thread genuinely panicked) |

### What changed
- **`ConversionError`** gains `Input`/`MissingFile` categories, a `From<NormalizeError>` bridge, and a category-aware `From<ConversionError> for PyErr` (`Input`→ValueError, `MissingFile`→FileNotFoundError, `Io`/`Npy`/`ReadNpy`→OSError, `WorkerPanicked`→RuntimeError). The `From<NormalizeError>` bridge is `#[cfg(feature = "conversion")]`-gated so the query-only build (gvl's path-dep config) still compiles.
- **Reader path** (`VcfChunkReader`) and the orchestrator reader thread/join thread `Result` end-to-end — bad contig, missing sample, REF mismatch, and symbolic ALT now surface as `ValueError` with the real message instead of a swallowed `WorkerPanicked`.
- **Writer threads** (`run_io_writer`/`run_long_allele_writer`/`write_bin`) and the two orchestrator writer joins propagate `ConversionError::Io` (the joins use the propagating `match`, not a swallowing `map_err(...)?`).
- **Merge/dense-merge/pack** (`merge_mini_sc`/`merge_dense_class`/`pack_snp_key_file`) return `Result`; the parallel gather uses `par_iter().try_for_each(...)?`. Happy-path merged output is byte-identical (proptest green).
- **Query sidecar loaders** (`load_offsets`/`load_max_del`/`load_dense_max_del`) and `LongAlleleReader::new` return `io::Result`, surfaced as `PyOSError` via the existing `ContigReader::open` seam. Missing-file → silent Ok-default (pure-SNP contigs) preserved; only a present-but-corrupt file errors. Per-call hot-path preads stay panics by design.
- **`bundle_from_dict`** (FFI) is fallible — a malformed `find_ranges` bundle raises `KeyError`/`TypeError` instead of aborting via `unwrap`.

### Tests
- New `tests/test_svar2_errors.py`: symbolic ALT / REF mismatch → `ValueError`; missing reference → `FileNotFoundError`; malformed bundle → `KeyError`.
- Rust unit tests for the writer/pack/sidecar `Io` paths and a missing-VCF `MissingFile` boundary test.
- Existing symbolic-ALT test tightened from `raises(Exception)` to `raises(ValueError, match="symbolic")`.
- Full suites green: `pixi run test` 536 passed / 0 failed; `cargo test --no-default-features --features conversion` all binaries 0 failed. Both build configs (query-only + `--features conversion`) compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
