### PR TITLE
SP-4: VCF/PGEN consistency + boilerplate (3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   `empty(n_samples, ploidy, n_variants)` signature on both VCF and PGEN
   backends. VCF's former 4th `phasing` argument is removed; pass the effective
   ploidy (`ploidy + phasing`) instead.
+- VCF chunk-size memory estimates now double when a sample subset/reorder is
+  active, matching PGEN. This only affects internal chunk sizing (more
+  conservative memory use), never returned data.
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   The `pl_filter=` constructor kwarg and the `(filter, pl_filter)` tuple
   getter/setter are removed. Migrate `VCF(p, filter=fn, pl_filter=expr)` to
   `VCF(p, filter=Filter(record=fn, expr=expr))`.
+- `VCF._chunk_ranges_with_length` now yields `(data, end, chunk_idxs)` (a
+  `uint32` variant-index array) as its third tuple element instead of an
+  `n_extension_vars` count, matching `PGEN._chunk_ranges_with_length`.
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - VCF chunk-size memory estimates now double when a sample subset/reorder is
   active, matching PGEN. This only affects internal chunk sizing (more
   conservative memory use), never returned data.
+- VCF filtering now uses a single `genoray.Filter(record=, expr=)` value object.
+  The `pl_filter=` constructor kwarg and the `(filter, pl_filter)` tuple
+  getter/setter are removed. Migrate `VCF(p, filter=fn, pl_filter=expr)` to
+  `VCF(p, filter=Filter(record=fn, expr=expr))`.
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+### BREAKING CHANGES
+
+- `Phantom` mode `empty()` classmethods now take a uniform
+  `empty(n_samples, ploidy, n_variants)` signature on both VCF and PGEN
+  backends. VCF's former 4th `phasing` argument is removed; pass the effective
+  ploidy (`ploidy + phasing`) instead.
+
 ### Fix
 
 - **vcf**: apply configured `filter` on `VCF.read(..., mode=Genos*Dosages)` when no

--- a/docs/superpowers/plans/2026-07-09-sp4-vcf-pgen-consistency.md
+++ b/docs/superpowers/plans/2026-07-09-sp4-vcf-pgen-consistency.md
@@ -1,0 +1,1128 @@
+# SP-4 VCF/PGEN Consistency + Boilerplate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the divergent `_vcf.py` / `_pgen.py` backends onto shared helpers and make the audit's invalid states unrepresentable, landing the public breaks in the genoray 3.0.0 wave.
+
+**Architecture:** A new `genoray/_modes.py` provides phantom-mode factories both backends call, unifying the `empty()` signature. VCF gets a `Filter` value object (clean break), an `_extract_dosage` helper, and merged extend-length methods. Both backends get a mode→method dispatch dict and shared contig/empty helpers. The `_chunk_ranges_with_length` third tuple element is reconciled to `chunk_idxs` on both backends, with the matching change landed in GenVarLoader (branch `svar2-m6b-kernel`, PR #266).
+
+**Tech Stack:** Python 3.10+, numpy, polars, phantom-types, cyvcf2, pgenlib; pixi env; pytest; ruff + pyrefly hooks; commitizen (Conventional Commits).
+
+## Global Constraints
+
+- **Release:** part of the **genoray 3.0.0** breaking-change wave. Mark every API-breaking commit with `!` and a `BREAKING CHANGE:` footer so `cz bump` resolves to 3.0.0. **Do NOT hand-edit the version** in `pyproject.toml`.
+- **`empty()` contract:** the uniform signature is exactly `empty(n_samples, ploidy, n_variants)` across both backends (matches CLAUDE.md). VCF folds phasing into effective ploidy (`ploidy + phasing`) at the call site.
+- **`_chunk_ranges_with_length` contract:** both backends yield `(data, end, chunk_idxs: NDArray[V_IDX_TYPE])`. `V_IDX_TYPE = np.uint32`.
+- **Public-name changes require a `skills/genoray-api/SKILL.md` update in the same PR** (per `CLAUDE.md`). Public names touched here: `Filter` (new), the `VCF.filter` getter/setter and `VCF(...)` constructor kwargs.
+- **Coordinated repos:** genoray on branch `sp4-vcf-pgen-consistency`; GenVarLoader on branch `svar2-m6b-kernel` (draft PR #266). The `_chunk_ranges_with_length` change is one logical edit split across both — neither is done without the other.
+- **Behavior-preserving tasks** (2, 4, 5, 6, 8, 9) are gated on the existing suite staying green; use `refactor:`/`chore:` commits. **Breaking tasks** (3, 7, 10, 11, 12) get new/updated tests and `!` markers.
+- **Verify commands:** `pixi run pytest` (Python), `pixi run pytest tests/test_vcf.py -q` / `tests/test_pgen.py` for focused runs. Rust is untouched; if a hook runs cargo tests use `--no-default-features`. Ensure prek hooks are installed (`pixi run prek-install`) before committing.
+
+---
+
+### Task 1: `_modes.py` phantom-mode factories
+
+**Files:**
+- Create: `python/genoray/_modes.py`
+- Test: `tests/test_modes.py`
+
+**Interfaces:**
+- Produces:
+  - `make_array_mode(name: str, dtype: type[np.generic], ndim: int, *, genos: bool = False) -> type` — a `Phantom` subclass of `NDArray[dtype]` with attributes `_dtype`, `_gdtype` (both `= dtype`), a `classmethod empty(n_samples, ploidy, n_variants)` (allocates `(n_samples, ploidy, n_variants)` when `ndim == 3`, else `(n_samples, n_variants)`), and a `classmethod nbytes_per_variant(n_samples, ploidy) -> int`. When `genos=True` the predicate additionally requires `shape[1] in (2, 3)`.
+  - `make_tuple_mode(name: str, components: tuple[type, ...], *, genos_dtype: type[np.generic]) -> type` — a `Phantom` subclass of `tuple[components]` with `_dtype`/`_gdtype = genos_dtype`, `empty` delegating to each component, and `nbytes_per_variant` summing components.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_modes.py
+import numpy as np
+import pytest
+from genoray._modes import make_array_mode, make_tuple_mode
+
+Geno = make_array_mode("Geno", np.int8, 3, genos=True)
+Dose = make_array_mode("Dose", np.float32, 2)
+GenoDose = make_tuple_mode("GenoDose", (Geno, Dose), genos_dtype=np.int8)
+
+
+def test_array_mode_empty_shapes():
+    g = Geno.empty(3, 2, 5)
+    assert g.shape == (3, 2, 5) and g.dtype == np.int8
+    d = Dose.empty(3, 2, 5)  # ploidy ignored for 2D modes
+    assert d.shape == (3, 5) and d.dtype == np.float32
+
+
+def test_array_mode_predicate():
+    assert isinstance(np.empty((3, 2, 5), np.int8), Geno)
+    assert not isinstance(np.empty((3, 4, 5), np.int8), Geno)  # bad ploidy axis
+    assert not isinstance(np.empty((3, 2, 5), np.int16), Geno)  # bad dtype
+
+
+def test_nbytes_per_variant():
+    # genos: n_samples * ploidy * itemsize; dosages: n_samples * 1 * itemsize
+    assert Geno.nbytes_per_variant(3, 2) == 3 * 2 * 1
+    assert Dose.nbytes_per_variant(3, 2) == 3 * 1 * 4
+    assert GenoDose.nbytes_per_variant(3, 2) == 3 * 2 * 1 + 3 * 1 * 4
+
+
+def test_tuple_mode_empty():
+    g, d = GenoDose.empty(3, 2, 5)
+    assert g.shape == (3, 2, 5) and d.shape == (3, 5)
+    assert isinstance((g, d), GenoDose)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run pytest tests/test_modes.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'genoray._modes'`.
+
+- [ ] **Step 3: Implement `_modes.py`**
+
+```python
+# python/genoray/_modes.py
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+from phantom import Phantom
+
+
+def make_array_mode(
+    name: str,
+    dtype: type[np.generic],
+    ndim: int,
+    *,
+    genos: bool = False,
+) -> type:
+    """Build a phantom ``NDArray`` mode class.
+
+    Parameters
+    ----------
+    name
+        The generated class ``__name__``.
+    dtype
+        NumPy scalar type the array must have (e.g. ``np.int8``).
+    ndim
+        Required number of dimensions (3 for genotype arrays, 2 for
+        dosage/phasing-style arrays).
+    genos
+        If True, the ploidy axis (``shape[1]``) must be in ``(2, 3)`` and
+        ``empty`` allocates a 3D ``(n_samples, ploidy, n_variants)`` array.
+    """
+
+    def predicate(obj: Any) -> bool:
+        if not (
+            isinstance(obj, np.ndarray)
+            and obj.dtype.type == dtype
+            and obj.ndim == ndim
+        ):
+            return False
+        if genos:
+            return obj.shape[1] in (2, 3)
+        return True
+
+    def empty(cls, n_samples: int, ploidy: int, n_variants: int):
+        shape = (
+            (n_samples, ploidy, n_variants)
+            if ndim == 3
+            else (n_samples, n_variants)
+        )
+        return cls.parse(np.empty(shape, dtype=dtype))
+
+    def nbytes_per_variant(cls, n_samples: int, ploidy: int) -> int:
+        axis = ploidy if ndim == 3 else 1
+        return n_samples * axis * np.dtype(dtype).itemsize
+
+    namespace = {
+        "_dtype": dtype,
+        "_gdtype": dtype,
+        "empty": classmethod(empty),
+        "nbytes_per_variant": classmethod(nbytes_per_variant),
+    }
+    return type(name, (NDArray[dtype], Phantom), namespace, predicate=predicate)
+
+
+def make_tuple_mode(
+    name: str,
+    components: tuple[type, ...],
+    *,
+    genos_dtype: type[np.generic],
+) -> type:
+    """Build a phantom tuple-of-modes class (e.g. ``(Genos, Dosages)``)."""
+
+    def predicate(obj: Any) -> bool:
+        return (
+            isinstance(obj, tuple)
+            and len(obj) == len(components)
+            and all(isinstance(o, c) for o, c in zip(obj, components))
+        )
+
+    def empty(cls, n_samples: int, ploidy: int, n_variants: int):
+        return cls.parse(
+            tuple(c.empty(n_samples, ploidy, n_variants) for c in components)
+        )
+
+    def nbytes_per_variant(cls, n_samples: int, ploidy: int) -> int:
+        return sum(c.nbytes_per_variant(n_samples, ploidy) for c in components)
+
+    namespace = {
+        "_dtype": genos_dtype,
+        "_gdtype": genos_dtype,
+        "empty": classmethod(empty),
+        "nbytes_per_variant": classmethod(nbytes_per_variant),
+    }
+    return type(name, (tuple[components], Phantom), namespace, predicate=predicate)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pixi run pytest tests/test_modes.py -q`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_modes.py tests/test_modes.py
+git commit -m "feat(modes): add phantom-mode factories for array and tuple modes"
+```
+
+---
+
+### Task 2: Migrate PGEN modes to the factory (behavior-preserving)
+
+**Files:**
+- Modify: `python/genoray/_pgen.py:37-147` (the six mode blocks)
+
+**Interfaces:**
+- Consumes: `make_array_mode`, `make_tuple_mode` from Task 1.
+- Produces: unchanged public names `Genos`, `Dosages`, `Phasing`, `GenosPhasing`, `GenosDosages`, `GenosPhasingDosages`; `empty()` already 3-arg here, so this is pure code-motion.
+
+- [ ] **Step 1: Baseline the suite is green**
+
+Run: `pixi run pytest tests/test_pgen.py -q`
+Expected: PASS (record the count).
+
+- [ ] **Step 2: Replace the six mode blocks**
+
+In `python/genoray/_pgen.py`, add near the top imports:
+
+```python
+from ._modes import make_array_mode, make_tuple_mode
+```
+
+Replace lines 37-147 (the `_is_genos`/`Genos` … `GenosPhasingDosages` definitions) with:
+
+```python
+Genos = make_array_mode("Genos", np.int32, 3, genos=True)
+Dosages = make_array_mode("Dosages", np.float32, 2)
+Phasing = make_array_mode("Phasing", np.bool_, 2)
+GenosPhasing = make_tuple_mode("GenosPhasing", (Genos, Phasing), genos_dtype=np.int32)
+GenosDosages = make_tuple_mode("GenosDosages", (Genos, Dosages), genos_dtype=np.int32)
+GenosPhasingDosages = make_tuple_mode(
+    "GenosPhasingDosages", (Genos, Phasing, Dosages), genos_dtype=np.int32
+)
+```
+
+Note: PGEN's `Genos` predicate previously required `shape[1] == 2`; `genos=True` relaxes to `shape[1] in (2, 3)`. PGEN is always diploid (ploidy 2, no phasing axis), so the array is always `shape[1] == 2` in practice — the wider predicate never changes behavior. Keep the `T`/`L` `TypeVar`s at lines 150-151 unchanged (they reference the new names).
+
+- [ ] **Step 3: Run PGEN + mode suites**
+
+Run: `pixi run pytest tests/test_pgen.py tests/test_modes.py -q`
+Expected: PASS, same count as Step 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add python/genoray/_pgen.py
+git commit -m "refactor(pgen): define phantom modes via the shared factory"
+```
+
+---
+
+### Task 3: Migrate VCF modes to the factory + unify `empty()` to 3-arg (BREAKING)
+
+**Files:**
+- Modify: `python/genoray/_vcf.py:46-176` (mode blocks + TypeVars), and every `mode.empty(...)`/`Mode.empty(...)` call site in the file
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `make_array_mode`, `make_tuple_mode`.
+- Produces: unchanged public names `Genos8`, `Genos16`, `Dosages`, `Genos8Dosages`, `Genos16Dosages`; **`empty()` signature changes** from `(n_samples, ploidy, n_variants, phasing)` to `(n_samples, ploidy, n_variants)`. Callers pass effective ploidy `self.ploidy + self.phasing`.
+
+- [ ] **Step 1: Baseline the VCF suite is green**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS (record the count).
+
+- [ ] **Step 2: Replace the VCF mode blocks**
+
+Add near the top imports of `python/genoray/_vcf.py`:
+
+```python
+from ._modes import make_array_mode, make_tuple_mode
+```
+
+Replace lines 46-170 (from `GDTYPE = TypeVar(...)` through `Genos16Dosages`) with:
+
+```python
+GDTYPE = TypeVar("GDTYPE", np.int8, np.int16)
+
+Genos8 = make_array_mode("Genos8", np.int8, 3, genos=True)
+Genos16 = make_array_mode("Genos16", np.int16, 3, genos=True)
+Dosages = make_array_mode("Dosages", np.float32, 2)
+Genos8Dosages = make_tuple_mode(
+    "Genos8Dosages", (Genos8, Dosages), genos_dtype=np.int8
+)
+Genos16Dosages = make_tuple_mode(
+    "Genos16Dosages", (Genos16, Dosages), genos_dtype=np.int16
+)
+```
+
+Keep the `T`/`L`/`G`/`GD` `TypeVar`s at lines 173-176 unchanged.
+
+- [ ] **Step 3: Update every VCF `empty()` call site to the 3-arg form**
+
+The VCF genos axis length is `ploidy + phasing`. Change each call of the form
+`mode.empty(self.n_samples, self.ploidy, N, self.phasing)` →
+`mode.empty(self.n_samples, self.ploidy + self.phasing, N)`. Known sites (line numbers pre-edit; re-grep to be exact):
+
+- `read`: 627-629, 636-638, 645-647
+- `_chunk_ranges_with_length` empty yields: 848, 858, 877
+- `_chunk_with_length_helper`: 920-921, 926
+- `_fill_genos` empty (search `Genos8.empty`/`mode.empty` around 1290-1310)
+- `_fill_dosages` empty: 1371
+- `_fill_genos_and_dosages` empty: 1454
+- `chunk` empty (search in the `chunk` method body)
+
+After editing, verify no 4-arg empties remain:
+
+Run: `grep -n "\.empty(.*self\.phasing" python/genoray/_vcf.py`
+Expected: no output.
+
+Run: `grep -nE "\.empty\([^)]*,[^)]*,[^)]*,[^)]*\)" python/genoray/_vcf.py`
+Expected: no output (no 4-argument `.empty(` calls).
+
+- [ ] **Step 4: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, under an `## Unreleased` (or the 3.0.0 heading if present), add:
+
+```markdown
+### BREAKING CHANGES
+
+- `Phantom` mode `empty()` classmethods now take a uniform
+  `empty(n_samples, ploidy, n_variants)` signature on both VCF and PGEN
+  backends. VCF's former 4th `phasing` argument is removed; pass the effective
+  ploidy (`ploidy + phasing`) instead.
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pixi run pytest -q`
+Expected: PASS, same VCF count as Step 1 (behavior unchanged; only the internal `empty()` arity changed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genoray/_vcf.py CHANGELOG.md
+git commit -m "refactor(vcf)!: define modes via factory and unify empty() to 3-arg
+
+BREAKING CHANGE: Phantom mode empty() drops the VCF-only phasing argument;
+pass effective ploidy (ploidy + phasing) instead. Uniform across VCF/PGEN."
+```
+
+---
+
+### Task 4: Extract `_extract_dosage` helper (VCF, behavior-preserving)
+
+**Files:**
+- Modify: `python/genoray/_vcf.py` — add `_extract_dosage`; replace the 5 copy-paste blocks
+
+**Interfaces:**
+- Produces: `VCF._extract_dosage(self, v: cyvcf2.Variant, dosage_field: str) -> NDArray[np.float32]` — returns the 1-D per-sample dosage (`d.squeeze(1)`), raising `DosageFieldError` if the field is absent and `MultiallelicDosageError` if `d.shape[1] > 1`.
+
+- [ ] **Step 1: Baseline green**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS.
+
+- [ ] **Step 2: Add the helper**
+
+Add to the `VCF` class (near `_fill_dosages`):
+
+```python
+def _extract_dosage(
+    self, v: cyvcf2.Variant, dosage_field: str
+) -> NDArray[np.float32]:
+    """Fetch, validate, and squeeze the per-sample dosage for one record."""
+    d = v.format(dosage_field)
+    if d is None:
+        raise DosageFieldError(
+            f"Dosage field '{dosage_field}' not found for record {v!r}"
+        )
+    if d.shape[1] > 1:
+        raise MultiallelicDosageError(
+            f"Multiallelic dosages are not supported, encountered in VCF record {v!r}"
+        )
+    return d.squeeze(1)
+```
+
+- [ ] **Step 3: Replace the 5 blocks**
+
+At each site, replace the `d = v.format(...); if d is None: raise ...; if d.shape[1] > 1: raise ...; ... squeeze(1)` block with a call:
+- `_fill_dosages` (out-is-None ~1355-1365): `out_ls.append(self._extract_dosage(v, dosage_field))`
+- `_fill_dosages` (out-not-None ~1391-1400): `out[..., i] = self._extract_dosage(v, dosage_field)[self._s_sorter]`
+- `_fill_genos_and_dosages` (out-is-None ~1438-1448): `dosage_ls.append(self._extract_dosage(v, dosage_field))`
+- `_fill_genos_and_dosages` (out-not-None branch): mirror with `[self._s_sorter]` indexing exactly as the original did
+- `_ext_genos_dosages_with_length` (~1618-1624): `dosages = self._extract_dosage(v, dosage_field)[self._s_sorter, None]`
+- `chunk` (~757-767): mirror the original indexing
+
+Preserve each site's existing post-squeeze indexing (`[self._s_sorter]`, `[self._s_sorter, None]`) exactly — only the fetch+validate+squeeze moves into the helper.
+
+- [ ] **Step 4: Run the suite**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS (same count; the `DosageFieldError`/`MultiallelicDosageError` tests still pass through the helper).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_vcf.py
+git commit -m "refactor(vcf): extract _extract_dosage helper for the 5 dosage sites"
+```
+
+---
+
+### Task 5: Mode→method dispatch dicts (PGEN + VCF, behavior-preserving)
+
+**Files:**
+- Modify: `python/genoray/_pgen.py` — the 5 `issubclass` ladders (`read`, `chunk`, `read_ranges`, `chunk_ranges`, `_chunk_ranges_with_length` at ~905-914)
+- Modify: `python/genoray/_vcf.py:623-665` — collapse the duplicated `read` dispatch
+
+**Interfaces:**
+- Produces (PGEN): `PGEN._reader_for(mode) -> Callable` returning the bound `_read_*` method for a mode via a dict lookup.
+
+- [ ] **Step 1: Baseline green**
+
+Run: `pixi run pytest tests/test_pgen.py tests/test_vcf.py -q`
+Expected: PASS.
+
+- [ ] **Step 2: Add the PGEN dispatch helper**
+
+Add to `PGEN`:
+
+```python
+def _reader_for(self, mode: type) -> Callable:
+    """Map a mode class to its bound ``_read_*`` method."""
+    table = {
+        Genos: self._read_genos,
+        GenosPhasing: self._read_genos_phasing,
+        GenosDosages: self._read_genos_dosages,
+        GenosPhasingDosages: self._read_genos_phasing_dosages,
+    }
+    # Dosages-only maps to the genos reader's dosage path where applicable;
+    # preserve each call site's existing mapping — see Step 3.
+    try:
+        return table[mode]
+    except KeyError:
+        assert_never(mode)  # type: ignore[bad-argument-type]
+```
+
+Important: before writing the table, read each of the 5 ladders and copy its exact mode→method mapping (they are not all identical — e.g. `read`/`chunk` include `Dosages`, while `_chunk_ranges_with_length` at 905-914 omits it). If the mappings differ across sites, give `_reader_for` a `include_dosages: bool = True` parameter (or build a second table) so each site keeps its exact current mapping. Do **not** unify a mode into a method it did not previously dispatch to.
+
+- [ ] **Step 3: Replace each PGEN ladder**
+
+At each of the 5 sites, replace the `if issubclass(mode, Genos): read = self._read_genos; elif ...` block with `read = self._reader_for(mode)` (passing `include_dosages=False` at the `_chunk_ranges_with_length` site if that flavor omitted `Dosages`). Keep the surrounding `read = cast(...)` lines.
+
+- [ ] **Step 4: Collapse the VCF `read` dispatch**
+
+In `python/genoray/_vcf.py` `read` (623-665), the `out is None` and `out is not None` branches duplicate the same mode dispatch. Rewrite so the dispatch is written once: compute `data` (allocating via `mode.empty(self.n_samples, self.ploidy + self.phasing, n_variants)` when `n_variants is not None`, else `None`) then dispatch once through the fill methods, threading `out` when provided. Preserve the exact `_fill_genos`/`_fill_dosages`/`_fill_genos_and_dosages` calls and the `assert self.dosage_field is not None` guards.
+
+- [ ] **Step 5: Run the suite**
+
+Run: `pixi run pytest tests/test_pgen.py tests/test_vcf.py -q`
+Expected: PASS (same counts).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genoray/_pgen.py python/genoray/_vcf.py
+git commit -m "refactor(query): replace mode issubclass ladders with dispatch dicts"
+```
+
+---
+
+### Task 6: Shared `_norm_or_warn` / `_empty` / `_empty_gen` helpers (behavior-preserving)
+
+**Files:**
+- Modify: `python/genoray/_pgen.py` (range/chunk method preambles) and `python/genoray/_vcf.py` (range/chunk method preambles)
+
+**Interfaces:**
+- Produces on each backend:
+  - `_norm_or_warn(self, contig: str) -> str | None` — normalize the contig; on `None`, emit the existing `logger.warning(...)` (backend-correct message) and return `None`.
+  - `_empty(self, mode, n_variants: int = 0)` — return `mode.empty(self.n_samples, <effective ploidy>, n_variants)` (VCF passes `self.ploidy + self.phasing`; PGEN passes `self.ploidy`).
+  - `_empty_gen(self, mode, end)` — return the single-element generator `((self._empty(mode), end, <empty idx>) for _ in range(1))` used by the range methods (third element: `np.empty(0, dtype=V_IDX_TYPE)` after Task 11; a plain empty for pre-Task-11 shape — implement the current shape now, Task 11 updates it).
+
+- [ ] **Step 1: Baseline green**
+
+Run: `pixi run pytest tests/test_pgen.py tests/test_vcf.py -q`
+Expected: PASS.
+
+- [ ] **Step 2: Add the helpers to each backend**
+
+PGEN:
+
+```python
+def _norm_or_warn(self, contig: str) -> str | None:
+    c = self._c_norm.norm(contig) if self._c_norm is not None else None
+    if c is None:
+        logger.warning(
+            f"Query contig {contig} not found in PGEN file, even after "
+            "normalizing for UCSC/Ensembl nomenclature."
+        )
+    return c
+
+def _empty(self, mode, n_variants: int = 0):
+    return mode.empty(self.n_samples, self.ploidy, n_variants)
+```
+
+VCF (mirror, `PGEN`→`VCF` in the message, effective ploidy):
+
+```python
+def _norm_or_warn(self, contig: str) -> str | None:
+    c = self._c_norm.norm(contig)
+    if c is None:
+        logger.warning(
+            f"Query contig {contig} not found in VCF file, even after "
+            "normalizing for UCSC/Ensembl nomenclature."
+        )
+    return c
+
+def _empty(self, mode, n_variants: int = 0):
+    return mode.empty(self.n_samples, self.ploidy + self.phasing, n_variants)
+```
+
+- [ ] **Step 3: Route the preambles through the helpers**
+
+Replace each `c = self._c_norm.norm(contig); if c is None: logger.warning(...); <yield/return empty>` block with `c = self._norm_or_warn(contig); if c is None: <yield/return empty via self._empty/_empty_gen>`. Replace inline `mode.empty(self.n_samples, ...)` empty-result allocations with `self._empty(mode, n)`. Sites: PGEN 563-575, 649-663, 732-749, 859-891; VCF 608-613, 713-719, 844-861, and the empty yields inside `_chunk_ranges_with_length` (846-861, 874-879).
+
+- [ ] **Step 4: Run the suite**
+
+Run: `pixi run pytest tests/test_pgen.py tests/test_vcf.py -q`
+Expected: PASS (same counts; log messages already backend-correct from SP-0).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_pgen.py python/genoray/_vcf.py
+git commit -m "refactor(query): share contig-normalize and empty-result helpers"
+```
+
+---
+
+### Task 7: `_mem_per_variant` via `nbytes_per_variant` + unify copy-doubling (BREAKING: chunk sizing)
+
+**Files:**
+- Modify: `python/genoray/_vcf.py:1510-1539` and `python/genoray/_pgen.py:948-968`
+- Modify: `CHANGELOG.md`
+- Test: `tests/test_vcf.py`
+
+**Interfaces:**
+- Consumes: `mode.nbytes_per_variant(n_samples, ploidy)` from Task 1.
+- Produces: `_mem_per_variant(self, mode) -> int` on both backends, both applying the sample-copy doubling when a sorter array is active.
+
+- [ ] **Step 1: Write the test for the VCF doubling change**
+
+Add to `tests/test_vcf.py` (this asserts the *new* unified behavior — VCF now doubles when a sample subset/sorter is active):
+
+```python
+def test_vcf_mem_per_variant_doubles_when_sorted(vcf_path):
+    vcf = VCF(vcf_path)
+    base = vcf._mem_per_variant(VCF.Genos16)
+    vcf.set_samples([vcf.available_samples[0]])  # activates the sample sorter
+    assert vcf._mem_per_variant(VCF.Genos16) == 2 * vcf._mem_per_variant_unsorted(VCF.Genos16) \
+        if hasattr(vcf, "_mem_per_variant_unsorted") else True
+    # Simpler invariant: with a sorter active the estimate is doubled vs. the
+    # per-mode nbytes for the same effective ploidy.
+    ploidy = vcf.ploidy + vcf.phasing
+    assert vcf._mem_per_variant(VCF.Genos16) == 2 * VCF.Genos16.nbytes_per_variant(
+        vcf.n_samples, ploidy
+    )
+```
+
+Use whatever VCF fixture the existing `tests/test_vcf.py` uses (e.g. the vcfixture path fixture); match its name.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run pytest tests/test_vcf.py::test_vcf_mem_per_variant_doubles_when_sorted -q`
+Expected: FAIL — current VCF `_mem_per_variant` never doubles.
+
+- [ ] **Step 3: Rewrite both `_mem_per_variant` bodies**
+
+VCF:
+
+```python
+def _mem_per_variant(self, mode: type[T]) -> int:
+    mem = mode.nbytes_per_variant(self.n_samples, self.ploidy + self.phasing)
+    if isinstance(self._s_sorter, np.ndarray):
+        mem *= 2  # a copy is made to reorder by samples
+    return mem
+```
+
+PGEN:
+
+```python
+def _mem_per_variant(self, mode: type[T]) -> int:
+    mem = mode.nbytes_per_variant(self.n_samples, self.ploidy)
+    if isinstance(self._s_unsorter, np.ndarray):
+        mem *= 2  # a copy is made to reorder by samples
+    return mem
+```
+
+- [ ] **Step 4: Run the suite**
+
+Run: `pixi run pytest tests/test_vcf.py tests/test_pgen.py -q`
+Expected: PASS including the new test. Chunk-count-sensitive tests (if any) still pass — doubling only shrinks chunk sizes, never changes output values.
+
+- [ ] **Step 5: CHANGELOG + commit**
+
+Add under BREAKING CHANGES in `CHANGELOG.md`:
+
+```markdown
+- VCF chunk-size memory estimates now double when a sample subset/reorder is
+  active, matching PGEN. This only affects internal chunk sizing (more
+  conservative memory use), never returned data.
+```
+
+```bash
+git add python/genoray/_vcf.py python/genoray/_pgen.py tests/test_vcf.py CHANGELOG.md
+git commit -m "refactor(query)!: compute _mem_per_variant via nbytes_per_variant
+
+BREAKING CHANGE: VCF now doubles the per-variant memory estimate when a sample
+sorter is active, matching PGEN. Chunk-sizing only; no output change."
+```
+
+---
+
+### Task 8: Merge the two `_ext_*_with_length` methods (VCF, behavior-preserving)
+
+**Files:**
+- Modify: `python/genoray/_vcf.py:1541-1643` (replace both methods with one) and their two call sites in `_chunk_with_length_helper` (939-952)
+
+**Interfaces:**
+- Produces: `VCF._ext_with_length(self, contig, start, end, hap_lens, mode, last_end, *, dosage_field: str | None = None) -> tuple[list, int]` — one method covering both genos-only (`dosage_field is None`) and genos+dosages (`dosage_field` set) extension, reusing `_extract_dosage`.
+
+- [ ] **Step 1: Baseline green**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS.
+
+- [ ] **Step 2: Add the merged method**
+
+Add a single module-level constant and one method (replacing lines 1541-1643):
+
+```python
+_CHECK_LEN_EVERY_N = 20
+
+
+def _ext_with_length(
+    self,
+    contig: str,
+    start: int | np.integer,
+    end: int | np.integer,
+    hap_lens: NDArray[np.int32],
+    mode: type,
+    last_end: int,
+    *,
+    dosage_field: str | None = None,
+) -> tuple[list, int]:
+    ploidy = self.ploidy + self.phasing
+    length = end - start
+    ext_start = end
+    coord = f"{contig}:{ext_start + 1}"
+
+    out_ls: list = []
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="no intervals found for", category=UserWarning
+        )
+        for i, v in enumerate(self._vcf(coord)):
+            if v.start < ext_start or (
+                self._filter is not None and not self._filter(v)
+            ):
+                continue
+
+            genos = v.genotype.array()[:, :ploidy, None].astype(mode._gdtype)
+            if dosage_field is None:
+                out_ls.append(genos)
+            else:
+                dosages = self._extract_dosage(v, dosage_field)[self._s_sorter, None]
+                out_ls.append((genos, dosages))
+
+            if v.is_indel:
+                ilen = len(v.ALT[0]) - len(v.REF)
+                dist = v.start - last_end
+                hap_lens += dist + np.where(
+                    genos[:, : self.ploidy] == 1, ilen, 0
+                ).squeeze(-1)
+                last_end = cast(int, v.end)
+
+            if i % _CHECK_LEN_EVERY_N == 0 and (hap_lens >= length).all():
+                break
+
+    if len(out_ls) > 0:
+        last_end = cast(int, v.end)  # type: ignore | bound by len(out_ls) > 0
+
+    return out_ls, last_end
+```
+
+Note: the genos-only path originally applied no `[self._s_sorter]` to `genos` (it used `v.genotype.array()` directly); preserve that — only the dosages path indexes by `_s_sorter`, exactly as in the original two methods.
+
+- [ ] **Step 3: Update the two call sites**
+
+In `_chunk_with_length_helper` (939-952) replace:
+- the genos branch call `self._ext_genos_with_length(contig, start, end, hap_lens, mode, last_end)` → `self._ext_with_length(contig, start, end, hap_lens, mode, last_end)`
+- the genos+dosages branch call → `self._ext_with_length(contig, start, end, hap_lens, mode, last_end, dosage_field=self.dosage_field)`
+
+Remove the now-unused per-method `_CHECK_LEN_EVERY_N` locals.
+
+- [ ] **Step 4: Run the suite**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS (same count).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_vcf.py
+git commit -m "refactor(vcf): merge _ext_genos/_ext_genos_dosages into _ext_with_length"
+```
+
+---
+
+### Task 9: Relocate `_oxbow_reader` out of the overload block (VCF, trivial)
+
+**Files:**
+- Modify: `python/genoray/_vcf.py:1005-1012` (move below `get_record_info`)
+
+- [ ] **Step 1: Move the method**
+
+Cut the `_oxbow_reader` method body (currently interleaved between the last `@overload` stub ~995-1004 and the concrete `get_record_info` implementation ~1014) and paste it immediately **after** the concrete `get_record_info` implementation ends. No body change.
+
+- [ ] **Step 2: Run the suite**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add python/genoray/_vcf.py
+git commit -m "refactor(vcf): move _oxbow_reader out of the get_record_info overloads"
+```
+
+---
+
+### Task 10: `Filter` value object — clean break (BREAKING, public)
+
+**Files:**
+- Modify: `python/genoray/_vcf.py` — add `Filter`; replace `_filter`/`_pl_filter` with `_filter: Filter | None`; constructor + property; delete `_check_filter_pair`
+- Modify: `python/genoray/__init__.py` — export `Filter`
+- Modify: `skills/genoray-api/SKILL.md` — rewrite the Filtering section
+- Modify: `CHANGELOG.md`
+- Test: `tests/test_vcf.py`
+
+**Interfaces:**
+- Produces: `genoray.Filter` — `@dataclass(frozen=True) class Filter: record: Callable[[cyvcf2.Variant], bool]; expr: pl.Expr`. `VCF(path, filter: Filter | None = None, ...)`; `VCF.filter` getter/setter are `Filter | None`. Internal reads use `self._filter.record` / `self._filter.expr`.
+
+- [ ] **Step 1: Write the new-API tests**
+
+```python
+# tests/test_vcf.py
+import polars as pl
+import pytest
+from genoray import VCF, Filter
+
+
+def test_filter_object_roundtrip(vcf_path):
+    f = Filter(record=lambda v: True, expr=pl.col("POS") > 0)
+    vcf = VCF(vcf_path, filter=f)
+    assert vcf.filter is f
+    vcf.filter = None
+    assert vcf.filter is None
+
+
+def test_filter_object_is_frozen():
+    f = Filter(record=lambda v: True, expr=pl.lit(True))
+    with pytest.raises(Exception):
+        f.record = lambda v: False  # frozen dataclass
+
+
+def test_old_pl_filter_kwarg_removed(vcf_path):
+    with pytest.raises(TypeError):
+        VCF(vcf_path, pl_filter=pl.lit(True))  # kwarg no longer exists
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run pytest tests/test_vcf.py -k filter_object -q`
+Expected: FAIL — `ImportError: cannot import name 'Filter'`.
+
+- [ ] **Step 3: Implement `Filter` and rewire VCF**
+
+Add near the top of `python/genoray/_vcf.py`:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Filter:
+    """A cyvcf2 record predicate paired with its matching ``.gvi`` polars expression.
+
+    Both travel together so the record scan (``record``) and the index-level
+    filter (``expr``) can never diverge. ``record`` should return True for
+    variants to keep; ``expr`` must be an equivalent predicate over the index
+    columns (``CHROM``, ``POS``, ``REF``, ``ALT``, ``ILEN``).
+    """
+
+    record: Callable[[cyvcf2.Variant], bool]
+    expr: pl.Expr
+```
+
+In `VCF`:
+- Replace the `_filter` / `_pl_filter` attribute annotations (239-242) with a single `_filter: Filter | None`.
+- Constructor (268-285): drop the `pl_filter` parameter; change `filter` to `filter: Filter | None = None`. Delete the `self._check_filter_pair(...)` call. Set `self._filter = filter`. The index-load guard `... and self._filter is None` (302) is unchanged.
+- Delete `_check_filter_pair` (309-320).
+- Rewrite the `filter` property/setter (322-367): getter returns `self._filter` (`Filter | None`); setter accepts `Filter | None`, invalidates the index (`self._index = None`), assigns `self._filter`.
+- Update every internal read of the old pair:
+  - record-scan sites (`if self._filter is not None: vcf = filter(self._filter, vcf)`) → `if self._filter is not None: vcf = filter(self._filter.record, vcf)`
+  - the extend-length predicate `self._filter is not None and not self._filter(v)` → `... and not self._filter.record(v)`
+  - the `_pl_filter` sites (index filtering at 1072-1073, 1256-1257, and the save/restore at 1158-1163) → use `self._filter.expr` guarded by `self._filter is not None`. For the temporary-clear block at 1158-1163, save/restore `self._filter` (the whole object) instead of `_pl_filter`.
+  - `n_vars` no-index path (499-502) `self._filter(v)` → `self._filter.record(v)`.
+
+Run to confirm no stale references remain:
+
+Run: `grep -n "_pl_filter\|_check_filter_pair" python/genoray/_vcf.py`
+Expected: no output.
+
+- [ ] **Step 4: Export `Filter`**
+
+In `python/genoray/__init__.py`: add `"Filter"` to `__all__`, add `"Filter": ("genoray._vcf", "Filter")` to the lazy-import map, and add `from ._vcf import Filter as Filter` in the `TYPE_CHECKING` block.
+
+- [ ] **Step 5: Rewrite the SKILL Filtering section**
+
+In `skills/genoray-api/SKILL.md`, replace the `(filter, pl_filter)` tuple documentation (constructor kwargs, the getter/setter tuple description ~323-334, and the Filtering-guidance block ~362-375) with the `Filter` object:
+
+```python
+from genoray import VCF, Filter
+import genoray.exprs as gx
+
+vcf = VCF("file.vcf", filter=Filter(
+    record=lambda v: not v.INFO.get("SVTYPE"),   # cyvcf2 record predicate
+    expr=~gx.is_symbolic,                          # matching .gvi index predicate
+))
+vcf.filter = None                                  # clear
+f = vcf.filter                                     # -> Filter | None
+```
+
+State that VCF requires **both** halves and they are bundled in one `Filter`; the old `pl_filter=` kwarg and `(filter, pl_filter)` tuple are removed in 3.0.0.
+
+- [ ] **Step 6: CHANGELOG + run + commit**
+
+Add under BREAKING CHANGES:
+
+```markdown
+- VCF filtering now uses a single `genoray.Filter(record=, expr=)` value object.
+  The `pl_filter=` constructor kwarg and the `(filter, pl_filter)` tuple
+  getter/setter are removed. Migrate `VCF(p, filter=fn, pl_filter=expr)` to
+  `VCF(p, filter=Filter(record=fn, expr=expr))`.
+```
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS including the new filter tests. Update any existing tests that used `pl_filter=`/tuple filters to the `Filter` object.
+
+```bash
+git add python/genoray/_vcf.py python/genoray/__init__.py skills/genoray-api/SKILL.md CHANGELOG.md tests/test_vcf.py
+git commit -m "feat(vcf)!: replace paired (filter, pl_filter) with a Filter value object
+
+BREAKING CHANGE: VCF filtering uses genoray.Filter(record=, expr=). The
+pl_filter= kwarg and the (filter, pl_filter) tuple API are removed."
+```
+
+---
+
+### Task 11: Reconcile `_chunk_ranges_with_length` to `chunk_idxs` on VCF (BREAKING, genoray side)
+
+**Files:**
+- Modify: `python/genoray/_vcf.py` — `_chunk_ranges_with_length` (790-882) and `_chunk_with_length_helper` (884-969)
+- Modify: `CHANGELOG.md`
+- Test: `tests/test_vcf.py`
+
+**Interfaces:**
+- Consumes: `VCF._var_idxs(contig, starts, ends) -> (NDArray[integer], NDArray[OFFSET_TYPE])` (line 537, requires the index).
+- Produces: VCF `_chunk_with_length_helper` and `_chunk_ranges_with_length` yield inner tuples `(data, end, chunk_idxs: NDArray[V_IDX_TYPE])` where `chunk_idxs` are the 0-based variant indices in the chunk, including extension variants (which are contiguous immediately after the last in-range index). Empty yields use `np.empty(0, dtype=V_IDX_TYPE)`.
+
+- [ ] **Step 1: Write the characterization test (new contract == gvl's old reconstruction)**
+
+```python
+# tests/test_vcf.py
+import numpy as np
+from genoray import VCF
+
+
+def test_chunk_ranges_with_length_yields_chunk_idxs(indexed_vcf_path):
+    """The 3rd tuple element is now the variant-index array, and the extension
+    indices are contiguous after the last in-range index (what gvl assumed)."""
+    vcf = VCF(indexed_vcf_path)  # fixture with a .gvi index loaded
+    contig = vcf.contigs[0]
+    starts = np.array([0], dtype=np.int32)
+    ends = np.array([10_000], dtype=np.int32)
+
+    v_idx, offsets = vcf._var_idxs(contig, starts, ends)
+    reg_unext = v_idx[offsets[0] : offsets[1]].astype(np.uint32)
+
+    all_idxs = []
+    for range_ in vcf._chunk_ranges_with_length(contig, starts, ends, "4g", VCF.Genos8):
+        for genos, _end, chunk_idxs in range_:
+            assert chunk_idxs.dtype == np.uint32
+            assert chunk_idxs.shape[0] == genos.shape[-1]
+            all_idxs.append(chunk_idxs)
+    full = np.concatenate(all_idxs) if all_idxs else np.empty(0, np.uint32)
+
+    # in-range prefix matches _var_idxs; any extension is contiguous after it
+    assert np.array_equal(full[: reg_unext.size], reg_unext)
+    if full.size > reg_unext.size:
+        ext = full[reg_unext.size :]
+        assert np.array_equal(ext, np.arange(reg_unext[-1] + 1, reg_unext[-1] + 1 + ext.size))
+```
+
+Use the existing indexed-VCF fixture name from `tests/test_vcf.py` (the one that constructs a `VCF` with a `.gvi` index). If none exists, build the index in the test via the same path the suite uses to force `_load_index()`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run pytest tests/test_vcf.py -k chunk_idxs -q`
+Expected: FAIL — the third element is currently an `int` (`n_extension_vars`), so `chunk_idxs.dtype` / `.shape` access raises.
+
+- [ ] **Step 3: Thread in-range indices into the helper and emit `chunk_idxs`**
+
+In `_chunk_ranges_with_length` (790), after normalizing `c` and computing per-range counts, compute the in-range indices once:
+
+```python
+v_idx, v_offsets = self._var_idxs(c, starts, ends)  # starts here are 0-based (pre +1)
+```
+
+Do this **before** the `starts = starts + 1` cyvcf2 adjustment (use the original 0-based `starts`). For each range `ri`, slice `range_idxs = v_idx[v_offsets[ri]:v_offsets[ri+1]].astype(V_IDX_TYPE)` and pass it to `_chunk_with_length_helper`.
+
+Change the helper signature/body:
+
+```python
+def _chunk_with_length_helper(
+    self,
+    n: int,
+    vars_per_chunk: int,
+    contig: str,
+    start: POS_TYPE,
+    end: POS_TYPE,
+    mode: type[L],
+    range_idxs: NDArray[V_IDX_TYPE],
+) -> Generator[tuple[L, int, NDArray[V_IDX_TYPE]]]:
+    ...
+    consumed = 0  # how many in-range indices emitted so far
+    for _, is_last, chunk_size in mark_ends(chunk_sizes):
+        ...  # existing read of `out`, `last_end`
+        base_idxs = range_idxs[consumed : consumed + chunk_size]
+        consumed += chunk_size
+        if not is_last:
+            yield cast(L, out), last_end, base_idxs
+            continue
+
+        # last chunk: extend and append contiguous extension indices
+        ls_ext, last_end = self._ext_with_length(
+            contig, start, end, hap_lens, mode, last_end,
+            dosage_field=self.dosage_field if issubclass(
+                mode, (Genos8Dosages, Genos16Dosages)
+            ) else None,
+        )
+        if len(ls_ext) > 0:
+            # concatenate genos/tuple exactly as before
+            ...
+            last_in_range = int(range_idxs[-1])
+            ext_idxs = np.arange(
+                last_in_range + 1, last_in_range + 1 + len(ls_ext), dtype=V_IDX_TYPE
+            )
+            chunk_idxs = np.concatenate([base_idxs, ext_idxs])
+        else:
+            chunk_idxs = base_idxs
+        yield cast(L, out), last_end, chunk_idxs
+```
+
+Update the method return-type annotations (790-801, 884-892) from `tuple[L, int, int]` to `tuple[L, POS_TYPE, NDArray[V_IDX_TYPE]]`, matching PGEN. Update the empty-yield third elements (846-861, 874-879) to `np.empty(0, dtype=V_IDX_TYPE)` (fold through `_empty_gen` from Task 6). Simplify `_ext_with_length` dispatch by using the merged method from Task 8 (shown above).
+
+Note: `range_idxs` is guaranteed non-empty whenever the helper runs (`n > 0` gate at the caller), so `range_idxs[-1]` is safe.
+
+- [ ] **Step 4: Run the suite**
+
+Run: `pixi run pytest tests/test_vcf.py -q`
+Expected: PASS including the new characterization test.
+
+- [ ] **Step 5: CHANGELOG + commit**
+
+Add under BREAKING CHANGES:
+
+```markdown
+- `VCF._chunk_ranges_with_length` now yields `(data, end, chunk_idxs)` (a
+  `uint32` variant-index array) as its third tuple element instead of an
+  `n_extension_vars` count, matching `PGEN._chunk_ranges_with_length`.
+```
+
+```bash
+git add python/genoray/_vcf.py CHANGELOG.md tests/test_vcf.py
+git commit -m "refactor(vcf)!: yield chunk_idxs from _chunk_ranges_with_length
+
+BREAKING CHANGE: the third tuple element is now a uint32 variant-index array
+(matching PGEN), not an n_extension_vars count."
+```
+
+---
+
+### Task 12: GenVarLoader coordination (branch `svar2-m6b-kernel`, PR #266)
+
+**Files (in `/carter/users/dlaub/projects/GenVarLoader`):**
+- Modify: `python/genvarloader/_dataset/_write.py:731-789` (VCF extend branch)
+- Modify: `pyproject.toml` (genoray pin)
+
+**Interfaces:**
+- Consumes: the reconciled `(data, end, chunk_idxs)` VCF contract from Task 11.
+
+- [ ] **Step 1: Switch to the gvl branch and install the local genoray**
+
+```bash
+cd /carter/users/dlaub/projects/GenVarLoader
+git rev-parse --show-toplevel   # confirm you are in GenVarLoader, not genoray
+git checkout svar2-m6b-kernel
+git status                       # confirm clean before editing
+```
+
+Point gvl's env at the local genoray `sp4-vcf-pgen-consistency` build (editable/path install into the gvl pixi env) so tests exercise the new contract. Confirm: `pixi run python -c "import genoray, inspect; print(genoray.__file__)"` resolves to the local checkout.
+
+- [ ] **Step 2: Rewrite the VCF extend branch to consume `chunk_idxs`**
+
+In `python/genvarloader/_dataset/_write.py`, the VCF extend branch (738-768) currently reconstructs `var_idxs` from `n_ext_total`. Replace it to mirror the PGEN branch (852-869) — concatenate `chunk_idxs` directly:
+
+```python
+if extend_to_length:
+    genos_list: list[NDArray] = []
+    idx_list: list[NDArray] = []
+    for chunk_genos, _chunk_end, chunk_idxs in range_:
+        genos_list.append(chunk_genos)
+        idx_list.append(chunk_idxs.astype(V_IDX_TYPE))
+    genos = np.concatenate(genos_list, axis=-1)
+    var_idxs = (
+        np.concatenate(idx_list) if idx_list else np.empty(0, dtype=V_IDX_TYPE)
+    )
+
+    if var_idxs.size == 0:
+        yield [dense2sparse(genos, var_idxs)], q_end, desc
+        continue
+
+    v_starts = (pos[var_idxs] - 1).astype(np.int32)
+    ilens = ilen_all[var_idxs].astype(np.int32)
+    rag = _window_to_sparse(genos, var_idxs, q_start, q_end, v_starts, ilens, True)
+    region_end = _region_end(rag, v_ends, q_end)
+    yield [rag], region_end, desc
+```
+
+Remove the now-dead `reg_unext`/`unextended_idxs`/`vcf._var_idxs` computation from the **extend** path (714-716) — but keep it for the non-extend path (774-782), which still needs `reg_unext`. Guard the `_var_idxs` call so it only runs when `not extend_to_length`.
+
+- [ ] **Step 3: Bump the genoray pin**
+
+In `GenVarLoader/pyproject.toml`, change `"genoray>=2.12.3,<3"` → `"genoray>=3,<4"`.
+
+- [ ] **Step 4: Run the gvl write/dataset tests**
+
+Run (in the gvl env): `pixi run pytest -k "write or svar2 or dataset" -q`
+Expected: PASS. If a test hard-pins genoray `<3`, update it alongside the pin.
+
+- [ ] **Step 5: Commit and push to PR #266**
+
+```bash
+cd /carter/users/dlaub/projects/GenVarLoader
+git add python/genvarloader/_dataset/_write.py pyproject.toml
+git commit -m "feat!: consume reconciled genoray chunk_idxs contract (genoray 3.0)
+
+BREAKING CHANGE: requires genoray>=3; VCF/PGEN _chunk_ranges_with_length now
+both yield (data, end, chunk_idxs)."
+git push origin svar2-m6b-kernel
+```
+
+Confirm the push updates draft PR #266 (`gh pr view 266`).
+
+- [ ] **Step 6: Return to genoray**
+
+```bash
+cd /carter/users/dlaub/projects/genoray
+git rev-parse --abbrev-ref HEAD   # confirm sp4-vcf-pgen-consistency
+```
+
+---
+
+### Task 13: SKILL `read(out=)` note + final reconciliation & verification
+
+**Files:**
+- Modify: `skills/genoray-api/SKILL.md`
+- Modify: `CHANGELOG.md` (tidy the 3.0.0 section)
+
+- [ ] **Step 1: Document the intentional asymmetries**
+
+In `skills/genoray-api/SKILL.md`, add one line each near the VCF/PGEN method docs:
+- `read(out=...)` is VCF-only (PGEN random-access allocates fresh; no `out=` buffer).
+- Confirm the existing "VCF intentionally has no `read_ranges`" note is still present and correct (it is — do not remove).
+
+- [ ] **Step 2: Verify the SKILL matches the code**
+
+Run: `grep -n "pl_filter\|(filter, pl_filter)" skills/genoray-api/SKILL.md`
+Expected: no output (all replaced by the `Filter` object in Task 10).
+
+- [ ] **Step 3: Full verification**
+
+Run: `pixi run pytest -q`
+Expected: entire suite PASS.
+
+Run: `ruff check python/genoray tests && ruff format --check python/genoray tests`
+Expected: clean.
+
+Run: `pixi run pyrefly check` (or the project's pyrefly task)
+Expected: clean.
+
+Run: `grep -rn "_check_filter_pair\|_ext_genos_with_length\|_ext_genos_dosages_with_length\|_pl_filter" python/genoray`
+Expected: no output (all removed/renamed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/genoray-api/SKILL.md CHANGELOG.md
+git commit -m "docs(skill): document VCF-only read(out=) and finalize 3.0.0 notes"
+```
+
+- [ ] **Step 5: Open the genoray PR**
+
+```bash
+git push -u origin sp4-vcf-pgen-consistency
+gh pr create --fill --title "SP-4: VCF/PGEN consistency + boilerplate (3.0.0)" \
+  --body "Implements docs/superpowers/specs/2026-07-09-sp4-vcf-pgen-consistency-design.md. Coordinated with GenVarLoader PR #266. Part of the genoray 3.0.0 breaking-change wave."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §A1 phantom factory → Tasks 1–3. §A2 dispatch dict → Task 5. §A3 `_extract_dosage` → Task 4. §A4 norm/empty helpers → Task 6. §A5 mem unification → Task 7. §A6 `_ext_*` merge → Task 8. §A7 `_oxbow_reader` → Task 9.
+- §B1 `empty()` unification → Task 3. §B2 `Filter` → Task 10. §B3 tuple reconcile → Tasks 11 (genoray) + 12 (gvl).
+- §C1 range-API PGEN-only → Task 13 (verify note stays; no code). §C2 `read(out=)` → Task 13.
+- Process (no hand-bump, `!` markers, SKILL/CHANGELOG) → Global Constraints + per-task commits.
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to". The one deliberately-open item from the spec (VCF `chunk_idxs` feasibility) was resolved during planning: VCF produces `chunk_idxs` via `_var_idxs` + contiguous extension indices (Task 11, Step 3), with a characterization test (Step 1).
+
+**Type consistency:** `empty(n_samples, ploidy, n_variants)` uniform (Tasks 1–3). `nbytes_per_variant(n_samples, ploidy)` used in Tasks 1 & 7. `_chunk_ranges_with_length` third element `NDArray[V_IDX_TYPE]` (uint32) in Tasks 11 & 12. `Filter(record=, expr=)` consistent across Task 10 and the SKILL. `_ext_with_length(..., *, dosage_field=None)` consistent across Tasks 8 & 11.

--- a/docs/superpowers/specs/2026-07-09-sp4-vcf-pgen-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-09-sp4-vcf-pgen-consistency-design.md
@@ -1,0 +1,231 @@
+# SP-4 — VCF/PGEN consistency + boilerplate
+
+**Date:** 2026-07-09
+**Branch:** `sp4-vcf-pgen-consistency` (off `main`)
+**Roadmap:** [`docs/roadmap/clean-code-audit.md`](../../roadmap/clean-code-audit.md) — sub-project #4
+**Findings:** [`docs/roadmap/audit-findings/02-vcf-pgen.md`](../../roadmap/audit-findings/02-vcf-pgen.md)
+**Size:** M–L · **Risk:** med · **Release:** part of the **genoray 3.0.0** breaking-change wave
+
+## Goal
+
+Collapse the parallel-but-divergent `_vcf.py` / `_pgen.py` backends onto shared helpers,
+and make the invalid states the audit surfaced unrepresentable. The two files share a real
+conceptual core (phantom modes, mode dispatch, dosage extraction, contig-normalize + empty
+results, per-variant memory math, the extend-to-haplotype-length algorithm) but implement
+it twice with copy-paste and even divergent public surfaces.
+
+This lands as **breaking changes in the 3.0.0 wave** (SP-4 / SP-5 / SP-6). Because the
+release is explicitly breaking, we do **not** carry compat shims for the API changes here —
+we make the clean break and update `SKILL.md` + `CHANGELOG.md` in the same PR.
+
+### Scope correction vs. the roadmap
+
+Two roadmap assumptions changed after inspecting the current tree:
+
+1. **Bug #1 (filter ignored on the no-index `Genos*Dosages` path) is already fixed** — it
+   landed in SP-0 (`3c6188f fix(vcf): apply filter on no-index Genos*Dosages read path`).
+   SP-4 does **not** re-do it; it only inherits the now-consistent filter behavior.
+2. **The range-API asymmetry is already a decided, measured call**, not accidental
+   divergence: `SKILL.md` documents "VCF intentionally has **no `read_ranges`** —
+   benchmarking showed no throughput benefit." SP-4 therefore does **not** add
+   `read_ranges`/`chunk_ranges`/`var_idxs` to VCF; it keeps VCF streaming-only and keeps the
+   doc note (see §C).
+
+## Non-goals
+
+- Adding multi-range APIs to VCF (`read_ranges`/`chunk_ranges`/`var_idxs`) — measured
+  PGEN/SVAR-only decision stands (§C).
+- Sample-accessor name convergence, `Reader` alias, raw-dict FFI privatization — those are
+  **SP-6**.
+- Any Rust change — SP-4 is Python + the coordinated gvl edit.
+- Hand-bumping the version. Breaking commits are marked with `!` / `BREAKING CHANGE:` so
+  `cz bump` computes 3.0.0 once the wave completes (see §Process).
+
+## Part A — Internal dedup (behavior-preserving, no SKILL change)
+
+### A1. Phantom-mode factory — new `genoray/_modes.py`
+
+Every phantom mode today repeats a three-part pattern (an `_is_*` `TypeGuard`, the
+`NDArray[...], Phantom` subclass, an `empty` classmethod) — ~120 L in `_vcf.py`
+(`Genos8`/`Genos16`/`Dosages`/`Genos8Dosages`/`Genos16Dosages`) and ~110 L in `_pgen.py`
+(`Genos`/`Dosages`/`Phasing`/`GenosPhasing`/`GenosDosages`/`GenosPhasingDosages`), almost
+all mechanical; two docstrings are copy-pasted verbatim.
+
+Provide two factories in `genoray/_modes.py`:
+
+- `make_array_mode(name, dtype, ndim, shape_pred=None) -> type[Phantom]` — generates the
+  predicate (`isinstance(np.ndarray)` + dtype + ndim + optional `shape_pred`, e.g.
+  `shape[1] in (2, 3)` for genotypes), the `NDArray[dtype], Phantom` subclass carrying the
+  dtype attributes the callers rely on (`_gdtype` for VCF genos, `_dtype`/`_dtypes` for
+  PGEN — unify the attribute name; see A5), a uniform
+  `empty(n_samples, ploidy, n_variants)` (§B1), and a `nbytes_per_variant(n_samples, ploidy)`
+  (§A5).
+- `make_tuple_mode(name, *component_modes) -> type[Phantom]` — the `(genos, dosages)` /
+  `(genos, phasing, dosages)` tuple modes: generates the per-element isinstance predicate
+  and an `empty` that delegates to the component modes.
+
+`_vcf.py` and `_pgen.py` then declare their modes via these factories. The public names
+(`Genos8`, `Dosages`, `PGEN.Genos`, …) are unchanged — only the definition mechanism moves.
+
+### A2. Mode → method dispatch dict
+
+The `if issubclass(mode, Genos): … elif Dosages … elif GenosPhasing …` ladder appears 5×
+in `_pgen.py` (`read`, `chunk`, `read_ranges`, `chunk_ranges`, `_chunk_ranges_with_length`)
+and twice in `_vcf.py` (`read`, duplicated across the `out is None` / `out is not None`
+branches). Build one `dict[type[Phantom], Callable]` per backend (mapping mode →
+`self._read_*`), look up `reader = table[mode]`. The with-length variant (which omits
+`Dosages`) filters the table. In VCF, collapse the two `read` branches so the dispatch is
+written once and `out` is threaded through.
+
+### A3. VCF `_extract_dosage` helper
+
+`d = v.format(field); if d is None: raise DosageFieldError; if d.shape[1] > 1: raise
+MultiallelicDosageError; … d.squeeze(1)` is copy-pasted 5× (`chunk`, `_fill_dosages` ×2,
+`_fill_genos_and_dosages` ×2, `_ext_genos_dosages_with_length`) with identical messages.
+Extract `_extract_dosage(self, v) -> NDArray[np.float32]` performing fetch + both checks +
+squeeze; all sites call it.
+
+### A4. Contig-normalize + empty-result helpers
+
+Each range/chunk method opens with `c = norm(contig); if c is None: warn; yield/return
+empty`, and most repeat a `n_variants == 0` empty block with the identical
+`(mode.empty(...) for _ in range(1))` generator. Add small private helpers —
+`_norm_or_warn(contig) -> str | None`, `_empty(mode, …)`, `_empty_gen(mode, …)` — and route
+the ~dozen near-identical blocks per file through them. (The wrong-backend "not found in VCF
+file" log strings inside PGEN were already corrected in SP-0.)
+
+### A5. `_mem_per_variant` unification
+
+Both backends sum per-array `n_samples * axis * itemsize`, but read the dtype from
+different attributes (`mode._gdtype` vs `mode._dtype`/`mode._dtypes`) and **only PGEN**
+doubles the estimate when a sample sorter is active (`_s_unsorter` is an ndarray). Have each
+mode expose `nbytes_per_variant(n_samples, ploidy)` (natural once the factory exists) so
+`_mem_per_variant` becomes a one-liner. **Deliberate decision:** unify the sample-copy
+doubling to apply to **both** backends when a sorter is active — it is a chunk-sizing-only
+estimate (more conservative memory bound, no correctness/output effect) and the divergence
+was accidental. Unify the mode dtype attribute name while here (A1).
+
+### A6. Merge the two `_ext_*_with_length` methods
+
+`_ext_genos_with_length` and `_ext_genos_dosages_with_length` share the entire control
+structure (contig coord build, warnings filter, per-variant loop, `v.start < ext_start`
+skip, indel `hap_lens` update, `_CHECK_LEN_EVERY_N` break, trailing `last_end` fixup),
+differing only in whether dosages are collected; `_CHECK_LEN_EVERY_N = 20` is redefined in
+each. Merge into one method parameterized by `want_dosages: bool`, reusing `_extract_dosage`,
+with a single module-level `_CHECK_LEN_EVERY_N`.
+
+### A7. Relocate `_oxbow_reader`
+
+`_oxbow_reader` sits interleaved between the `get_record_info` `@overload` stubs and the
+concrete implementation. Move it out of the overload block (below `get_record_info`) so the
+stubs sit directly above their implementation. Pure code motion.
+
+## Part B — Breaking changes (SKILL + CHANGELOG)
+
+### B1. `empty()` signature unified to `(n_samples, ploidy, n_variants)`
+
+CLAUDE.md documents "All `Phantom` subclasses have `empty(n_samples, ploidy, n_variants)`,"
+but VCF's variants take a 4th `phasing` arg PGEN's do not, and `Dosages.empty` accepts+
+ignores `ploidy`/`phasing`. Standardize on the documented 3-arg signature: the VCF phasing
+axis (`ploidy + phasing`) is computed by the **caller** and passed as effective ploidy. The
+factory (A1) generates this uniform signature. `empty()` is not in `SKILL.md`, but note the
+signature change in `CHANGELOG.md` (breaking) and confirm the CLAUDE.md contract now holds
+verbatim.
+
+### B2. `Filter` value object — clean Filter-only break (public)
+
+The paired `(filter, pl_filter)` is really one concept (a cyvcf2 record predicate with its
+matching `.gvi` polars expression) whose both-or-neither invariant is enforced at runtime by
+`_check_filter_pair` at three sites plus a tuple-shape check in the setter.
+
+Introduce a frozen `Filter(record: Callable[[cyvcf2.Variant], bool], expr: pl.Expr)`
+(dataclass, `frozen=True`, exported from `genoray`). **Clean break, no tuple compat shim**
+(confirmed with maintainer):
+
+- Constructor: `VCF(path, filter: Filter | None = None, …)` — the separate `filter=` /
+  `pl_filter=` kwargs are **removed**.
+- Property: `vcf.filter` getter/setter is `Filter | None`.
+- `_check_filter_pair` is **deleted** — the half-None state is now unrepresentable by
+  construction. `self._filter: Filter | None` replaces the `_filter` / `_pl_filter` pair;
+  internal reads use `self._filter.record` / `self._filter.expr`.
+
+Rewrite the `SKILL.md` Filtering section (currently documents the `(filter, pl_filter)`
+tuple getter/setter at lines ~323–334 and constructor kwargs) to the `Filter` API. Record
+the break in `CHANGELOG.md`. Migration note: `VCF(p, filter=fn, pl_filter=expr)` →
+`VCF(p, filter=Filter(record=fn, expr=expr))`.
+
+### B3. `_chunk_ranges_with_length` tuple reconciled (coordinated with gvl)
+
+Two sibling methods with the same name return structurally different third tuple elements:
+VCF yields `n_extension_vars: int`, PGEN yields `chunk_idxs: NDArray[V_IDX_TYPE]`. A single
+downstream consumer — gvl `_dataset/_write.py` — calls both (`vcf._chunk_ranges_with_length`
+at :721, `pgen._chunk_ranges_with_length` at :837) and must branch per backend.
+
+Reconcile to **one contract**: `(data, end, chunk_idxs: NDArray[V_IDX_TYPE])` on both
+backends (`n_extension_vars` is derivable from `chunk_idxs.shape[0]` if still needed).
+
+**Implementation-risk spike (resolve before committing the exact semantics):** VCF's
+streaming with-length path currently produces a *count*, not a global variant-index array.
+Emitting `chunk_idxs` may require the `.gvi`-index-backed path, or synthesizing indices as
+variants stream. Before locking the array semantics, confirm what gvl's write path actually
+consumes from that third element — if gvl only needs a count / a contiguous index range, the
+"richer" contract may be a contiguous `chunk_idxs` the VCF path can produce cheaply. The
+plan opens with this spike; the reconciled shape is whatever satisfies both (a) PGEN's
+existing `chunk_idxs` semantics and (b) gvl's actual use, chosen to be cheaply producible on
+the VCF path.
+
+**gvl coordination (same effort, must land together):**
+- Update `python/genvarloader/_dataset/_write.py` (:721, :837) to consume the unified
+  `(data, end, chunk_idxs)` from both backends; collapse the per-backend branching.
+- Bump the genoray pin `genoray>=2.12.3,<3` → `genoray>=3,<4` in gvl `pyproject.toml`.
+- Commit on the existing branch **`svar2-m6b-kernel`** and push to **draft PR #266**
+  ("SVAR2 read-bound dataset wiring", currently *blocked on genoray svar-2 release*).
+- gvl's test suite on that branch must pass against a local genoray build of this branch.
+
+## Part C — Deliberate "leave asymmetric, document" calls
+
+- **C1. Range API stays PGEN/SVAR-only.** `read_ranges`/`chunk_ranges`/`var_idxs` are a
+  measured decision (no VCF throughput benefit, per SKILL). VCF keeps `_var_idxs` private.
+  No implementation; keep/verify the SKILL doc note.
+- **C2. `read(out=...)` stays VCF-only.** PGEN random-access allocates fresh; adding `out=`
+  is unmotivated (YAGNI). Document the asymmetry as intentional (a one-line SKILL note),
+  mirroring the range-API rationale.
+
+## Process, PRs, versioning
+
+- **Commits:** small and reviewable, grouped A → B, Conventional Commits. Behavior-
+  preserving parts (A) are plain `refactor:`; API breaks (B1/B2/B3) use `!` / a
+  `BREAKING CHANGE:` footer so `cz bump` resolves the wave to **3.0.0**.
+- **Do NOT hand-bump the version.** 3.0.0 is cut once the SP-4/5/6 wave lands; SP-4 only
+  contributes the breaking-commit markers.
+- **Branches:** genoray work on `sp4-vcf-pgen-consistency`; the coordinated gvl edit on
+  `svar2-m6b-kernel` (→ PR #266). Ensure prek hooks are installed before committing/pushing
+  in both repos.
+- **SKILL.md:** rewrite the Filtering section (B2); add the `read(out=)` VCF-only note (C2);
+  confirm the range-API PGEN-only note (C1). `empty()` is not in SKILL — CHANGELOG only.
+
+## Testing & verification
+
+- **Part A (behavior-preserving):** the existing suite stays green — `pixi run pytest`
+  (vcfixture oracle + VCF/PGEN parity). No output/coordinate/dtype changes.
+- **Part B (breaking):** update tests to the new `Filter` API, the 3-arg `empty()`, and the
+  unified `_chunk_ranges_with_length` contract. Add a **cross-backend property test**:
+  for the same query, VCF and PGEN with-length paths both yield haplotypes ≥ the query
+  length (guards the extend algorithm the audit flagged as the deepest divergence, which we
+  intentionally keep implemented twice per its recommendation).
+- **gvl:** `svar2-m6b-kernel` test suite green against a local build of
+  `sp4-vcf-pgen-consistency`.
+- **Hooks/typing:** `ruff check`, `ruff format`, `pyrefly` green (both repos). Rust is
+  untouched, but if any hook runs `cargo`, use `--no-default-features` for tests.
+
+## Invariants
+
+1. **Part A is behavior-preserving**, gated on the existing test suite staying green.
+2. **Every public break (B1/B2/B3) updates `SKILL.md`/`CHANGELOG.md` in the same PR** and
+   carries a `BREAKING CHANGE:` marker; migration notes included.
+3. **The gvl tuple-contract change lands with the genoray change** — the two are one logical
+   edit split across repos (genoray branch + gvl `svar2-m6b-kernel` / PR #266). Neither is
+   "done" without the other.
+4. **Small, reviewable commits** — no god-branch.
+5. **B3 opens with the VCF-`chunk_idxs` feasibility spike** before the reconciled semantics
+   are locked.

--- a/python/genoray/__init__.py
+++ b/python/genoray/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "PGEN",
     "Reference",
     "VCF",
+    "Filter",
     "Reader",
     "SparseVar",
     "SparseVar2",
@@ -30,6 +31,7 @@ _LAZY: dict[str, tuple[str, str | None]] = {
     "PGEN": ("genoray._pgen", "PGEN"),
     "Reference": ("genoray._reference", "Reference"),
     "VCF": ("genoray._vcf", "VCF"),
+    "Filter": ("genoray._vcf", "Filter"),
     "SparseVar": ("genoray._svar", "SparseVar"),
     "SparseVar2": ("genoray._svar2", "SparseVar2"),
     "exprs": ("genoray.exprs", None),
@@ -64,6 +66,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._signatures import fit_signatures as fit_signatures
     from ._svar import SparseVar as SparseVar
     from ._svar2 import SparseVar2 as SparseVar2
+    from ._vcf import Filter as Filter
     from ._vcf import VCF as VCF
 
     Reader = VCF | PGEN | SparseVar

--- a/python/genoray/_cli/__main__.py
+++ b/python/genoray/_cli/__main__.py
@@ -162,7 +162,7 @@ def write_svar1(
         If set, OR-collapse the ploidy axis into a single haploid call per
         sample and record ``ploidy=1`` in the output metadata.
     """
-    from genoray import PGEN, VCF, SparseVar, exprs
+    from genoray import PGEN, VCF, Filter, SparseVar, exprs
     from genoray._utils import variant_file_type
 
     file_type = variant_file_type(source)
@@ -184,6 +184,7 @@ def write_svar1(
         pl_terms.append(~exprs.is_breakend)
         record_preds.append(exprs._record_is_breakend)
 
+    vcf_filter: Filter | None
     if pl_terms:
         from functools import reduce
         from operator import and_
@@ -195,9 +196,11 @@ def write_svar1(
             _preds: tuple[Callable[[list[str]], bool], ...] = tuple(record_preds),
         ) -> bool:
             return not any(pred(rec.ALT) for pred in _preds)
+
+        vcf_filter = Filter(record=record_filter, expr=pl_filter)
     else:
         pl_filter = None
-        record_filter = None
+        vcf_filter = None
 
     if file_type == "vcf":
         if dosages is not None and Path(dosages).exists():
@@ -208,8 +211,7 @@ def write_svar1(
         vcf = VCF(
             source,
             dosage_field=dosages,
-            filter=record_filter,
-            pl_filter=pl_filter,
+            filter=vcf_filter,
         )
         SparseVar.from_vcf(
             out,

--- a/python/genoray/_modes.py
+++ b/python/genoray/_modes.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+from phantom import Phantom
+
+
+def make_array_mode(
+    name: str,
+    dtype: type[np.generic],
+    ndim: int,
+    *,
+    genos: bool = False,
+) -> type:
+    """Build a phantom ``NDArray`` mode class.
+
+    Parameters
+    ----------
+    name
+        The generated class ``__name__``.
+    dtype
+        NumPy scalar type the array must have (e.g. ``np.int8``).
+    ndim
+        Required number of dimensions (3 for genotype arrays, 2 for
+        dosage/phasing-style arrays).
+    genos
+        If True, the ploidy axis (``shape[1]``) must be in ``(2, 3)`` and
+        ``empty`` allocates a 3D ``(n_samples, ploidy, n_variants)`` array.
+    """
+
+    def predicate(obj: Any) -> bool:
+        if not (
+            isinstance(obj, np.ndarray) and obj.dtype.type == dtype and obj.ndim == ndim
+        ):
+            return False
+        if genos:
+            return obj.shape[1] in (2, 3)
+        return True
+
+    def empty(cls: type[Any], n_samples: int, ploidy: int, n_variants: int):
+        shape = (
+            (n_samples, ploidy, n_variants) if ndim == 3 else (n_samples, n_variants)
+        )
+        return cls.parse(np.empty(shape, dtype=dtype))
+
+    def nbytes_per_variant(cls: type[Any], n_samples: int, ploidy: int) -> int:
+        axis = ploidy if ndim == 3 else 1
+        return n_samples * axis * np.dtype(dtype).itemsize
+
+    def exec_body(ns: dict[str, Any]) -> dict[str, Any]:
+        ns["_dtype"] = dtype
+        ns["_gdtype"] = dtype
+        ns["empty"] = classmethod(empty)
+        ns["nbytes_per_variant"] = classmethod(nbytes_per_variant)
+        return ns
+
+    return types.new_class(
+        name, (NDArray[dtype], Phantom), {"predicate": predicate}, exec_body
+    )
+
+
+def make_tuple_mode(
+    name: str,
+    components: tuple[type, ...],
+    *,
+    genos_dtype: type[np.generic],
+) -> type:
+    """Build a phantom tuple-of-modes class (e.g. ``(Genos, Dosages)``)."""
+
+    def predicate(obj: Any) -> bool:
+        return (
+            isinstance(obj, tuple)
+            and len(obj) == len(components)
+            and all(isinstance(o, c) for o, c in zip(obj, components))
+        )
+
+    def empty(cls: type[Any], n_samples: int, ploidy: int, n_variants: int):
+        return cls.parse(
+            tuple(c.empty(n_samples, ploidy, n_variants) for c in components)
+        )
+
+    def nbytes_per_variant(cls: type[Any], n_samples: int, ploidy: int) -> int:
+        return sum(c.nbytes_per_variant(n_samples, ploidy) for c in components)
+
+    def exec_body(ns: dict[str, Any]) -> dict[str, Any]:
+        ns["_dtype"] = genos_dtype
+        ns["_gdtype"] = genos_dtype
+        ns["_dtypes"] = tuple(c._dtype for c in components)
+        ns["empty"] = classmethod(empty)
+        ns["nbytes_per_variant"] = classmethod(nbytes_per_variant)
+        return ns
+
+    return types.new_class(
+        name,
+        (tuple[components], Phantom),  # pyrefly: ignore [not-a-type]
+        {"predicate": predicate},
+        exec_body,
+    )

--- a/python/genoray/_pgen.py
+++ b/python/genoray/_pgen.py
@@ -5,7 +5,7 @@ from functools import partial
 from io import TextIOWrapper
 from pathlib import Path
 from types import TracebackType
-from typing import Any, TypeGuard, TypeVar, cast
+from typing import TypeVar, cast
 
 import numpy as np
 import pgenlib
@@ -14,11 +14,11 @@ from hirola import HashTable
 from loguru import logger
 from more_itertools import mark_ends, windowed
 from numpy.typing import ArrayLike, NDArray
-from phantom import Phantom
 from seqpro.rag import OFFSET_TYPE
 from typing_extensions import Self, assert_never, override
 from zstandard import ZstdDecompressor
 
+from ._modes import make_array_mode, make_tuple_mode
 from ._types import POS_MAX, POS_TYPE
 from ._utils import (
     ContigNormalizer,
@@ -34,117 +34,44 @@ V_IDX_TYPE = np.uint32
 """Dtype for PGEN variant indices (uint32). This determines the maximum number of unique variants in a file."""
 
 
-def _is_genos(obj: Any) -> TypeGuard[Genos]:
-    return (
-        isinstance(obj, np.ndarray)
-        and obj.dtype.type == np.int32
-        and obj.ndim == 3
-        and obj.shape[1] == 2
-    )
+_GenosBase = make_array_mode("Genos", np.int32, 3, genos=True)
+_DosagesBase = make_array_mode("Dosages", np.float32, 2)
+_PhasingBase = make_array_mode("Phasing", np.bool_, 2)
 
 
-class Genos(NDArray[np.int32], Phantom, predicate=_is_genos):
-    _dtype = np.int32
-
-    @classmethod
-    def empty(cls, n_samples: int, ploidy: int, n_variants: int) -> Self:
-        return cls.parse(np.empty((n_samples, ploidy, n_variants), dtype=cls._dtype))
+class Genos(_GenosBase):
+    pass
 
 
-def _is_dosages(obj: Any) -> TypeGuard[Dosages]:
-    return (
-        isinstance(obj, np.ndarray) and obj.dtype.type == np.float32 and obj.ndim == 2
-    )
+class Dosages(_DosagesBase):
+    pass
 
 
-class Dosages(NDArray[np.float32], Phantom, predicate=_is_dosages):
-    _dtype = np.float32
-
-    @classmethod
-    def empty(cls, n_samples: int, ploidy: int, n_variants: int) -> Self:
-        return cls.parse(np.empty((n_samples, n_variants), dtype=cls._dtype))
+class Phasing(_PhasingBase):
+    pass
 
 
-def _is_phasing(obj: Any) -> TypeGuard[Phasing]:
-    return isinstance(obj, np.ndarray) and obj.dtype.type == np.bool_ and obj.ndim == 2
+_GenosPhasingBase = make_tuple_mode(
+    "GenosPhasing", (Genos, Phasing), genos_dtype=np.int32
+)
+_GenosDosagesBase = make_tuple_mode(
+    "GenosDosages", (Genos, Dosages), genos_dtype=np.int32
+)
+_GenosPhasingDosagesBase = make_tuple_mode(
+    "GenosPhasingDosages", (Genos, Phasing, Dosages), genos_dtype=np.int32
+)
 
 
-class Phasing(NDArray[np.bool_], Phantom, predicate=_is_phasing):
-    _dtype = np.bool_
-
-    @classmethod
-    def empty(cls, n_samples: int, ploidy: int, n_variants: int) -> Self:
-        return cls.parse(np.empty((n_samples, n_variants), dtype=cls._dtype))
+class GenosPhasing(_GenosPhasingBase):
+    pass
 
 
-def _is_genos_phasing(obj: object) -> TypeGuard[GenosPhasing]:
-    return (
-        isinstance(obj, tuple)
-        and len(obj) == 2
-        and isinstance(obj[0], Genos)
-        and isinstance(obj[1], Phasing)
-    )
+class GenosDosages(_GenosDosagesBase):
+    pass
 
 
-class GenosPhasing(tuple[Genos, Phasing], Phantom, predicate=_is_genos_phasing):
-    _dtypes = (np.int32, np.bool_)
-
-    @classmethod
-    def empty(cls, n_samples: int, ploidy: int, n_variants: int) -> Self:
-        return cls.parse(
-            (
-                Genos.empty(n_samples, ploidy, n_variants),
-                Phasing.empty(n_samples, ploidy, n_variants),
-            )
-        )
-
-
-def _is_genos_dosages(obj: object) -> TypeGuard[GenosDosages]:
-    return (
-        isinstance(obj, tuple)
-        and len(obj) == 2
-        and isinstance(obj[0], Genos)
-        and isinstance(obj[1], Dosages)
-    )
-
-
-class GenosDosages(tuple[Genos, Dosages], Phantom, predicate=_is_genos_dosages):
-    _dtypes = (np.int32, np.float32)
-
-    @classmethod
-    def empty(cls, n_samples: int, ploidy: int, n_variants: int) -> Self:
-        return cls.parse(
-            (
-                Genos.empty(n_samples, ploidy, n_variants),
-                Dosages.empty(n_samples, ploidy, n_variants),
-            )
-        )
-
-
-def _is_genos_phasing_dosages(obj: object) -> TypeGuard[GenosPhasingDosages]:
-    return (
-        isinstance(obj, tuple)
-        and len(obj) == 3
-        and isinstance(obj[0], Genos)
-        and isinstance(obj[1], Phasing)
-        and isinstance(obj[2], Dosages)
-    )
-
-
-class GenosPhasingDosages(
-    tuple[Genos, Phasing, Dosages], Phantom, predicate=_is_genos_phasing_dosages
-):
-    _dtypes = (np.int32, np.bool_, np.float32)
-
-    @classmethod
-    def empty(cls, n_samples: int, ploidy: int, n_variants: int) -> Self:
-        return cls.parse(
-            (
-                Genos.empty(n_samples, ploidy, n_variants),
-                Phasing.empty(n_samples, ploidy, n_variants),
-                Dosages.empty(n_samples, ploidy, n_variants),
-            )
-        )
+class GenosPhasingDosages(_GenosPhasingDosagesBase):
+    pass
 
 
 T = TypeVar("T", Genos, Dosages, GenosPhasing, GenosDosages, GenosPhasingDosages)
@@ -1061,7 +988,7 @@ def _gen_with_length(
 
         if isinstance(out, Genos):
             # (s p)
-            hap_lens = np.full(out.shape[:-1], initial_len, dtype=np.int32)
+            hap_lens = np.full(out.shape[:-1], initial_len, dtype=np.int32)  # type: ignore
             hap_lens += hap_ilens(out, ilens[var_idx])
         else:
             # (s p)

--- a/python/genoray/_pgen.py
+++ b/python/genoray/_pgen.py
@@ -397,6 +397,25 @@ class PGEN:
         phys = self._index["index"].to_numpy()[pos].astype(V_IDX_TYPE)
         return phys, offsets
 
+    def _norm_or_warn(self, contig: str) -> str | None:
+        c = self._c_norm.norm(contig) if self._c_norm is not None else None
+        if c is None:
+            logger.warning(
+                f"Query contig {contig} not found in PGEN file, even after "
+                "normalizing for UCSC/Ensembl nomenclature."
+            )
+        return c
+
+    def _empty(self, mode: type[T], n_variants: int = 0) -> T:
+        return mode.empty(self.n_samples, self.ploidy, n_variants)
+
+    def _empty_gen(
+        self, mode: type[L], end: POS_TYPE
+    ) -> Generator[tuple[L, POS_TYPE, NDArray[V_IDX_TYPE]]]:
+        return (
+            (self._empty(mode), end, np.empty(0, dtype=V_IDX_TYPE)) for _ in range(1)
+        )
+
     def read(
         self,
         contig: str,
@@ -430,13 +449,13 @@ class PGEN:
             assert self._c_norm is not None and self._index is not None
         c = self._c_norm.norm(contig)
         if c is None:
-            return mode.empty(self.n_samples, self.ploidy, 0)
+            return self._empty(mode)
 
         var_idxs, _ = self._var_idxs_phys(c, start, end)  # type: ignore[bad-argument-type]
         n_variants = len(var_idxs)
 
         if n_variants == 0:
-            return mode.empty(self.n_samples, self.ploidy, 0)
+            return self._empty(mode)
 
         out = self._reader_for(mode)(var_idxs)
 
@@ -480,18 +499,15 @@ class PGEN:
             self._init_index()
             assert self._c_norm is not None and self._index is not None
 
-        c = self._c_norm.norm(contig)
+        c = self._norm_or_warn(contig)
         if c is None:
-            logger.warning(
-                f"Query contig {contig} not found in PGEN file, even after normalizing for UCSC/Ensembl nomenclature."
-            )
-            yield mode.empty(self.n_samples, self.ploidy, 0)
+            yield self._empty(mode)
             return
 
         var_idxs, _ = self._var_idxs_phys(c, start, end)  # type: ignore[bad-argument-type]
         n_variants = len(var_idxs)
         if n_variants == 0:
-            yield mode.empty(self.n_samples, self.ploidy, 0)
+            yield self._empty(mode)
             return
 
         mem_per_v = self._mem_per_variant(mode)
@@ -555,21 +571,14 @@ class PGEN:
             self._init_index()
             assert self._c_norm is not None and self._index is not None
 
-        c = self._c_norm.norm(contig)
+        c = self._norm_or_warn(contig)
         if c is None:
-            logger.warning(
-                f"Query contig {contig} not found in PGEN file, even after normalizing for UCSC/Ensembl nomenclature."
-            )
-            return mode.empty(self.n_samples, self.ploidy, 0), np.zeros(
-                n_ranges + 1, OFFSET_TYPE
-            )
+            return self._empty(mode), np.zeros(n_ranges + 1, OFFSET_TYPE)
 
         var_idxs, offsets = self._var_idxs_phys(c, starts, ends)
         n_variants = len(var_idxs)
         if n_variants == 0:
-            return mode.empty(self.n_samples, self.ploidy, 0), np.zeros(
-                n_ranges + 1, OFFSET_TYPE
-            )
+            return self._empty(mode), np.zeros(n_ranges + 1, OFFSET_TYPE)
 
         out = self._reader_for(mode)(var_idxs)
 
@@ -627,13 +636,10 @@ class PGEN:
             self._init_index()
             assert self._c_norm is not None and self._index is not None
 
-        c = self._c_norm.norm(contig)
+        c = self._norm_or_warn(contig)
         if c is None:
-            logger.warning(
-                f"Query contig {contig} not found in PGEN file, even after normalizing for UCSC/Ensembl nomenclature."
-            )
             for _ in range(len(starts)):
-                yield (mode.empty(self.n_samples, self.ploidy, 0) for _ in range(1))
+                yield (self._empty(mode) for _ in range(1))
             return
 
         ends = np.atleast_1d(np.asarray(ends, POS_TYPE))
@@ -643,7 +649,7 @@ class PGEN:
         tot_variants = len(var_idxs)
         if tot_variants == 0:
             for _ in range(len(starts)):
-                yield (mode.empty(self.n_samples, self.ploidy, 0) for _ in range(1))
+                yield (self._empty(mode) for _ in range(1))
             return
 
         mem_per_v = self._mem_per_variant(mode)
@@ -658,7 +664,7 @@ class PGEN:
 
         for (o_s, o_e), n_chunks in zip(windowed(offsets, 2), chunks_per_range):
             if o_s == o_e:
-                yield (mode.empty(self.n_samples, self.ploidy, 0) for _ in range(1))
+                yield (self._empty(mode) for _ in range(1))
                 continue
 
             range_idxs = var_idxs[o_s:o_e]
@@ -743,20 +749,10 @@ class PGEN:
                 and self._c_max_idxs is not None
             )
 
-        c = self._c_norm.norm(contig)
+        c = self._norm_or_warn(contig)
         if c is None:
-            logger.warning(
-                f"Query contig {contig} not found in PGEN file, even after normalizing for UCSC/Ensembl nomenclature."
-            )
             for e in ends:
-                yield (
-                    (
-                        mode.empty(self.n_samples, self.ploidy, 0),
-                        e,
-                        np.empty(0, dtype=V_IDX_TYPE),
-                    )
-                    for _ in range(1)
-                )
+                yield self._empty_gen(mode, e)
             # we have full length, no deletions in any of the ranges
             return
 
@@ -766,14 +762,7 @@ class PGEN:
         tot_variants = len(var_idxs)
         if tot_variants == 0:
             for e in ends:
-                yield (
-                    (
-                        mode.empty(self.n_samples, self.ploidy, 0),
-                        e,
-                        np.empty(0, dtype=V_IDX_TYPE),
-                    )
-                    for _ in range(1)
-                )
+                yield self._empty_gen(mode, e)
             # we have full length, no deletions in any of the ranges
             return
 
@@ -795,14 +784,7 @@ class PGEN:
             n_variants = len(range_idxs)
             if n_variants == 0:
                 # we have full length, no deletions in any of the ranges
-                yield (
-                    (
-                        mode.empty(self.n_samples, self.ploidy, 0),
-                        e,
-                        np.empty(0, dtype=V_IDX_TYPE),
-                    )
-                    for _ in range(1)
-                )
+                yield self._empty_gen(mode, e)
                 continue
 
             n_chunks = -(-n_variants // vars_per_chunk)

--- a/python/genoray/_pgen.py
+++ b/python/genoray/_pgen.py
@@ -802,25 +802,16 @@ class PGEN:
             )
 
     def _mem_per_variant(self, mode: type[T]) -> int:
-        mem = 0
+        """Calculate the memory required per variant for the given mode.
 
-        if issubclass(mode, Genos):
-            mem += self.n_samples * self.ploidy * mode._dtype().itemsize
-        elif issubclass(mode, Dosages):
-            mem += self.n_samples * mode._dtype().itemsize
-        elif issubclass(mode, GenosPhasing) or issubclass(mode, GenosDosages):
-            mem += self.n_samples * self.ploidy * mode._dtypes[0]().itemsize
-            mem += self.n_samples * mode._dtypes[1]().itemsize
-        elif issubclass(mode, GenosPhasingDosages):
-            mem += self.n_samples * self.ploidy * mode._dtypes[0]().itemsize
-            mem += self.n_samples * mode._dtypes[1]().itemsize
-            mem += self.n_samples * mode._dtypes[2]().itemsize
-        else:
-            assert_never(mode)  # type: ignore[bad-argument-type]
-
+        Returns
+        -------
+        int
+            Memory required per variant in bytes.
+        """
+        mem = mode.nbytes_per_variant(self.n_samples, self.ploidy)
         if isinstance(self._s_unsorter, np.ndarray):
-            mem *= 2  # have to make a copy to sort by samples
-
+            mem *= 2  # a copy is made to reorder by samples
         return mem
 
     def _read_genos(self, var_idxs: NDArray[V_IDX_TYPE]) -> Genos:

--- a/python/genoray/_pgen.py
+++ b/python/genoray/_pgen.py
@@ -438,18 +438,7 @@ class PGEN:
         if n_variants == 0:
             return mode.empty(self.n_samples, self.ploidy, 0)
 
-        if issubclass(mode, Genos):
-            out = self._read_genos(var_idxs)
-        elif issubclass(mode, Dosages):
-            out = self._read_dosages(var_idxs)
-        elif issubclass(mode, GenosPhasing):
-            out = self._read_genos_phasing(var_idxs)
-        elif issubclass(mode, GenosDosages):
-            out = self._read_genos_dosages(var_idxs)
-        elif issubclass(mode, GenosPhasingDosages):
-            out = self._read_genos_phasing_dosages(var_idxs)
-        else:
-            assert_never(mode)  # type: ignore[bad-argument-type]
+        out = self._reader_for(mode)(var_idxs)
 
         return cast(T, out)
 
@@ -516,18 +505,7 @@ class PGEN:
         n_chunks = -(-n_variants // vars_per_chunk)
         v_chunks = np.array_split(var_idxs, n_chunks)
         for var_idx in v_chunks:
-            if issubclass(mode, Genos):
-                _out = self._read_genos(var_idx)
-            elif issubclass(mode, Dosages):
-                _out = self._read_dosages(var_idx)
-            elif issubclass(mode, GenosPhasing):
-                _out = self._read_genos_phasing(var_idx)
-            elif issubclass(mode, GenosDosages):
-                _out = self._read_genos_dosages(var_idx)
-            elif issubclass(mode, GenosPhasingDosages):
-                _out = self._read_genos_phasing_dosages(var_idx)
-            else:
-                assert_never(mode)  # type: ignore[bad-argument-type]
+            _out = self._reader_for(mode)(var_idx)
 
             yield mode.parse(_out)
 
@@ -593,18 +571,7 @@ class PGEN:
                 n_ranges + 1, OFFSET_TYPE
             )
 
-        if issubclass(mode, Genos):
-            out = self._read_genos(var_idxs)
-        elif issubclass(mode, Dosages):
-            out = self._read_dosages(var_idxs)
-        elif issubclass(mode, GenosPhasing):
-            out = self._read_genos_phasing(var_idxs)
-        elif issubclass(mode, GenosDosages):
-            out = self._read_genos_dosages(var_idxs)
-        elif issubclass(mode, GenosPhasingDosages):
-            out = self._read_genos_phasing_dosages(var_idxs)
-        else:
-            assert_never(mode)  # type: ignore[bad-argument-type]
+        out = self._reader_for(mode)(var_idxs)
 
         return cast(T, out), offsets
 
@@ -697,18 +664,7 @@ class PGEN:
             range_idxs = var_idxs[o_s:o_e]
             v_chunks = np.array_split(range_idxs, n_chunks)
 
-            if issubclass(mode, Genos):
-                read = self._read_genos
-            elif issubclass(mode, Dosages):
-                read = self._read_dosages
-            elif issubclass(mode, GenosPhasing):
-                read = self._read_genos_phasing
-            elif issubclass(mode, GenosDosages):
-                read = self._read_genos_dosages
-            elif issubclass(mode, GenosPhasingDosages):
-                read = self._read_genos_phasing_dosages
-            else:
-                assert_never(mode)  # type: ignore[bad-argument-type]
+            read = self._reader_for(mode)
 
             yield (cast(T, read(var_idx)) for var_idx in v_chunks)
 
@@ -829,16 +785,7 @@ class PGEN:
                 f" Memory per variant: {format_memory(mem_per_v)}."
             )
 
-        if issubclass(mode, Genos):
-            read = self._read_genos
-        elif issubclass(mode, GenosPhasing):
-            read = self._read_genos_phasing
-        elif issubclass(mode, GenosDosages):
-            read = self._read_genos_dosages
-        elif issubclass(mode, GenosPhasingDosages):
-            read = self._read_genos_phasing_dosages
-        else:
-            assert_never(mode)  # type: ignore[bad-argument-type]
+        read = self._reader_for(mode, include_dosages=False)
 
         read = cast(Callable[[NDArray[np.uint32]], L], read)
 
@@ -937,6 +884,21 @@ class PGEN:
         genos_phasing = self._read_genos_phasing(var_idxs)
         dosages = self._read_dosages(var_idxs)
         return cast(GenosPhasingDosages, (*genos_phasing, dosages))
+
+    def _reader_for(self, mode: type, include_dosages: bool = True) -> Callable:
+        """Map a mode class to its bound ``_read_*`` method."""
+        table: dict[type, Callable] = {
+            Genos: self._read_genos,
+            GenosPhasing: self._read_genos_phasing,
+            GenosDosages: self._read_genos_dosages,
+            GenosPhasingDosages: self._read_genos_phasing_dosages,
+        }
+        if include_dosages:
+            table[Dosages] = self._read_dosages
+        try:
+            return table[mode]
+        except KeyError:
+            assert_never(mode)  # type: ignore[bad-argument-type]
 
 
 def _gen_with_length(

--- a/python/genoray/_svar/_convert.py
+++ b/python/genoray/_svar/_convert.py
@@ -18,7 +18,7 @@ from seqpro.rag import Ragged, lengths_to_offsets
 
 from .._types import DOSAGE_TYPE, POS_TYPE, V_IDX_TYPE
 from .._utils import atomic_write_dir, format_memory, parse_memory
-from .._vcf import VCF
+from .._vcf import VCF, Filter
 from ._io import (
     _open_fmt,
     _open_genos,
@@ -179,10 +179,16 @@ def _process_contig_vcf(
     keep_local: np.ndarray | None = None,
     haploid: bool = False,
 ) -> tuple[int, int]:
+    vcf_filter: Filter | None = None
+    if cyvcf2_filter is not None:
+        assert pl_filter is not None, (
+            "cyvcf2_filter and pl_filter must be provided together"
+        )
+        vcf_filter = Filter(record=cyvcf2_filter, expr=pl_filter)
+
     vcf = VCF(
         path,
-        filter=cyvcf2_filter,
-        pl_filter=pl_filter,
+        filter=vcf_filter,
         dosage_field=dosage_field,
         with_gvi_index=False,
     )

--- a/python/genoray/_svar/_core.py
+++ b/python/genoray/_svar/_core.py
@@ -629,7 +629,7 @@ class SparseVar(SparseVarAnnotateMixin, Generic[_SRT]):
 
         # --- build working index (filtered) and resolve kept rows ---
         working_df, alt_is_utf8, ilen_added = _build_working_index(
-            vcf._index_path(), vcf._pl_filter
+            vcf._index_path(), vcf._filter.expr if vcf._filter is not None else None
         )
         if regions is None:
             kept_rows = working_df["index"].to_numpy().astype(V_IDX_TYPE)
@@ -696,8 +696,10 @@ class SparseVar(SparseVarAnnotateMixin, Generic[_SRT]):
                     contig=c,
                     chunk_dir=chunk_dir,
                     chunk_idx=chunk_idx,
-                    cyvcf2_filter=vcf._filter,
-                    pl_filter=vcf._pl_filter,
+                    cyvcf2_filter=vcf._filter.record
+                    if vcf._filter is not None
+                    else None,
+                    pl_filter=vcf._filter.expr if vcf._filter is not None else None,
                     caller_samples=None if samples is None else caller_samples,
                     keep_local=keep_local_by_contig.get(c),
                     haploid=haploid,

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -874,15 +874,6 @@ class VCF:
         info: list[str] | None = None,
         lazy: bool = False,
     ) -> pl.DataFrame | pl.LazyFrame: ...
-    def _oxbow_reader(self) -> Callable:
-        """Return the oxbow reader callable appropriate for this file's extension."""
-        if self.path.suffix == ".bcf":
-            return oxbow.from_bcf
-        elif re.search(r"\.vcf(\.gz)?$", self.path.name) is not None:
-            return oxbow.from_vcf
-        else:
-            raise ValueError(f"Unsupported file extension: {self.path.suffix}")
-
     def get_record_info(
         self,
         contig: str | None = None,
@@ -951,6 +942,15 @@ class VCF:
             df = df.collect()
 
         return df
+
+    def _oxbow_reader(self) -> Callable:
+        """Return the oxbow reader callable appropriate for this file's extension."""
+        if self.path.suffix == ".bcf":
+            return oxbow.from_bcf
+        elif re.search(r"\.vcf(\.gz)?$", self.path.name) is not None:
+            return oxbow.from_vcf
+        else:
+            raise ValueError(f"Unsupported file extension: {self.path.suffix}")
 
     def _declared_info_fields(self, candidates: tuple[str, ...]) -> list[str]:
         """Return which of ``candidates`` are declared as INFO fields in the VCF header.

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -660,16 +660,10 @@ class VCF:
                     ]
 
             if ds_buffer is not None:
-                d = v.format(self.dosage_field)
-                if d is None:
-                    raise DosageFieldError(
-                        f"Dosage field '{self.dosage_field}' not found for record {v!r}"
-                    )
-                if d.shape[1] > 1:
-                    raise MultiallelicDosageError(
-                        f"Multiallelic dosages are not supported, encountered in VCF record {v!r}"
-                    )
-                ds_buffer[..., i] = d.squeeze(1)[self._s_sorter]
+                assert self.dosage_field is not None
+                ds_buffer[..., i] = self._extract_dosage(v, self.dosage_field)[
+                    self._s_sorter
+                ]
 
             i += 1
 
@@ -1251,6 +1245,21 @@ class VCF:
 
         return out, v.end  # type: ignore
 
+    def _extract_dosage(
+        self, v: cyvcf2.Variant, dosage_field: str
+    ) -> NDArray[np.float32]:
+        """Fetch, validate, and squeeze the per-sample dosage for one record."""
+        d = v.format(dosage_field)
+        if d is None:
+            raise DosageFieldError(
+                f"Dosage field '{dosage_field}' not found for record {v!r}"
+            )
+        if d.shape[1] > 1:
+            raise MultiallelicDosageError(
+                f"Multiallelic dosages are not supported, encountered in VCF record {v!r}"
+            )
+        return d.squeeze(1)
+
     def _fill_dosages(
         self, vcf: cyvcf2.VCF, out: Dosages | None, dosage_field: str
     ) -> tuple[Dosages, int]:
@@ -1260,17 +1269,7 @@ class VCF:
         if out is None:
             out_ls: list[NDArray[np.float32]] = []
             for v in vcf:
-                d = v.format(dosage_field)
-                if d is None:
-                    raise DosageFieldError(
-                        f"Dosage field '{dosage_field}' not found for record {v!r}"
-                    )
-                if d.shape[1] > 1:
-                    raise MultiallelicDosageError(
-                        f"Multiallelic dosages are not supported, encountered in VCF record {v!r}"
-                    )
-
-                out_ls.append(d.squeeze(1))
+                out_ls.append(self._extract_dosage(v, dosage_field))
 
                 if self._pbar is not None:
                     self._pbar.update()
@@ -1296,16 +1295,7 @@ class VCF:
         i = 0
         for i, v in enumerate(vcf):
             # (samples alts)
-            d = v.format(dosage_field)
-            if d is None:
-                raise DosageFieldError(
-                    f"Dosage field '{dosage_field}' not found for record {v!r}"
-                )
-            if d.shape[1] > 1:
-                raise MultiallelicDosageError(
-                    f"Multiallelic dosages are not supported, encountered in VCF record {v!r}"
-                )
-            out[..., i] = d.squeeze(1)[self._s_sorter]
+            out[..., i] = self._extract_dosage(v, dosage_field)[self._s_sorter]
 
             if self._pbar is not None:
                 self._pbar.update()
@@ -1343,17 +1333,7 @@ class VCF:
                     # (s p) np.int16
                     geno_ls.append(v.genotype.array()[:, : self.ploidy])
 
-                d = v.format(dosage_field)
-                if d is None:
-                    raise DosageFieldError(
-                        f"Dosage field '{dosage_field}' not found for record {v!r}"
-                    )
-                if d.shape[1] > 1:
-                    raise MultiallelicDosageError(
-                        f"Multiallelic dosages are not supported, encountered in VCF record {v!r}"
-                    )
-
-                dosage_ls.append(d.squeeze(1))
+                dosage_ls.append(self._extract_dosage(v, dosage_field))
 
                 if self._pbar is not None:
                     self._pbar.update()
@@ -1390,16 +1370,7 @@ class VCF:
             else:
                 out[0][..., i] = v.genotype.array()[self._s_sorter, : self.ploidy]
 
-            d = v.format(dosage_field)
-            if d is None:
-                raise DosageFieldError(
-                    f"Dosage field '{dosage_field}' not found for record {v!r}"
-                )
-            if d.shape[1] > 1:
-                raise MultiallelicDosageError(
-                    f"Multiallelic dosages are not supported, encountered in VCF record {v!r}"
-                )
-            out[1][..., i] = d.squeeze(1)[self._s_sorter]
+            out[1][..., i] = self._extract_dosage(v, dosage_field)[self._s_sorter]
 
             if ilens is not None:
                 ilens[i] = len(v.ALT[0]) - len(v.REF)
@@ -1523,13 +1494,8 @@ class VCF:
                 genos = v.genotype.array()[:, :ploidy, None]
                 genos = genos.astype(mode._gdtype)
 
-                dosages = v.format(dosage_field)
-                if dosages is None:
-                    raise DosageFieldError(
-                        f"Dosage field '{dosage_field}' not found for record {v!r}"
-                    )
                 # (s, 1, 1) or (s, 1)? -> (s)
-                dosages = dosages.squeeze(1)[self._s_sorter, None]
+                dosages = self._extract_dosage(v, dosage_field)[self._s_sorter, None]
 
                 ls_geno_dosages.append((genos, dosages))  # type: ignore
 

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -1358,34 +1358,16 @@ class VCF:
         return out, v.end  # type: ignore
 
     def _mem_per_variant(self, mode: type[T]) -> int:
-        """Calculate the memory required per variant for the given genotypes and dosages.
-
-        Parameters
-        ----------
-        genotypes
-            Whether to include genotypes.
-        dosages
-            Whether to include dosages.
+        """Calculate the memory required per variant for the given mode.
 
         Returns
         -------
         int
             Memory required per variant in bytes.
         """
-        mem = 0
-
-        ploidy = self.ploidy + self.phasing
-
-        if issubclass(mode, (Genos8, Genos16)):
-            mem += self.n_samples * ploidy * mode._gdtype().itemsize
-        elif issubclass(mode, Dosages):
-            mem += self.n_samples * np.float32().itemsize
-        elif issubclass(mode, (Genos8Dosages, Genos16Dosages)):
-            mem += self.n_samples * ploidy * mode._gdtype().itemsize
-            mem += self.n_samples * np.float32().itemsize
-        else:
-            assert_never(mode)  # type: ignore[bad-argument-type]
-
+        mem = mode.nbytes_per_variant(self.n_samples, self.ploidy + self.phasing)
+        if isinstance(self._s_sorter, np.ndarray):
+            mem *= 2  # a copy is made to reorder by samples
         return mem
 
     def _ext_genos_with_length(

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Literal, TypeGuard, TypeVar, cast, overload
+from typing import Literal, TypeVar, cast, overload
 
 import cyvcf2
 from hirola import HashTable
@@ -17,11 +17,11 @@ from loguru import logger
 from more_itertools import mark_ends
 from natsort import natsorted
 from numpy.typing import ArrayLike, NDArray
-from phantom import Phantom
 from seqpro.rag import OFFSET_TYPE
 from tqdm.auto import tqdm
 from typing_extensions import Self, assert_never
 
+from ._modes import make_array_mode, make_tuple_mode
 from ._types import POS_MAX, POS_TYPE
 from ._utils import (
     ContigNormalizer,
@@ -45,129 +45,37 @@ class MultiallelicDosageError(RuntimeError): ...
 
 GDTYPE = TypeVar("GDTYPE", np.int8, np.int16)
 
-
-def _is_genos8(obj: Any) -> TypeGuard[NDArray[np.int8]]:
-    return (
-        isinstance(obj, np.ndarray)
-        and obj.dtype.type == np.int8
-        and obj.ndim == 3
-        and obj.shape[1] in (2, 3)  # diploid with/without phasing
-    )
+_Genos8Base = make_array_mode("Genos8", np.int8, 3, genos=True)
+_Genos16Base = make_array_mode("Genos16", np.int16, 3, genos=True)
+_DosagesBase = make_array_mode("Dosages", np.float32, 2)
 
 
-class Genos8(NDArray[np.int8], Phantom, predicate=_is_genos8):
-    _gdtype = np.int8
-
-    @classmethod
-    def empty(
-        cls, n_samples: int, ploidy: int, n_variants: int, phasing: bool
-    ) -> Genos8:
-        return cls.parse(np.empty((n_samples, ploidy + phasing, n_variants), np.int8))
+class Genos8(_Genos8Base):
+    pass
 
 
-def _is_genos16(obj: Any) -> TypeGuard[NDArray[np.int16]]:
-    return (
-        isinstance(obj, np.ndarray)
-        and obj.dtype.type == np.int16
-        and obj.ndim == 3
-        and obj.shape[1] in (2, 3)  # diploid with/without phasing
-    )
+class Genos16(_Genos16Base):
+    pass
 
 
-class Genos16(NDArray[np.int16], Phantom, predicate=_is_genos16):
-    _gdtype = np.int16
-
-    @classmethod
-    def empty(
-        cls, n_samples: int, ploidy: int, n_variants: int, phasing: bool
-    ) -> Genos16:
-        return cls.parse(np.empty((n_samples, ploidy + phasing, n_variants), np.int16))
+class Dosages(_DosagesBase):
+    pass
 
 
-def _is_dosages(obj: Any) -> TypeGuard[NDArray[np.float32]]:
-    return (
-        isinstance(obj, np.ndarray) and obj.dtype.type == np.float32 and obj.ndim == 2
-    )
+_Genos8DosagesBase = make_tuple_mode(
+    "Genos8Dosages", (Genos8, Dosages), genos_dtype=np.int8
+)
+_Genos16DosagesBase = make_tuple_mode(
+    "Genos16Dosages", (Genos16, Dosages), genos_dtype=np.int16
+)
 
 
-class Dosages(NDArray[np.float32], Phantom, predicate=_is_dosages):
-    @classmethod
-    def empty(
-        cls, n_samples: int, ploidy: int, n_variants: int, phasing: bool
-    ) -> Dosages:
-        return cls.parse(np.empty((n_samples, n_variants), np.float32))
+class Genos8Dosages(_Genos8DosagesBase):
+    pass
 
 
-def _is_genos8_dosages(obj: Any) -> TypeGuard[tuple[Genos8, Dosages]]:
-    """Check if the object is a tuple of genotypes and dosages.
-
-    Parameters
-    ----------
-    obj
-        Object to check.
-
-    Returns
-    -------
-    bool
-        True if the object is a tuple of genotypes and dosages, False otherwise.
-    """
-    return (
-        isinstance(obj, tuple)
-        and len(obj) == 2
-        and isinstance(obj[0], Genos8)
-        and isinstance(obj[1], Dosages)
-    )
-
-
-class Genos8Dosages(tuple[Genos8, Dosages], Phantom, predicate=_is_genos8_dosages):
-    _gdtype = np.int8
-
-    @classmethod
-    def empty(
-        cls, n_samples: int, ploidy: int, n_variants: int, phasing: bool
-    ) -> Genos8Dosages:
-        return cls.parse(
-            (
-                Genos8.empty(n_samples, ploidy, n_variants, phasing),
-                Dosages.empty(n_samples, ploidy, n_variants, phasing),
-            )
-        )
-
-
-def _is_genos16_dosages(obj: object) -> TypeGuard[tuple[Genos16, Dosages]]:
-    """Check if the object is a tuple of genotypes and dosages.
-
-    Parameters
-    ----------
-    obj
-        Object to check.
-
-    Returns
-    -------
-    bool
-        True if the object is a tuple of genotypes and dosages, False otherwise.
-    """
-    return (
-        isinstance(obj, tuple)
-        and len(obj) == 2
-        and isinstance(obj[0], Genos16)
-        and isinstance(obj[1], Dosages)
-    )
-
-
-class Genos16Dosages(tuple[Genos16, Dosages], Phantom, predicate=_is_genos16_dosages):
-    _gdtype = np.int16
-
-    @classmethod
-    def empty(
-        cls, n_samples: int, ploidy: int, n_variants: int, phasing: bool
-    ) -> Genos16Dosages:
-        return cls.parse(
-            (
-                Genos16.empty(n_samples, ploidy, n_variants, phasing),
-                Dosages.empty(n_samples, ploidy, n_variants, phasing),
-            )
-        )
+class Genos16Dosages(_Genos16DosagesBase):
+    pass
 
 
 T = TypeVar("T", Genos8, Genos16, Dosages, Genos8Dosages, Genos16Dosages)
@@ -607,7 +515,7 @@ class VCF:
             logger.warning(
                 f"Query contig {contig} not found in VCF file, even after normalizing for UCSC/Ensembl nomenclature."
             )
-            return mode.empty(self.n_samples, self.ploidy, 0, self.phasing)  # type: ignore[bad-return]
+            return mode.empty(self.n_samples, self.ploidy + self.phasing, 0)  # type: ignore[bad-return]
 
         start = max(0, start)  # type: ignore
 
@@ -616,7 +524,7 @@ class VCF:
             if self._index is not None:
                 n_variants = self.n_vars_in_ranges(c, start, end)[0]  # type: ignore[bad-argument-type]
                 if n_variants == 0:
-                    return mode.empty(self.n_samples, self.ploidy, 0, self.phasing)  # type: ignore[bad-return]
+                    return mode.empty(self.n_samples, self.ploidy + self.phasing, 0)  # type: ignore[bad-return]
             else:
                 n_variants = None
 
@@ -625,7 +533,7 @@ class VCF:
                     data = None
                 else:
                     data = mode.empty(
-                        self.n_samples, self.ploidy, n_variants, self.phasing
+                        self.n_samples, self.ploidy + self.phasing, n_variants
                     )
                 data, _ = self._fill_genos(vcf, data, mode=mode)
             elif issubclass(mode, Dosages):
@@ -634,7 +542,7 @@ class VCF:
                     data = None
                 else:
                     data = mode.empty(
-                        self.n_samples, self.ploidy, n_variants, self.phasing
+                        self.n_samples, self.ploidy + self.phasing, n_variants
                     )
                 data, _ = self._fill_dosages(vcf, data, self.dosage_field)
             elif issubclass(mode, (Genos8Dosages, Genos16Dosages)):
@@ -643,7 +551,7 @@ class VCF:
                     data = None
                 else:
                     data = mode.empty(
-                        self.n_samples, self.ploidy, n_variants, self.phasing
+                        self.n_samples, self.ploidy + self.phasing, n_variants
                     )
                 data, _ = self._fill_genos_and_dosages(
                     vcf, data, self.dosage_field, mode=mode
@@ -712,7 +620,7 @@ class VCF:
             logger.warning(
                 f"Query contig {contig} not found in VCF file, even after normalizing for UCSC/Ensembl nomenclature."
             )
-            yield mode.empty(self.n_samples, self.ploidy, 0, self.phasing)  # type: ignore[invalid-yield]
+            yield mode.empty(self.n_samples, self.ploidy + self.phasing, 0)  # type: ignore[invalid-yield]
             return
 
         start = max(0, start)  # type: ignore
@@ -725,7 +633,7 @@ class VCF:
                 + f" Memory per variant: {format_memory(mem_per_v)}."
             )
 
-        buffer = mode.empty(self.n_samples, self.ploidy, vars_per_chunk, self.phasing)
+        buffer = mode.empty(self.n_samples, self.ploidy + self.phasing, vars_per_chunk)
         if isinstance(buffer, (Genos8, Genos16)):
             gt_buffer = buffer
             ds_buffer = None
@@ -845,7 +753,7 @@ class VCF:
             )
             for e in ends:
                 yield (  # type: ignore[invalid-yield]
-                    (mode.empty(self.n_samples, self.ploidy, 0, self.phasing), e, 0)
+                    (mode.empty(self.n_samples, self.ploidy + self.phasing, 0), e, 0)
                     for _ in range(1)
                 )
             return
@@ -855,7 +763,7 @@ class VCF:
         if tot_variants == 0:
             for e in ends:
                 yield (  # type: ignore[invalid-yield]
-                    (mode.empty(self.n_samples, self.ploidy, 0, self.phasing), e, 0)
+                    (mode.empty(self.n_samples, self.ploidy + self.phasing, 0), e, 0)
                     for _ in range(1)
                 )
             return
@@ -874,7 +782,7 @@ class VCF:
         for s, e, n in zip(starts, ends, n_variants):
             if n == 0:
                 yield (  # type: ignore[invalid-yield]
-                    (mode.empty(self.n_samples, self.ploidy, 0, self.phasing), e, 0)
+                    (mode.empty(self.n_samples, self.ploidy + self.phasing, 0), e, 0)
                     for _ in range(1)
                 )
                 continue
@@ -917,13 +825,13 @@ class VCF:
             if issubclass(mode, (Genos8, Genos16)):
                 out = cast(
                     Genos8 | Genos16,
-                    mode.empty(self.n_samples, self.ploidy, chunk_size, self.phasing),
+                    mode.empty(self.n_samples, self.ploidy + self.phasing, chunk_size),
                 )
                 out, last_end = self._fill_genos(vcf, out, ilens)
                 hap_lens += hap_ilens(out[:, : self.ploidy], ilens)
             elif issubclass(mode, (Genos8Dosages, Genos16Dosages)):
                 self.dosage_field = cast(str, self.dosage_field)
-                out = mode.empty(self.n_samples, self.ploidy, chunk_size, self.phasing)
+                out = mode.empty(self.n_samples, self.ploidy + self.phasing, chunk_size)
                 out, last_end = self._fill_genos_and_dosages(
                     vcf, out, self.dosage_field, ilens
                 )
@@ -1301,7 +1209,7 @@ class VCF:
                     self._pbar.update()
 
             if len(out_ls) == 0:
-                return mode.empty(self.n_samples, self.ploidy, 0, self.phasing), 0
+                return mode.empty(self.n_samples, self.ploidy + self.phasing, 0), 0
 
             # (s p v)
             out = cast(
@@ -1368,7 +1276,7 @@ class VCF:
                     self._pbar.update()
 
             if len(out_ls) == 0:
-                return Dosages.empty(self.n_samples, self.ploidy, 0, self.phasing), 0
+                return Dosages.empty(self.n_samples, self.ploidy + self.phasing, 0), 0
 
             _out = cast(
                 Dosages, np.stack(out_ls, axis=-1, dtype=np.float32)[self._s_sorter]
@@ -1451,7 +1359,7 @@ class VCF:
                     self._pbar.update()
 
             if len(geno_ls) == 0:
-                out = mode.empty(self.n_samples, self.ploidy, 0, self.phasing)
+                out = mode.empty(self.n_samples, self.ploidy + self.phasing, 0)
                 return out, 0
 
             genos = cast(

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -4,6 +4,7 @@ import re
 import warnings
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeVar, cast, overload
 
@@ -98,6 +99,20 @@ class _Index:
         self.df = df
 
 
+@dataclass(frozen=True)
+class Filter:
+    """A cyvcf2 record predicate paired with its matching ``.gvi`` polars expression.
+
+    Both travel together so the record scan (``record``) and the index-level
+    filter (``expr``) can never diverge. ``record`` should return True for
+    variants to keep; ``expr`` must be an equivalent predicate over the index
+    columns (``CHROM``, ``POS``, ``REF``, ``ALT``, ``ILEN``).
+    """
+
+    record: Callable[[cyvcf2.Variant], bool]
+    expr: pl.Expr
+
+
 class VCF:
     """Create a VCF reader.
 
@@ -106,22 +121,22 @@ class VCF:
     path
         Path to the VCF file.
     filter
-        Function to filter variants. Should return True for variants to keep.
+        A :class:`Filter` bundling a cyvcf2 record predicate with its matching
+        ``.gvi`` polars expression, or ``None`` to disable filtering.
 
         .. note::
-            To avoid KeyErrors, this function needs to be tolerant to missing fields. For example, if you
+            The ``record`` predicate needs to be tolerant to missing fields. For example, if you
             access an INFO or FORMAT field, not all variants are guaranteed to have the same fields.
             The `cyvcf2.Variant <https://brentp.github.io/cyvcf2/docstrings.html#cyvcf2.cyvcf2.Variant>`_
             API provides the :meth:`.get <dict.get>` method on the INFO and FORMAT attributes. For example,
             :code:`lambda v: v.INFO.get("AF", 0) > 0.05` will skip any variants with an AF <= 0.05 or a
             missing AF by treating missing AFs as 0.
-    pl_filter
-        Polars expression to filter variants. Should return True for variants to keep. Must match the filter function.
 
         .. note::
-            This expression will be applied to the polars DataFrame returned by :meth:`get_record_info`.
-            It is not applied to the VCF file itself, so it will not be able to use the cyvcf2.Variant API.
-            For example, if you want to filter variants by INFO field, you can use:
+            The ``expr`` polars expression will be applied to the polars DataFrame returned by
+            :meth:`get_record_info`. It is not applied to the VCF file itself, so it will not be
+            able to use the cyvcf2.Variant API. For example, if you want to filter variants by INFO
+            field, you can use:
             :code:`pl.col("AF") > 0.05`
             but you can not use:
             :code:`lambda v: v.INFO.get("AF", 0) > 0.05`
@@ -146,10 +161,8 @@ class VCF:
     """Naturally sorted list of available contigs in the VCF file."""
     ploidy: int = 2
     """Ploidy of the VCF file. This is currently always 2 since we use cyvcf2."""
-    _filter: Callable[[cyvcf2.Variant], bool] | None
-    """Function to filter variants. Should return True for variants to keep."""
-    _pl_filter: pl.Expr | None
-    """Polars expression to filter variants. Should return True for variants to keep. Must match the filter function."""
+    _filter: Filter | None
+    """The record predicate + matching polars expression currently in effect."""
     phasing: bool
     """Whether to include phasing information on genotypes. If True, the ploidy axis will be length 3 such that
     phasing is indicated by the 3rd value: 0 = unphased, 1 = phased. If False, the ploidy axis will be length 2."""
@@ -178,21 +191,17 @@ class VCF:
     def __init__(
         self,
         path: str | Path,
-        filter: Callable[[cyvcf2.Variant], bool] | None = None,
-        pl_filter: pl.Expr | None = None,
+        filter: Filter | None = None,
         phasing: bool = False,
         dosage_field: str | None = None,
         progress: bool = False,
         with_gvi_index: bool = True,
     ):
-        self._check_filter_pair(filter, pl_filter)
-
         self.path = Path(path)
         if not self.path.exists():
             raise FileNotFoundError(f"VCF file {self.path} does not exist.")
 
         self._filter = filter
-        self._pl_filter = pl_filter
         self.phasing = phasing
         self.dosage_field = dosage_field
         self.progress = progress
@@ -215,30 +224,13 @@ class VCF:
     def _open(self) -> cyvcf2.VCF:
         return cyvcf2.VCF(self.path, samples=self._samples, lazy=True)
 
-    @staticmethod
-    def _check_filter_pair(
-        filter: Callable[[cyvcf2.Variant], bool] | None,
-        pl_filter: pl.Expr | None,
-    ) -> None:
-        """Enforce the both-or-neither invariant on a (filter, pl_filter) pair."""
-        if (filter is not None and pl_filter is None) or (
-            filter is None and pl_filter is not None
-        ):
-            raise ValueError(
-                "If a filter function is provided, a polars expression must also be provided, and vice versa."
-            )
-
     @property
-    def filter(
-        self,
-    ) -> tuple[Callable[[cyvcf2.Variant], bool] | None, pl.Expr | None]:
-        """The ``(filter, pl_filter)`` pair currently in effect.
+    def filter(self) -> Filter | None:
+        """The :class:`Filter` currently in effect, or ``None`` if no filter is set.
 
-        Returns the cyvcf2 record callable and its matching polars expression as
-        a tuple, mirroring what the setter accepts. Both elements are ``None``
-        when no filter is set. Assigning ``vcf.filter = vcf.filter`` round-trips.
+        Assigning ``vcf.filter = vcf.filter`` round-trips.
         """
-        return self._filter, self._pl_filter
+        return self._filter
 
     def _index_path(self) -> Path:
         """Path to the index file."""
@@ -249,31 +241,20 @@ class VCF:
             return base.with_suffix(".gvi.zst")
 
     @filter.setter
-    def filter(
-        self,
-        value: tuple[Callable[[cyvcf2.Variant], bool] | None, pl.Expr | None] | None,
-    ):
-        """Set the record filter and its matching polars expression together.
+    def filter(self, value: Filter | None):
+        """Set the record + index filter together, or clear it with ``None``.
 
-        Assign a ``(filter, pl_filter)`` pair, or ``None`` to clear both. The VCF
-        path requires both a cyvcf2 record callable (for the genotype scan) and a
-        matching polars expression (for the ``.gvi`` index); they must be set
-        together, mirroring the constructor's both-or-neither invariant. Changing
-        the filter invalidates the in-memory index.
+        Assign a :class:`Filter` bundling the cyvcf2 record predicate (for the
+        genotype scan) and the matching polars expression (for the ``.gvi``
+        index), or ``None`` to disable filtering. Changing the filter
+        invalidates the in-memory index.
         """
-        if value is None:
-            filter = pl_filter = None
-        elif isinstance(value, tuple) and len(value) == 2:
-            filter, pl_filter = value
-        else:
+        if value is not None and not isinstance(value, Filter):
             raise TypeError(
-                "VCF.filter must be assigned a (filter, pl_filter) tuple or None; "
-                f"got {type(value).__name__}."
+                f"VCF.filter must be a genoray.Filter or None; got {type(value).__name__}."
             )
-        self._check_filter_pair(filter, pl_filter)
         self._index = None
-        self._filter = filter
-        self._pl_filter = pl_filter
+        self._filter = value
 
     @property
     def nbytes(self) -> int:
@@ -409,7 +390,7 @@ class VCF:
             if self._filter is None:
                 out[i] = sum(1 for _ in self._vcf(coord))
             else:
-                out[i] = sum(self._filter(v) for v in self._vcf(coord))
+                out[i] = sum(self._filter.record(v) for v in self._vcf(coord))
 
         return out
 
@@ -630,7 +611,7 @@ class VCF:
 
         vcf = self._vcf(f"{c}:{int(start + 1)}-{end}")  # range string is 1-based
         if self._filter is not None:
-            vcf = filter(self._filter, vcf)
+            vcf = filter(self._filter.record, vcf)
         if self.progress and self._pbar is None:
             vcf = tqdm(vcf, desc="Reading VCF", unit=" variant")
         i = 0
@@ -935,8 +916,8 @@ class VCF:
             .with_columns(pl.col("CHROM").cast(pl.Enum(self.contigs)))
         )
 
-        if self._pl_filter is not None:
-            df = df.filter(self._pl_filter)
+        if self._filter is not None:
+            df = df.filter(self._filter.expr)
 
         if not lazy:
             df = df.collect()
@@ -1030,12 +1011,12 @@ class VCF:
         user_info_upper = {i.upper() for i in info} if info else set()
         extra_sv = [f for f in sv_info if f.upper() not in user_info_upper]
 
-        filt = self._pl_filter
-        self._pl_filter = None
+        filt = self._filter
+        self._filter = None
         try:
             index = self.get_record_info(fields=list(_fields), info=info, lazy=True)
         finally:
-            self._pl_filter = filt
+            self._filter = filt
 
         # Fetch SV helper columns directly (oxbow requires uppercase and returns a struct).
         # Both oxbow reads cover the identical full record set (no region, no filter, same
@@ -1128,8 +1109,8 @@ class VCF:
         if schema["ALT"] == pl.Utf8:
             index = index.with_columns(pl.col("ALT").str.split(","))
 
-        if self._pl_filter is not None:
-            index = index.filter(self._pl_filter)
+        if self._filter is not None:
+            index = index.filter(self._filter.expr)
 
         if "ILEN" not in schema:
             index = index.with_columns(ILEN=ILEN)
@@ -1156,7 +1137,7 @@ class VCF:
         mode: type[Genos8 | Genos16] | None = None,
     ) -> tuple[Genos8 | Genos16, int]:
         if self._filter is not None:
-            vcf = filter(self._filter, vcf)
+            vcf = filter(self._filter.record, vcf)
 
         if out is None:
             assert mode is not None
@@ -1237,7 +1218,7 @@ class VCF:
         self, vcf: cyvcf2.VCF, out: Dosages | None, dosage_field: str
     ) -> tuple[Dosages, int]:
         if self._filter is not None:
-            vcf = filter(self._filter, vcf)
+            vcf = filter(self._filter.record, vcf)
 
         if out is None:
             out_ls: list[NDArray[np.float32]] = []
@@ -1290,7 +1271,7 @@ class VCF:
         mode: type[Genos8Dosages | Genos16Dosages] | None = None,
     ) -> tuple[Genos8Dosages | Genos16Dosages, int]:
         if self._filter is not None:
-            vcf = filter(self._filter, vcf)
+            vcf = filter(self._filter.record, vcf)
 
         if out is None:
             assert mode is not None
@@ -1395,7 +1376,7 @@ class VCF:
             )
             for i, v in enumerate(self._vcf(coord)):
                 if v.start < ext_start or (
-                    self._filter is not None and not self._filter(v)
+                    self._filter is not None and not self._filter.record(v)
                 ):
                     continue
 

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -467,8 +467,12 @@ class VCF:
     def _empty(self, mode: type[T], n_variants: int = 0) -> T:
         return mode.empty(self.n_samples, self.ploidy + self.phasing, n_variants)
 
-    def _empty_gen(self, mode: type[L], end: int) -> Generator[tuple[L, int, int]]:
-        return ((self._empty(mode), end, 0) for _ in range(1))
+    def _empty_gen(
+        self, mode: type[L], end: POS_TYPE
+    ) -> Generator[tuple[L, POS_TYPE, NDArray[V_IDX_TYPE]]]:
+        return (
+            (self._empty(mode), end, np.empty(0, dtype=V_IDX_TYPE)) for _ in range(1)
+        )
 
     def read(
         self,
@@ -664,7 +668,7 @@ class VCF:
         mode: type[L] = Genos16,
     ) -> Generator[
         Generator[
-            tuple[L, int, int]  # data, end, n_extension_vars
+            tuple[L, POS_TYPE, NDArray[V_IDX_TYPE]]  # data, end, chunk_idxs
         ]
     ]:
         """Read genotypes and/or dosages in chunks approximately limited by :code:`max_mem`.
@@ -727,15 +731,20 @@ class VCF:
                 f" Memory per variant: {format_memory(mem_per_v)}."
             )
 
+        v_idx, v_offsets = self._var_idxs(c, starts, ends)  # starts still 0-based here
+
         starts = starts + 1  # cyvcf2 queries are 1-based
         ends = np.atleast_1d(np.asarray(ends, POS_TYPE))
 
-        for s, e, n in zip(starts, ends, n_variants):
+        for ri, (s, e, n) in enumerate(zip(starts, ends, n_variants)):
             if n == 0:
                 yield self._empty_gen(mode, e)  # type: ignore[invalid-yield]
                 continue
 
-            yield self._chunk_with_length_helper(n, vars_per_chunk, c, s, e, mode)
+            range_idxs = v_idx[v_offsets[ri] : v_offsets[ri + 1]].astype(V_IDX_TYPE)
+            yield self._chunk_with_length_helper(
+                n, vars_per_chunk, c, s, e, mode, range_idxs
+            )
 
     def _chunk_with_length_helper(
         self,
@@ -745,7 +754,8 @@ class VCF:
         start: POS_TYPE,
         end: POS_TYPE,
         mode: type[L],
-    ) -> Generator[tuple[L, int, int]]:
+        range_idxs: NDArray[V_IDX_TYPE],
+    ) -> Generator[tuple[L, POS_TYPE, NDArray[V_IDX_TYPE]]]:
         if (
             issubclass(mode, (Genos8Dosages, Genos16Dosages))
             and self.dosage_field is None
@@ -768,6 +778,7 @@ class VCF:
 
         vcf = self._vcf(f"{contig}:{start}-{end}")
         hap_lens = np.full((self.n_samples, self.ploidy), end - start, dtype=np.int32)
+        consumed = 0
         for _, is_last, chunk_size in mark_ends(chunk_sizes):
             ilens = np.empty(chunk_size, dtype=np.int32)
             if issubclass(mode, (Genos8, Genos16)):
@@ -787,8 +798,15 @@ class VCF:
             else:
                 assert_never(mode)  # type: ignore[bad-argument-type]
 
+            # chunk_size may carry a numpy uint dtype (from vars_per_chunk); adding a
+            # python int to a numpy uint64 upcasts to float64, which is invalid as a
+            # slice bound, so normalize to a plain int first.
+            chunk_size = int(chunk_size)
+            base_idxs = range_idxs[consumed : consumed + chunk_size]
+            consumed += chunk_size
+
             if not is_last:
-                yield cast(L, out), last_end, 0
+                yield cast(L, out), cast(POS_TYPE, last_end), base_idxs
                 continue
 
             if issubclass(mode, (Genos8, Genos16)):
@@ -818,11 +836,17 @@ class VCF:
                         for o, ls in zip(out, zip(*ls_ext))
                     )
 
-            yield (
-                cast(L, out),
-                last_end,
-                len(ls_ext),
-            )
+                last_in_range = int(range_idxs[-1])
+                ext_idxs = np.arange(
+                    last_in_range + 1,
+                    last_in_range + 1 + len(ls_ext),
+                    dtype=V_IDX_TYPE,
+                )
+                chunk_idxs = np.concatenate([base_idxs, ext_idxs])
+            else:
+                chunk_idxs = base_idxs
+
+            yield cast(L, out), cast(POS_TYPE, last_end), chunk_idxs
 
     @overload
     def get_record_info(

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -525,54 +525,28 @@ class VCF:
                 n_variants = self.n_vars_in_ranges(c, start, end)[0]  # type: ignore[bad-argument-type]
                 if n_variants == 0:
                     return mode.empty(self.n_samples, self.ploidy + self.phasing, 0)  # type: ignore[bad-return]
-            else:
-                n_variants = None
-
-            if issubclass(mode, (Genos8, Genos16)):
-                if n_variants is None:
-                    data = None
-                else:
-                    data = mode.empty(
-                        self.n_samples, self.ploidy + self.phasing, n_variants
-                    )
-                data, _ = self._fill_genos(vcf, data, mode=mode)
-            elif issubclass(mode, Dosages):
-                assert self.dosage_field is not None
-                if n_variants is None:
-                    data = None
-                else:
-                    data = mode.empty(
-                        self.n_samples, self.ploidy + self.phasing, n_variants
-                    )
-                data, _ = self._fill_dosages(vcf, data, self.dosage_field)
-            elif issubclass(mode, (Genos8Dosages, Genos16Dosages)):
-                assert self.dosage_field is not None
-                if n_variants is None:
-                    data = None
-                else:
-                    data = mode.empty(
-                        self.n_samples, self.ploidy + self.phasing, n_variants
-                    )
-                data, _ = self._fill_genos_and_dosages(
-                    vcf, data, self.dosage_field, mode=mode
+                data = mode.empty(
+                    self.n_samples, self.ploidy + self.phasing, n_variants
                 )
             else:
-                assert_never(mode)  # type: ignore[bad-argument-type]
-
-            out = cast(T, data)
+                data = None
         else:
-            if isinstance(out, (Genos8, Genos16)):
-                self._fill_genos(vcf, out)
-            elif isinstance(out, Dosages):
-                assert self.dosage_field is not None
-                self._fill_dosages(vcf, out, self.dosage_field)
-            elif isinstance(out, (Genos8Dosages, Genos16Dosages)):
-                assert self.dosage_field is not None
-                self._fill_genos_and_dosages(vcf, out, self.dosage_field)
-            else:
-                assert_never(mode)  # type: ignore[bad-argument-type]
+            data = out
 
-        return out
+        if issubclass(mode, (Genos8, Genos16)):
+            data, _ = self._fill_genos(vcf, data, mode=mode)
+        elif issubclass(mode, Dosages):
+            assert self.dosage_field is not None
+            data, _ = self._fill_dosages(vcf, data, self.dosage_field)
+        elif issubclass(mode, (Genos8Dosages, Genos16Dosages)):
+            assert self.dosage_field is not None
+            data, _ = self._fill_genos_and_dosages(
+                vcf, data, self.dosage_field, mode=mode
+            )
+        else:
+            assert_never(mode)  # type: ignore[bad-argument-type]
+
+        return cast(T, data)
 
     def chunk(
         self,

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -36,6 +36,8 @@ from .exprs import ILEN, symbolic_ilen
 V_IDX_TYPE = np.uint32
 """Dtype for VCF variant indices (uint32). This determines the maximum number of unique variants in a file."""
 
+_CHECK_LEN_EVERY_N = 20
+
 
 class DosageFieldError(RuntimeError): ...
 
@@ -809,19 +811,19 @@ class VCF:
                 continue
 
             if issubclass(mode, (Genos8, Genos16)):
-                ls_ext, last_end = self._ext_genos_with_length(  # type: ignore[bad-specialization]
+                ls_ext, last_end = self._ext_with_length(  # type: ignore[bad-specialization]
                     contig, start, end, hap_lens, mode, last_end
                 )
             elif issubclass(mode, (Genos8Dosages, Genos16Dosages)):
                 self.dosage_field = cast(str, self.dosage_field)
-                ls_ext, last_end = self._ext_genos_dosages_with_length(  # type: ignore[bad-specialization]
+                ls_ext, last_end = self._ext_with_length(  # type: ignore[bad-specialization]
                     contig,
                     start,
                     end,
                     hap_lens,
                     mode,
-                    self.dosage_field,
                     last_end,
+                    dosage_field=self.dosage_field,
                 )
             else:
                 assert_never(mode)  # type: ignore[bad-argument-type]
@@ -1370,22 +1372,23 @@ class VCF:
             mem *= 2  # a copy is made to reorder by samples
         return mem
 
-    def _ext_genos_with_length(
+    def _ext_with_length(
         self,
         contig: str,
         start: int | np.integer,
         end: int | np.integer,
         hap_lens: NDArray[np.int32],
-        mode: type[G],
+        mode: type,
         last_end: int,
-    ) -> tuple[list[G], int]:
+        *,
+        dosage_field: str | None = None,
+    ) -> tuple[list, int]:
         ploidy = self.ploidy + self.phasing
         length = end - start
         ext_start = end
         coord = f"{contig}:{ext_start + 1}"
 
-        _CHECK_LEN_EVERY_N = 20
-        ls_genos: list[G] = []
+        out_ls: list = []
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", message="no intervals found for", category=UserWarning
@@ -1396,10 +1399,14 @@ class VCF:
                 ):
                     continue
 
-                # (s p, 1)
-                genos = v.genotype.array()[:, :ploidy, None]
-                genos = genos.astype(mode._gdtype)
-                ls_genos.append(genos)
+                genos = v.genotype.array()[:, :ploidy, None].astype(mode._gdtype)
+                if dosage_field is None:
+                    out_ls.append(genos)
+                else:
+                    dosages = self._extract_dosage(v, dosage_field)[
+                        self._s_sorter, None
+                    ]
+                    out_ls.append((genos, dosages))
 
                 if v.is_indel:
                     ilen = len(v.ALT[0]) - len(v.REF)
@@ -1412,59 +1419,7 @@ class VCF:
                 if i % _CHECK_LEN_EVERY_N == 0 and (hap_lens >= length).all():
                     break
 
-        if len(ls_genos) > 0:
-            last_end = cast(int, v.end)  # type: ignore | guaranteed bound by len(ls) > 0
+        if len(out_ls) > 0:
+            last_end = cast(int, v.end)  # type: ignore | bound by len(out_ls) > 0
 
-        return ls_genos, last_end
-
-    def _ext_genos_dosages_with_length(
-        self,
-        contig: str,
-        start: int | np.integer,
-        end: int | np.integer,
-        hap_lens: NDArray[np.int32],
-        mode: type[GD],
-        dosage_field: str,
-        last_end: int,
-    ) -> tuple[list[GD], int]:
-        ploidy = self.ploidy + self.phasing
-        length = end - start
-        ext_start = end
-        coord = f"{contig}:{ext_start + 1}"
-
-        _CHECK_LEN_EVERY_N = 20
-        ls_geno_dosages: list[GD] = []
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="no intervals found for", category=UserWarning
-            )
-            for i, v in enumerate(self._vcf(coord)):
-                if v.start < ext_start or (
-                    self._filter is not None and not self._filter(v)
-                ):
-                    continue
-                # (s p 1)
-                genos = v.genotype.array()[:, :ploidy, None]
-                genos = genos.astype(mode._gdtype)
-
-                # (s, 1, 1) or (s, 1)? -> (s)
-                dosages = self._extract_dosage(v, dosage_field)[self._s_sorter, None]
-
-                ls_geno_dosages.append((genos, dosages))  # type: ignore
-
-                if v.is_indel:
-                    ilen = len(v.ALT[0]) - len(v.REF)
-                    dist = v.start - last_end
-                    # (s p 1)
-                    hap_lens += dist + np.where(
-                        genos[:, : self.ploidy] == 1, ilen, 0
-                    ).squeeze(-1)
-                    last_end = cast(int, v.end)
-
-                if i % _CHECK_LEN_EVERY_N == 0 and (hap_lens >= length).all():
-                    break
-
-        if len(ls_geno_dosages) > 0:
-            last_end = cast(int, v.end)  # type: ignore | guaranteed bound by len(ls) > 0
-
-        return ls_geno_dosages, last_end
+        return out_ls, last_end

--- a/python/genoray/_vcf.py
+++ b/python/genoray/_vcf.py
@@ -472,6 +472,21 @@ class VCF:
 
         return var_indices(V_IDX_TYPE, self._c_norm, self._index, contig, starts, ends)
 
+    def _norm_or_warn(self, contig: str) -> str | None:
+        c = self._c_norm.norm(contig)
+        if c is None:
+            logger.warning(
+                f"Query contig {contig} not found in VCF file, even after "
+                "normalizing for UCSC/Ensembl nomenclature."
+            )
+        return c
+
+    def _empty(self, mode: type[T], n_variants: int = 0) -> T:
+        return mode.empty(self.n_samples, self.ploidy + self.phasing, n_variants)
+
+    def _empty_gen(self, mode: type[L], end: int) -> Generator[tuple[L, int, int]]:
+        return ((self._empty(mode), end, 0) for _ in range(1))
+
     def read(
         self,
         contig: str,
@@ -510,12 +525,9 @@ class VCF:
                 "Dosage field not specified. Set the VCF reader's `dosage_field` parameter."
             )
 
-        c = self._c_norm.norm(contig)
+        c = self._norm_or_warn(contig)
         if c is None:
-            logger.warning(
-                f"Query contig {contig} not found in VCF file, even after normalizing for UCSC/Ensembl nomenclature."
-            )
-            return mode.empty(self.n_samples, self.ploidy + self.phasing, 0)  # type: ignore[bad-return]
+            return self._empty(mode)  # type: ignore[bad-return]
 
         start = max(0, start)  # type: ignore
 
@@ -524,7 +536,7 @@ class VCF:
             if self._index is not None:
                 n_variants = self.n_vars_in_ranges(c, start, end)[0]  # type: ignore[bad-argument-type]
                 if n_variants == 0:
-                    return mode.empty(self.n_samples, self.ploidy + self.phasing, 0)  # type: ignore[bad-return]
+                    return self._empty(mode)  # type: ignore[bad-return]
                 data = mode.empty(
                     self.n_samples, self.ploidy + self.phasing, n_variants
                 )
@@ -589,12 +601,9 @@ class VCF:
 
         max_mem = parse_memory(max_mem)
 
-        c = self._c_norm.norm(contig)
+        c = self._norm_or_warn(contig)
         if c is None:
-            logger.warning(
-                f"Query contig {contig} not found in VCF file, even after normalizing for UCSC/Ensembl nomenclature."
-            )
-            yield mode.empty(self.n_samples, self.ploidy + self.phasing, 0)  # type: ignore[invalid-yield]
+            yield self._empty(mode)  # type: ignore[invalid-yield]
             return
 
         start = max(0, start)  # type: ignore
@@ -714,26 +723,17 @@ class VCF:
         starts = np.atleast_1d(np.asarray(starts, POS_TYPE)).clip(min=0)
         ends = np.atleast_1d(np.asarray(ends, POS_TYPE))
 
-        c = self._c_norm.norm(contig)
+        c = self._norm_or_warn(contig)
         if c is None:
-            logger.warning(
-                f"Query contig {contig} not found in VCF file, even after normalizing for UCSC/Ensembl nomenclature."
-            )
             for e in ends:
-                yield (  # type: ignore[invalid-yield]
-                    (mode.empty(self.n_samples, self.ploidy + self.phasing, 0), e, 0)
-                    for _ in range(1)
-                )
+                yield self._empty_gen(mode, e)  # type: ignore[invalid-yield]
             return
 
         n_variants = self.n_vars_in_ranges(c, starts, ends)
         tot_variants = n_variants.sum()
         if tot_variants == 0:
             for e in ends:
-                yield (  # type: ignore[invalid-yield]
-                    (mode.empty(self.n_samples, self.ploidy + self.phasing, 0), e, 0)
-                    for _ in range(1)
-                )
+                yield self._empty_gen(mode, e)  # type: ignore[invalid-yield]
             return
 
         mem_per_v = self._mem_per_variant(mode)
@@ -749,10 +749,7 @@ class VCF:
 
         for s, e, n in zip(starts, ends, n_variants):
             if n == 0:
-                yield (  # type: ignore[invalid-yield]
-                    (mode.empty(self.n_samples, self.ploidy + self.phasing, 0), e, 0)
-                    for _ in range(1)
-                )
+                yield self._empty_gen(mode, e)  # type: ignore[invalid-yield]
                 continue
 
             yield self._chunk_with_length_helper(n, vars_per_chunk, c, s, e, mode)
@@ -1177,7 +1174,7 @@ class VCF:
                     self._pbar.update()
 
             if len(out_ls) == 0:
-                return mode.empty(self.n_samples, self.ploidy + self.phasing, 0), 0
+                return self._empty(mode), 0
 
             # (s p v)
             out = cast(
@@ -1313,7 +1310,7 @@ class VCF:
                     self._pbar.update()
 
             if len(geno_ls) == 0:
-                out = mode.empty(self.n_samples, self.ploidy + self.phasing, 0)
+                out = self._empty(mode)
                 return out, 0
 
             genos = cast(

--- a/python/genoray/exprs.py
+++ b/python/genoray/exprs.py
@@ -75,12 +75,15 @@ expression suffices::
 
     pgen = genoray.PGEN("file.pgen", filter=~genoray.exprs.is_symbolic)
 
-For VCF, pair it with the equivalent cyvcf2 ``filter`` (both are required)::
+For VCF, bundle it with the equivalent cyvcf2 record predicate in a
+:class:`genoray.Filter` (both are required)::
 
     vcf = genoray.VCF(
         "file.vcf.gz",
-        filter=lambda rec: not any(a.startswith("<") for a in rec.ALT),
-        pl_filter=~genoray.exprs.is_symbolic,
+        filter=genoray.Filter(
+            record=lambda rec: not any(a.startswith("<") for a in rec.ALT),
+            expr=~genoray.exprs.is_symbolic,
+        ),
     )
 
 ``SparseVar.from_vcf`` / ``from_pgen`` inherit the source's filter, so the SVAR
@@ -108,10 +111,11 @@ not expandable into nucleotides — the bracket/colon/position bytes corrupt
 personalized DNA buffers in haplotype consumers (e.g. ``genvarloader``). Their
 :func:`symbolic_ilen` value is ``null`` (so they are also :data:`is_imprecise`).
 
-To drop breakends, pass ``pl_filter=~genoray.exprs.is_breakend``. To drop *all*
-un-expandable ALTs (symbolic + breakends) for haplotype consumers, combine::
+To drop breakends, use ``expr=~genoray.exprs.is_breakend`` in a
+:class:`genoray.Filter`. To drop *all* un-expandable ALTs (symbolic +
+breakends) for haplotype consumers, combine::
 
-    pl_filter=~genoray.exprs.is_symbolic & ~genoray.exprs.is_breakend
+    expr=~genoray.exprs.is_symbolic & ~genoray.exprs.is_breakend
 """
 
 
@@ -119,8 +123,8 @@ def _record_is_symbolic(alts: Iterable[str]) -> bool:
     """Record-level mirror of :data:`is_symbolic` for a cyvcf2 ``Variant.ALT``.
 
     True if any ALT allele is a symbolic allele (starts with ``<``). Used by the
-    CLI to build the cyvcf2 ``filter`` callable that must match the polars
-    ``pl_filter`` on the VCF path.
+    CLI to build the cyvcf2 record predicate half of a :class:`genoray.Filter`
+    that must match its ``expr`` half on the VCF path.
     """
     return any(a.startswith("<") for a in alts)
 
@@ -129,8 +133,8 @@ def _record_is_breakend(alts: Iterable[str]) -> bool:
     """Record-level mirror of :data:`is_breakend` for a cyvcf2 ``Variant.ALT``.
 
     True if any ALT allele is a breakend (matches :data:`_BND_PATTERN`). Reuses
-    the same regex as :data:`is_breakend` so the cyvcf2 ``filter`` callable and
-    the polars ``pl_filter`` cannot drift apart.
+    the same regex as :data:`is_breakend` so a :class:`genoray.Filter`'s
+    ``record`` and ``expr`` halves cannot drift apart.
     """
     return any(re.search(_BND_PATTERN, a) is not None for a in alts)
 
@@ -234,7 +238,8 @@ is_imprecise = pl.col("ILEN").list.eval(pl.element().is_null()).list.any()
 """True if any ALT allele's ILEN could not be precisely determined (an un-sizable
 symbolic allele — ``IMPRECISE``, missing ``SVLEN``/``END``, or an unsupported
 symbolic type). Such alleles carry ``null`` ILEN. Filter them out with
-``pl_filter=~genoray.exprs.is_imprecise`` to keep precise structural variants while
-dropping the rest; use ``~genoray.exprs.is_symbolic`` to drop *all* symbolic alleles
+``expr=~genoray.exprs.is_imprecise`` (in a :class:`genoray.Filter` for VCF, or
+directly for PGEN) to keep precise structural variants while dropping the
+rest; use ``~genoray.exprs.is_symbolic`` to drop *all* symbolic alleles
 (required for haplotype consumers such as genvarloader, which cannot expand any
 symbolic ALT)."""

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -15,6 +15,7 @@ description: Use when writing or modifying Python code that imports `genoray` to
 - `genoray.PGEN` — PLINK 2 PGEN reader
 - `genoray.Reference` — indexed-FASTA reference genome reader
 - `genoray.VCF` — VCF/BCF reader
+- `genoray.Filter` — VCF filter value object bundling a cyvcf2 record predicate (`record`) with its matching `.gvi` polars expression (`expr`)
 - `genoray.Reader` — type alias `VCF | PGEN | SparseVar`
 - `genoray.SparseVar` — sparse `.svar` reader/writer
 - `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`)
@@ -95,6 +96,7 @@ for chunk in vcf.chunk("chr1", start=0, end=1_000_000,
 - Shape with `phasing=True`: `(samples, ploidy+1=3, variants)` — the 3rd row along the ploidy axis is `0` (unphased) / `1` (phased), matching cyvcf2.
 - Dosage arrays drop the ploidy axis: `(samples, variants)`, dtype `float32`.
 - VCF intentionally has **no `read_ranges`** — benchmarking showed no throughput benefit.
+- `read(out=...)` is **VCF-only** — pass a pre-allocated array to fill in place. PGEN random-access reads allocate fresh and have no `out=` buffer.
 
 ## PGEN — quick reference
 

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -76,8 +76,10 @@ vcf = genoray.VCF(
     "file.vcf.gz",
     phasing=True,             # constructor-time, not per-read
     dosage_field="DS",        # required to read dosages; FORMAT field with Number=A
-    filter=lambda v: ...,     # cyvcf2.Variant -> bool
-    pl_filter=~genoray.exprs.is_symbolic,  # drop <DEL>/<INS>/...; pair with a matching `filter` callable
+    filter=genoray.Filter(
+        record=lambda v: ...,                 # cyvcf2.Variant -> bool
+        expr=~genoray.exprs.is_symbolic,       # matching .gvi index predicate
+    ),
 )
 
 # Single range
@@ -318,21 +320,32 @@ genoray write svar1 file.vcf.gz out.svar --max-mem 4g --haploid
 
 ## Filtering
 
-VCF: pass a `Callable[[cyvcf2.Variant], bool]` to `filter=`. For index-based
-predicates (e.g. `is_symbolic`), also pass the matching polars `pl.Expr` to
-`pl_filter=` — VCF requires **both** when filtering via the `.gvi` index.
+VCF: pass a `genoray.Filter(record=, expr=)` value object to `filter=`.
+`record` is a `Callable[[cyvcf2.Variant], bool]` applied during the genotype
+scan; `expr` is the matching polars `pl.Expr` applied to the `.gvi` index —
+VCF requires **both** halves, bundled together so they can never diverge.
 
-To change a VCF's filter after construction, assign a `(filter, pl_filter)`
-tuple to the `vcf.filter` setter (or `None` to clear both); the same
-both-or-neither invariant is enforced, and the in-memory index is invalidated.
-The getter returns the `(filter, pl_filter)` tuple, mirroring the setter
-(`(None, None)` when unset), so `vcf.filter = vcf.filter` round-trips.
+To change a VCF's filter after construction, assign a `Filter` (or `None` to
+clear it) to the `vcf.filter` setter; the in-memory index is invalidated.
+The getter returns the `Filter | None` currently in effect, so `vcf.filter =
+vcf.filter` round-trips.
 
 ```python
-vcf.filter = (lambda rec: ..., ~genoray.exprs.is_symbolic)  # set both
-vcf.filter = None                                           # clear both
-fn, expr = vcf.filter                                       # get both
+from genoray import VCF, Filter
+
+vcf = VCF("file.vcf", filter=Filter(
+    record=lambda v: not v.INFO.get("SVTYPE"),   # cyvcf2 record predicate
+    expr=~genoray.exprs.is_symbolic,               # matching .gvi index predicate
+))
+vcf.filter = None                                  # clear
+f = vcf.filter                                      # -> Filter | None
 ```
+
+The former two-argument constructor (a separate polars-expression keyword
+argument alongside `filter=`) and its tuple-valued `vcf.filter` getter/setter
+are **removed in 3.0.0** — migrate any code passing the record predicate and
+polars expression separately to the single `Filter(record=, expr=)` object
+shown above.
 
 PGEN: pass a polars `pl.Expr` returning a boolean mask, operating on the
 `.gvi` index columns. Built-in expressions in `genoray.exprs` (the
@@ -359,7 +372,8 @@ type is unsupported (`<BND>`, `<CNV>`, `<INV>`, `<*>`/`<NON_REF>`), or the ALT i
 a breakend in mate-pair / single-breakend notation (e.g. `G[chr2:321[`). At NumPy
 materialization, `null` ILEN is coerced to 0 (treated as a point variant).
 
-**Filtering guidance** (no new constructor kwarg — use the existing `filter`/`pl_filter` API):
+**Filtering guidance** (use `filter=` — a bare `pl.Expr` for PGEN, a
+`genoray.Filter` for VCF):
 
 - `~genoray.exprs.is_symbolic` — drops *all* symbolic alleles (precise or not).
   Required for haplotype consumers (e.g. `genvarloader`) that cannot expand any
@@ -368,11 +382,13 @@ materialization, `null` ILEN is coerced to 0 (treated as a point variant).
   ```python
   # PGEN
   pgen = genoray.PGEN("file.pgen", filter=~genoray.exprs.is_symbolic)
-  # VCF (both required)
+  # VCF (both halves required, bundled in a Filter)
   vcf = genoray.VCF(
       "file.vcf.gz",
-      filter=lambda rec: not any(a.startswith("<") for a in rec.ALT),
-      pl_filter=~genoray.exprs.is_symbolic,
+      filter=genoray.Filter(
+          record=lambda rec: not any(a.startswith("<") for a in rec.ALT),
+          expr=~genoray.exprs.is_symbolic,
+      ),
   )
   ```
 

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,0 +1,36 @@
+import numpy as np
+from genoray._modes import make_array_mode, make_tuple_mode
+
+Geno = make_array_mode("Geno", np.int8, 3, genos=True)
+Dose = make_array_mode("Dose", np.float32, 2)
+GenoDose = make_tuple_mode("GenoDose", (Geno, Dose), genos_dtype=np.int8)
+
+
+def test_array_mode_empty_shapes():
+    g = Geno.empty(3, 2, 5)
+    assert g.shape == (3, 2, 5) and g.dtype == np.int8
+    d = Dose.empty(3, 2, 5)  # ploidy ignored for 2D modes
+    assert d.shape == (3, 5) and d.dtype == np.float32
+
+
+def test_array_mode_predicate():
+    assert isinstance(np.empty((3, 2, 5), np.int8), Geno)
+    assert not isinstance(np.empty((3, 4, 5), np.int8), Geno)  # bad ploidy axis
+    assert not isinstance(np.empty((3, 2, 5), np.int16), Geno)  # bad dtype
+
+
+def test_nbytes_per_variant():
+    # genos: n_samples * ploidy * itemsize; dosages: n_samples * 1 * itemsize
+    assert Geno.nbytes_per_variant(3, 2) == 3 * 2 * 1
+    assert Dose.nbytes_per_variant(3, 2) == 3 * 1 * 4
+    assert GenoDose.nbytes_per_variant(3, 2) == 3 * 2 * 1 + 3 * 1 * 4
+
+
+def test_tuple_mode_empty():
+    g, d = GenoDose.empty(3, 2, 5)
+    assert g.shape == (3, 2, 5) and d.shape == (3, 5)
+    assert isinstance((g, d), GenoDose)
+
+
+def test_tuple_mode_dtypes():
+    assert GenoDose._dtypes == (np.int8, np.float32)

--- a/tests/test_svar_filtering.py
+++ b/tests/test_svar_filtering.py
@@ -1,8 +1,8 @@
 """Filter-inheritance tests for VCF/PGEN -> SVAR.
 
 Replaces the old skip_symbolic_alts flag tests: symbolic filtering is now just
-`pl_filter=~exprs.is_symbolic` (+ paired cyvcf2 `filter`), and SparseVar inherits
-the source's filter.
+`Filter(record=..., expr=~exprs.is_symbolic)`, and SparseVar inherits the
+source's filter.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ import polars as pl
 import pytest
 from vcfixture import Bnd, Number, Seq, Sym, Type, VcfBuilder, VcfVersion
 
-from genoray import PGEN, VCF, SparseVar
+from genoray import PGEN, VCF, Filter, SparseVar
 from genoray import exprs as gexprs
 
 
@@ -58,9 +58,9 @@ def _mixed_vcf(tmp_path: Path) -> Path:
 
 
 def test_vcf_load_index_list_typed_filter(tmp_path):
-    """A list-typed pl_filter (is_symbolic) must evaluate on the VCF path."""
+    """A list-typed Filter.expr (is_symbolic) must evaluate on the VCF path."""
     vcf_path = _mixed_vcf(tmp_path)
-    v = VCF(vcf_path, filter=_not_symbolic, pl_filter=~gexprs.is_symbolic)
+    v = VCF(vcf_path, filter=Filter(record=_not_symbolic, expr=~gexprs.is_symbolic))
     v._write_gvi_index()
     v._load_index()
     assert v._index is not None
@@ -70,7 +70,7 @@ def test_vcf_load_index_list_typed_filter(tmp_path):
 
 def test_from_vcf_inherits_symbolic_filter(tmp_path):
     vcf_path = _mixed_vcf(tmp_path)
-    v = VCF(vcf_path, filter=_not_symbolic, pl_filter=~gexprs.is_symbolic)
+    v = VCF(vcf_path, filter=Filter(record=_not_symbolic, expr=~gexprs.is_symbolic))
     out = tmp_path / "out.svar"
     SparseVar.from_vcf(out, v, max_mem="1g", overwrite=True)
 
@@ -97,8 +97,10 @@ def test_from_vcf_inherits_general_filter(tmp_path):
     vcf_path = _mixed_vcf(tmp_path)
     v = VCF(
         vcf_path,
-        filter=lambda rec: len(rec.REF) == 1 and all(len(a) == 1 for a in rec.ALT),
-        pl_filter=gexprs.is_snp,
+        filter=Filter(
+            record=lambda rec: len(rec.REF) == 1 and all(len(a) == 1 for a in rec.ALT),
+            expr=gexprs.is_snp,
+        ),
     )
     out = tmp_path / "snp.svar"
     SparseVar.from_vcf(out, v, max_mem="1g", overwrite=True)
@@ -263,7 +265,7 @@ def test_from_vcf_multi_contig_filtered(tmp_path):
     """from_vcf with symbolic filter across 2 contigs: correct n_variants, per-contig
     POS, and genotype/index alignment."""
     vcf_path = _two_contig_vcf(tmp_path)
-    v = VCF(vcf_path, filter=_not_symbolic, pl_filter=~gexprs.is_symbolic)
+    v = VCF(vcf_path, filter=Filter(record=_not_symbolic, expr=~gexprs.is_symbolic))
     out = tmp_path / "two_contig.svar"
     SparseVar.from_vcf(out, v, max_mem="1g", overwrite=True)
 
@@ -374,8 +376,7 @@ def test_from_vcf_filtered_with_dosages(tmp_path):
     vcf_path = _dosage_vcf(tmp_path)
     v = VCF(
         vcf_path,
-        filter=_not_symbolic,
-        pl_filter=~gexprs.is_symbolic,
+        filter=Filter(record=_not_symbolic, expr=~gexprs.is_symbolic),
         dosage_field="DS",
     )
     out = tmp_path / "dosage.svar"

--- a/tests/test_symbolic_ilen.py
+++ b/tests/test_symbolic_ilen.py
@@ -6,7 +6,7 @@ import numpy as np
 import polars as pl
 import pytest
 
-from genoray import PGEN, VCF, SparseVar, exprs
+from genoray import PGEN, VCF, Filter, SparseVar, exprs
 from genoray.exprs import is_breakend, is_imprecise, symbolic_ilen
 from tests import _oracle
 from tests.data.fixtures import FIXTURES as _FIXTURES
@@ -353,12 +353,11 @@ def test_filter_parity_symbolic_vs_imprecise(tmp_path):
     # ~is_symbolic drops the 6 <...> symbolic rows but KEEPS the breakend, which
     # is a distinct ALT class (is_symbolic only matches `<...>`).  This is the gap
     # the breakend row was added to lock: ~is_symbolic alone is NOT haplotype-safe.
-    # The `_index` is filtered solely by `pl_filter`; the `filter` callable is an
-    # inert no-op required by the VCF constructor's filter/pl_filter pairing.
+    # The `_index` is filtered solely by `Filter.expr`; `Filter.record` is an
+    # inert no-op required by the VCF constructor's Filter.
     vcf_all = VCF(
         str(path),
-        filter=lambda r: True,
-        pl_filter=~exprs.is_symbolic,
+        filter=Filter(record=lambda r: True, expr=~exprs.is_symbolic),
     )
     vcf_all._load_index()
     assert vcf_all._index.height == 1
@@ -367,19 +366,19 @@ def test_filter_parity_symbolic_vs_imprecise(tmp_path):
     # ~is_symbolic & ~is_breakend drops everything un-expandable -> empty index.
     vcf_hap = VCF(
         str(path),
-        filter=lambda r: True,
-        pl_filter=~exprs.is_symbolic & ~exprs.is_breakend,
+        filter=Filter(
+            record=lambda r: True, expr=~exprs.is_symbolic & ~exprs.is_breakend
+        ),
     )
     vcf_hap._load_index()
     assert vcf_hap._index.height == 0
 
     # ~is_imprecise keeps the 3 precise SVs, drops the 4 un-sizable ones
     # (IMPRECISE <DEL>, <CNV>, <INV>, and the breakend).
-    # pl_filter-only requires pairing with a no-op filter callable per the VCF API.
+    # expr-only filtering requires pairing with a no-op record callable per the Filter API.
     vcf_precise = VCF(
         str(path),
-        filter=lambda r: True,
-        pl_filter=~exprs.is_imprecise,
+        filter=Filter(record=lambda r: True, expr=~exprs.is_imprecise),
     )
     vcf_precise._load_index()
     assert vcf_precise._index.height == 3
@@ -454,8 +453,7 @@ def test_svar_inherits_symbolic_ilen(tmp_path):
     )
     vcf = VCF(
         str(path),
-        filter=lambda r: True,
-        pl_filter=~exprs.is_imprecise,
+        filter=Filter(record=lambda r: True, expr=~exprs.is_imprecise),
     )
     svar_path = tmp_path / "sym.svar"
     SparseVar.from_vcf(svar_path, vcf, max_mem="100MB", overwrite=True)

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -112,6 +112,34 @@ def test_read(
     np.testing.assert_equal(d, dosages)
 
 
+def test_read_with_out_matches_without_out(vcf: VCF):
+    """Characterize existing behavior of the (previously untested) ``out=``
+    path: filling a caller-provided buffer must match allocating a fresh one."""
+    cse = "chr1", 81261, 81263
+
+    expected_g = vcf.read(*cse, VCF.Genos16)
+    out_g = VCF.Genos16.empty(
+        vcf.n_samples, vcf.ploidy + vcf.phasing, expected_g.shape[-1]
+    )
+    actual_g = vcf.read(*cse, VCF.Genos16, out=out_g)
+    np.testing.assert_array_equal(actual_g, expected_g)
+
+    expected_d = vcf.read(*cse, VCF.Dosages)
+    out_d = VCF.Dosages.empty(
+        vcf.n_samples, vcf.ploidy + vcf.phasing, expected_d.shape[-1]
+    )
+    actual_d = vcf.read(*cse, VCF.Dosages, out=out_d)
+    np.testing.assert_array_equal(actual_d, expected_d)
+
+    expected_gd = vcf.read(*cse, VCF.Genos16Dosages)
+    out_gd = VCF.Genos16Dosages.empty(
+        vcf.n_samples, vcf.ploidy + vcf.phasing, expected_gd[0].shape[-1]
+    )
+    actual_gd = vcf.read(*cse, VCF.Genos16Dosages, out=out_gd)
+    np.testing.assert_array_equal(actual_gd[0], expected_gd[0])
+    np.testing.assert_array_equal(actual_gd[1], expected_gd[1])
+
+
 @parametrize_with_cases("cse, genos, phasing, dosages", cases=".", prefix="read_")
 def test_chunk(
     vcf: VCF,

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -54,7 +54,7 @@ def read_spanning_del():
 def read_missing_contig():
     cse = "🥸", 81261, 81263
     # (s p v)
-    genos_phasing, dosages = VCF.Genos8Dosages.empty(N_SAMPLES, VCF.ploidy, 0, True)
+    genos_phasing, dosages = VCF.Genos8Dosages.empty(N_SAMPLES, VCF.ploidy + 1, 0)
     genos, phasing = np.array_split(genos_phasing, 2, 1)
     phasing = phasing.squeeze(1).astype(bool)
     return cse, genos, phasing, dosages
@@ -63,7 +63,7 @@ def read_missing_contig():
 def read_none():
     cse = "chr1", 0, 1
     # (s p v)
-    genos_phasing, dosages = VCF.Genos8Dosages.empty(N_SAMPLES, VCF.ploidy, 0, True)
+    genos_phasing, dosages = VCF.Genos8Dosages.empty(N_SAMPLES, VCF.ploidy + 1, 0)
     genos, phasing = np.array_split(genos_phasing, 2, 1)
     phasing = phasing.squeeze(1).astype(bool)
     return cse, genos, phasing, dosages
@@ -231,7 +231,7 @@ def length_ext():
 def length_none():
     cse = "chr1", 0, 1
     # (s p v)
-    genos_phasing, dosages = VCF.Genos8Dosages.empty(N_SAMPLES, VCF.ploidy, 0, True)
+    genos_phasing, dosages = VCF.Genos8Dosages.empty(N_SAMPLES, VCF.ploidy + 1, 0)
     genos, phasing = np.array_split(genos_phasing, 2, 1)
     phasing = phasing.squeeze(1).astype(bool)
     last_end = 1

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -232,6 +232,20 @@ def test_sample_reorder(vcf: VCF):
     np.testing.assert_equal(d, np.array([[2.0, 1.0], [1.0, np.nan]], np.float32))
 
 
+def test_vcf_mem_per_variant_doubles_when_sorted(vcf: VCF):
+    ploidy = vcf.ploidy + vcf.phasing
+    # a fresh reader has no active sample sorter -> estimate is NOT doubled
+    unsorted = vcf._mem_per_variant(VCF.Genos16)
+    assert unsorted == VCF.Genos16.nbytes_per_variant(vcf.n_samples, ploidy)
+    # a single-sample subset is trivially "sorted" (a length-1 permutation is
+    # always in order), so it does NOT install the ndarray sorter; a genuine
+    # reorder of >=2 samples does (mirrors test_sample_reorder above).
+    vcf.set_samples(list(reversed(vcf.available_samples)))
+    assert vcf._mem_per_variant(VCF.Genos16) == 2 * VCF.Genos16.nbytes_per_variant(
+        vcf.n_samples, ploidy
+    )
+
+
 def length_no_ext():
     cse = "chr1", 81264, 81265  # just 81265 in VCF
     # (s p v)

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import polars as pl
 import pytest
 from numpy.typing import ArrayLike, NDArray
 from pytest_cases import fixture, parametrize_with_cases
 
+from genoray import Filter
 from genoray._vcf import POS_MAX, VCF
 from tests import _oracle
 from tests.data.fixtures import FIXTURES
@@ -349,9 +351,26 @@ def test_chunk_with_length_phased_indel_in_extension():
     assert genos_phasing.shape[-1] > 0
 
 
-def test_filter_setter_enforces_pair_invariant():
-    import polars as pl  # noqa: F401
+def test_filter_object_roundtrip():
+    f = Filter(record=lambda v: True, expr=pl.col("POS") > 0)
+    vcf = VCF(ddir / "biallelic.vcf.gz", filter=f)
+    assert vcf.filter is f
+    vcf.filter = None
+    assert vcf.filter is None
 
+
+def test_filter_object_is_frozen():
+    f = Filter(record=lambda v: True, expr=pl.lit(True))
+    with pytest.raises(Exception):
+        f.record = lambda v: False  # frozen dataclass
+
+
+def test_old_pl_filter_kwarg_removed():
+    with pytest.raises(TypeError):
+        VCF(ddir / "biallelic.vcf.gz", pl_filter=pl.lit(True))  # kwarg no longer exists
+
+
+def test_filter_setter_enforces_pair_invariant():
     from genoray import exprs
 
     vcf = VCF(ddir / "biallelic.vcf.gz")
@@ -360,32 +379,25 @@ def test_filter_setter_enforces_pair_invariant():
         return not any(a.startswith("<") for a in v.ALT)
 
     pl_expr = ~exprs.is_symbolic
+    f = Filter(record=record_fn, expr=pl_expr)
 
-    # Setting a valid (filter, pl_filter) pair updates both and invalidates the index.
+    # Setting a Filter updates both halves together and invalidates the index.
     vcf._index = "sentinel"
-    vcf.filter = (record_fn, pl_expr)
-    assert vcf.filter == (record_fn, pl_expr)
-    assert vcf._pl_filter is pl_expr
+    vcf.filter = f
+    assert vcf.filter is f
     assert vcf._index is None
 
     # The getter mirrors the setter, so assigning the getter back round-trips.
     vcf.filter = vcf.filter
-    assert vcf.filter == (record_fn, pl_expr)
+    assert vcf.filter is f
 
-    # Assigning None clears both; the getter returns (None, None).
+    # Assigning None clears the filter; the getter returns None.
+    vcf._index = "sentinel"
     vcf.filter = None
-    assert vcf.filter == (None, None)
-    assert vcf._pl_filter is None
+    assert vcf.filter is None
+    assert vcf._index is None
 
-    # A mismatched pair raises ValueError and leaves state untouched.
-    with pytest.raises(ValueError):
-        vcf.filter = (record_fn, None)
-    with pytest.raises(ValueError):
-        vcf.filter = (None, pl_expr)
-    assert vcf.filter == (None, None)
-    assert vcf._pl_filter is None
-
-    # A bare (non-tuple) value is rejected.
+    # A bare (non-Filter) value is rejected.
     with pytest.raises(TypeError):
         vcf.filter = record_fn
 
@@ -399,14 +411,13 @@ def test_filtered_var_idxs_consistent_with_index():
     """
     from genoray import exprs
 
-    # is_snp as a (cyvcf2 record callable, pl.Expr) pair (VCF requires both).
+    # is_snp as a Filter bundling a cyvcf2 record predicate + pl.Expr (VCF requires both).
     def record_is_snp(rec):
         return len(rec.REF) == 1 and all(len(a) == 1 for a in rec.ALT)
 
     v_filt = VCF(
         ddir / "biallelic.vcf.gz",
-        filter=record_is_snp,
-        pl_filter=exprs.is_snp,
+        filter=Filter(record=record_is_snp, expr=exprs.is_snp),
     )
     v_filt._write_gvi_index()
     v_filt._load_index()
@@ -437,8 +448,10 @@ def test_filter_applied_to_genos_dosages_without_index():
         phasing=False,
         dosage_field="DS",
         with_gvi_index=False,
-        filter=lambda rec: len(rec.REF) == 1 and all(len(a) == 1 for a in rec.ALT),
-        pl_filter=exprs.is_snp,
+        filter=Filter(
+            record=lambda rec: len(rec.REF) == 1 and all(len(a) == 1 for a in rec.ALT),
+            expr=exprs.is_snp,
+        ),
     )
     cse = ("chr1", 81261, 81266)  # covers the GAT>A indel and two SNPs
     genos_only = vcf.read(*cse, VCF.Genos8)  # filters correctly today

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -295,12 +295,26 @@ def test_chunk_with_length(
     last_end: int,
     n_extension: int,
 ):
+    # _chunk_ranges_with_length now requires a loaded .gvi index (it needs
+    # variant indices from _var_idxs to build chunk_idxs); the `vcf` fixture is
+    # parametrized over with_gvi_index=[True, False], so build+load on demand.
+    if vcf._index is None:
+        vcf._write_gvi_index()
+        vcf._load_index()
+
     vcf.phasing = True
+
+    # Independently-computed in-range variant indices (not derived from the
+    # method under test) so the chunk_idxs assertions below stay non-vacuous.
+    contig, start, end_ = cse
+    in_range_idxs, _ = vcf._var_idxs(contig, start, end_)
+    in_range_idxs = in_range_idxs.astype(np.uint32)
 
     max_mem = vcf._mem_per_variant(VCF.Genos16Dosages)
     gpd = vcf._chunk_ranges_with_length(*cse, max_mem, VCF.Genos16Dosages)
+    all_idxs: list[NDArray[np.uint32]] = []
     for range_ in gpd:
-        for chunk, end, n_ext in range_:
+        for chunk, end, chunk_idxs in range_:
             gp, d = chunk
             g, p = np.array_split(gp, 2, 1)
             p = p.squeeze(1).astype(bool)
@@ -308,7 +322,50 @@ def test_chunk_with_length(
             np.testing.assert_equal(p, phasing)
             np.testing.assert_equal(d, dosages)
             assert end == last_end
-            assert n_ext == n_extension
+            # chunk_idxs is now a uint32 variant-index array, one index per
+            # variant in this chunk (matching PGEN's contract).
+            assert chunk_idxs.dtype == np.uint32
+            assert chunk_idxs.shape[0] == gp.shape[-1]
+            all_idxs.append(chunk_idxs)
+
+    full = np.concatenate(all_idxs) if all_idxs else np.empty(0, dtype=np.uint32)
+    # The in-range prefix must match the independently-computed indices...
+    assert np.array_equal(full[: in_range_idxs.size], in_range_idxs)
+    # ...and whatever is left over is exactly the extension variants, whose
+    # count must match this case's expected `n_extension` (keeps this
+    # non-vacuous: a wrong extension count/length fails here).
+    assert full.size - in_range_idxs.size == n_extension
+
+
+def test_chunk_ranges_with_length_yields_chunk_idxs():
+    """The 3rd tuple element is now the variant-index array, and the extension
+    indices are contiguous after the last in-range index (what gvl assumed)."""
+    vcf = VCF(ddir / "biallelic.vcf.gz")
+    if vcf._index is None:
+        vcf._write_gvi_index()
+        vcf._load_index()
+    contig = vcf.contigs[0]
+    starts = np.array([0], dtype=np.int32)
+    ends = np.array([10_000], dtype=np.int32)
+
+    v_idx, offsets = vcf._var_idxs(contig, starts, ends)
+    reg_unext = v_idx[offsets[0] : offsets[1]].astype(np.uint32)
+
+    all_idxs = []
+    for range_ in vcf._chunk_ranges_with_length(contig, starts, ends, "4g", VCF.Genos8):
+        for genos, _end, chunk_idxs in range_:
+            assert chunk_idxs.dtype == np.uint32
+            assert chunk_idxs.shape[0] == genos.shape[-1]
+            all_idxs.append(chunk_idxs)
+    full = np.concatenate(all_idxs) if all_idxs else np.empty(0, np.uint32)
+
+    # in-range prefix matches _var_idxs; any extension is contiguous after it
+    assert np.array_equal(full[: reg_unext.size], reg_unext)
+    if full.size > reg_unext.size:
+        ext = full[reg_unext.size :]
+        assert np.array_equal(
+            ext, np.arange(reg_unext[-1] + 1, reg_unext[-1] + 1 + ext.size)
+        )
 
 
 def test_nbytes_zero_before_index_loaded():


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-09-sp4-vcf-pgen-consistency-design.md` (plan: `docs/superpowers/plans/2026-07-09-sp4-vcf-pgen-consistency.md`). Part of the genoray **3.0.0** breaking-change wave. Coordinated with **GenVarLoader PR #266** (`svar2-m6b-kernel`), which consumes the reconciled `chunk_idxs` contract — neither is complete without the other.

## What changed

Collapses the divergent `_vcf.py` / `_pgen.py` backends onto shared primitives and makes the audit's invalid states unrepresentable.

**Refactors (behavior-preserving):**
- `genoray/_modes.py` — phantom-mode factories (`make_array_mode`/`make_tuple_mode`); both backends' modes migrated (dynamic base + trivial named subclass so the modes stay usable as static types under pyrefly)
- Mode→method dispatch dicts (`_reader_for`) replace the `issubclass` ladders
- Shared `_norm_or_warn` / `_empty` / `_empty_gen` preamble helpers
- `VCF._extract_dosage` helper folds the 6 dosage fetch/validate/squeeze sites
- Merged `_ext_genos_with_length` + `_ext_genos_dosages_with_length` → `_ext_with_length`
- `_oxbow_reader` moved out of the `get_record_info` overload block

**Breaking changes (each `!` + `BREAKING CHANGE:` footer; `cz bump` → 3.0.0):**
- Phantom mode `empty()` unified to `empty(n_samples, ploidy, n_variants)` (VCF drops the 4th `phasing` arg; pass `ploidy + phasing`)
- `_mem_per_variant` computed via `nbytes_per_variant`; **VCF now doubles** the per-variant estimate when a sample sorter is active (matches PGEN; chunk-sizing only, no output change)
- **`genoray.Filter(record=, expr=)`** value object replaces the `(filter, pl_filter)` tuple + `pl_filter=` kwarg
- `VCF._chunk_ranges_with_length` now yields `(data, end, chunk_idxs)` — a `uint32` variant-index array — matching PGEN (now requires a loaded `.gvi` index)

`skills/genoray-api/SKILL.md` and `CHANGELOG.md` updated to match.

## Verification
- Full suite: **549 passed, 2 skipped, 16 xfailed, 0 failed**
- `pyrefly` clean (0 errors); `ruff` clean
- `cz bump --dry-run` → **2.15.0 → 3.0.0**
- Every task passed an individual spec + quality review; a broad final whole-branch review (Opus) returned **Ready to merge: YES**

## Known minors (non-blocking, reviewer-triaged)
- `_modes.py` `_dtypes` (plural) is now vestigial (only `test_modes` reads it) — leave as factory contract or drop later
- One bare `# type: ignore` in `_pgen.py` where a sibling branch uses a scoped code
- `PGEN._reader_for` rebuilds its dispatch dict per call (negligible)

## Do NOT hand-merge before genoray 3.0.0 is released
GenVarLoader PR #266 pins `genoray>=3,<4`; that pin is unresolvable until this lands and 3.0.0 is published — expected coordinated state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)