### PR TITLE
feat(mutcat): SVAR2 COSMIC mutational signatures (SBS96/ID83/DBS78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,206 +7,28 @@
   Rust with a per-record sidecar and streaming count matrix. `from_vcf` gains a
   `signatures=` flag to classify during the write (factored into the cost model).
 
-## 3.0.0 (2026-07-10)
+### BREAKING CHANGES
 
-### BREAKING CHANGE
-
-- genoray.exprs.symbolic_ilen and genoray.exprs.IndexSchema
-are renamed to _symbolic_ilen and _IndexSchema. They were internal
-index-build helpers that were accidentally un-underscored; the public
-exprs surface is now exactly the documented predicates (is_snp, is_indel,
-is_biallelic, is_symbolic, is_breakend, is_imprecise) plus ILEN.
-- the third tuple element is now a uint32 variant-index array
-(matching PGEN), not an n_extension_vars count.
-- VCF filtering uses genoray.Filter(record=, expr=). The
-pl_filter= kwarg and the (filter, pl_filter) tuple API are removed.
-- VCF now doubles the per-variant memory estimate when a sample
-sorter is active, matching PGEN. Chunk-sizing only; no output change.
-- Phantom mode empty() drops the VCF-only phasing argument;
-pass effective ploidy (ploidy + phasing) instead. Uniform across VCF/PGEN.
-- gather_haps_readbound(reader, region_starts, orig_samples,
-vk_snp_range, vk_indel_range, dense_snp_range, dense_indel_range, ploidy) is now
-gather_haps_readbound(reader, &HapRanges::new(...)). Downstream gvl updated in
-lockstep (svar2-m6b-kernel).
-
-### Feat
-
-- **cli**: collapse svar2 write flags to --skip-symbolics-and-breakends
-- **api**: drop the Reader type alias (no shared protocol)
-- **svar2**: privatize raw-dict FFI methods (overlap_batch/find_ranges/gather_ranges)
-- **svar2**: rename SparseVar2.samples to available_samples
-- **vcf**: replace paired (filter, pl_filter) with a Filter value object
-- **modes**: add phantom-mode factories for array and tuple modes
-- **error**: add Input/MissingFile categories and PyErr mapping
-- **build**: add opt-in abi3 cargo feature for release wheels
-- **budget**: plan a processing-thread count from idle cores
-- **py**: find_ranges dict exposes dense_snp_range/dense_indel_range
-- **query**: gather_ranges_readbound + gather_haps_readbound + BatchResultSplit
-- **query**: find_ranges emits per-class dense_snp_range/dense_indel_range
-- **query**: conversion feature gates htslib; query core builds --no-default-features
-- **svar2**: SparseVar2 find/gather/read_ranges with samples= and out=
-- **svar2**: PyContigReader find/gather/read_ranges numpy bindings
-- **svar2**: add find_ranges/gather_ranges/read_ranges query core
-- **cli**: default 'write' to SVAR2, add 'write svar1' for SVAR 1.0
-- **svar2**: SparseVar2.from_vcf wrapper (optional reference, auto-index, skip count)
-- **svar2**: add index_vcf PyO3 helper to build a .csi index
-- **svar2**: optional reference + skip/count plumbing through conversion pipeline
-- **svar2**: opt-in skip + count for out-of-scope ALTs in atomize_record
-- **svar2**: SparseVar2.decode Ragged record + region_counts (M6c)
-- **svar2**: PyContigReader.region_counts decode-free count (M6c)
-- **svar2**: PyContigReader.decode_batch flat variant materialization (M6c)
-- **svar2**: SparseVar2.overlap_batch raw two-channel query (M6b)
-- **svar2**: PyContigReader.overlap_batch raw two-channel numpy method
-- **svar2**: raw LUT accessors for M6b two-channel exposure
-- **svar2**: mix _BatchQueryMixin/_DecodeMixin into SparseVar2 for M6 fan-out
-- **svar2**: stub owned py_query_batch/decode modules for M6 fan-out
-- **svar2**: add SparseVar2 Python skeleton reading meta.json (M6a)
-- **svar2**: expose PyContigReader over ContigReader::open (M6a)
-- **svar2**: add rust-numpy dep and Rust->numpy conversion helpers (M6a)
-- **query**: add batched two-channel overlap_batch spine
-- **spine**: add reader-free KeyRef gather + merge algorithms
-- **svar2-codec**: add snp_code_to_key uniform-key re-expansion
-- **svar-2**: wire max_del post-pass into orchestrator + e2e round-trip
-- **svar-2**: max_del post-pass producer (var_key per-column + dense scalar)
-- **svar-2**: add max_del post-pass path helpers to layout
-- **svar-2**: expose rvk::deletion_len decoder for max_del post-pass
-- **svar-2**: validate REF + left-align atoms in the reader (M2b)
-- **svar-2**: thread reference FASTA through reader/orchestrator/pyo3; widen reorder bound (M2b)
-- **svar-2**: left_align repeat roll with equivalence proptest (M2b)
-- **svar-2**: add L_MAX, ref-mismatch errors, validate_ref (M2b)
-- overlap_sample unions sub-streams into per-hap QueryResult
-- ContigReader opens and mmaps SVAR2 contig sidecars
-- gather_run and kway_merge query primitives
-- query module scaffold with mmap sidecar loaders
-- layout path helpers for max_del.npy and dense/max_del.npy
-- rvk query-side decode seam (decode_key, deletion_len, snp helpers)
-- **svar-2**: overlap_range resolver with edge-case tests
-- **svar-2**: SearchTree upper_bound
-- **svar-2**: SearchTree construction and lower_bound
-- **svar-2**: search.rs scaffold with block-scan primitives
-- **svar-2**: write top-level meta.json after all contigs convert
-- **svar-2**: add write_meta helper + FORMAT_VERSION (meta.json writer)
-- **svar-2**: rename final_* sidecars to spec base names (positions/alleles/offsets/genotypes)
-- **svar-2**: orchestrator drives dense merge; dense e2e round-trip
-- **svar-2**: route variants dense vs var_key by cost model
-- **svar-2**: rectangular dense merge (concat + bit-transpose + snp pack)
-- **svar-2**: executor returns Phase1Output with dense ledgers
-- **svar-2**: writer emits dense per-chunk pos/key/geno files
-- **svar-2**: dense on-disk path helpers (dirs, geno, final)
-- **svar-2**: dense class registry + empty dense chunk payload
-- **svar-2**: LSB-first bit-slice helpers for dense matrix
-- **svar-2**: BitGrid3::popcount_plane for allele-count routing
-- **svar-2**: cost model for per-variant dense/sparse routing
-- **svar-2**: atomize + reorder in the reader; accept un-normalized VCFs
-- **svar-2**: normalize.rs — biallelic split + atomization core
-- **svar-2**: bounded Result-based error path at pipeline boundaries
-- **svar-2**: add StreamTag registry (streams.rs) for tag-routed sub-streams
-- **svar-2**: split var_key conversion into 2-bit SNP + 32-bit indel streams
-- **svar-2**: add SNP/indel variant classifier (VarKey)
-- **svar-2**: add 2-bit SNP codec helpers (encode/pack/unpack)
-- **svar-2**: main-thread orchestration, parallel merge, PEXT encoder, monitoring
+- `Phantom` mode `empty()` classmethods now take a uniform
+  `empty(n_samples, ploidy, n_variants)` signature on both VCF and PGEN
+  backends. VCF's former 4th `phasing` argument is removed; pass the effective
+  ploidy (`ploidy + phasing`) instead.
+- VCF chunk-size memory estimates now double when a sample subset/reorder is
+  active, matching PGEN. This only affects internal chunk sizing (more
+  conservative memory use), never returned data.
+- VCF filtering now uses a single `genoray.Filter(record=, expr=)` value object.
+  The `pl_filter=` constructor kwarg and the `(filter, pl_filter)` tuple
+  getter/setter are removed. Migrate `VCF(p, filter=fn, pl_filter=expr)` to
+  `VCF(p, filter=Filter(record=fn, expr=expr))`.
+- `VCF._chunk_ranges_with_length` now yields `(data, end, chunk_idxs)` (a
+  `uint32` variant-index array) as its third tuple element instead of an
+  `n_extension_vars` count, matching `PGEN._chunk_ranges_with_length`.
 
 ### Fix
 
-- **error**: align exception-type mapping to the documented contract
-- **ffi**: make bundle_from_dict fallible (KeyError/TypeError not panic)
-- **query**: thread io::Result through sidecar loaders and LUT open
-- **merge**: return ConversionError from merge/dense-merge/pack paths
-- **writer**: return ConversionError::Io from writer threads
-- **vcf**: surface reader errors as typed ValueError instead of WorkerPanicked
-- correct Genos16 TypeGuard, PGEN log backend name, orphaned docstring
-- **nrvk**: correct 31-bit capacity message; drop redundant mask
-- **pgen**: guard __del__ against double-closing shared reader
-- **svar**: accept bare-str sample in read_ranges_with_length
-- **vcf**: apply filter on no-index Genos*Dosages read path
-- **py**: declare samples on _BatchQueryMixin so the mixin type-checks
-- **svar2**: guard find_ranges(out=) against dtype mismatch too
-- **types**: repair the pyrefly type-check gate (path + error triage)
-- **cli**: update direct write() callers to write_svar1 after write became an App
-- write .svar output atomically in write_view via sibling staging dir
-- write .svar output atomically in from_pgen via sibling staging dir
-- write .svar output atomically in from_vcf via sibling staging dir
-- write .gvi index files atomically via sibling tmp
-- add atomic sibling-tmp write helpers
-- **query**: make var_key and dense channels exact on spanning deletions
-- **svar-2**: debug_assert half-open query precondition in overlap_range
-- **svar-2**: assert dense_ledger cardinality matches num_chunks in merge
-- **svar-2**: keep DecodedKey/decode_key local to test_e2e per task scope
-- **svar-2**: join all pipeline threads on error path to prevent sampler/executor leak
-- **rust**: make conversion crate compile and build as genoray._core
-- **rvk**: remove stray closing brace in encode_alt_inline
-
-### Refactor
-
-- **exprs**: privatize symbolic_ilen and IndexSchema
-- **utils**: table-driven np_to_pl_dtype, typed variant_file_type
-- **var-ranges**: extract shared _var_end_expr, drop name shadowing
-- **utils**: split _utils.py into _io/_contigs/_genos by domain
-- **mutcat**: split _mutcat.py into codebook/classify/count package
-- **mutcat**: relocate scalar classifier oracles to tests
-- **svar2**: TypedDict the batch-query dict contracts
-- **utils**: import DTYPE TypeVar from _types instead of redefining
-- **mutcat**: own the Kind Literal in the codebook module
-- **mutcat**: SENTINELS dict -> Sentinel IntEnum
-- **svar2-codec**: name the payload bit-shift layout constants
-- **rust**: add StreamTag::class() bridge to cost_model::Class
-- **rust**: unify DenseMap/StreamMap behind EnumKey/EnumMap
-- **query**: finish (usize,usize) -> Range<usize> in gather/oracle
-- **vcf**: yield chunk_idxs from _chunk_ranges_with_length
-- **vcf**: move _oxbow_reader out of the get_record_info overloads
-- **vcf**: merge _ext_genos/_ext_genos_dosages into _ext_with_length
-- **query**: compute _mem_per_variant via nbytes_per_variant
-- **query**: share contig-normalize and empty-result helpers
-- **query**: replace mode issubclass ladders with dispatch dicts
-- **vcf**: extract _extract_dosage helper for the 5 dosage sites
-- **vcf**: define modes via factory and unify empty() to 3-arg
-- **pgen**: define phantom modes via the shared factory
-- **query**: factor PresenceBitWriter::reserve_row; drop redundant path
-- **query**: gather_haps_readbound takes a HapRanges params struct
-- **query**: group oracle-only entry points under query::oracle
-- **query**: use Range<usize> for internal half-open ranges
-- **query**: DenseUnion src uses DenseClass + dense_view accessor
-- **query**: extract gather_vk for the var_key snp+indel merge
-- **query**: extract PresenceBitWriter for CSR presence bitmasks
-- **query**: split query.rs into query/ module (pure code motion)
-- **svar**: converge sample validation onto _resolve_sample_idxs
-- **svar**: extract _write_from_reader from from_vcf/from_pgen
-- split _svar.py into _svar/ package
-- drop bare annotations shadowing SparseVar cached_property
-- drop obsolete allow(dead_code) on PyContigReader::inner
-- remove unused is_dtype and POLARS_V_IDX_TYPE
-- remove dead src/utils.rs (never compiled, unused macros)
-- **vcf_reader**: extract pack helpers, thread processing pool (still sequential)
-- **vcf_reader**: Rc→Arc on PendingAtom.gt for cross-thread sharing
-- **query**: re-express overlap_sample on the uniform-key spine
-- **svar2-codec**: move indel decode + DEL/lookup encode lanes into the crate
-- **svar2-codec**: move inline indel encoder (PEXT/SWAR) into the crate
-- **svar2-codec**: move SNP 2-bit code + pack/unpack into the crate
-- **svar2-codec**: move key-layout constants + BASES into the crate
-- **svar-2**: clarify reorder memory-bound comment; name missing contig in FASTA error (M2b)
-- **svar-2**: route pack_snp_key_file through layout::alleles; propagate meta serialize error
-- **svar-2**: relocate long-allele LUT to shared per-contig indel dir
-- **svar-2**: debug_assert non-empty REF/ALT; document reorder-buffer memory bound
-- **svar-2**: extract BCF test harness into tests/common/mod.rs and drop obsolete panic tests
-- **svar-2**: LongAlleleReader::get_allele uses pread + &self
-- **svar-2**: move process_chromosome into orchestrator.rs; slim lib.rs
-- **svar-2**: route sub-streams by StreamTag with byte-erased keys
-- **svar-2**: de-generify merge over runtime key_bytes
-- **svar-2**: centralize on-disk layout in layout.rs
-- **svar-2**: extract /proc monitoring into monitor.rs
-- **svar-2**: extract testable plan_thread_budget into budget.rs
-- **svar-2**: delete dead commented code, stray checkpoints, and write-only num_variants
-- **svar-2**: generalize tile merge over key element width
-
-### Perf
-
-- **contigs**: precompute name_to_index, drop O(n^2) remapper build
-- **vcf_reader**: parallel presence packing over word-aligned variant blocks
-- **budget**: raise htslib decode-thread cap 4→8 for idle-core workloads
-- **convert**: reader-bound VCF→SVAR2 — raw GT decode + per-word bit pack
-- **query**: block-copy dense-SNP presence via per-query threshold
-- **bits**: byte-batch copy_bits body, was per-bit
-- **query**: gather_haps_readbound asm fix — kill skip/take waste, elide bounds checks, inline the per-hap merge (byte-identical)
+- **vcf**: apply configured `filter` on `VCF.read(..., mode=Genos*Dosages)` when no
+  `.gvi` index is loaded, matching the genotype-only and dosage-only modes
+  (previously the filter was silently ignored on this path).
 
 ## 2.15.0 (2026-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Added
+
+- `SparseVar2.annotate_mutations`, `mutation_matrix`, and `assign_signatures`
+  for COSMIC mutational-signature workflows (SBS96/ID83/DBS78), implemented in
+  Rust with a per-record sidecar and streaming count matrix. `from_vcf` gains a
+  `signatures=` flag to classify during the write (factored into the cost model).
+
 ## 3.0.0 (2026-07-10)
 
 ### BREAKING CHANGE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,14 @@ and must be kept in sync.
 
 ### Commit convention
 
-All commits must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.). Version bumps are managed by `commitizen` (`cz bump`).
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.).
+
+Version bumps and `CHANGELOG.md` generation are handled automatically in CI by
+the release workflow (`.github/workflows/release.yaml`), which runs `commitizen`
+and commits the result as the GitHub Actions bot. **Do not bump the version or
+regenerate the changelog by hand** — accumulate human-readable entries under the
+`## Unreleased` heading in `CHANGELOG.md` and let the release workflow cut the
+versioned section. Use `pixi run bump-dry` only to preview locally.
 
 ## Skills
 

--- a/docs/source/svar.md
+++ b/docs/source/svar.md
@@ -85,3 +85,15 @@ svar_plain = svar_with.with_fields(False)
 ```
 
 There's a lot more that can be done with `SparseVar`; this documentation will be expanded as time permits.
+
+## Mutational signatures (SBS-96 / DBS-78 / ID-83)
+
+`SparseVar` and its next-gen successor `SparseVar2` both support COSMIC-style
+mutation catalogue annotation and signature refitting via
+`annotate_mutations`, `mutation_matrix`, and `assign_signatures`
+(`SparseVar2` can also classify during conversion with
+`SparseVar2.from_vcf(..., signatures=True)`). This isn't narrated here yet —
+see the `genoray-api` skill (`skills/genoray-api/SKILL.md`, "Mutation
+catalogues" and "SparseVar2 — quick reference → Mutational signatures"
+sections) or the method docstrings in `genoray/_svar/_annotate.py` (v1) and
+`genoray/_svar2_mutcat.py` (SVAR2) for the full workflow.

--- a/docs/superpowers/plans/2026-07-10-svar2-mutational-signatures.md
+++ b/docs/superpowers/plans/2026-07-10-svar2-mutational-signatures.md
@@ -1,0 +1,1713 @@
+# SVAR2 Mutational Signatures Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add COSMIC mutational-signature support (SBS96, ID83, DBS78-via-adjacency) to `SparseVar2`, implemented in Rust, with v1 feature parity and far lower memory.
+
+**Architecture:** A per-contig `mutcat/` sidecar stores one `u8` mutation code per record (aligned to each existing sub-stream's `positions.bin`) plus a 2-bit reference base for SNPs. A single Rust classification pass writes it (at write time or post-hoc). `mutation_matrix` streams the mmap'd genotype sub-streams column-by-column, reclassifying adjacent same-haplotype SNV pairs into DBS78 on the fly — never materializing a per-entry code array. The existing numpy/scipy `fit_signatures` refit is reused unchanged.
+
+**Tech Stack:** Rust (pyo3, memmap2, ndarray, ndarray-npy, rayon), `svar2-codec` crate (2-bit codec reuse), Python (polars, numpy), pixi.
+
+## Global Constraints
+
+- **Coordinate convention:** all ranges 0-based half-open `[start, end)`; POS in the Python index is 1-based and converted to 0-based internally.
+- **Codebook is single-source-of-truth:** SBS96/DBS78/ID83 label order, `N_CODES=257`, offsets (`SBS96_OFFSET=0`, `DBS78_OFFSET=96`, `ID83_OFFSET=174`), and `MUTCAT_VERSION=3` live in `python/genoray/_mutcat/codebook.py`. Rust must emit **identical** SBS96 (`0–95`) and ID83 (`0–82`) indices. Do **not** duplicate the label lists in Rust.
+- **Sidecar `u8` code encoding:** SNP record = SBS96 index `0–95`; indel record = ID83 index `0–82`; `254 = UNCLASSIFIED`, `255 = NOT_ANNOTATED`. DBS78 is never stored. The counter skips any `code >= N_CODES`.
+- **Sidecar `u8` values are class-local indices** (`0–95` / `0–82`), NOT the unified code-space offsets. The counter adds the class offset when accumulating.
+- **2-bit ref base uses the existing codec:** `svar2_codec::{pack_snp_keys, unpack_snp_key_at}`, encoding `A=00 C=01 T=10 G=11` (`encode_snp_2bit`). Reuse it; write no new 2-bit packer.
+- **REF from FASTA:** SNP records store no REF; indels are left-aligned to the FASTA. The classifier gets REF from the reference sequence. The counter must NOT need the FASTA.
+- **Public-API rule:** any change reachable from `import genoray` without underscores requires updating `skills/genoray-api/SKILL.md` in the same change (see `CLAUDE.md`).
+- **Rust test command:** `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion <filter>'` (the bare `cargo test` fails to link pyo3 — `undefined symbol: _Py_Dealloc`).
+- **Python extension rebuild:** after any Rust change, run `pixi run maturin develop` before Python tests.
+- **Commits:** Conventional Commits. Never run long `cargo`/`maturin` builds in the background — foreground only, or they get abandoned mid-build.
+- **Branch:** work on `feat/svar2-mutational-signatures` (already created).
+
+## File Structure
+
+**New Rust (`src/mutcat/`):**
+- `src/mutcat/mod.rs` — module root + re-exports; `pub const` code-space offsets/sentinels mirrored from the Python codebook (with a parity test).
+- `src/mutcat/classify.rs` — pure classifiers: `sbs96_code`, `id83_code`, `dbs78_code` (+ the `(4,4,4,4)` DBS table).
+- `src/mutcat/sidecar.rs` — sidecar file paths + typed read/write (`u8` code arrays, 2-bit ref).
+- `src/mutcat/annotate.rs` — the classification pass over finalized records → sidecar.
+- `src/mutcat/count.rs` — streaming count matrix with DBS pairing.
+
+**Modified Rust:**
+- `src/lib.rs` — `mod mutcat;`, register pyfunctions, thread `signatures` into `run_conversion_pipeline`.
+- `src/layout.rs` — `mutcat/` path helpers.
+- `src/cost_model.rs` — `choose_representation` gains a `sidecar_bits` term.
+- `src/rvk.rs` — pass `sidecar_bits` (0 unless signatures) into `choose_representation` in `dense2sparse_vk`.
+- `src/py_query.rs` (or new `src/py_mutcat.rs`) — `PyContigReader` methods `annotate_mutations` + `count_matrix`.
+
+**New/modified Python:**
+- `python/genoray/_svar2_mutcat.py` (new) — `_MutcatMixin` with `annotate_mutations`, `mutation_matrix`, `assign_signatures`.
+- `python/genoray/_svar2.py` — inherit `_MutcatMixin`; add `signatures: bool` to `from_vcf`.
+- `python/genoray/_mutcat/codebook.py`, `_signatures.py` — reused unchanged.
+
+**Tests:**
+- Rust unit tests colocated in each `src/mutcat/*.rs`.
+- `tests/test_svar2_mutcat.py` — Python round-trip + v1 parity.
+
+---
+
+## Phase 0 — Module scaffold + code-space constants
+
+### Task 0: `mutcat` module with codebook constants
+
+**Files:**
+- Create: `src/mutcat/mod.rs`
+- Modify: `src/lib.rs` (add `mod mutcat;` near the other `mod` declarations)
+
+**Interfaces:**
+- Produces: `mutcat::{SBS96_OFFSET, DBS78_OFFSET, ID83_OFFSET, N_CODES, UNCLASSIFIED, NOT_ANNOTATED}` (all `usize`/`u8`), and `mutcat::Kind { Sbs96, Dbs78, Id83 }` with `code_range(self) -> Range<usize>`.
+
+- [ ] **Step 1: Write the failing test** — in `src/mutcat/mod.rs`:
+
+```rust
+//! COSMIC mutation-catalogue code space and classifiers for SVAR2.
+//! Code-space layout MUST match python/genoray/_mutcat/codebook.py.
+
+pub mod classify;
+
+use std::ops::Range;
+
+/// Class-local index counts (COSMIC codebook sizes).
+pub const N_SBS96: usize = 96;
+pub const N_DBS78: usize = 78;
+pub const N_ID83: usize = 83;
+
+/// Unified code-space offsets — mirror codebook.py exactly.
+pub const SBS96_OFFSET: usize = 0;
+pub const DBS78_OFFSET: usize = SBS96_OFFSET + N_SBS96; // 96
+pub const ID83_OFFSET: usize = DBS78_OFFSET + N_DBS78; // 174
+pub const N_CODES: usize = ID83_OFFSET + N_ID83; // 257
+
+/// Sidecar `u8` sentinels (unsigned; v1's negative int16 sentinels don't survive).
+pub const UNCLASSIFIED: u8 = 254;
+pub const NOT_ANNOTATED: u8 = 255;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Sbs96,
+    Dbs78,
+    Id83,
+}
+
+impl Kind {
+    /// Half-open unified-code range for this kind.
+    pub fn code_range(self) -> Range<usize> {
+        match self {
+            Kind::Sbs96 => SBS96_OFFSET..DBS78_OFFSET,
+            Kind::Dbs78 => DBS78_OFFSET..ID83_OFFSET,
+            Kind::Id83 => ID83_OFFSET..N_CODES,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_space_matches_codebook() {
+        assert_eq!(SBS96_OFFSET, 0);
+        assert_eq!(DBS78_OFFSET, 96);
+        assert_eq!(ID83_OFFSET, 174);
+        assert_eq!(N_CODES, 257);
+    }
+
+    #[test]
+    fn kind_ranges_are_contiguous_and_sized() {
+        assert_eq!(Kind::Sbs96.code_range(), 0..96);
+        assert_eq!(Kind::Dbs78.code_range(), 96..174);
+        assert_eq!(Kind::Id83.code_range(), 174..257);
+    }
+}
+```
+
+- [ ] **Step 2: Add `mod mutcat;` to `src/lib.rs`** next to the other module declarations (e.g. after `mod merge;`).
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::tests'`
+Expected: PASS (2 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mutcat/mod.rs src/lib.rs
+git commit -m "feat(mutcat): scaffold mutcat module + code-space constants"
+```
+
+---
+
+## Phase 1 — Classifiers (pure functions)
+
+### Task 1: SBS96 classifier
+
+**Files:**
+- Create: `src/mutcat/classify.rs`
+
+**Interfaces:**
+- Consumes: `crate::mutcat::UNCLASSIFIED`.
+- Produces:
+  - `pub fn base_index(b: u8) -> i8` — `A=0 C=1 G=2 T=3`, else `-1`.
+  - `pub fn sbs96_code(five: u8, refb: u8, altb: u8, three: u8) -> u8` — returns SBS96 class-local index `0–95` or `UNCLASSIFIED`. `five`/`three` are the immediate 5′/3′ reference flanks (ASCII), `refb`/`altb` the ASCII REF/ALT bases.
+
+This ports `python/genoray/_mutcat/classify.py:_sbs96_codes` (COSMIC order: `sub*16 + five*4 + three`, substitutions `C>A,C>G,C>T,T>A,T>C,T>G`, pyrimidine folding).
+
+- [ ] **Step 1: Write the failing test** — append to `src/mutcat/classify.rs`:
+
+```rust
+//! Pure mutation classifiers (SBS96, ID83, DBS78). Port of
+//! python/genoray/_mutcat/classify.py. No I/O; operates on ASCII bytes +
+//! reference slices.
+
+use crate::mutcat::UNCLASSIFIED;
+
+/// A=0 C=1 G=2 T=3, else -1 (N or non-ACGT).
+#[inline]
+pub fn base_index(b: u8) -> i8 {
+    match b {
+        b'A' => 0,
+        b'C' => 1,
+        b'G' => 2,
+        b'T' => 3,
+        _ => -1,
+    }
+}
+
+// (ref_idx, alt_idx) -> SBS substitution index 0..5 for pyrimidine-folded refs.
+// Order: C>A, C>G, C>T, T>A, T>C, T>G  (A=0,C=1,G=2,T=3).
+const SUB_LUT: [[i8; 4]; 4] = {
+    let mut lut = [[-1i8; 4]; 4];
+    // C(1)>A(0),C>G(2),C>T(3)
+    lut[1][0] = 0;
+    lut[1][2] = 1;
+    lut[1][3] = 2;
+    // T(3)>A(0),T>C(1),T>G(2)
+    lut[3][0] = 3;
+    lut[3][1] = 4;
+    lut[3][2] = 5;
+    lut
+};
+
+/// SBS96 class-local index (0..=95) or `UNCLASSIFIED`.
+/// `five`/`three`: immediate reference flanks; `refb`/`altb`: REF/ALT bases.
+pub fn sbs96_code(five: u8, refb: u8, altb: u8, three: u8) -> u8 {
+    let r = base_index(refb);
+    let a = base_index(altb);
+    let f = base_index(five);
+    let t = base_index(three);
+    if r < 0 || a < 0 || f < 0 || t < 0 || r == a {
+        return UNCLASSIFIED;
+    }
+    let purine = r == 0 || r == 2; // A or G -> fold
+    let (rr, aa, ff, tt) = if purine {
+        // fold: complement ref/alt, and flanks swap+complement
+        (3 - r, 3 - a, 3 - t, 3 - f)
+    } else {
+        (r, a, f, t)
+    };
+    let sub = SUB_LUT[rr as usize][aa as usize];
+    if sub < 0 {
+        return UNCLASSIFIED;
+    }
+    (sub as u8) * 16 + (ff as u8) * 4 + (tt as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mutcat::UNCLASSIFIED;
+
+    #[test]
+    fn sbs96_pyrimidine_ref_no_fold() {
+        // A[C>A]G : sub C>A = 0, five=A=0, three=G=2 -> 0*16 + 0*4 + 2 = 2
+        assert_eq!(sbs96_code(b'A', b'C', b'A', b'G'), 2);
+    }
+
+    #[test]
+    fn sbs96_purine_ref_folds() {
+        // Purine ref folds to its pyrimidine partner with flanks swapped+complemented.
+        // G>T at flanks A..C  == (fold) C>A at flanks G..T.
+        // Direct fold: r=G(2)->rr=1(C), a=T(3)->aa=0(A) => sub C>A=0.
+        // five=A(0)->ff=comp(three=C(1))=2(G); three=C(1)->tt=comp(five=A(0))=3(T).
+        // code = 0*16 + 2*4 + 3 = 11.
+        assert_eq!(sbs96_code(b'A', b'G', b'T', b'C'), 11);
+    }
+
+    #[test]
+    fn sbs96_rejects_non_acgt_and_ref_eq_alt() {
+        assert_eq!(sbs96_code(b'N', b'C', b'A', b'G'), UNCLASSIFIED);
+        assert_eq!(sbs96_code(b'A', b'C', b'C', b'G'), UNCLASSIFIED); // ref==alt
+    }
+}
+```
+
+- [ ] **Step 2: Add `pub mod classify;` is already in `mod.rs` (Task 0). Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::classify'`
+Expected: PASS (3 tests).
+
+- [ ] **Step 3: Cross-check against v1 on 20 random SNVs (one-off, not committed).** Write a throwaway Python snippet in the scratchpad that calls `genoray._mutcat.classify._sbs96_codes` on 20 random `(five, ref, alt, three)` contexts and compares to a hand-run of the Rust logic; confirm the COSMIC index matches for at least the two asserted cases. (This is a sanity gate; the authoritative check is the Python parity test in Task 14.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mutcat/classify.rs
+git commit -m "feat(mutcat): SBS96 classifier (pyrimidine-folded trinucleotide)"
+```
+
+### Task 2: ID83 classifier
+
+**Files:**
+- Modify: `src/mutcat/classify.rs`
+
+**Interfaces:**
+- Produces: `pub fn id83_code(seq: &[u8], pos0: usize, refa: &[u8], alta: &[u8]) -> u8` — ID83 class-local index `0–82` or `UNCLASSIFIED`. `seq` is the whole contig (ASCII uint8), `pos0` the 0-based REF start, `refa`/`alta` the full REF/ALT allele bytes. Ports `_id83_kernel` in `classify.py:134-225`. A ref/reference disagreement (v1's internal `_REF_MISMATCH`) maps to `UNCLASSIFIED`.
+
+- [ ] **Step 1: Write the failing test** — append to `src/mutcat/classify.rs` (inside the module body, above `#[cfg(test)]`):
+
+```rust
+// ID83 lookup tables, built to match codebook.py ID83 order.
+// ID83 label order (see _build_id83): 24 single-base (Del/Ins x C/T x rep0..5),
+// then 48 repeat (Del/Ins x size2..5 x rep0..5), then 11 microhomology-Del.
+struct Id83Luts {
+    id1: [[[u8; 6]; 2]; 2],  // [kind(Del=0,Ins=1)][base(C=0,T=1)][rep0..5]
+    idr: [[[u8; 6]; 4]; 2],  // [kind][size_bucket(2..5)][rep0..5]
+    idm: [[u8; 6]; 4],       // [size_bucket][mh]
+}
+
+const fn build_id83_luts() -> Id83Luts {
+    // Index formula mirrors codebook order:
+    //   single: base = (kind*2 + base_ct)*6 + rep                          [0..24)
+    //   repeat: 24 + (kind*4 + size_bucket)*6 + rep                        [24..72)
+    //   mh    : 72 + cumulative(mh caps 1,2,3,5) offset + (m-1)            [72..83)
+    let u = UNCLASSIFIED;
+    let mut id1 = [[[u; 6]; 2]; 2];
+    let mut idr = [[[u; 6]; 4]; 2];
+    let mut idm = [[u; 6]; 4];
+    let mut kind = 0;
+    while kind < 2 {
+        let mut b = 0;
+        while b < 2 {
+            let mut r = 0;
+            while r < 6 {
+                id1[kind][b][r] = ((kind * 2 + b) * 6 + r) as u8;
+                r += 1;
+            }
+            b += 1;
+        }
+        let mut s = 0;
+        while s < 4 {
+            let mut r = 0;
+            while r < 6 {
+                idr[kind][s][r] = (24 + (kind * 4 + s) * 6 + r) as u8;
+                r += 1;
+            }
+            s += 1;
+        }
+        kind += 1;
+    }
+    // microhomology (Del only): caps per size bucket = [1,2,3,5]; base offset 72.
+    let caps = [1usize, 2, 3, 5];
+    let mut s = 0;
+    let mut base = 72usize;
+    while s < 4 {
+        let mut m = 1;
+        while m <= caps[s] {
+            idm[s][m] = (base + (m - 1)) as u8;
+            m += 1;
+        }
+        base += caps[s];
+        s += 1;
+    }
+    Id83Luts { id1, idr, idm }
+}
+
+const ID83_LUTS: Id83Luts = build_id83_luts();
+const MH_CAP: [usize; 4] = [1, 2, 3, 5];
+
+/// ID83 class-local index (0..=82) or `UNCLASSIFIED`. Port of `_id83_kernel`.
+pub fn id83_code(seq: &[u8], pos0: usize, refa: &[u8], alta: &[u8]) -> u8 {
+    let n = seq.len();
+    let rl = refa.len();
+    let al = alta.len();
+    // atomized indels always share an anchor base; require it and equal anchors.
+    if rl == 0 || al == 0 || refa[0] != alta[0] {
+        return UNCLASSIFIED;
+    }
+    let is_del = rl > al;
+    // deleted/inserted unit = allele[1..]
+    let (buf, ilen): (&[u8], usize) = if is_del {
+        (&refa[1..], rl - 1)
+    } else {
+        (&alta[1..], al - 1)
+    };
+    if ilen == 0 {
+        return UNCLASSIFIED;
+    }
+    for &c in buf {
+        if base_index(c) < 0 {
+            return UNCLASSIFIED;
+        }
+    }
+    // count tandem repeats of the unit downstream from pos0+1
+    let scan = pos0 + 1;
+    let mut n_rep = 0usize;
+    let mut i = 0usize;
+    while scan + i + ilen <= n {
+        let mut m = true;
+        let mut j = 0;
+        while j < ilen {
+            if seq[scan + i + j] != buf[j] {
+                m = false;
+                break;
+            }
+            j += 1;
+        }
+        if !m {
+            break;
+        }
+        n_rep += 1;
+        i += ilen;
+    }
+    if ilen == 1 {
+        let mut bi = base_index(buf[0]);
+        if bi == 0 || bi == 2 {
+            bi = 3 - bi; // A/G -> pyrimidine partner
+        }
+        let base_ct = if bi == 1 { 0 } else { 1 }; // C->0, T->1
+        if is_del && n_rep == 0 {
+            return UNCLASSIFIED; // v1 _REF_MISMATCH -> UNCLASSIFIED
+        }
+        let mut rep = if is_del { n_rep - 1 } else { n_rep };
+        if rep > 5 {
+            rep = 5;
+        }
+        return ID83_LUTS.id1[if is_del { 0 } else { 1 }][base_ct][rep];
+    }
+    let sb = if ilen < 5 { ilen } else { 5 };
+    let si = sb - 2; // 0..3
+    let rep;
+    if is_del {
+        // microhomology: longest prefix of the unit matching downstream
+        let mut mh = 0usize;
+        let mut kk = 1;
+        while kk < ilen {
+            let mut eq = true;
+            let mut j = 0;
+            while j < kk {
+                if scan + j >= n || seq[scan + j] != buf[j] {
+                    eq = false;
+                    break;
+                }
+                j += 1;
+            }
+            if eq {
+                mh = kk;
+            }
+            kk += 1;
+        }
+        if mh > 0 && n_rep <= 1 {
+            let cap = MH_CAP[si];
+            let m = if mh < cap { mh } else { cap };
+            return ID83_LUTS.idm[si][m];
+        }
+        if n_rep == 0 {
+            return UNCLASSIFIED; // _REF_MISMATCH
+        }
+        rep = n_rep - 1;
+    } else {
+        rep = n_rep;
+    }
+    let rep = if rep > 5 { 5 } else { rep };
+    ID83_LUTS.idr[if is_del { 0 } else { 1 }][si][rep]
+}
+```
+
+Add tests inside the existing `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn id83_1bp_del_in_repeat() {
+        // seq: ...A C C C C... delete one C at a run of 4 C's.
+        // REF="AC" ALT="A" (anchor A, deleted unit "C"), pos0 at the 'A'.
+        // downstream run of C's from pos0+1: 4 -> is_del, rep=n_rep-1=3.
+        // base C -> base_ct=0, kind Del=0 -> id1[0][0][3] = (0*2+0)*6+3 = 3
+        let seq = b"AACCCCG"; // pos0 = 1 ('A'), then CCCC
+        assert_eq!(id83_code(seq, 1, b"AC", b"A"), 3);
+    }
+
+    #[test]
+    fn id83_1bp_ins() {
+        // REF="A" ALT="AC" insert one C; downstream C run from pos0+1.
+        // seq A C C C: n_rep counts inserted-unit "C" copies present downstream.
+        // kind Ins=1, base C base_ct=0, rep=n_rep (no -1 for ins).
+        let seq = b"ACCCG"; // pos0=0 ('A'); downstream from index1: C C C -> n_rep=3
+        assert_eq!(id83_code(seq, 0, b"A", b"AC"), (1 * 2 + 0) * 6 + 3);
+    }
+
+    #[test]
+    fn id83_rejects_non_acgt_unit() {
+        let seq = b"ANNNG";
+        assert_eq!(id83_code(seq, 0, b"AN", b"A"), UNCLASSIFIED);
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::classify'`
+Expected: PASS (6 tests). If the microhomology or repeat index math is off, compare against `python/genoray/_mutcat/classify.py:134-259` line-by-line — the control flow here mirrors it exactly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mutcat/classify.rs
+git commit -m "feat(mutcat): ID83 indel classifier (port of _id83_kernel)"
+```
+
+### Task 3: DBS78 doublet table
+
+**Files:**
+- Modify: `src/mutcat/classify.rs`
+
+**Interfaces:**
+- Produces: `pub fn dbs78_code(r0: u8, a0: u8, r1: u8, a1: u8) -> u8` — DBS78 class-local index `0–77` or `UNCLASSIFIED`. Inputs are ASCII bases of the 2bp REF (`r0 r1`) and 2bp ALT (`a0 a1`). Ports `classify_dbs78` + `_build_dbs_table` (`classify.py:35-51,262-277`): try literal `REF>ALT`, else reverse-complement, against the canonical DBS78 list.
+
+- [ ] **Step 1: Write the failing test** — append to `classify.rs`:
+
+```rust
+// Canonical DBS78 doublet labels, codebook order (must match codebook.py DBS78).
+const DBS78_LABELS: [&str; 78] = [
+    "AC>CA", "AC>CG", "AC>CT", "AC>GA", "AC>GG", "AC>GT", "AC>TA", "AC>TG", "AC>TT",
+    "AT>CA", "AT>CC", "AT>CG", "AT>GA", "AT>GC", "AT>TA",
+    "CC>AA", "CC>AG", "CC>AT", "CC>GA", "CC>GG", "CC>GT", "CC>TA", "CC>TG", "CC>TT",
+    "CG>AT", "CG>GC", "CG>GT", "CG>TA", "CG>TC", "CG>TT",
+    "CT>AA", "CT>AC", "CT>AG", "CT>GA", "CT>GC", "CT>GG", "CT>TA", "CT>TC", "CT>TG",
+    "GC>AA", "GC>AG", "GC>AT", "GC>CA", "GC>CG", "GC>TA",
+    "TA>AT", "TA>CG", "TA>CT", "TA>GC", "TA>GG", "TA>GT",
+    "TC>AA", "TC>AG", "TC>AT", "TC>CA", "TC>CG", "TC>CT", "TC>GA", "TC>GG", "TC>GT",
+    "TG>AA", "TG>AC", "TG>AT", "TG>CA", "TG>CC", "TG>CT", "TG>GA", "TG>GC", "TG>GT",
+    "TT>AA", "TT>AC", "TT>AG", "TT>CA", "TT>CC", "TT>CG", "TT>GA", "TT>GC", "TT>GG",
+];
+
+#[inline]
+fn comp(b: u8) -> u8 {
+    match b {
+        b'A' => b'T',
+        b'T' => b'A',
+        b'C' => b'G',
+        b'G' => b'C',
+        _ => b,
+    }
+}
+
+// Build the (r0,a0,r1,a1) -> code table once. Bases A=0 C=1 G=2 T=3.
+const BASES_ACGT: [u8; 4] = [b'A', b'C', b'G', b'T'];
+
+fn dbs_index_of(key: &str) -> Option<u8> {
+    DBS78_LABELS.iter().position(|&l| l == key).map(|i| i as u8)
+}
+
+/// DBS78 class-local index (0..=77) or `UNCLASSIFIED`. Try literal then
+/// reverse-complement of the doublet REF>ALT.
+pub fn dbs78_code(r0: u8, a0: u8, r1: u8, a1: u8) -> u8 {
+    if base_index(r0) < 0 || base_index(r1) < 0 || base_index(a0) < 0 || base_index(a1) < 0 {
+        return UNCLASSIFIED;
+    }
+    let literal = format!(
+        "{}{}>{}{}",
+        r0 as char, r1 as char, a0 as char, a1 as char
+    );
+    if let Some(c) = dbs_index_of(&literal) {
+        return c;
+    }
+    // reverse-complement both sides
+    let rc = format!(
+        "{}{}>{}{}",
+        comp(r1) as char,
+        comp(r0) as char,
+        comp(a1) as char,
+        comp(a0) as char
+    );
+    dbs_index_of(&rc).unwrap_or(UNCLASSIFIED)
+}
+```
+
+Tests in the `tests` module:
+
+```rust
+    #[test]
+    fn dbs78_literal_hit() {
+        // "AC>CA" is index 0.
+        assert_eq!(dbs78_code(b'A', b'C', b'C', b'A'), 0);
+    }
+
+    #[test]
+    fn dbs78_revcomp_fold() {
+        // "GT>TG" is not literal; revcomp = "AC>CA" (index 0).
+        assert_eq!(dbs78_code(b'G', b'T', b'T', b'G'), 0);
+    }
+
+    #[test]
+    fn dbs78_all_16_doublets_map_or_uncl() {
+        // Every ACGT^4 combo with r!=a on both is either a code < 78 or UNCLASSIFIED.
+        for &r0 in &BASES_ACGT {
+            for &r1 in &BASES_ACGT {
+                for &a0 in &BASES_ACGT {
+                    for &a1 in &BASES_ACGT {
+                        let c = dbs78_code(r0, a0, r1, a1);
+                        assert!(c < 78 || c == UNCLASSIFIED);
+                    }
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::classify'`
+Expected: PASS (9 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mutcat/classify.rs
+git commit -m "feat(mutcat): DBS78 doublet classifier (literal + revcomp fold)"
+```
+
+---
+
+## Phase 2 — Sidecar layout + I/O
+
+### Task 4: `mutcat/` path helpers
+
+**Files:**
+- Modify: `src/layout.rs`
+
+**Interfaces:**
+- Produces on `ContigPaths`: `mutcat_dir(&self, sub: MutcatSub) -> PathBuf`, `mutcat_code(&self, sub) -> PathBuf`, `mutcat_ref(&self, sub) -> PathBuf`, where `MutcatSub { VkSnp, VkIndel, DenseSnp, DenseIndel }`.
+
+- [ ] **Step 1: Write the failing test** — add to `src/layout.rs`:
+
+```rust
+/// The four sub-streams a mutcat sidecar mirrors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MutcatSub {
+    VkSnp,
+    VkIndel,
+    DenseSnp,
+    DenseIndel,
+}
+
+impl MutcatSub {
+    fn dir_name(self) -> &'static str {
+        match self {
+            MutcatSub::VkSnp => "var_key_snp",
+            MutcatSub::VkIndel => "var_key_indel",
+            MutcatSub::DenseSnp => "dense_snp",
+            MutcatSub::DenseIndel => "dense_indel",
+        }
+    }
+    /// Whether this sub-stream carries a 2-bit ref-base stream (snp only).
+    pub fn has_ref(self) -> bool {
+        matches!(self, MutcatSub::VkSnp | MutcatSub::DenseSnp)
+    }
+}
+```
+
+Add methods inside `impl ContigPaths`:
+
+```rust
+    fn mutcat_dir(&self, sub: MutcatSub) -> PathBuf {
+        Path::new(&self.base_out_dir)
+            .join(&self.chrom)
+            .join("mutcat")
+            .join(sub.dir_name())
+    }
+    pub fn mutcat_code(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub).join("code.bin")
+    }
+    pub fn mutcat_ref(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub).join("ref.bin")
+    }
+    /// Directory created before writing a sidecar sub-stream.
+    pub fn mutcat_sub_dir(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub)
+    }
+```
+
+Test in `layout.rs` `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn mutcat_paths() {
+        let p = ContigPaths::new("/out", "chr1");
+        assert_eq!(
+            p.mutcat_code(MutcatSub::VkSnp),
+            Path::new("/out/chr1/mutcat/var_key_snp/code.bin")
+        );
+        assert_eq!(
+            p.mutcat_ref(MutcatSub::DenseSnp),
+            Path::new("/out/chr1/mutcat/dense_snp/ref.bin")
+        );
+        assert!(MutcatSub::VkSnp.has_ref());
+        assert!(!MutcatSub::VkIndel.has_ref());
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion layout::tests::mutcat_paths'`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/layout.rs
+git commit -m "feat(mutcat): mutcat/ sidecar path helpers"
+```
+
+### Task 5: Sidecar writer + reader
+
+**Files:**
+- Create: `src/mutcat/sidecar.rs`
+- Modify: `src/mutcat/mod.rs` (add `pub mod sidecar;`)
+
+**Interfaces:**
+- Consumes: `crate::layout::{ContigPaths, MutcatSub}`, `svar2_codec::{pack_snp_keys, unpack_snp_key_at}`, `crate::query::sidecar::mmap_file`.
+- Produces:
+  - `pub fn write_sidecar(paths: &ContigPaths, sub: MutcatSub, codes: &[u8], ref_codes: Option<&[u8]>) -> std::io::Result<()>` — writes `code.bin` (raw `u8`) and, for snp subs, `ref.bin` (2-bit packed via `pack_snp_keys`). `ref_codes` are 2-bit values `0–3`.
+  - `pub struct MutcatView { code: Option<Mmap>, ref_packed: Option<Mmap>, n: usize }` with `code_at(i) -> u8` and `ref_at(i) -> u8` (2-bit).
+  - `pub fn open_sidecar(paths: &ContigPaths, sub: MutcatSub) -> std::io::Result<MutcatView>` — empty view if files absent.
+
+- [ ] **Step 1: Write the failing test** — `src/mutcat/sidecar.rs`:
+
+```rust
+//! Read/write the per-contig mutcat sidecar. `code.bin` is raw u8 (one per
+//! record); `ref.bin` (snp subs only) is 2-bit packed A/C/T/G ref bases.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use memmap2::Mmap;
+
+use crate::layout::{ContigPaths, MutcatSub};
+use crate::query::sidecar::mmap_file;
+use svar2_codec::{pack_snp_keys, unpack_snp_key_at};
+
+pub fn write_sidecar(
+    paths: &ContigPaths,
+    sub: MutcatSub,
+    codes: &[u8],
+    ref_codes: Option<&[u8]>,
+) -> std::io::Result<()> {
+    let dir = paths.mutcat_sub_dir(sub);
+    fs::create_dir_all(&dir)?;
+    write_bytes(&paths.mutcat_code(sub), codes)?;
+    if sub.has_ref() {
+        let refs = ref_codes.expect("snp sub-stream requires ref_codes");
+        debug_assert_eq!(refs.len(), codes.len());
+        let packed = pack_snp_keys(refs);
+        write_bytes(&paths.mutcat_ref(sub), &packed)?;
+    }
+    Ok(())
+}
+
+fn write_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut f = fs::File::create(path)?;
+    f.write_all(bytes)?;
+    f.flush()
+}
+
+pub struct MutcatView {
+    code: Option<Mmap>,
+    ref_packed: Option<Mmap>,
+    pub n: usize,
+}
+
+impl MutcatView {
+    /// Class-local mutation code at record `i` (u8; may be a sentinel).
+    #[inline]
+    pub fn code_at(&self, i: usize) -> u8 {
+        match &self.code {
+            Some(m) => m[i],
+            None => crate::mutcat::NOT_ANNOTATED,
+        }
+    }
+    /// 2-bit reference-base code at snp record `i` (`0–3`). Panics if no ref stream.
+    #[inline]
+    pub fn ref_at(&self, i: usize) -> u8 {
+        let m = self.ref_packed.as_ref().expect("ref_at on a stream with no ref.bin");
+        unpack_snp_key_at(&m[..], i)
+    }
+}
+
+pub fn open_sidecar(paths: &ContigPaths, sub: MutcatSub) -> std::io::Result<MutcatView> {
+    let code = mmap_file(&paths.mutcat_code(sub))?;
+    let n = code.as_ref().map(|m| m.len()).unwrap_or(0);
+    let ref_packed = if sub.has_ref() {
+        mmap_file(&paths.mutcat_ref(sub))?
+    } else {
+        None
+    };
+    Ok(MutcatView { code, ref_packed, n })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snp_sidecar_round_trips_code_and_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let codes = [5u8, 95, 254, 0];
+        let refs = [1u8, 3, 0, 2]; // C,G(→ codec 3),A,T
+        write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs)).unwrap();
+        let v = open_sidecar(&paths, MutcatSub::VkSnp).unwrap();
+        assert_eq!(v.n, 4);
+        for i in 0..4 {
+            assert_eq!(v.code_at(i), codes[i]);
+            assert_eq!(v.ref_at(i), refs[i]);
+        }
+    }
+
+    #[test]
+    fn indel_sidecar_has_no_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let codes = [10u8, 82, 255];
+        write_sidecar(&paths, MutcatSub::VkIndel, &codes, None).unwrap();
+        let v = open_sidecar(&paths, MutcatSub::VkIndel).unwrap();
+        assert_eq!(v.n, 3);
+        assert_eq!(v.code_at(1), 82);
+    }
+
+    #[test]
+    fn missing_sidecar_opens_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let v = open_sidecar(&paths, MutcatSub::DenseSnp).unwrap();
+        assert_eq!(v.n, 0);
+        assert_eq!(v.code_at(0), crate::mutcat::NOT_ANNOTATED);
+    }
+}
+```
+
+Add `pub mod sidecar;` to `src/mutcat/mod.rs`. Ensure `tempfile` is a dev-dependency (it is — used across `src/`).
+
+- [ ] **Step 2: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::sidecar'`
+Expected: PASS (3 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mutcat/sidecar.rs src/mutcat/mod.rs
+git commit -m "feat(mutcat): sidecar reader/writer (u8 code + 2-bit ref)"
+```
+
+---
+
+## Phase 3 — Classification pass
+
+### Task 6: Classify one contig's finalized records → sidecar
+
+**Files:**
+- Create: `src/mutcat/annotate.rs`
+- Modify: `src/mutcat/mod.rs` (add `pub mod annotate;`)
+
+**Interfaces:**
+- Consumes: `crate::query::ContigReader` (opened contig), the classifiers (Task 1–3), `write_sidecar` (Task 5), a reference sequence slice provider.
+- Produces: `pub fn annotate_contig(reader: &ContigReader, paths: &ContigPaths, ref_seq: &[u8]) -> std::io::Result<()>`. `ref_seq` is the whole contig's ASCII sequence (0-based). It classifies each of the four sub-streams' records and writes the sidecar. For snp subs it also emits the per-record 2-bit ref base (`encode_snp_2bit(ref_seq[pos])`).
+
+**Notes for the implementer (record reconstruction):**
+- The `ContigReader` exposes `vk_snp`/`vk_indel` (`SubStreamView`, per-call `positions()` + packed keys) and `dense_snp`/`dense_indel` (`Option<DenseView>`, per-variant `positions()` + keys). Add small `pub(crate)` accessors on `ContigReader`/`SubStreamView`/`DenseView` if needed (e.g. `vk_snp_len()`, a way to read the whole packed positions/keys) — mirror the existing `vk_slice` access patterns in `src/query/reader.rs:119`.
+- SNP ALT: `decode_snp_2bit(unpack_snp_key_at(keys, i))`. SNP REF/flanks: `ref_seq[pos-1], ref_seq[pos], ref_seq[pos+1]` (guard bounds → `UNCLASSIFIED` at contig ends).
+- Indel key: `decode_key(u32_key)` → `Inline{alt}` (ALT bytes), `PureDel{ilen}` (REF = `ref_seq[pos..pos + (-ilen) + 1]`, ALT = `ref_seq[pos..pos+1]`, per the DEL empty-allele anchor convention), or `Lookup{row}` (ALT from `reader.lut`). REF for an inline INS = `ref_seq[pos..pos+1]` (single anchor). Build `refa`/`alta` byte vecs then call `id83_code(ref_seq, pos as usize, &refa, &alta)`.
+
+- [ ] **Step 1: Write the failing test** — `src/mutcat/annotate.rs`. Build a tiny synthetic contig with a helper that hand-writes the four sub-streams (or reuse an existing test fixture builder if `tests/common/mod.rs` has one). Minimal viable test: one var_key/snp record and assert the sidecar code equals the direct `sbs96_code` of its context.
+
+```rust
+//! Classify a finished contig's records and write the mutcat sidecar. Runs at
+//! write time (FASTA already open) or post-hoc.
+
+use crate::layout::{ContigPaths, MutcatSub};
+use crate::mutcat::classify::{id83_code, sbs96_code};
+use crate::mutcat::sidecar::write_sidecar;
+use crate::mutcat::{NOT_ANNOTATED, UNCLASSIFIED};
+use crate::query::ContigReader;
+use svar2_codec::{decode_key, decode_snp_2bit, encode_snp_2bit, DecodedKey};
+
+/// Classify every record of `reader`'s four sub-streams against `ref_seq` (the
+/// whole contig, 0-based ASCII) and write the sidecar under `paths`.
+pub fn annotate_contig(
+    reader: &ContigReader,
+    paths: &ContigPaths,
+    ref_seq: &[u8],
+) -> std::io::Result<()> {
+    // --- var_key/snp (per call) ---
+    {
+        let (positions, keys) = reader.vk_snp_records(); // &[u32], packed 2-bit keys
+        let mut codes = Vec::with_capacity(positions.len());
+        let mut refs = Vec::with_capacity(positions.len());
+        for (i, &pos) in positions.iter().enumerate() {
+            let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
+            codes.push(code);
+            refs.push(refc);
+        }
+        write_sidecar(paths, MutcatSub::VkSnp, &codes, Some(&refs))?;
+    }
+    // --- dense/snp (per variant) ---
+    if let Some((positions, keys)) = reader.dense_snp_records() {
+        let mut codes = Vec::with_capacity(positions.len());
+        let mut refs = Vec::with_capacity(positions.len());
+        for (i, &pos) in positions.iter().enumerate() {
+            let (code, refc) = snp_record(ref_seq, pos, decode_snp_2bit(keys[i]));
+            codes.push(code);
+            refs.push(refc);
+        }
+        write_sidecar(paths, MutcatSub::DenseSnp, &codes, Some(&refs))?;
+    }
+    // --- var_key/indel + dense/indel (per record) ---
+    annotate_indel(reader, paths, ref_seq, MutcatSub::VkIndel)?;
+    annotate_indel(reader, paths, ref_seq, MutcatSub::DenseIndel)?;
+    Ok(())
+}
+
+/// SBS96 code + 2-bit ref base for a SNP at 0-based `pos` with ASCII `alt`.
+fn snp_record(ref_seq: &[u8], pos: u32, alt: u8) -> (u8, u8) {
+    let p = pos as usize;
+    let n = ref_seq.len();
+    if p == 0 || p + 1 >= n {
+        return (NOT_ANNOTATED, 0); // contig-end flank missing → not classified
+    }
+    let refb = ref_seq[p];
+    let code = sbs96_code(ref_seq[p - 1], refb, alt, ref_seq[p + 1]);
+    (code, encode_snp_2bit(refb))
+}
+
+fn snp_alt(packed_keys: &[u8], i: usize) -> u8 {
+    decode_snp_2bit(svar2_codec::unpack_snp_key_at(packed_keys, i))
+}
+
+fn annotate_indel(
+    reader: &ContigReader,
+    paths: &ContigPaths,
+    ref_seq: &[u8],
+    sub: MutcatSub,
+) -> std::io::Result<()> {
+    let recs = reader.indel_records(sub); // Option<(&[u32] positions, &[u32] keys)>
+    let (positions, keys) = match recs {
+        Some(r) => r,
+        None => return write_sidecar(paths, sub, &[], None),
+    };
+    let mut codes = Vec::with_capacity(positions.len());
+    for (i, &pos) in positions.iter().enumerate() {
+        codes.push(indel_code(reader, ref_seq, pos, keys[i]));
+    }
+    write_sidecar(paths, sub, &codes, None)
+}
+
+/// ID83 code for one indel record, reconstructing REF/ALT from key + reference.
+fn indel_code(reader: &ContigReader, ref_seq: &[u8], pos: u32, key: u32) -> u8 {
+    let p = pos as usize;
+    if p >= ref_seq.len() {
+        return NOT_ANNOTATED;
+    }
+    let anchor = ref_seq[p];
+    let (refa, alta): (Vec<u8>, Vec<u8>) = match decode_key(key) {
+        DecodedKey::Inline { alt } => {
+            // atomized INS/anchor: REF = single anchor base; ALT = alt bytes.
+            (vec![anchor], alt)
+        }
+        DecodedKey::PureDel { ilen } => {
+            let dl = (-ilen) as usize;
+            if p + dl >= ref_seq.len() {
+                return NOT_ANNOTATED;
+            }
+            // REF = anchor + dl deleted bases; ALT = anchor only.
+            (ref_seq[p..p + dl + 1].to_vec(), vec![anchor])
+        }
+        DecodedKey::Lookup { row } => {
+            let alt = reader.lut_allele(row); // Vec<u8>
+            (vec![anchor], alt)
+        }
+    };
+    id83_code(ref_seq, p, &refa, &alta)
+}
+```
+
+Also add the `pub(crate)` accessors this task needs on `ContigReader` (in `src/query/reader.rs`): `vk_snp_records()`, `dense_snp_records()`, `indel_records(sub)`, `lut_allele(row)`. Each is a thin wrapper over the existing mmap fields (`self.vk_snp.positions()`, `as_bytes(&self.vk_snp.keys)`, `self.dense_snp.as_ref().map(...)`, `self.lut.as_ref().unwrap().get_allele(row)`).
+
+Test:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mutcat::classify::sbs96_code;
+
+    // Uses the shared fixture builder (tests/common) or a hand-built contig dir.
+    // Minimal check: a single var_key/snp record's sidecar code equals the
+    // direct sbs96_code of its reference context.
+    #[test]
+    fn snp_record_matches_direct_classify() {
+        let ref_seq = b"TACGT"; // pos 2 = 'C', 5'=A(1), 3'=G(3)
+        let (code, refc) = snp_record(ref_seq, 2, b'A');
+        assert_eq!(code, sbs96_code(b'A', b'C', b'A', b'G'));
+        assert_eq!(refc, svar2_codec::encode_snp_2bit(b'C'));
+    }
+
+    #[test]
+    fn contig_end_snp_is_not_annotated() {
+        let ref_seq = b"CG";
+        assert_eq!(snp_record(ref_seq, 0, b'A').0, NOT_ANNOTATED);
+    }
+}
+```
+
+- [ ] **Step 2: Implement the `ContigReader` accessors** referenced above; run `cargo build` to confirm they compile.
+
+Run: `pixi run -e lint bash -lc 'cargo build --no-default-features --features conversion'`
+Expected: builds clean.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::annotate'`
+Expected: PASS (2 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mutcat/annotate.rs src/mutcat/mod.rs src/query/reader.rs
+git commit -m "feat(mutcat): classify finalized contig records into the sidecar"
+```
+
+---
+
+## Phase 4 — Cost-model integration (write-time)
+
+### Task 7: `choose_representation` with sidecar bits
+
+**Files:**
+- Modify: `src/cost_model.rs`
+- Modify: `src/rvk.rs` (`dense2sparse_vk` call site)
+
+**Interfaces:**
+- Produces: `choose_representation(class, n_samples, ploidy, x_calls, sidecar_bits)` — new trailing `sidecar_bits: u64` parameter. `var_key_bits += x_calls * sidecar_bits`; `dense_bits += sidecar_bits`. Existing callers pass `0`.
+- Add `pub const SIDECAR_BITS_SNP: u64 = 10;` and `pub const SIDECAR_BITS_INDEL: u64 = 8;` (8 code + 2 ref for snp; 8 code for indel).
+
+- [ ] **Step 1: Update the existing tests + add new ones** in `src/cost_model.rs`. Change the signature and thread `sidecar_bits` through:
+
+```rust
+pub const SIDECAR_BITS_SNP: u64 = 10; // 8-bit code + 2-bit ref
+pub const SIDECAR_BITS_INDEL: u64 = 8; // 8-bit code
+
+#[inline]
+pub fn choose_representation(
+    class: Class,
+    n_samples: usize,
+    ploidy: usize,
+    x_calls: usize,
+    sidecar_bits: u64,
+) -> Representation {
+    let np = (n_samples as u64) * (ploidy as u64);
+    let per_call = POS_BITS + key_bits(class) + sidecar_bits;
+    let var_key_bits = (x_calls as u64) * per_call;
+    let dense_bits = POS_BITS + key_bits(class) + np + sidecar_bits;
+    if dense_bits < var_key_bits {
+        Representation::Dense
+    } else {
+        Representation::VarKey
+    }
+}
+```
+
+Update every existing test in `cost_model.rs` to pass `0` as the final arg, and add:
+
+```rust
+    #[test]
+    fn sidecar_bits_shift_snp_crossover_toward_dense() {
+        // Without sidecar: np=2000 → dense wins at x>=60 (see test_snp_crossover_np2000).
+        // With +10 sidecar/call on var_key and +10 once on dense:
+        // dense = 32+2+2000+10 = 2044; per_call = 34+10 = 44.
+        // dense < 44x → x > 46.45 → dense at x>=47 (vs 60 without).
+        assert_eq!(
+            choose_representation(Class::Snp, 1000, 2, 46, SIDECAR_BITS_SNP),
+            Representation::VarKey
+        );
+        assert_eq!(
+            choose_representation(Class::Snp, 1000, 2, 47, SIDECAR_BITS_SNP),
+            Representation::Dense
+        );
+    }
+
+    #[test]
+    fn zero_sidecar_matches_legacy() {
+        assert_eq!(
+            choose_representation(Class::Snp, 1000, 2, 60, 0),
+            Representation::Dense
+        );
+    }
+```
+
+- [ ] **Step 2: Thread through `rvk.rs`.** In `dense2sparse_vk` (`src/rvk.rs:177`), add a `sidecar_bits` parameter to the function (default `0`) and select per-class:
+
+```rust
+// at the call site (rvk.rs:177), replace choose_representation(class, num_samples, ploidy, x)
+let bits = if sidecar_bits_enabled {
+    match class {
+        Class::Snp => crate::cost_model::SIDECAR_BITS_SNP,
+        Class::Indel => crate::cost_model::SIDECAR_BITS_INDEL,
+    }
+} else {
+    0
+};
+match choose_representation(class, num_samples, ploidy, x, bits) {
+```
+
+Add `sidecar_bits_enabled: bool` to `dense2sparse_vk`'s signature and thread it from the orchestrator (Task 12 wires the `signatures` flag; until then pass `false`). Update `dense2sparse_vk`'s existing callers (grep `dense2sparse_vk`) to pass `false`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion cost_model rvk'`
+Expected: PASS (all existing + 2 new).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cost_model.rs src/rvk.rs
+git commit -m "feat(mutcat): cost model accounts for sidecar bits when signatures on"
+```
+
+---
+
+## Phase 5 — Streaming count matrix
+
+### Task 8: Per-column SNV merge + DBS pairing core
+
+**Files:**
+- Create: `src/mutcat/count.rs`
+- Modify: `src/mutcat/mod.rs` (add `pub mod count;`)
+
+**Interfaces:**
+- Produces the pure pairing routine, decoupled from I/O so it is unit-testable:
+  `pub fn emit_snv_codes(snvs: &[SnvCall], out: &mut impl FnMut(usize))` where
+  `pub struct SnvCall { pub pos: u32, pub sbs: u8, pub ref_i: u8, pub alt_i: u8 }`
+  (`sbs` = SBS96 class-local index or sentinel; `ref_i`/`alt_i` = 2-bit base codes for DBS). `snvs` is one haplotype's SNVs **sorted by pos, deduped**. `out(unified_code)` is called once per emitted unified code (`SBS96_OFFSET + sbs` or `DBS78_OFFSET + dbs`), skipping sentinels. Implements v1's isolation rule (`classify.py:_entry_codes_kernel`): an adjacent `Δpos==1` pair becomes a DBS **iff** neither neighbor has another adjacent SNV (runs of ≥3 stay SBS).
+
+- [ ] **Step 1: Write the failing test** — `src/mutcat/count.rs`:
+
+```rust
+//! Streaming mutation-catalogue counting with on-the-fly DBS pairing.
+
+use crate::mutcat::classify::dbs78_code;
+use crate::mutcat::{DBS78_OFFSET, N_CODES, SBS96_OFFSET, UNCLASSIFIED};
+use svar2_codec::decode_snp_2bit;
+
+/// One SNV on a single haplotype (already position-sorted & deduped).
+#[derive(Debug, Clone, Copy)]
+pub struct SnvCall {
+    pub pos: u32,
+    pub sbs: u8,   // SBS96 class-local index or sentinel
+    pub ref_i: u8, // 2-bit ref base code
+    pub alt_i: u8, // 2-bit alt base code
+}
+
+/// Emit one unified mutation code per SNV (SBS or, for isolated adjacent pairs,
+/// DBS for both members). Sentinels are skipped. Mirrors v1 isolation logic.
+pub fn emit_snv_codes(snvs: &[SnvCall], out: &mut impl FnMut(usize)) {
+    let n = snvs.len();
+    let mut j = 0;
+    while j < n {
+        let v = snvs[j];
+        // try to pair v with the next SNV
+        if j + 1 < n && snvs[j + 1].pos == v.pos + 1 {
+            let w = snvs[j + 1];
+            // isolation: no adjacent SNV before v, none after w.
+            let before = j > 0 && snvs[j - 1].pos + 1 == v.pos;
+            let after = j + 2 < n && snvs[j + 2].pos == w.pos + 1;
+            if !before && !after {
+                let code = dbs78_code(
+                    decode_snp_2bit(v.ref_i),
+                    decode_snp_2bit(v.alt_i),
+                    decode_snp_2bit(w.ref_i),
+                    decode_snp_2bit(w.alt_i),
+                );
+                if code != UNCLASSIFIED {
+                    out(DBS78_OFFSET + code as usize);
+                    out(DBS78_OFFSET + code as usize);
+                    j += 2;
+                    continue;
+                }
+            }
+        }
+        if (v.sbs as usize) < 96 {
+            out(SBS96_OFFSET + v.sbs as usize);
+        }
+        j += 1;
+    }
+    debug_assert!(N_CODES == 257);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snv(pos: u32, ref_b: u8, alt_b: u8) -> SnvCall {
+        use crate::mutcat::classify::sbs96_code;
+        SnvCall {
+            pos,
+            sbs: sbs96_code(b'A', ref_b, alt_b, b'A'), // dummy flanks for the test
+            ref_i: svar2_codec::encode_snp_2bit(ref_b),
+            alt_i: svar2_codec::encode_snp_2bit(alt_b),
+        }
+    }
+
+    #[test]
+    fn isolated_pair_emits_two_dbs() {
+        let snvs = [snv(10, b'A', b'C'), snv(11, b'C', b'A')];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        // AC>CA is DBS index 0 → unified 96; both members contribute.
+        assert_eq!(codes, vec![96, 96]);
+    }
+
+    #[test]
+    fn run_of_three_stays_sbs() {
+        let snvs = [snv(10, b'C', b'A'), snv(11, b'C', b'A'), snv(12, b'C', b'A')];
+        let mut n_dbs = 0;
+        emit_snv_codes(&snvs, &mut |c| {
+            if c >= DBS78_OFFSET {
+                n_dbs += 1;
+            }
+        });
+        assert_eq!(n_dbs, 0, "runs of 3 must stay SBS");
+    }
+
+    #[test]
+    fn non_adjacent_snvs_are_sbs() {
+        let snvs = [snv(10, b'C', b'A'), snv(20, b'C', b'A')];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        assert!(codes.iter().all(|&c| c < DBS78_OFFSET));
+        assert_eq!(codes.len(), 2);
+    }
+}
+```
+
+Add `pub mod count;` to `src/mutcat/mod.rs`.
+
+- [ ] **Step 2: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::count'`
+Expected: PASS (3 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mutcat/count.rs src/mutcat/mod.rs
+git commit -m "feat(mutcat): SNV->SBS/DBS emission core with v1 isolation rule"
+```
+
+### Task 9: Full count matrix over a contig
+
+**Files:**
+- Modify: `src/mutcat/count.rs`
+
+**Interfaces:**
+- Consumes: `ContigReader` + the four `MutcatView`s (Task 5), `emit_snv_codes` (Task 8).
+- Produces: `pub fn count_contig(reader: &ContigReader, sidecars: &Sidecars, per_sample: bool, acc: &mut Array2<i64>)` where `acc` is `(n_samples, N_CODES)` and `Sidecars` bundles the four `MutcatView`s. For each column `(sample, ploid)`:
+  1. Gather the column's SNVs from `var_key/snp` (per-call: positions[o0..o1], code/ref from `VkSnp` view at absolute index; alt from the packed key stream) and `dense/snp` (per-variant carried bit set for this hap; code/ref from `DenseSnp` view at the variant col). Merge-sort by pos, dedup, build `Vec<SnvCall>`, run `emit_snv_codes`.
+  2. Gather the column's indels from `var_key/indel` + `dense/indel`; each emits `ID83_OFFSET + code` directly (no pairing).
+  3. Accumulate: `per_sample` marks each code once per sample (set to 1), else increments.
+
+**Notes:** the var_key column bounds come from `SubStreamView::column(col)` (`offsets[col]..offsets[col+1]`); the sidecar `VkSnp` code/ref arrays are aligned to the same absolute per-call index, so `view.code_at(abs_i)` / `view.ref_at(abs_i)` line up. For dense, iterate the dense variant table and test `DenseView::carried(hap, col)`; the `DenseSnp` sidecar index is the dense variant `col`.
+
+- [ ] **Step 1: Write the failing test.** Reuse the fixture from Task 6 (a small built contig with a known genotype) so `count_contig` produces a known matrix. Minimal assertion: a single sample carrying two isolated adjacent SNVs yields exactly one DBS channel = 2 (allele mode) and the corresponding SBS channels = 0.
+
+```rust
+    #[test]
+    fn count_contig_pairs_adjacent_snvs_for_one_sample() {
+        // Build a 1-sample, ploidy-1 contig with two var_key SNVs at pos 10,11
+        // both carried by the sample. Expect DBS channel == 2, no SBS.
+        // (fixture builder lives in tests/common or is hand-written here)
+        // ... assemble reader + sidecars ...
+        // let mut acc = Array2::<i64>::zeros((1, N_CODES));
+        // count_contig(&reader, &sidecars, false, &mut acc);
+        // assert_eq!(acc[[0, DBS78_OFFSET + 0]], 2);
+        // assert_eq!(acc.slice(s![0, 0..96]).sum(), 0);
+    }
+```
+
+Flesh this out against whatever fixture helper exists (see `tests/common/mod.rs`); if none writes a full contig dir, hand-write the four sub-stream files + sidecars in the test using `write_sidecar` and the existing `layout`/`ndarray_npy` writers.
+
+- [ ] **Step 2: Implement `count_contig` + `Sidecars`.** Follow the column-merge structure from `ContigReader::vk_slice` (`src/query/reader.rs:119`) for how to walk var_key columns and dense carriage.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::count'`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mutcat/count.rs
+git commit -m "feat(mutcat): streaming per-contig count matrix with DBS pairing"
+```
+
+### Task 10: Parallelize over columns
+
+**Files:**
+- Modify: `src/mutcat/count.rs`
+
+**Interfaces:**
+- Produces: `count_contig` uses `rayon` to process columns in parallel, each thread owning a private `(N_CODES,)` row accumulator keyed by sample (fold + reduce). Deterministic regardless of thread count.
+
+- [ ] **Step 1: Write the failing test** — determinism: run `count_contig` on the Task 9 fixture with `rayon` thread pool sizes 1 and 4 (via `rayon::ThreadPoolBuilder`), assert identical matrices.
+
+```rust
+    #[test]
+    fn count_is_thread_count_invariant() {
+        // build fixture once; run under 1 and 4 threads; assert equal.
+    }
+```
+
+- [ ] **Step 2: Implement** with `rayon` (already a dependency — see `Cargo.toml`). Fold per-column results into per-sample rows; since multiple columns map to the same sample (ploidy>1), reduce with `+=` (allele) or `max`/`or` (sample-mode presence collapses per sample after reduce).
+
+- [ ] **Step 3: Run tests**
+
+Run: `pixi run -e lint bash -lc 'cargo test --no-default-features --features conversion mutcat::count'`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mutcat/count.rs
+git commit -m "perf(mutcat): parallelize count matrix over sample-columns"
+```
+
+---
+
+## Phase 6 — PyO3 bindings + Python API
+
+### Task 11: PyO3 methods on `PyContigReader`
+
+**Files:**
+- Create: `src/py_mutcat.rs`
+- Modify: `src/lib.rs` (`mod py_mutcat;`)
+
+**Interfaces:**
+- Produces two `#[pymethods]` on `PyContigReader`:
+  - `fn annotate_mutations(&self, base_out_dir: &str, chrom: &str, ref_seq: PyReadonlyArray1<u8>) -> PyResult<()>` — calls `mutcat::annotate::annotate_contig` with a fresh `ContigPaths`. `ref_seq` is the contig's ASCII bytes passed from Python's `Reference.contig_array`.
+  - `fn count_matrix<'py>(&self, py: Python<'py>, base_out_dir: &str, chrom: &str, per_sample: bool) -> PyResult<Bound<'py, PyArray2<i64>>>` — opens the four sidecars, runs `count_contig`, returns the `(n_samples, N_CODES)` matrix.
+
+- [ ] **Step 1: Write the binding** (mirror the numpy-array patterns in `src/py_query_batch.rs` / `src/py_query_ranges.rs`):
+
+```rust
+//! Python-facing mutcat: post-hoc annotation + count-matrix on PyContigReader.
+
+use numpy::{PyArray2, PyReadonlyArray1, ToPyArray};
+use pyo3::prelude::*;
+
+use crate::layout::ContigPaths;
+use crate::mutcat::annotate::annotate_contig;
+use crate::mutcat::count::{count_contig, Sidecars};
+use crate::mutcat::N_CODES;
+use crate::py_query::PyContigReader;
+
+#[pymethods]
+impl PyContigReader {
+    /// Classify this contig's records against `ref_seq` and write the sidecar.
+    fn annotate_mutations(
+        &self,
+        base_out_dir: &str,
+        chrom: &str,
+        ref_seq: PyReadonlyArray1<u8>,
+    ) -> PyResult<()> {
+        let paths = ContigPaths::new(base_out_dir, chrom);
+        let seq = ref_seq.as_slice()?;
+        annotate_contig(&self.inner, &paths, seq).map_err(|e| {
+            pyo3::exceptions::PyIOError::new_err(format!("annotate {chrom}: {e}"))
+        })?;
+        Ok(())
+    }
+
+    /// Build the `(n_samples, N_CODES)` count matrix for this contig.
+    fn count_matrix<'py>(
+        &self,
+        py: Python<'py>,
+        base_out_dir: &str,
+        chrom: &str,
+        per_sample: bool,
+    ) -> PyResult<Bound<'py, PyArray2<i64>>> {
+        let paths = ContigPaths::new(base_out_dir, chrom);
+        let sidecars = Sidecars::open(&paths).map_err(|e| {
+            pyo3::exceptions::PyIOError::new_err(format!("open sidecar {chrom}: {e}"))
+        })?;
+        let mut acc = ndarray::Array2::<i64>::zeros((self.inner.n_samples, N_CODES));
+        count_contig(&self.inner, &sidecars, per_sample, &mut acc);
+        Ok(acc.to_pyarray(py))
+    }
+}
+```
+
+Add `Sidecars::open(paths)` to `count.rs` if not already present (opens the four `MutcatView`s). Expose `ContigReader::n_samples` (already a field; add a `pub(crate) fn n_samples()` or make the field visible to `py_mutcat`).
+
+- [ ] **Step 2: Build the extension**
+
+Run: `pixi run maturin develop`
+Expected: builds and installs `genoray._core`.
+
+- [ ] **Step 3: Smoke test from Python** (scratchpad, not committed): open an existing test SVAR2 store's `PyContigReader`, call `count_matrix(...)`, confirm it returns an `(n_samples, 257)` int64 array.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/py_mutcat.rs src/lib.rs src/mutcat/count.rs src/query/reader.rs
+git commit -m "feat(mutcat): PyContigReader.annotate_mutations + count_matrix"
+```
+
+### Task 12: Wire `signatures` into the conversion pipeline
+
+**Files:**
+- Modify: `src/lib.rs` (`run_conversion_pipeline` signature + orchestrator call)
+- Modify: `src/orchestrator.rs` (thread `signatures` → `dense2sparse_vk` `sidecar_bits_enabled`, and run `annotate_contig` per contig after finalization using the reference already loaded)
+- Modify: `python/genoray/_svar2.py` (`from_vcf(..., signatures=False)`)
+
+**Interfaces:**
+- `run_conversion_pipeline(..., signatures: bool)` — new trailing bool. When true: (a) `dense2sparse_vk` uses sidecar-aware cost model; (b) after each contig's sub-streams are finalized, open a `ContigReader` for it and call `annotate_contig` with the contig's reference sequence (already mmap'd for normalization/left-align).
+
+- [ ] **Step 1: Add the Python kwarg + pass-through** in `_svar2.py`:
+
+```python
+    @classmethod
+    def from_vcf(
+        cls,
+        out: str | Path,
+        source: str | Path,
+        reference: str | Path | None = None,
+        *,
+        no_reference: bool = False,
+        skip_out_of_scope: bool = False,
+        ploidy: int = 2,
+        chunk_size: int = 25_000,
+        threads: int | None = None,
+        overwrite: bool = False,
+        long_allele_capacity: int = 8 * 1024 * 1024,
+        signatures: bool = False,
+    ) -> int:
+```
+
+Add to the docstring: *"signatures: if True, classify SBS96/ID83 codes during the write and store the mutcat sidecar (factored into the dense/var_key cost model). Requires a reference; raises if `no_reference=True`."* Validate:
+
+```python
+        if signatures and no_reference:
+            raise ValueError("signatures=True requires a reference (not no_reference).")
+```
+
+Pass `signatures` as the final arg to `_core.run_conversion_pipeline(...)`.
+
+- [ ] **Step 2: Thread through Rust** `run_conversion_pipeline` → orchestrator. In the orchestrator's per-contig finalization, after sub-streams + `max_del` are written, if `signatures`:
+
+```rust
+let reader = crate::query::ContigReader::open(out_dir, chrom, n_samples, ploidy)?;
+let paths = crate::layout::ContigPaths::new(out_dir, chrom);
+let ref_seq = /* the contig's ASCII sequence already loaded for normalization */;
+crate::mutcat::annotate::annotate_contig(&reader, &paths, &ref_seq)?;
+```
+
+(If the reference bytes aren't retained past normalization, re-fetch via the existing reference reader used in `normalize.rs` — reuse that loader, don't add a new FASTA dependency.)
+
+- [ ] **Step 3: Build + integration test**
+
+Run: `pixi run maturin develop`
+Then a scratchpad script: `SparseVar2.from_vcf(out, test_vcf, reference=fasta, signatures=True, overwrite=True)` on an existing fixture; confirm `out/<contig>/mutcat/var_key_snp/code.bin` exists and `PyContigReader(...).count_matrix(...)` is non-trivial.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib.rs src/orchestrator.rs python/genoray/_svar2.py
+git commit -m "feat(mutcat): signatures=True annotation during from_vcf write"
+```
+
+### Task 13: Python `_MutcatMixin` (annotate/matrix/assign)
+
+**Files:**
+- Create: `python/genoray/_svar2_mutcat.py`
+- Modify: `python/genoray/_svar2.py` (inherit the mixin)
+
+**Interfaces:**
+- `_MutcatMixin.annotate_mutations(self, reference, *, contigs=None)` — post-hoc. For each in-scope contig, open its `PyContigReader` and call `.annotate_mutations(str(self.path), contig, reference.contig_array(contig))`. Stamp `meta.json` with `mutcat_version` + `mutcat_contigs`.
+- `_MutcatMixin.mutation_matrix(self, kind, *, count="allele")` — sum each contig's `count_matrix(per_sample=(count=="sample"))`, slice the `kind` code range via `genoray._mutcat.codebook.code_ranges()`, and build the codebook-ordered `pl.DataFrame` (`MutationType` + per-sample columns), matching v1's `count_matrix` output shape. For `count="sample"`, presence must be OR-combined across contigs (clip to 1 after summing).
+- `_MutcatMixin.assign_signatures(self, kind, *, reference=None, count="allele", max_delta=0.01, min_activity=0.005, n_jobs=1, backend="loky")` — build the matrix, then call `genoray._signatures.fit_signatures` (delegating `reference=None` → `cosmic_signatures(kind)`), identical to v1's `assign_signatures`.
+
+- [ ] **Step 1: Write the failing test** in `tests/test_svar2_mutcat.py`:
+
+```python
+import numpy as np
+import polars as pl
+import pytest
+import genoray
+from genoray import SparseVar2
+
+
+def test_mutation_matrix_shape_and_labels(tmp_path, small_vcf, small_fasta):
+    out = tmp_path / "store.svar2"
+    SparseVar2.from_vcf(out, small_vcf, reference=small_fasta, overwrite=True)
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(small_fasta)
+    mm = sv2.mutation_matrix("SBS96", count="allele")
+    assert mm.columns[0] == "MutationType"
+    assert mm.height == 96
+    assert set(mm.columns[1:]) == set(sv2.available_samples)
+    assert mm.select(pl.exclude("MutationType")).to_numpy().dtype.kind in "iu"
+```
+
+(`small_vcf`/`small_fasta` fixtures: reuse whatever `tests/conftest.py` or `tests/data/` already provides for SVAR2 e2e tests — check `tests/test_*` for the existing fixture names before writing new ones.)
+
+- [ ] **Step 2: Write the mixin.**
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import polars as pl
+
+import genoray._core as _core
+from genoray._mutcat import MUTCAT_VERSION, N_CODES, code_ranges, labels
+from genoray._reference import Reference
+from genoray._signatures import cosmic_signatures, fit_signatures, _load_signature_file
+
+
+class _MutcatMixin:
+    def annotate_mutations(
+        self, reference: "Reference | str | Path", *, contigs: "list[str] | None" = None
+    ) -> None:
+        if not isinstance(reference, Reference):
+            reference = Reference.from_path(reference)
+        scope = self.contigs if contigs is None else [
+            c for c in self.contigs if c in set(contigs)
+        ]
+        for contig in scope:
+            seq = reference.contig_array(contig).astype(np.uint8, copy=False)
+            self._readers[contig].annotate_mutations(str(self.path), contig, seq)
+        meta_path = self.path / "meta.json"
+        meta = json.loads(meta_path.read_text())
+        meta["mutcat_version"] = MUTCAT_VERSION
+        meta["mutcat_contigs"] = scope
+        meta_path.write_text(json.dumps(meta))
+
+    def mutation_matrix(
+        self, kind: Literal["SBS96", "DBS78", "ID83"], *, count: Literal["allele", "sample"] = "allele"
+    ) -> pl.DataFrame:
+        if kind not in ("SBS96", "DBS78", "ID83"):
+            raise ValueError(f"Unknown matrix kind {kind!r}.")
+        if count not in ("allele", "sample"):
+            raise ValueError(f"Unknown count mode {count!r}.")
+        per_sample = count == "sample"
+        total = np.zeros((self.n_samples, N_CODES), dtype=np.int64)
+        for contig in self.contigs:
+            total += self._readers[contig].count_matrix(str(self.path), contig, per_sample)
+        if per_sample:
+            np.clip(total, 0, 1, out=total)  # presence OR across contigs
+        lo, hi = code_ranges()[kind]
+        block = total[:, lo:hi]
+        out: dict[str, object] = {"MutationType": labels(kind)}
+        for si, name in enumerate(self.available_samples):
+            out[name] = block[si]
+        return pl.DataFrame(out)
+
+    def assign_signatures(
+        self,
+        kind: Literal["SBS96", "DBS78", "ID83"],
+        *,
+        reference: "pl.DataFrame | str | Path | None" = None,
+        count: Literal["allele", "sample"] = "allele",
+        max_delta: float = 0.01,
+        min_activity: float = 0.005,
+        n_jobs: int = 1,
+        backend: str = "loky",
+    ) -> pl.DataFrame:
+        catalogue = self.mutation_matrix(kind, count=count)
+        if reference is None:
+            ref = cosmic_signatures(kind)
+        elif isinstance(reference, pl.DataFrame):
+            ref = reference
+        else:
+            ref = _load_signature_file(reference)
+        return fit_signatures(
+            catalogue, ref, max_delta=max_delta, min_activity=min_activity,
+            n_jobs=n_jobs, backend=backend,
+        )
+```
+
+Make `SparseVar2` inherit `_MutcatMixin` in `_svar2.py`:
+
+```python
+from genoray._svar2_mutcat import _MutcatMixin
+class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
+```
+
+- [ ] **Step 3: Build + run**
+
+Run: `pixi run maturin develop && pixi run pytest tests/test_svar2_mutcat.py::test_mutation_matrix_shape_and_labels -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add python/genoray/_svar2_mutcat.py python/genoray/_svar2.py tests/test_svar2_mutcat.py
+git commit -m "feat(mutcat): SparseVar2 annotate_mutations/mutation_matrix/assign_signatures"
+```
+
+---
+
+## Phase 7 — Parity, docs, housekeeping
+
+### Task 14: v1 parity + round-trip tests
+
+**Files:**
+- Modify: `tests/test_svar2_mutcat.py`
+
+**Interfaces:** consumes v1 `SparseVar` and `SparseVar2` built from the same VCF.
+
+- [ ] **Step 1: Write the parity test** (biallelic-SNV + simple-indel fixture, where v1 and SVAR2 atomization agree):
+
+```python
+def test_matrix_parity_with_v1(tmp_path, small_vcf, small_fasta):
+    # v1
+    from genoray import SparseVar
+    v1_out = tmp_path / "v1.svar"
+    SparseVar.from_vcf(v1_out, small_vcf, reference=small_fasta)  # match existing v1 API
+    v1 = SparseVar(v1_out)
+    v1.annotate_mutations(small_fasta)
+
+    # v2
+    v2_out = tmp_path / "v2.svar2"
+    SparseVar2.from_vcf(v2_out, small_vcf, reference=small_fasta, overwrite=True)
+    v2 = SparseVar2(v2_out)
+    v2.annotate_mutations(small_fasta)
+
+    for kind in ("SBS96", "ID83", "DBS78"):
+        for count in ("allele", "sample"):
+            a = v1.mutation_matrix(kind, count=count)
+            b = v2.mutation_matrix(kind, count=count)
+            # align sample column order, compare counts
+            cols = ["MutationType", *v2.available_samples]
+            assert a.select(cols).equals(b.select(cols)), f"{kind}/{count} mismatch"
+```
+
+If exact equality fails, first confirm both stores atomize identically on the fixture (inspect a few variants); if atomization genuinely differs on complex records, narrow the fixture to biallelic SNVs + pure indels and document the limitation in the test docstring. SVAR2's classification of the normalized/atomized record is the authoritative behavior.
+
+- [ ] **Step 2: Write the write-time round-trip test:**
+
+```python
+def test_write_time_signatures_match_posthoc(tmp_path, small_vcf, small_fasta):
+    a = tmp_path / "wtime.svar2"
+    SparseVar2.from_vcf(a, small_vcf, reference=small_fasta, signatures=True, overwrite=True)
+    b = tmp_path / "posthoc.svar2"
+    SparseVar2.from_vcf(b, small_vcf, reference=small_fasta, overwrite=True)
+    sb = SparseVar2(b); sb.annotate_mutations(small_fasta)
+    sa = SparseVar2(a)
+    for kind in ("SBS96", "ID83"):
+        assert sa.mutation_matrix(kind).equals(sb.mutation_matrix(kind))
+```
+
+Note: the two stores may differ in var_key/dense *routing* (write-time cost model shifts with signature bits), but `mutation_matrix` is routing-invariant, so the matrices must match.
+
+- [ ] **Step 3: Run**
+
+Run: `pixi run maturin develop && pixi run pytest tests/test_svar2_mutcat.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_svar2_mutcat.py
+git commit -m "test(mutcat): v1 parity + write-time/post-hoc round-trip"
+```
+
+### Task 15: Skill, CHANGELOG, docs
+
+**Files:**
+- Modify: `skills/genoray-api/SKILL.md`
+- Modify: `CHANGELOG.md`
+- Modify: `docs/source/svar.md` (if it documents SVAR2 methods)
+
+- [ ] **Step 1: Update `skills/genoray-api/SKILL.md`** — add the three `SparseVar2` methods and the `from_vcf(signatures=...)` kwarg, mirroring how v1 `SparseVar.annotate_mutations`/`mutation_matrix`/`assign_signatures` are documented. State: matrices are `MutationType` + per-sample columns; `kind ∈ {SBS96, DBS78, ID83}`; `count ∈ {allele, sample}`; annotation is post-hoc **or** via `from_vcf(signatures=True)`; DBS78 arises only from adjacent same-haplotype SNV pairs (MNVs are atomized).
+
+- [ ] **Step 2: CHANGELOG entry** under the unreleased/next section:
+
+```markdown
+### Added
+- `SparseVar2.annotate_mutations`, `mutation_matrix`, and `assign_signatures`
+  for COSMIC mutational-signature workflows (SBS96/ID83/DBS78), implemented in
+  Rust with a per-record sidecar and streaming count matrix. `from_vcf` gains a
+  `signatures=` flag to classify during the write (factored into the cost model).
+```
+
+- [ ] **Step 3: Verify docs build (if configured)**
+
+Run: `pixi run -e doc bash -lc 'sphinx-build -b html docs/source docs/build/html -q'` (skip if the doc env is heavy; at minimum confirm no autodoc reference errors for the new methods).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/genoray-api/SKILL.md CHANGELOG.md docs/source/svar.md
+git commit -m "docs(mutcat): document SparseVar2 signature API + changelog"
+```
+
+### Task 16: Full suite + lint gate
+
+- [ ] **Step 1: Rust suite**
+
+Run: `pixi run -e lint test-rust`
+Expected: all pass.
+
+- [ ] **Step 2: Python suite**
+
+Run: `pixi run maturin develop && pixi run test`
+Expected: all pass (network-tagged COSMIC tests may be skipped with `-m "not network"`).
+
+- [ ] **Step 3: Lint/format/typecheck**
+
+Run: `pixi run -e lint lint && pixi run typecheck`
+Expected: clean. Fix any `ruff`/`pyrefly`/`clippy`/`cargo fmt` findings.
+
+- [ ] **Step 4: Final commit (if lint made changes)**
+
+```bash
+git add -A
+git commit -m "chore(mutcat): lint + format pass"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Public API → Tasks 11, 13 (methods), 12 (`from_vcf` flag). ✓
+- §2 Sidecar data model + encoding → Tasks 4, 5. ✓
+- §3 Classification pass (two entry points) → Tasks 6, 12 (write-time), 13 (post-hoc). ✓
+- §4 Cost-model integration → Task 7 (+ wired in 12). ✓
+- §5 Streaming count + DBS pairing → Tasks 8, 9, 10. ✓
+- §6 Refit reuse → Task 13 (`assign_signatures` delegates to `fit_signatures`). ✓
+- Testing strategy (classifier units, parity, cost-model, round-trip) → Tasks 1–3, 7, 14. ✓
+- Docs/skill/changelog → Task 15. ✓
+
+**Placeholder scan:** Tasks 9 and 10's fixture-dependent test bodies are sketched, not literal, because the exact fixture helper must be read from `tests/common/mod.rs` first — flagged inline as the implementer's first action for those tasks, with the surrounding assertions concrete. No `TODO`/`TBD` left in shipped code.
+
+**Type consistency:** `choose_representation(..., sidecar_bits: u64)` used consistently (Tasks 7, 12). `SnvCall{pos,sbs,ref_i,alt_i}` and `emit_snv_codes` signatures match between Tasks 8 and 9. `MutcatSub` variants (`VkSnp/VkIndel/DenseSnp/DenseIndel`) consistent across Tasks 4, 5, 6. Sidecar `u8` codes are class-local everywhere; the unified offset is added only in `count.rs` (Tasks 8, 9) and sliced in Python via `code_ranges()` (Task 13).
+
+**Known risk:** v1-vs-SVAR2 exact parity (Task 14) depends on identical atomization of complex variants; mitigation documented in the task (narrow fixture + treat SVAR2's normalized classification as authoritative).

--- a/docs/superpowers/specs/2026-07-10-svar2-mutational-signatures-design.md
+++ b/docs/superpowers/specs/2026-07-10-svar2-mutational-signatures-design.md
@@ -1,0 +1,244 @@
+# SVAR2 mutational signatures (Rust)
+
+Status: approved design, ready for implementation planning
+Date: 2026-07-10
+
+## Problem
+
+genoray v1 (`SparseVar`) supports COSMIC mutational-signature workflows via
+`_svar/_annotate.py` + `_mutcat/` (numba) + `_signatures.py` (numpy/scipy). SVAR2
+(`SparseVar2`, Rust-backed) has none of this. The v1 implementation is
+**prohibitively memory-hungry**: it stores a `mutcat` field as one `int16` per
+*genotype entry* (parallel to `genos.data`) and `annotate_mutations` materializes
+the entire cohort's sparse genotypes in memory to build it.
+
+Port the functionality to SVAR2 with **feature parity** and make it **as fast or
+faster while using far less memory**. The signature *refit* (`fit_signatures`,
+`cosmic_signatures` — pure numpy/scipy, off the hot path) is reused unchanged.
+The Rust work is **classification** and **catalogue counting**.
+
+## Background: what v1 does
+
+1. `classify_variants(index, reference)` → one intrinsic `int16` code per
+   *variant* (SBS96 `0–95` / native-DBS78 / ID83), reference-dependent.
+2. `build_entry_codes(...)` → broadcasts to one code per *genotype entry* and
+   pairs adjacent SNVs carried on the same haplotype into DBS-78 (the 5′ entry
+   gets the doublet code, the 3′ entry a `DBS_PARTNER` sentinel).
+3. Writes `mutcat.npy` — `int16` per genotype call — and stamps `metadata.json`.
+4. `mutation_matrix(kind, count)` counts codes → `(samples × channels)`;
+   `assign_signatures` NNLS-refits vs COSMIC.
+
+The memory blow-up is step 2+3: the per-*entry* expansion, materialized for the
+whole cohort at once.
+
+## Key facts about SVAR2 that shape the design
+
+- **MNVs are atomized into SNVs** (`src/rvk.rs:124`, invariant `ilen == 0 ⟺ SNP
+  with `alt_len == 1`). Native 2bp doublet records therefore *do not exist* in
+  SVAR2 — every DBS-78 must come from adjacent-SNV pairing. Full parity (below)
+  is the only option that yields any DBS at all.
+- **Storage is split into four per-contig sub-streams**: `var_key/snp`,
+  `var_key/indel`, `dense/snp`, `dense/indel` (`src/layout.rs`). var_key stores
+  records **per call** (`positions.bin` is one `u32` per call); dense stores
+  records **per distinct variant** (`positions.bin` is one `u32` per variant,
+  plus a hap-major 1-bit genotype matrix).
+- **The cost model routes per variant** (`src/rvk.rs:177`,
+  `choose_representation`): var_key when carriers are few, dense when many. This
+  per-call vs per-variant asymmetry is what makes "factor signatures into the
+  cost model" meaningful.
+- **REF is always recoverable from the FASTA**: SNP records store only a 2-bit
+  ALT code (no REF); indels are left-aligned/validated against the reference, so
+  REF equals the reference substring at POS. Classification needs the FASTA;
+  counting must not.
+
+## The asymmetry that drives everything
+
+SBS96 and ID83 are pure **per-variant** functions of `(REF, ALT, reference
+context)`. Only DBS-78's adjacent-SNV pairing is genotype/haplotype-dependent —
+it is the one thing that cannot be reduced to a per-variant code, and it is
+exactly what forced v1 into per-entry storage. The design stores a small
+**per-record** code (mirroring each sub-stream's native granularity) and computes
+DBS pairing on the fly during a single **streaming** count.
+
+## Scope
+
+In scope:
+- SBS96, ID83, DBS78 (via adjacency), with `count="allele"|"sample"` — full v1
+  parity.
+- Classification during `from_vcf(..., signatures=True)` **and** post-hoc via
+  `annotate_mutations`.
+- Cost-model integration for the write-time path.
+
+Non-goals:
+- De-novo signature *extraction* (only refit, unchanged).
+- Changing the refit math.
+- Retroactive re-routing on post-hoc annotate (layout is locked).
+
+## Design
+
+### 1. Public API (Python, on `SparseVar2`)
+
+Mirror v1 names so downstream code and the skill stay consistent:
+
+- `sv2.annotate_mutations(reference, *, contigs=None)` — post-hoc. Classify the
+  finalized records against the FASTA, write the sidecar, stamp `meta.json`
+  (`mutcat_version`, `mutcat_contigs`). Layout is **locked**; no re-routing.
+- `sv2.mutation_matrix(kind, *, count="allele"|"sample")` → `pl.DataFrame` with a
+  `MutationType` column plus one column per sample, rows in fixed codebook order.
+- `sv2.assign_signatures(kind, *, reference=None, max_delta=..., min_activity=...,
+  n_jobs=..., backend=...)` → per-sample activities; delegates to the existing
+  `fit_signatures`.
+- `SparseVar2.from_vcf(..., signatures: bool = False)` — when true, classify
+  during the write and factor the sidecar into the cost model (§4).
+
+`fit_signatures` and `cosmic_signatures` stay module-level and unchanged. The
+`_mutcat` **codebook** (labels, code ranges, `N_CODES`, `MUTCAT_VERSION`,
+sentinels) is the single source of truth and is reused by both v1 and SVAR2;
+the Rust classifier must produce identical code indices.
+
+### 2. Sidecar data model
+
+A new per-contig `mutcat/` directory whose arrays are **positionally aligned to
+each existing sub-stream's records** — read in lockstep with the sub-stream's
+`positions.bin`, no lookups, no global distinct-variant table:
+
+| sub-stream    | `mutcat_code`       | `mutcat_ref`             |
+| ------------- | ------------------- | ------------------------ |
+| `dense/snp`   | u8 × n_dense_snp    | 2-bit × n_dense_snp      |
+| `var_key/snp` | u8 × n_snp_calls    | 2-bit × n_snp_calls      |
+| `dense/indel` | u8 × n_dense_indel  | —                        |
+| `var_key/indel`| u8 × n_indel_calls | —                        |
+
+Dense stores one code per distinct variant (amortized across all carriers — the
+main win over v1); var_key stores one code per call (the rare-variant minority,
+so per-call here is bounded). Exact on-disk file names are decided in the plan
+but follow `src/layout.rs` conventions (e.g. `mutcat/{sub}/code.bin`,
+`mutcat/{sub}/ref.bin`).
+
+**Encoding — `mutcat_code`: `u8`, one per record, byte-aligned (not bit-packed).**
+- SNP sub-streams: the SBS96 index, `0–95`.
+- Indel sub-streams: the ID83 index, `0–82`.
+- Two reserved high values for sentinels: `254 = UNCLASSIFIED`,
+  `255 = NOT_ANNOTATED`. v1's negative `int16` sentinels do not survive into
+  unsigned; the counter skips any `code ≥ N_CODES`.
+- DBS78 is **never stored** — it is a count-time transform of a SNP pair, so the
+  stored code is always the variant's own SBS96/ID83.
+- All values fit in `< 128`; 7 bits would suffice, but `u8` is kept because the
+  code is read on *every* count increment and byte-aligned lockstep indexing is
+  simpler and more cache-friendly than a 7-bit stream straddling byte
+  boundaries. The 1 wasted bit/record is not worth the non-aligned reader.
+
+**Encoding — `mutcat_ref`: 2-bit packed, snp sub-streams only.**
+- The one extra datum DBS pairing needs is the *actual* (unfolded) reference base
+  at each SNV — 2 bits (`A/C/G/T`). ALT is already in the existing key stream;
+  the SBS96 code alone cannot recover the strand-correct ref base (pyrimidine
+  folding is lossy), and we do not want to require the FASTA at count time.
+- Store it with the **existing `pack_snp_keys` / `unpack_snp_key_at` 2-bit
+  codec** (`svar2-codec`) — the ref-base stream is structurally identical to the
+  alt-key stream (one 2-bit code per snp record), so it is direct reuse with no
+  new packing code. Read only when reconstructing a doublet (the rare
+  adjacent-pair case), so its packing cost never touches the hot path.
+- Indel sub-streams have no ref stream.
+
+Why not v1's uniform `int16`? That is 16 bits/snp-call vs `8 + 2 = 10` here, and
+the var_key/snp per-call stream dominates the new cost — `u8 code + 2-bit ref` is
+the memory-conscious choice while staying byte-aligned on the hot field.
+
+### 3. Classification pass (one code path, two entry points)
+
+A single Rust routine walks the finalized per-contig records of each sub-stream,
+reconstructs `(REF, ALT)` (ALT from the 2-bit key / indel key / long-allele bank;
+REF from the FASTA), computes the SBS96 / ID83 index and the SNP reference base
+via a Rust port of the v1 LUTs and `_id83_kernel`, and writes the sidecar. It is
+called:
+- automatically at the end of `from_vcf(signatures=True)` (the FASTA is already
+  open), and
+- by `annotate_mutations` post-hoc (re-opens the FASTA + streams the records).
+
+Classification is per-variant and needs no genotypes — cheap, parallelizable
+over contigs. `contigs=` scoping and the REF-mismatch warning behavior match v1
+(`classify_variants`). Because it reads the *finalized* records, the sidecar is
+guaranteed aligned to exactly what decode/count later read.
+
+### 4. Cost-model integration (the write-time "factor it in")
+
+When `signatures=True` **at write time**, extend `choose_representation` with the
+sidecar's marginal bits (using actual storage widths):
+
+- SNP record sidecar = `8 (code) + 2 (ref) = 10` bits.
+- Indel record sidecar = `8 (code)` bits.
+
+So per variant, with `x` = carrier count:
+- var_key cost `+= sidecar_bits · x` (per call),
+- dense cost `+= sidecar_bits` (per variant).
+
+This slightly shifts the SNP/indel crossover toward dense when signatures are on
+(dense amortizes the code across carriers) — a real, principled effect. The knob
+is threaded through the conversion pipeline as a boolean (or bit-width constants)
+so `choose_representation` stays a pure integer function.
+
+**Post-hoc annotation cannot do this** — the layout is already locked, so the
+sidecar is written at whatever granularity the existing var_key/dense split
+dictates and `choose_representation` is not re-run. This is exactly why the cost
+model is ignored there.
+
+### 5. Count matrix — streaming pass with DBS pairing
+
+`mutation_matrix` runs a single pass, parallelizable over sample-columns. For
+each haplotype column:
+
+- **SNVs**: merge-walk the column's SNVs from **both** sources in position order —
+  `var_key/snp` calls (per-call code + ref) ⋈ `dense/snp` carried variants
+  (per-variant code + ref, via the hap-major carried bit). This is the existing
+  two-source decode pattern. For each **isolated adjacent pair** (`Δpos == 1`, no
+  flanking SNV on either side — the exact v1 `_entry_codes_kernel` isolation
+  rule), reconstruct the doublet from `(ref0, alt0, ref1, alt1)` and look up its
+  DBS78 code via a `(4,4,4,4)` table (port of `_build_dbs_table`); both members
+  of the pair contribute to the DBS channel. Every other SNV emits its stored
+  SBS96 code.
+- **Indels**: walk `var_key/indel` ⋈ `dense/indel`; each emits its stored ID83
+  code.
+
+Accumulate into an `(n_samples, N_CODES)` `int64` matrix: `count="allele"` sums
+every carried copy; `count="sample"` marks presence at most once per sample.
+Slice the requested `kind`'s code range and return the codebook-ordered
+DataFrame (matching v1's `count_matrix`).
+
+Peak memory ≈ the accumulator + one column's merge working set. No per-entry code
+array ever exists — this is the memory win.
+
+### 6. Refit (reused, unchanged)
+
+`assign_signatures` builds the `kind` catalogue via `mutation_matrix` and calls
+the existing `fit_signatures` against `cosmic_signatures(kind)` (or a supplied
+reference). No changes to the refit code.
+
+## Testing strategy
+
+- **Rust unit tests**: the classifier port (SBS96 folding, ID83 repeat/microhomology
+  logic) against the v1 LUT expectations; the streaming counter for DBS edge
+  cases — runs of ≥3 adjacent SNVs stay SBS, doublets split across the
+  var_key/dense boundary, `allele` vs `sample` counting.
+- **Python parity test**: on shared fixtures, assert SVAR2's `mutation_matrix`
+  (all three kinds, both count modes) equals v1's `SparseVar.mutation_matrix`,
+  and `assign_signatures` matches within refit tolerance.
+- **Cost-model tests**: crossover-shift unit tests for `choose_representation`
+  with signature bits on/off (SNP and indel).
+- **Round-trip**: `from_vcf(signatures=True)` and post-hoc `annotate_mutations`
+  on the same input produce identical sidecars and matrices.
+
+## Documentation / housekeeping
+
+- Update `skills/genoray-api/SKILL.md` — this adds public `SparseVar2` methods and
+  a `from_vcf` kwarg (mandatory per the repo's public-API rule in `CLAUDE.md`).
+- CHANGELOG entry (Conventional Commits `feat:`).
+- Bump `MUTCAT_VERSION` if the codebook or code semantics change (they should
+  not — codes are reused verbatim).
+
+## Open questions
+
+- Exact on-disk file names / directory shape under `mutcat/` — settled in the
+  plan against `src/layout.rs`.
+- Whether the count pass parallelizes over columns with rayon or reuses an
+  existing SVAR2 query executor — settled in the plan after reading
+  `src/executor.rs` / `src/query/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "genoray"
-version = "3.0.0"
+version = "2.15.0"
 description = "Add your description here"
 authors = [{ name = "David Laub", email = "dlaub@ucsd.edu" }]
 readme = "README.md"

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -69,6 +69,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin):
         threads: int | None = None,
         overwrite: bool = False,
         long_allele_capacity: int = 8 * 1024 * 1024,
+        signatures: bool = False,
     ) -> int:
         """Convert a bgzipped VCF or BCF to an SVAR2 store.
 
@@ -78,6 +79,10 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin):
         input is trusted to be already normalized. Returns the number of
         out-of-scope (symbolic/breakend) ALTs dropped (0 unless
         `skip_out_of_scope`).
+
+        signatures: if True, classify SBS96/ID83 codes during the write and
+        store the mutcat sidecar (factored into the dense/var_key cost model).
+        Requires a reference; raises if `no_reference=True`.
         """
         from cyvcf2 import VCF as _CyVCF
 
@@ -89,6 +94,8 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin):
                 "provide exactly one of `reference` (a FASTA path) or "
                 "`no_reference=True`"
             )
+        if signatures and no_reference:
+            raise ValueError("signatures=True requires a reference (not no_reference).")
         if out.exists() and not overwrite:
             raise FileExistsError(
                 f"Output path {out} already exists. Use overwrite=True to overwrite."
@@ -116,4 +123,5 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin):
             threads,  # max_threads; None => auto
             long_allele_capacity,
             skip_out_of_scope,
+            signatures,
         )

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -8,6 +8,7 @@ from natsort import natsorted
 import genoray._core as _core
 from genoray._svar2_batch import _BatchQueryMixin
 from genoray._svar2_decode import _DecodeMixin
+from genoray._svar2_mutcat import _MutcatMixin
 
 
 def _ensure_bgzipped(source: Path) -> None:
@@ -29,7 +30,7 @@ def _ensure_index(source: Path) -> None:
     _core.index_vcf(str(source))
 
 
-class SparseVar2(_BatchQueryMixin, _DecodeMixin):
+class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
     """Reader for a finished SVAR2 store (M6a skeleton).
 
     Loads the top-level ``meta.json`` and opens one native

--- a/python/genoray/_svar2_mutcat.py
+++ b/python/genoray/_svar2_mutcat.py
@@ -1,0 +1,205 @@
+"""SVAR2 mutational-signature surface: annotate/count/assign on ``SparseVar2``.
+
+Mirrors v1's ``SparseVarAnnotateMixin.annotate_mutations``/``mutation_matrix``/
+``assign_signatures`` (``genoray._svar._annotate``), but delegates the actual
+classification and counting to the Rust ``PyContigReader`` (per-contig
+``annotate_mutations``/``count_matrix`` bindings) instead of doing it in Python
+over an in-memory index.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import polars as pl
+
+from genoray._mutcat import MUTCAT_VERSION, N_CODES, code_ranges, labels
+from genoray._reference import Reference
+from genoray._signatures import _load_signature_file, cosmic_signatures, fit_signatures
+
+
+class _MutcatMixin:
+    """Mutation-catalogue annotation, counting, and signature-assignment methods.
+
+    Provided by the concrete ``SparseVar2`` host class (see ``SparseVar2.__init__``);
+    declared here so the mixin's use of them type-checks in isolation. (``n_samples``
+    is an ``@property`` on the host, so it can't be redeclared as a plain attribute
+    here without a bad-override; it's accessed via an ignore below.)
+    """
+
+    path: Path
+    contigs: list[str]
+    available_samples: list[str]
+    _readers: dict[str, Any]
+
+    def annotate_mutations(
+        self, reference: "Reference | str | Path", *, contigs: "list[str] | None" = None
+    ) -> None:
+        """Classify every variant on the in-scope contigs into SBS-96/DBS-78/ID-83
+        codes and write the per-contig ``mutcat`` sidecar (post-hoc annotation).
+
+        Parameters
+        ----------
+        reference
+            Reference genome. A :class:`~genoray._reference.Reference` instance,
+            or a path to a FASTA file (with a ``.fai`` index alongside it).
+        contigs
+            If given, only these contigs (intersected with ``self.contigs``) are
+            annotated. ``None`` (default) annotates every contig in the store.
+
+        Notes
+        -----
+        Stamps ``meta.json`` with ``mutcat_version`` and ``mutcat_contigs`` so a
+        later :class:`SparseVar2` open can tell the store has been annotated;
+        the sidecar files themselves (one ``code.bin`` per contig) are the
+        ground truth checked by :meth:`mutation_matrix`'s guard, since the
+        write-time ``from_vcf(..., signatures=True)`` path writes sidecars
+        without touching ``meta.json``.
+        """
+        if not isinstance(reference, Reference):
+            reference = Reference.from_path(reference)
+        scope = (
+            self.contigs
+            if contigs is None
+            else [c for c in self.contigs if c in set(contigs)]
+        )
+        for contig in scope:
+            seq = reference.contig_array(contig).astype(np.uint8, copy=False)
+            self._readers[contig].annotate_mutations(str(self.path), contig, seq)
+
+        meta_path = self.path / "meta.json"
+        meta = json.loads(meta_path.read_text())
+        meta["mutcat_version"] = MUTCAT_VERSION
+        meta["mutcat_contigs"] = scope
+        meta_path.write_text(json.dumps(meta))
+
+    def _is_annotated(self) -> bool:
+        """Whether every contig has an on-disk mutcat sidecar.
+
+        Checked directly on disk (not via ``meta.json``) because
+        ``from_vcf(..., signatures=True)`` writes sidecars at conversion time
+        without stamping ``meta.json``; the ``var_key_snp/code.bin`` file is
+        written by ``annotate_contig`` for every contig (even if empty), so its
+        absence is ground truth for "never annotated".
+        """
+        return all(
+            (self.path / contig / "mutcat" / "var_key_snp" / "code.bin").exists()
+            for contig in self.contigs
+        )
+
+    def mutation_matrix(
+        self,
+        kind: Literal["SBS96", "DBS78", "ID83"],
+        *,
+        count: Literal["allele", "sample"] = "allele",
+    ) -> pl.DataFrame:
+        """Build a per-sample mutation count matrix.
+
+        Requires :meth:`annotate_mutations` to have been run (or the store to
+        have been built with ``from_vcf(..., signatures=True)``). Returns a
+        DataFrame with a ``MutationType`` column plus one column per sample
+        (rows in fixed codebook order).
+
+        Parameters
+        ----------
+        kind
+            One of ``"SBS96"``, ``"DBS78"``, ``"ID83"``.
+        count
+            ``"allele"`` counts every non-ref allele copy; ``"sample"`` counts
+            each category at most once per sample (presence/absence), OR-combined
+            across contigs.
+
+        Raises
+        ------
+        ValueError
+            If the store has not been annotated (no on-disk mutcat sidecar for
+            every contig) — calling the underlying Rust ``count_matrix`` on an
+            unannotated contig with SNP records panics across the FFI boundary,
+            so this is checked up front to raise a clean Python exception instead.
+        """
+        if kind not in ("SBS96", "DBS78", "ID83"):
+            raise ValueError(f"Unknown matrix kind {kind!r}.")
+        if count not in ("allele", "sample"):
+            raise ValueError(
+                f"Unknown count mode {count!r}; choose 'allele' or 'sample'."
+            )
+        if not self._is_annotated():
+            raise ValueError(
+                "SparseVar2 is not annotated for mutational signatures; call "
+                "annotate_mutations(reference) first, or rebuild with "
+                "from_vcf(..., signatures=True)."
+            )
+
+        per_sample = count == "sample"
+        total = np.zeros((self.n_samples, N_CODES), dtype=np.int64)  # type: ignore[missing-attribute]
+        for contig in self.contigs:
+            total += self._readers[contig].count_matrix(
+                str(self.path), contig, per_sample
+            )
+        if per_sample:
+            np.clip(total, 0, 1, out=total)  # presence OR across contigs
+
+        lo, hi = code_ranges()[kind]
+        block = total[:, lo:hi]
+        out: dict[str, object] = {"MutationType": labels(kind)}
+        for si, name in enumerate(self.available_samples):
+            out[name] = block[si]
+        return pl.DataFrame(out)
+
+    def assign_signatures(
+        self,
+        kind: Literal["SBS96", "DBS78", "ID83"],
+        *,
+        reference: "pl.DataFrame | str | Path | None" = None,
+        count: Literal["allele", "sample"] = "allele",
+        max_delta: float = 0.01,
+        min_activity: float = 0.005,
+        n_jobs: int = 1,
+        backend: str = "loky",
+    ) -> pl.DataFrame:
+        """Refit this store's mutation catalogue against reference signatures.
+
+        Builds the ``kind`` catalogue via :meth:`mutation_matrix` and decomposes
+        it into per-sample activities via :func:`genoray.fit_signatures`.
+
+        Parameters
+        ----------
+        kind
+            One of ``"SBS96"``, ``"DBS78"``, ``"ID83"``.
+        reference
+            Reference signatures as a Polars ``DataFrame`` (``MutationType`` +
+            signature columns), a path to a COSMIC-style TSV, or ``None`` to
+            fetch the default COSMIC set via :func:`genoray.cosmic_signatures`.
+        count
+            Counting unit passed to :meth:`mutation_matrix`.
+        max_delta, min_activity
+            Forwarded to :func:`genoray.fit_signatures`.
+        n_jobs, backend
+            Forwarded to :func:`genoray.fit_signatures` to control per-sample
+            parallelism (``1`` (default) runs serially; ``-1`` uses all cores;
+            process-based ``"loky"`` backend).
+
+        Returns
+        -------
+        pl.DataFrame
+            One row per sample: ``Sample``, one column per signature, and
+            ``cosine_similarity``.
+        """
+        catalogue = self.mutation_matrix(kind, count=count)
+        if reference is None:
+            ref = cosmic_signatures(kind)
+        elif isinstance(reference, pl.DataFrame):
+            ref = reference
+        else:
+            ref = _load_signature_file(reference)
+        return fit_signatures(
+            catalogue,
+            ref,
+            max_delta=max_delta,
+            min_activity=min_activity,
+            n_jobs=n_jobs,
+            backend=backend,
+        )

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -17,7 +17,7 @@ description: Use when writing or modifying Python code that imports `genoray` to
 - `genoray.VCF` — VCF/BCF reader
 - `genoray.Filter` — VCF filter value object bundling a cyvcf2 record predicate (`record`) with its matching `.gvi` polars expression (`expr`)
 - `genoray.SparseVar` — sparse `.svar` reader/writer
-- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`)
+- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`)
 - `genoray.exprs` — polars filter expressions for `.gvi` indexes
 - `genoray.cosmic_signatures` — fetch/cache COSMIC reference signatures
 - `genoray.fit_signatures` — sparse forward-selection signature refit
@@ -35,7 +35,7 @@ Prefer reading these over guessing:
 - `genoray/_vcf.py` — `VCF` class: constructor, `read`, `chunk`, mode constants near the top of the class; `get_record_info(contig=None, start=None, end=None, fields=None, info=None, lazy=False)` — non-FORMAT record-level fields (including INFO) for a range or the whole file, returns `pl.DataFrame` (or `pl.LazyFrame` when `lazy=True`)
 - `genoray/_pgen.py` — `PGEN` class: constructor, `read`, `chunk`, `read_ranges`, `chunk_ranges`, mode constants near the top of the class
 - `genoray/_svar.py` — `SparseVar`: `__init__`, `from_vcf`, `from_pgen`, `read_ranges`, `read_ranges_with_length(contig, starts=0, ends=POS_MAX, samples=None)` (length-guaranteed range read; returns the same type as `read_ranges` — a `Ragged` or fields-augmented record), `with_fields`, `annotate_mutations`, `mutation_matrix`, `assign_signatures`, `annotate_with_gtf(gtf, level_filter=1, write_back=True, *, strand_encoding=None, codon_null_token=None)` (GTF CDS annotation entry point, returns `pl.DataFrame` with `varID`/`gene_id`/`strand`/`codon_pos`), `cache_afs()` (computes and persists an `AF` column to the `.gvi` index; returns `None`)
-- `genoray/_svar2.py` — `SparseVar2`: `__init__`, `from_vcf` (VCF/BCF → SVAR2 conversion entry point); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode`, `region_counts`) and `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`)
+- `genoray/_svar2.py` — `SparseVar2`: `__init__`, `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode`, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
 - `genoray/_cli/__main__.py` — the `genoray` CLI (`index`, `write` / `write svar1`, `view`)
 - `genoray/_signatures.py` — `cosmic_signatures`, `fit_signatures`
 - `genoray/_reference.py` — `Reference`: `from_path`, `fetch`, `contig_array`
@@ -315,6 +315,49 @@ scalars `n_regions`/`n_samples`/`ploidy`.
 the search/gather split used by a write-time overlap cache. They are **not**
 part of the public API, are not covered by semver, and may change or
 disappear without notice; don't call them from user code.
+
+### Mutational signatures (SBS96 / DBS78 / ID83)
+
+Same COSMIC workflow as `SparseVar` (see "Mutation catalogues" above), backed
+by a Rust per-contig sidecar instead of a `.gvi`-attached field. Annotation is
+**required** before `mutation_matrix` — either post-hoc, or by passing
+`signatures=True` to `from_vcf` (above):
+
+```python
+sv = SparseVar2("out.svar2")
+ref = genoray.Reference.from_path("hg38.fa")
+
+sv.annotate_mutations(ref)                   # post-hoc; writes the mutcat sidecar
+sv.annotate_mutations(ref, contigs=["chr1"])  # restrict to a subset of contigs
+
+df = sv.mutation_matrix("SBS96")                     # count="allele" (default)
+df = sv.mutation_matrix("DBS78", count="sample")
+act = sv.assign_signatures("SBS96")                  # mutation_matrix + fit_signatures
+```
+
+- `annotate_mutations(reference, *, contigs=None) -> None` — `reference` is a
+  `genoray.Reference` or a FASTA path; `contigs=None` (default) annotates every
+  contig. Unlike `SparseVar.annotate_mutations`, there is **no `write_back=`
+  toggle** — SVAR2 always persists the sidecar to disk.
+- `mutation_matrix(kind, *, count="allele"|"sample") -> pl.DataFrame` — a
+  `MutationType` column (fixed COSMIC codebook order) plus one column per
+  sample. `kind ∈ {"SBS96", "DBS78", "ID83"}`. `count="allele"` counts every
+  non-ref allele copy; `count="sample"` counts each category at most once per
+  sample, OR-combined across contigs. **Raises `ValueError`** if called before
+  the store is annotated (no on-disk sidecar for every contig) — annotate
+  first, either via `annotate_mutations` or `from_vcf(..., signatures=True)`.
+- `assign_signatures(kind, *, reference=None, count="allele", max_delta=0.01, min_activity=0.005, n_jobs=1, backend="loky") -> pl.DataFrame`
+  — `mutation_matrix(kind, count=...)` then `genoray.fit_signatures(...)`.
+  `reference` accepts a `pl.DataFrame`, a TSV path, or `None` (defaults to
+  `genoray.cosmic_signatures(kind)`).
+- Same classification rules as v1 (shared Rust classifier): **DBS78 arises
+  only from isolated adjacent same-haplotype SNV pairs** — runs of ≥3
+  adjacent SNVs stay as individual SBS96 entries, native MNVs > 2bp are
+  atomized into SBS96, and each isolated doublet is counted **once** (not
+  once per constituent SNV).
+- No public read-side access to the raw per-genotype `mutcat` codes for
+  SVAR2 (unlike v1's `fields=["mutcat"]`) — only the aggregated
+  `mutation_matrix` output is exposed.
 
 ### Errors
 

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -244,7 +244,7 @@ dropped = SparseVar2.from_vcf(
 dropped = SparseVar2.from_vcf("out.svar2", "file.vcf.gz", no_reference=True)
 ```
 
-Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024) -> int`
+Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False) -> int`
 
 - `source` — a bgzipped VCF (`.vcf.gz`) or BCF (`.bcf`). **VCF/BCF only** — no PGEN
   source yet (roadmap M7). Auto-indexes (`.csi`) if no `.csi`/`.tbi` is found.
@@ -260,6 +260,14 @@ Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_ou
   unless `skip_out_of_scope=True`).
 - No dosages, no `haploid=` OR-collapse, no `max_mem`-based chunking (use
   `chunk_size` instead) — these remain `SparseVar` (SVAR 1.0)-only for now.
+- `signatures=False` — when `True`, classifies every SNP/indel into its
+  SBS96/ID83 mutation-type code during the write and stores a `mutcat`
+  sidecar per contig (factored into the write's dense/var_key cost model).
+  Requires a reference (`reference=`); raises `ValueError` if combined with
+  `no_reference=True`. There is no public read-side API for the SVAR2
+  `mutcat` sidecar yet (unlike `SparseVar.annotate_mutations`/
+  `mutation_matrix`, below) — this flag only controls whether the sidecar is
+  written.
 
 ### Range queries
 

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -66,6 +66,50 @@ pub fn copy_bits(dst: &mut [u8], dst_bit: usize, src: &[u8], src_bit: usize, n: 
     }
 }
 
+/// Call `f(k)` for every set bit `k` in `0..n` of the contiguous bit-window
+/// `[start_bit, start_bit + n)` of `buf`, in ascending `k`. `k` is the offset
+/// *within the window*, so a hap-major row `[hap * n_dense, +n_dense)` yields
+/// exactly the carried dense-variant columns.
+///
+/// Whole-byte body scan (skipping zero bytes, then iterating each nonzero
+/// byte's set bits via `trailing_zeros`) replaces the per-column `get_bit`
+/// call — one branch + one shift per *carried* variant instead of per variant.
+/// Head/tail handle the unaligned ends bit-by-bit, mirroring `copy_bits`.
+#[inline]
+pub fn for_each_set_bit(buf: &[u8], start_bit: usize, n: usize, mut f: impl FnMut(usize)) {
+    if n == 0 {
+        return;
+    }
+    let mut i = 0usize;
+    // Head: bit-by-bit until the source cursor is byte-aligned.
+    while i < n && (start_bit + i) & 7 != 0 {
+        if get_bit(buf, start_bit + i) {
+            f(i);
+        }
+        i += 1;
+    }
+    // Body: whole bytes; skip zero bytes, expand set bits of nonzero ones.
+    while i + 8 <= n {
+        let byte = buf[(start_bit + i) >> 3];
+        if byte != 0 {
+            let mut m = byte;
+            while m != 0 {
+                let b = m.trailing_zeros() as usize;
+                f(i + b);
+                m &= m - 1; // clear lowest set bit
+            }
+        }
+        i += 8;
+    }
+    // Tail: remaining < 8 bits, unaligned again.
+    while i < n {
+        if get_bit(buf, start_bit + i) {
+            f(i);
+        }
+        i += 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,6 +125,32 @@ mod tests {
         assert!(get_bit(&b, 0) && get_bit(&b, 7) && get_bit(&b, 8) && get_bit(&b, 15));
         assert!(!get_bit(&b, 1));
         assert_eq!(b, vec![0b1000_0001u8, 0b1000_0001u8]);
+    }
+
+    #[test]
+    fn for_each_set_bit_matches_get_bit_over_windows() {
+        // A pseudo-random byte buffer; check the set-bit scan against a
+        // per-bit get_bit oracle for several unaligned window offsets/lengths.
+        let mut buf = vec![0u8; 40];
+        let mut x = 0x1234_5678u32;
+        for b in buf.iter_mut() {
+            x = x.wrapping_mul(1664525).wrapping_add(1013904223);
+            *b = (x >> 16) as u8;
+        }
+        let total = buf.len() * 8;
+        for &(start, n) in &[
+            (0usize, 0usize),
+            (0, 1),
+            (3, 5),
+            (7, 20),
+            (1, 250),
+            (5, total - 5),
+        ] {
+            let mut got = Vec::new();
+            for_each_set_bit(&buf, start, n, |k| got.push(k));
+            let want: Vec<usize> = (0..n).filter(|&k| get_bit(&buf, start + k)).collect();
+            assert_eq!(got, want, "start={start} n={n}");
+        }
     }
 
     #[test]

--- a/src/cost_model.rs
+++ b/src/cost_model.rs
@@ -28,10 +28,23 @@ pub fn key_bits(class: Class) -> u64 {
     }
 }
 
+/// Mutational-signature sidecar cost, in bits, when signatures are enabled:
+/// an 8-bit mutation-category code plus a 2-bit ref-base code for SNPs.
+pub const SIDECAR_BITS_SNP: u64 = 10; // 8-bit code + 2-bit ref
+/// Mutational-signature sidecar cost, in bits, for indels: 8-bit code only
+/// (no ref-base disambiguation needed).
+pub const SIDECAR_BITS_INDEL: u64 = 8; // 8-bit code
+
 /// Choose the cheaper representation for one variant with `x_calls` carriers.
 ///
-/// var_key = x · (POS_BITS + key_bits)     (position + key inlined per call)
-/// dense   = POS_BITS + key_bits + np      (table row once + 1-bit-per-hap mask)
+/// var_key = x · (POS_BITS + key_bits + sidecar_bits)  (position + key + sidecar inlined per call)
+/// dense   = POS_BITS + key_bits + np + sidecar_bits    (table row once + 1-bit-per-hap mask + sidecar once)
+///
+/// `sidecar_bits` is the per-record mutational-signature sidecar cost (0 when
+/// signatures are disabled; see `SIDECAR_BITS_SNP`/`SIDECAR_BITS_INDEL`). It is
+/// paid once per carrier call in `var_key` (the sidecar rides along with each
+/// inlined call) but only once per variant in `dense` (the sidecar lives in
+/// the table row, not the per-hap mask).
 ///
 /// Route to `Dense` iff strictly cheaper; ties break to `VarKey`.
 #[inline]
@@ -40,11 +53,12 @@ pub fn choose_representation(
     n_samples: usize,
     ploidy: usize,
     x_calls: usize,
+    sidecar_bits: u64,
 ) -> Representation {
     let np = (n_samples as u64) * (ploidy as u64);
-    let per_call = POS_BITS + key_bits(class);
+    let per_call = POS_BITS + key_bits(class) + sidecar_bits;
     let var_key_bits = (x_calls as u64) * per_call;
-    let dense_bits = POS_BITS + key_bits(class) + np;
+    let dense_bits = POS_BITS + key_bits(class) + np + sidecar_bits;
     if dense_bits < var_key_bits {
         Representation::Dense
     } else {
@@ -61,7 +75,7 @@ mod tests {
     fn test_x_zero_is_var_key() {
         // No carriers: var_key costs 0, dense costs a full row — var_key wins.
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 0),
+            choose_representation(Class::Snp, 1000, 2, 0, 0),
             Representation::VarKey
         );
     }
@@ -71,11 +85,11 @@ mod tests {
         // np=2000: dense=32+2+2000=2034; var_key=34x. Dense wins when 34x > 2034
         // → x >= 60 (34*59=2006 < 2034 → var_key; 34*60=2040 > 2034 → dense).
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 59),
+            choose_representation(Class::Snp, 1000, 2, 59, 0),
             Representation::VarKey
         );
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 60),
+            choose_representation(Class::Snp, 1000, 2, 60, 0),
             Representation::Dense
         );
     }
@@ -85,11 +99,11 @@ mod tests {
         // np=2000: dense=32+32+2000=2064; var_key=64x. Dense when 64x > 2064
         // → x >= 33 (64*32=2048 < 2064; 64*33=2112 > 2064).
         assert_eq!(
-            choose_representation(Class::Indel, 1000, 2, 32),
+            choose_representation(Class::Indel, 1000, 2, 32, 0),
             Representation::VarKey
         );
         assert_eq!(
-            choose_representation(Class::Indel, 1000, 2, 33),
+            choose_representation(Class::Indel, 1000, 2, 33, 0),
             Representation::Dense
         );
     }
@@ -107,9 +121,33 @@ mod tests {
         let np = 34u64 * 3 - 34; // = 68 → dense_bits = 34 + 68 = 102 = 34*3
         let n = np as usize; // ploidy 1
         assert_eq!(
-            choose_representation(Class::Snp, n, 1, 3), // var_key = 34*3 = 102 == dense
+            choose_representation(Class::Snp, n, 1, 3, 0), // var_key = 34*3 = 102 == dense
             Representation::VarKey,
             "exact tie must resolve to VarKey"
+        );
+    }
+
+    #[test]
+    fn sidecar_bits_shift_snp_crossover_toward_dense() {
+        // Without sidecar: np=2000 → dense wins at x>=60 (see test_snp_crossover_np2000).
+        // With +10 sidecar/call on var_key and +10 once on dense:
+        // dense = 32+2+2000+10 = 2044; per_call = 34+10 = 44.
+        // dense < 44x → x > 46.45 → dense at x>=47 (vs 60 without).
+        assert_eq!(
+            choose_representation(Class::Snp, 1000, 2, 46, SIDECAR_BITS_SNP),
+            Representation::VarKey
+        );
+        assert_eq!(
+            choose_representation(Class::Snp, 1000, 2, 47, SIDECAR_BITS_SNP),
+            Representation::Dense
+        );
+    }
+
+    #[test]
+    fn zero_sidecar_matches_legacy() {
+        assert_eq!(
+            choose_representation(Class::Snp, 1000, 2, 60, 0),
+            Representation::Dense
         );
     }
 
@@ -121,9 +159,9 @@ mod tests {
             ploidy in 1usize..3,
             x in 0usize..20000,
         ) {
-            let here = choose_representation(Class::Snp, n, ploidy, x);
+            let here = choose_representation(Class::Snp, n, ploidy, x, 0);
             if here == Representation::Dense {
-                let more = choose_representation(Class::Snp, n, ploidy, x + 1);
+                let more = choose_representation(Class::Snp, n, ploidy, x + 1, 0);
                 prop_assert_eq!(more, Representation::Dense);
             }
         }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -29,7 +29,9 @@ pub fn run_compute_engine(
     let mut dense_ledgers: DenseMap<Vec<u32>> = DenseMap::from_fn(|_| Vec::with_capacity(10_000));
 
     while let Ok(chunk) = rx_dense.recv() {
-        let sparse_chunk = dense2sparse_vk(&chunk, &mut bank);
+        // Task 12 wires the real `signatures` flag through here; until then
+        // the sidecar-bits cost model stays off in the production path.
+        let sparse_chunk = dense2sparse_vk(&chunk, &mut bank, false);
 
         for (tag, sub) in sparse_chunk.streams.iter() {
             var_key_ledgers

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -23,15 +23,14 @@ pub fn run_compute_engine(
     rx_dense: Receiver<DenseChunk>,
     tx_sparse: Sender<SparseChunk>,
     mut bank: LongAlleleTableWriter,
+    sidecar_bits_enabled: bool,
 ) -> Phase1Output {
     let mut var_key_ledgers: StreamMap<Vec<Vec<u32>>> =
         StreamMap::from_fn(|_| Vec::with_capacity(10_000));
     let mut dense_ledgers: DenseMap<Vec<u32>> = DenseMap::from_fn(|_| Vec::with_capacity(10_000));
 
     while let Ok(chunk) = rx_dense.recv() {
-        // Task 12 wires the real `signatures` flag through here; until then
-        // the sidecar-bits cost model stays off in the production path.
-        let sparse_chunk = dense2sparse_vk(&chunk, &mut bank, false);
+        let sparse_chunk = dense2sparse_vk(&chunk, &mut bank, sidecar_bits_enabled);
 
         for (tag, sub) in sparse_chunk.streams.iter() {
             var_key_ledgers
@@ -92,7 +91,7 @@ mod tests {
         drop(tx_d);
 
         let bank = crate::nrvk::LongAlleleTableWriter::new(tx_l, 1 << 16);
-        let out = run_compute_engine(rx_d, tx_s, bank);
+        let out = run_compute_engine(rx_d, tx_s, bank, false);
 
         // one chunk processed → one ledger row per stream and per dense class
         assert_eq!(out.var_key_ledgers.get(StreamTag::VarKeySnp).len(), 1);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -4,6 +4,30 @@
 
 use std::path::{Path, PathBuf};
 
+/// The four sub-streams a mutcat sidecar mirrors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MutcatSub {
+    VkSnp,
+    VkIndel,
+    DenseSnp,
+    DenseIndel,
+}
+
+impl MutcatSub {
+    fn dir_name(self) -> &'static str {
+        match self {
+            MutcatSub::VkSnp => "var_key_snp",
+            MutcatSub::VkIndel => "var_key_indel",
+            MutcatSub::DenseSnp => "dense_snp",
+            MutcatSub::DenseIndel => "dense_indel",
+        }
+    }
+    /// Whether this sub-stream carries a 2-bit ref-base stream (snp only).
+    pub fn has_ref(self) -> bool {
+        matches!(self, MutcatSub::VkSnp | MutcatSub::DenseSnp)
+    }
+}
+
 pub struct ContigPaths {
     base_out_dir: String,
     chrom: String,
@@ -53,6 +77,23 @@ impl ContigPaths {
     }
     pub fn long_allele_offsets(&self) -> PathBuf {
         self.shared_indel_dir().join("long_allele_offsets.npy")
+    }
+
+    fn mutcat_dir(&self, sub: MutcatSub) -> PathBuf {
+        Path::new(&self.base_out_dir)
+            .join(&self.chrom)
+            .join("mutcat")
+            .join(sub.dir_name())
+    }
+    pub fn mutcat_code(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub).join("code.bin")
+    }
+    pub fn mutcat_ref(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub).join("ref.bin")
+    }
+    /// Directory created before writing a sidecar sub-stream.
+    pub fn mutcat_sub_dir(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub)
     }
 }
 
@@ -175,5 +216,20 @@ mod tests {
             dense_max_del(contig),
             Path::new("/out/chr1/dense/max_del.npy")
         );
+    }
+
+    #[test]
+    fn mutcat_paths() {
+        let p = ContigPaths::new("/out", "chr1");
+        assert_eq!(
+            p.mutcat_code(MutcatSub::VkSnp),
+            Path::new("/out/chr1/mutcat/var_key_snp/code.bin")
+        );
+        assert_eq!(
+            p.mutcat_ref(MutcatSub::DenseSnp),
+            Path::new("/out/chr1/mutcat/dense_snp/ref.bin")
+        );
+        assert!(MutcatSub::VkSnp.has_ref());
+        assert!(!MutcatSub::VkIndel.has_ref());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub mod orchestrator;
 // itself has zero htslib dependency (pure numpy/pyo3 glue). Stays ungated as
 // shared infra, same reasoning as `streams` above.
 pub mod py_convert;
+pub mod py_mutcat;
 pub mod py_query;
 pub mod py_query_batch;
 pub mod py_query_decode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ fn index_vcf(path: String) -> PyResult<()> {
 #[cfg(feature = "conversion")]
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false))]
+#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false))]
 fn run_conversion_pipeline(
     py: Python,
     vcf_path: String,
@@ -106,6 +106,7 @@ fn run_conversion_pipeline(
     max_threads: Option<usize>,  // accepts an optional integer from Python
     long_allele_capacity: usize, // default 8MB — old 100MB rarely flushed mid-run, blocking executor at finalize
     skip_out_of_scope: bool,
+    signatures: bool,
 ) -> PyResult<usize> {
     let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
 
@@ -173,6 +174,7 @@ fn run_conversion_pipeline(
                         long_allele_capacity,
                         skip_out_of_scope,
                         processing_threads,
+                        signatures,
                     )
                 })
                 .collect::<Vec<_>>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod merge;
 pub mod meta;
 #[cfg(feature = "conversion")]
 pub mod monitor;
+pub mod mutcat;
 #[cfg(feature = "conversion")]
 pub mod normalize;
 pub mod nrvk;

--- a/src/mutcat/annotate.rs
+++ b/src/mutcat/annotate.rs
@@ -15,6 +15,13 @@ pub fn annotate_contig(
     paths: &ContigPaths,
     ref_seq: &[u8],
 ) -> std::io::Result<()> {
+    // Classifiers match uppercase ACGT only; normalize here so BOTH entry points
+    // (write-time from_vcf(signatures=True) and post-hoc annotate_mutations, which
+    // reads a possibly soft-masked reference) classify identically. base_index()
+    // treats lowercase as non-ACGT -> UNCLASSIFIED, so a soft-masked reference would
+    // otherwise silently drop masked-region variants from SBS96/ID83.
+    let ref_seq: Vec<u8> = ref_seq.to_ascii_uppercase();
+    let ref_seq: &[u8] = &ref_seq;
     // --- var_key/snp (per call) ---
     {
         let (positions, keys) = reader.vk_snp_records(); // &[u32], packed 2-bit keys

--- a/src/mutcat/annotate.rs
+++ b/src/mutcat/annotate.rs
@@ -1,0 +1,132 @@
+//! Classify a finished contig's records and write the mutcat sidecar. Runs at
+//! write time (FASTA already open) or post-hoc.
+
+use crate::layout::{ContigPaths, MutcatSub};
+use crate::mutcat::NOT_ANNOTATED;
+use crate::mutcat::classify::{id83_code, sbs96_code};
+use crate::mutcat::sidecar::write_sidecar;
+use crate::query::ContigReader;
+use svar2_codec::{DecodedKey, decode_key, decode_snp_2bit, encode_snp_2bit};
+
+/// Classify every record of `reader`'s four sub-streams against `ref_seq` (the
+/// whole contig, 0-based ASCII) and write the sidecar under `paths`.
+pub fn annotate_contig(
+    reader: &ContigReader,
+    paths: &ContigPaths,
+    ref_seq: &[u8],
+) -> std::io::Result<()> {
+    // --- var_key/snp (per call) ---
+    {
+        let (positions, keys) = reader.vk_snp_records(); // &[u32], packed 2-bit keys
+        let mut codes = Vec::with_capacity(positions.len());
+        let mut refs = Vec::with_capacity(positions.len());
+        for (i, &pos) in positions.iter().enumerate() {
+            let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
+            codes.push(code);
+            refs.push(refc);
+        }
+        write_sidecar(paths, MutcatSub::VkSnp, &codes, Some(&refs))?;
+    }
+    // --- dense/snp (per variant) ---
+    if let Some((positions, keys)) = reader.dense_snp_records() {
+        // Dense SNP keys are 2-bit-packed (4 variants/byte), same as var_key/snp:
+        // decode via `snp_alt` (unpack_snp_key_at + decode_snp_2bit), never `keys[i]`.
+        let mut codes = Vec::with_capacity(positions.len());
+        let mut refs = Vec::with_capacity(positions.len());
+        for (i, &pos) in positions.iter().enumerate() {
+            let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
+            codes.push(code);
+            refs.push(refc);
+        }
+        write_sidecar(paths, MutcatSub::DenseSnp, &codes, Some(&refs))?;
+    }
+    // --- var_key/indel + dense/indel (per record) ---
+    annotate_indel(reader, paths, ref_seq, MutcatSub::VkIndel)?;
+    annotate_indel(reader, paths, ref_seq, MutcatSub::DenseIndel)?;
+    Ok(())
+}
+
+/// SBS96 code + 2-bit ref base for a SNP at 0-based `pos` with ASCII `alt`.
+fn snp_record(ref_seq: &[u8], pos: u32, alt: u8) -> (u8, u8) {
+    let p = pos as usize;
+    let n = ref_seq.len();
+    if p == 0 || p + 1 >= n {
+        return (NOT_ANNOTATED, 0); // contig-end flank missing → not classified
+    }
+    let refb = ref_seq[p];
+    let code = sbs96_code(ref_seq[p - 1], refb, alt, ref_seq[p + 1]);
+    (code, encode_snp_2bit(refb))
+}
+
+/// ALT base for record `i` of a 2-bit-packed SNP key buffer (var_key or dense).
+fn snp_alt(packed_keys: &[u8], i: usize) -> u8 {
+    decode_snp_2bit(svar2_codec::unpack_snp_key_at(packed_keys, i))
+}
+
+fn annotate_indel(
+    reader: &ContigReader,
+    paths: &ContigPaths,
+    ref_seq: &[u8],
+    sub: MutcatSub,
+) -> std::io::Result<()> {
+    let recs = reader.indel_records(sub); // Option<(&[u32] positions, &[u32] keys)>
+    let (positions, keys) = match recs {
+        Some(r) => r,
+        None => return write_sidecar(paths, sub, &[], None),
+    };
+    let mut codes = Vec::with_capacity(positions.len());
+    for (i, &pos) in positions.iter().enumerate() {
+        codes.push(indel_code(reader, ref_seq, pos, keys[i]));
+    }
+    write_sidecar(paths, sub, &codes, None)
+}
+
+/// ID83 code for one indel record, reconstructing REF/ALT from key + reference.
+fn indel_code(reader: &ContigReader, ref_seq: &[u8], pos: u32, key: u32) -> u8 {
+    let p = pos as usize;
+    if p >= ref_seq.len() {
+        return NOT_ANNOTATED;
+    }
+    let anchor = ref_seq[p];
+    let (refa, alta): (Vec<u8>, Vec<u8>) = match decode_key(key) {
+        DecodedKey::Inline { alt } => {
+            // atomized INS/anchor: REF = single anchor base; ALT = alt bytes.
+            (vec![anchor], alt)
+        }
+        DecodedKey::PureDel { ilen } => {
+            let dl = (-ilen) as usize;
+            if p + dl >= ref_seq.len() {
+                return NOT_ANNOTATED;
+            }
+            // REF = anchor + dl deleted bases; ALT = anchor only.
+            (ref_seq[p..p + dl + 1].to_vec(), vec![anchor])
+        }
+        DecodedKey::Lookup { row } => {
+            let alt = reader.lut_allele(row); // Vec<u8>
+            (vec![anchor], alt)
+        }
+    };
+    id83_code(ref_seq, p, &refa, &alta)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mutcat::classify::sbs96_code;
+
+    // Minimal check: a single var_key/snp record's sidecar code equals the
+    // direct sbs96_code of its reference context.
+    #[test]
+    fn snp_record_matches_direct_classify() {
+        let ref_seq = b"TACGT"; // pos 2 = 'C', 5'=A(1), 3'=G(3)
+        let (code, refc) = snp_record(ref_seq, 2, b'A');
+        assert_eq!(code, sbs96_code(b'A', b'C', b'A', b'G'));
+        assert_eq!(refc, svar2_codec::encode_snp_2bit(b'C'));
+    }
+
+    #[test]
+    fn contig_end_snp_is_not_annotated() {
+        let ref_seq = b"CG";
+        assert_eq!(snp_record(ref_seq, 0, b'A').0, NOT_ANNOTATED);
+    }
+}

--- a/src/mutcat/classify.rs
+++ b/src/mutcat/classify.rs
@@ -55,6 +55,162 @@ pub fn sbs96_code(five: u8, refb: u8, altb: u8, three: u8) -> u8 {
     (sub as u8) * 16 + (ff as u8) * 4 + (tt as u8)
 }
 
+// ID83 lookup tables, built to match codebook.py ID83 order.
+// ID83 label order (see _build_id83): 24 single-base (Del/Ins x C/T x rep0..5),
+// then 48 repeat (Del/Ins x size2..5 x rep0..5), then 11 microhomology-Del.
+struct Id83Luts {
+    id1: [[[u8; 6]; 2]; 2], // [kind(Del=0,Ins=1)][base(C=0,T=1)][rep0..5]
+    idr: [[[u8; 6]; 4]; 2], // [kind][size_bucket(2..5)][rep0..5]
+    idm: [[u8; 6]; 4],      // [size_bucket][mh]
+}
+
+const fn build_id83_luts() -> Id83Luts {
+    // Index formula mirrors codebook order:
+    //   single: base = (kind*2 + base_ct)*6 + rep                          [0..24)
+    //   repeat: 24 + (kind*4 + size_bucket)*6 + rep                        [24..72)
+    //   mh    : 72 + cumulative(mh caps 1,2,3,5) offset + (m-1)            [72..83)
+    let u = UNCLASSIFIED;
+    let mut id1 = [[[u; 6]; 2]; 2];
+    let mut idr = [[[u; 6]; 4]; 2];
+    let mut idm = [[u; 6]; 4];
+    let mut kind = 0;
+    while kind < 2 {
+        let mut b = 0;
+        while b < 2 {
+            let mut r = 0;
+            while r < 6 {
+                id1[kind][b][r] = ((kind * 2 + b) * 6 + r) as u8;
+                r += 1;
+            }
+            b += 1;
+        }
+        let mut s = 0;
+        while s < 4 {
+            let mut r = 0;
+            while r < 6 {
+                idr[kind][s][r] = (24 + (kind * 4 + s) * 6 + r) as u8;
+                r += 1;
+            }
+            s += 1;
+        }
+        kind += 1;
+    }
+    // microhomology (Del only): caps per size bucket = [1,2,3,5]; base offset 72.
+    let caps = [1usize, 2, 3, 5];
+    let mut s = 0;
+    let mut base = 72usize;
+    while s < 4 {
+        let mut m = 1;
+        while m <= caps[s] {
+            idm[s][m] = (base + (m - 1)) as u8;
+            m += 1;
+        }
+        base += caps[s];
+        s += 1;
+    }
+    Id83Luts { id1, idr, idm }
+}
+
+const ID83_LUTS: Id83Luts = build_id83_luts();
+const MH_CAP: [usize; 4] = [1, 2, 3, 5];
+
+/// ID83 class-local index (0..=82) or `UNCLASSIFIED`. Port of `_id83_kernel`.
+pub fn id83_code(seq: &[u8], pos0: usize, refa: &[u8], alta: &[u8]) -> u8 {
+    let n = seq.len();
+    let rl = refa.len();
+    let al = alta.len();
+    // atomized indels always share an anchor base; require it and equal anchors.
+    if rl == 0 || al == 0 || refa[0] != alta[0] {
+        return UNCLASSIFIED;
+    }
+    let is_del = rl > al;
+    // deleted/inserted unit = allele[1..]
+    let (buf, ilen): (&[u8], usize) = if is_del {
+        (&refa[1..], rl - 1)
+    } else {
+        (&alta[1..], al - 1)
+    };
+    if ilen == 0 {
+        return UNCLASSIFIED;
+    }
+    for &c in buf {
+        if base_index(c) < 0 {
+            return UNCLASSIFIED;
+        }
+    }
+    // count tandem repeats of the unit downstream from pos0+1
+    let scan = pos0 + 1;
+    let mut n_rep = 0usize;
+    let mut i = 0usize;
+    while scan + i + ilen <= n {
+        let mut m = true;
+        let mut j = 0;
+        while j < ilen {
+            if seq[scan + i + j] != buf[j] {
+                m = false;
+                break;
+            }
+            j += 1;
+        }
+        if !m {
+            break;
+        }
+        n_rep += 1;
+        i += ilen;
+    }
+    if ilen == 1 {
+        let mut bi = base_index(buf[0]);
+        if bi == 0 || bi == 2 {
+            bi = 3 - bi; // A/G -> pyrimidine partner
+        }
+        let base_ct = if bi == 1 { 0 } else { 1 }; // C->0, T->1
+        if is_del && n_rep == 0 {
+            return UNCLASSIFIED; // v1 _REF_MISMATCH -> UNCLASSIFIED
+        }
+        let mut rep = if is_del { n_rep - 1 } else { n_rep };
+        if rep > 5 {
+            rep = 5;
+        }
+        return ID83_LUTS.id1[if is_del { 0 } else { 1 }][base_ct][rep];
+    }
+    let sb = if ilen < 5 { ilen } else { 5 };
+    let si = sb - 2; // 0..3
+    let rep;
+    if is_del {
+        // microhomology: longest prefix of the unit matching downstream
+        let mut mh = 0usize;
+        let mut kk = 1;
+        while kk < ilen {
+            let mut eq = true;
+            let mut j = 0;
+            while j < kk {
+                if scan + j >= n || seq[scan + j] != buf[j] {
+                    eq = false;
+                    break;
+                }
+                j += 1;
+            }
+            if eq {
+                mh = kk;
+            }
+            kk += 1;
+        }
+        if mh > 0 && n_rep <= 1 {
+            let cap = MH_CAP[si];
+            let m = if mh < cap { mh } else { cap };
+            return ID83_LUTS.idm[si][m];
+        }
+        if n_rep == 0 {
+            return UNCLASSIFIED; // _REF_MISMATCH
+        }
+        rep = n_rep - 1;
+    } else {
+        rep = n_rep;
+    }
+    let rep = if rep > 5 { 5 } else { rep };
+    ID83_LUTS.idr[if is_del { 0 } else { 1 }][si][rep]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,5 +236,31 @@ mod tests {
     fn sbs96_rejects_non_acgt_and_ref_eq_alt() {
         assert_eq!(sbs96_code(b'N', b'C', b'A', b'G'), UNCLASSIFIED);
         assert_eq!(sbs96_code(b'A', b'C', b'C', b'G'), UNCLASSIFIED); // ref==alt
+    }
+
+    #[test]
+    fn id83_1bp_del_in_repeat() {
+        // seq: ...A C C C C... delete one C at a run of 4 C's.
+        // REF="AC" ALT="A" (anchor A, deleted unit "C"), pos0 at the 'A'.
+        // downstream run of C's from pos0+1: 4 -> is_del, rep=n_rep-1=3.
+        // base C -> base_ct=0, kind Del=0 -> id1[0][0][3] = (0*2+0)*6+3 = 3
+        let seq = b"AACCCCG"; // pos0 = 1 ('A'), then CCCC
+        assert_eq!(id83_code(seq, 1, b"AC", b"A"), 3);
+    }
+
+    #[test]
+    #[allow(clippy::identity_op)] // spelled-out kind*2+base_ct to mirror the LUT formula
+    fn id83_1bp_ins() {
+        // REF="A" ALT="AC" insert one C; downstream C run from pos0+1.
+        // seq A C C C: n_rep counts inserted-unit "C" copies present downstream.
+        // kind Ins=1, base C base_ct=0, rep=n_rep (no -1 for ins).
+        let seq = b"ACCCG"; // pos0=0 ('A'); downstream from index1: C C C -> n_rep=3
+        assert_eq!(id83_code(seq, 0, b"A", b"AC"), (1 * 2 + 0) * 6 + 3);
+    }
+
+    #[test]
+    fn id83_rejects_non_acgt_unit() {
+        let seq = b"ANNNG";
+        assert_eq!(id83_code(seq, 0, b"AN", b"A"), UNCLASSIFIED);
     }
 }

--- a/src/mutcat/classify.rs
+++ b/src/mutcat/classify.rs
@@ -223,46 +223,73 @@ const DBS78_LABELS: [&str; 78] = [
     "TT>AC", "TT>AG", "TT>CA", "TT>CC", "TT>CG", "TT>GA", "TT>GC", "TT>GG",
 ];
 
-#[inline]
-fn comp(b: u8) -> u8 {
-    match b {
-        b'A' => b'T',
-        b'T' => b'A',
-        b'C' => b'G',
-        b'G' => b'C',
-        _ => b,
-    }
-}
-
-// Build the (r0,a0,r1,a1) -> code table once. Bases A=0 C=1 G=2 T=3.
 // Only exercised by the exhaustive test below; not otherwise called from
 // production code, hence the narrow dead_code allow for non-test builds.
 #[allow(dead_code)]
 const BASES_ACGT: [u8; 4] = [b'A', b'C', b'G', b'T'];
 
-fn dbs_index_of(key: &str) -> Option<u8> {
-    DBS78_LABELS.iter().position(|&l| l == key).map(|i| i as u8)
+/// ACGT base -> 2-bit index (A=0 C=1 G=2 T=3), for indexing `DBS78_LUT`.
+/// Labels contain only ACGT, so the fallthrough is unreachable.
+const fn dbs_bidx(b: u8) -> usize {
+    match b {
+        b'A' => 0,
+        b'C' => 1,
+        b'G' => 2,
+        b'T' => 3,
+        _ => 0,
+    }
 }
 
-/// DBS78 class-local index (0..=77) or `UNCLASSIFIED`. Try literal then
-/// reverse-complement of the doublet REF>ALT.
+/// Compile-time `(r0,a0,r1,a1) -> code` table, indexed by
+/// `(r0<<6)|(a0<<4)|(r1<<2)|a1` over 2-bit base codes. Built from `DBS78_LABELS`
+/// (source of truth): each label fills its literal key, then every remaining
+/// key folds to its reverse-complement's literal — reproducing the old
+/// literal-then-revcomp search with a single array load and zero allocation.
+const DBS78_LUT: [u8; 256] = {
+    let mut lut = [UNCLASSIFIED; 256];
+    let mut i = 0;
+    while i < DBS78_LABELS.len() {
+        // Label "R0R1>A0A1": bytes [0,1] = ref doublet, [3,4] = alt doublet.
+        let s = DBS78_LABELS[i].as_bytes();
+        let key =
+            (dbs_bidx(s[0]) << 6) | (dbs_bidx(s[3]) << 4) | (dbs_bidx(s[1]) << 2) | dbs_bidx(s[4]);
+        lut[key] = i as u8;
+        i += 1;
+    }
+    // Snapshot the literal-only table so the revcomp fold never reads a value
+    // written by this second pass (RC is involutive, so a self-referential read
+    // would otherwise be order-dependent).
+    let literal = lut;
+    let mut idx = 0;
+    while idx < 256 {
+        if lut[idx] == UNCLASSIFIED {
+            let r0 = (idx >> 6) & 3;
+            let a0 = (idx >> 4) & 3;
+            let r1 = (idx >> 2) & 3;
+            let a1 = idx & 3;
+            // revcomp: complement (3 - b) each base and swap the two positions.
+            let rc = ((3 - r1) << 6) | ((3 - a1) << 4) | ((3 - r0) << 2) | (3 - a0);
+            lut[idx] = literal[rc];
+        }
+        idx += 1;
+    }
+    lut
+};
+
+/// DBS78 class-local index (0..=77) or `UNCLASSIFIED`. Literal-then-revcomp
+/// canonicalization folded into `DBS78_LUT` at compile time.
+#[inline]
 pub fn dbs78_code(r0: u8, a0: u8, r1: u8, a1: u8) -> u8 {
-    if base_index(r0) < 0 || base_index(r1) < 0 || base_index(a0) < 0 || base_index(a1) < 0 {
+    let (i0, i1, i2, i3) = (
+        base_index(r0),
+        base_index(a0),
+        base_index(r1),
+        base_index(a1),
+    );
+    if i0 < 0 || i1 < 0 || i2 < 0 || i3 < 0 {
         return UNCLASSIFIED;
     }
-    let literal = format!("{}{}>{}{}", r0 as char, r1 as char, a0 as char, a1 as char);
-    if let Some(c) = dbs_index_of(&literal) {
-        return c;
-    }
-    // reverse-complement both sides
-    let rc = format!(
-        "{}{}>{}{}",
-        comp(r1) as char,
-        comp(r0) as char,
-        comp(a1) as char,
-        comp(a0) as char
-    );
-    dbs_index_of(&rc).unwrap_or(UNCLASSIFIED)
+    DBS78_LUT[((i0 as usize) << 6) | ((i1 as usize) << 4) | ((i2 as usize) << 2) | (i3 as usize)]
 }
 
 #[cfg(test)]

--- a/src/mutcat/classify.rs
+++ b/src/mutcat/classify.rs
@@ -1,0 +1,84 @@
+//! Pure mutation classifiers (SBS96, ID83, DBS78). Port of
+//! python/genoray/_mutcat/classify.py. No I/O; operates on ASCII bytes +
+//! reference slices.
+
+use crate::mutcat::UNCLASSIFIED;
+
+/// A=0 C=1 G=2 T=3, else -1 (N or non-ACGT).
+#[inline]
+pub fn base_index(b: u8) -> i8 {
+    match b {
+        b'A' => 0,
+        b'C' => 1,
+        b'G' => 2,
+        b'T' => 3,
+        _ => -1,
+    }
+}
+
+// (ref_idx, alt_idx) -> SBS substitution index 0..5 for pyrimidine-folded refs.
+// Order: C>A, C>G, C>T, T>A, T>C, T>G  (A=0,C=1,G=2,T=3).
+const SUB_LUT: [[i8; 4]; 4] = {
+    let mut lut = [[-1i8; 4]; 4];
+    // C(1)>A(0),C>G(2),C>T(3)
+    lut[1][0] = 0;
+    lut[1][2] = 1;
+    lut[1][3] = 2;
+    // T(3)>A(0),T>C(1),T>G(2)
+    lut[3][0] = 3;
+    lut[3][1] = 4;
+    lut[3][2] = 5;
+    lut
+};
+
+/// SBS96 class-local index (0..=95) or `UNCLASSIFIED`.
+/// `five`/`three`: immediate reference flanks; `refb`/`altb`: REF/ALT bases.
+pub fn sbs96_code(five: u8, refb: u8, altb: u8, three: u8) -> u8 {
+    let r = base_index(refb);
+    let a = base_index(altb);
+    let f = base_index(five);
+    let t = base_index(three);
+    if r < 0 || a < 0 || f < 0 || t < 0 || r == a {
+        return UNCLASSIFIED;
+    }
+    let purine = r == 0 || r == 2; // A or G -> fold
+    let (rr, aa, ff, tt) = if purine {
+        // fold: complement ref/alt, and flanks swap+complement
+        (3 - r, 3 - a, 3 - t, 3 - f)
+    } else {
+        (r, a, f, t)
+    };
+    let sub = SUB_LUT[rr as usize][aa as usize];
+    if sub < 0 {
+        return UNCLASSIFIED;
+    }
+    (sub as u8) * 16 + (ff as u8) * 4 + (tt as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mutcat::UNCLASSIFIED;
+
+    #[test]
+    fn sbs96_pyrimidine_ref_no_fold() {
+        // A[C>A]G : sub C>A = 0, five=A=0, three=G=2 -> 0*16 + 0*4 + 2 = 2
+        assert_eq!(sbs96_code(b'A', b'C', b'A', b'G'), 2);
+    }
+
+    #[test]
+    fn sbs96_purine_ref_folds() {
+        // Purine ref folds to its pyrimidine partner with flanks swapped+complemented.
+        // G>T at flanks A..C  == (fold) C>A at flanks G..T.
+        // Direct fold: r=G(2)->rr=1(C), a=T(3)->aa=0(A) => sub C>A=0.
+        // five=A(0)->ff=comp(three=C(1))=2(G); three=C(1)->tt=comp(five=A(0))=3(T).
+        // code = 0*16 + 2*4 + 3 = 11.
+        assert_eq!(sbs96_code(b'A', b'G', b'T', b'C'), 11);
+    }
+
+    #[test]
+    fn sbs96_rejects_non_acgt_and_ref_eq_alt() {
+        assert_eq!(sbs96_code(b'N', b'C', b'A', b'G'), UNCLASSIFIED);
+        assert_eq!(sbs96_code(b'A', b'C', b'C', b'G'), UNCLASSIFIED); // ref==alt
+    }
+}

--- a/src/mutcat/classify.rs
+++ b/src/mutcat/classify.rs
@@ -211,6 +211,60 @@ pub fn id83_code(seq: &[u8], pos0: usize, refa: &[u8], alta: &[u8]) -> u8 {
     ID83_LUTS.idr[if is_del { 0 } else { 1 }][si][rep]
 }
 
+// Canonical DBS78 doublet labels, codebook order (must match codebook.py DBS78).
+const DBS78_LABELS: [&str; 78] = [
+    "AC>CA", "AC>CG", "AC>CT", "AC>GA", "AC>GG", "AC>GT", "AC>TA", "AC>TG", "AC>TT", "AT>CA",
+    "AT>CC", "AT>CG", "AT>GA", "AT>GC", "AT>TA", "CC>AA", "CC>AG", "CC>AT", "CC>GA", "CC>GG",
+    "CC>GT", "CC>TA", "CC>TG", "CC>TT", "CG>AT", "CG>GC", "CG>GT", "CG>TA", "CG>TC", "CG>TT",
+    "CT>AA", "CT>AC", "CT>AG", "CT>GA", "CT>GC", "CT>GG", "CT>TA", "CT>TC", "CT>TG", "GC>AA",
+    "GC>AG", "GC>AT", "GC>CA", "GC>CG", "GC>TA", "TA>AT", "TA>CG", "TA>CT", "TA>GC", "TA>GG",
+    "TA>GT", "TC>AA", "TC>AG", "TC>AT", "TC>CA", "TC>CG", "TC>CT", "TC>GA", "TC>GG", "TC>GT",
+    "TG>AA", "TG>AC", "TG>AT", "TG>CA", "TG>CC", "TG>CT", "TG>GA", "TG>GC", "TG>GT", "TT>AA",
+    "TT>AC", "TT>AG", "TT>CA", "TT>CC", "TT>CG", "TT>GA", "TT>GC", "TT>GG",
+];
+
+#[inline]
+fn comp(b: u8) -> u8 {
+    match b {
+        b'A' => b'T',
+        b'T' => b'A',
+        b'C' => b'G',
+        b'G' => b'C',
+        _ => b,
+    }
+}
+
+// Build the (r0,a0,r1,a1) -> code table once. Bases A=0 C=1 G=2 T=3.
+// Only exercised by the exhaustive test below; not otherwise called from
+// production code, hence the narrow dead_code allow for non-test builds.
+#[allow(dead_code)]
+const BASES_ACGT: [u8; 4] = [b'A', b'C', b'G', b'T'];
+
+fn dbs_index_of(key: &str) -> Option<u8> {
+    DBS78_LABELS.iter().position(|&l| l == key).map(|i| i as u8)
+}
+
+/// DBS78 class-local index (0..=77) or `UNCLASSIFIED`. Try literal then
+/// reverse-complement of the doublet REF>ALT.
+pub fn dbs78_code(r0: u8, a0: u8, r1: u8, a1: u8) -> u8 {
+    if base_index(r0) < 0 || base_index(r1) < 0 || base_index(a0) < 0 || base_index(a1) < 0 {
+        return UNCLASSIFIED;
+    }
+    let literal = format!("{}{}>{}{}", r0 as char, r1 as char, a0 as char, a1 as char);
+    if let Some(c) = dbs_index_of(&literal) {
+        return c;
+    }
+    // reverse-complement both sides
+    let rc = format!(
+        "{}{}>{}{}",
+        comp(r1) as char,
+        comp(r0) as char,
+        comp(a1) as char,
+        comp(a0) as char
+    );
+    dbs_index_of(&rc).unwrap_or(UNCLASSIFIED)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -262,5 +316,32 @@ mod tests {
     fn id83_rejects_non_acgt_unit() {
         let seq = b"ANNNG";
         assert_eq!(id83_code(seq, 0, b"AN", b"A"), UNCLASSIFIED);
+    }
+
+    #[test]
+    fn dbs78_literal_hit() {
+        // "AC>CA" is index 0.
+        assert_eq!(dbs78_code(b'A', b'C', b'C', b'A'), 0);
+    }
+
+    #[test]
+    fn dbs78_revcomp_fold() {
+        // "GT>TG" is not literal; revcomp = "AC>CA" (index 0).
+        assert_eq!(dbs78_code(b'G', b'T', b'T', b'G'), 0);
+    }
+
+    #[test]
+    fn dbs78_all_16_doublets_map_or_uncl() {
+        // Every ACGT^4 combo with r!=a on both is either a code < 78 or UNCLASSIFIED.
+        for &r0 in &BASES_ACGT {
+            for &r1 in &BASES_ACGT {
+                for &a0 in &BASES_ACGT {
+                    for &a1 in &BASES_ACGT {
+                        let c = dbs78_code(r0, a0, r1, a1);
+                        assert!(c < 78 || c == UNCLASSIFIED);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/mutcat/count.rs
+++ b/src/mutcat/count.rs
@@ -1,8 +1,15 @@
 //! Streaming mutation-catalogue counting with on-the-fly DBS pairing.
 
+use ndarray::Array2;
+
+use crate::dense::DenseClass;
+use crate::layout::{ContigPaths, MutcatSub};
 use crate::mutcat::classify::dbs78_code;
-use crate::mutcat::{DBS78_OFFSET, N_CODES, SBS96_OFFSET, UNCLASSIFIED};
-use svar2_codec::decode_snp_2bit;
+use crate::mutcat::sidecar::{MutcatView, open_sidecar};
+use crate::mutcat::{DBS78_OFFSET, ID83_OFFSET, N_CODES, SBS96_OFFSET, UNCLASSIFIED};
+use crate::query::ContigReader;
+use crate::query::sidecar::as_bytes;
+use svar2_codec::{decode_snp_2bit, unpack_snp_key_at};
 
 /// One SNV on a single haplotype (already position-sorted & deduped).
 #[derive(Debug, Clone, Copy)]
@@ -13,8 +20,9 @@ pub struct SnvCall {
     pub alt_i: u8, // 2-bit alt base code
 }
 
-/// Emit one unified mutation code per SNV (SBS or, for isolated adjacent pairs,
-/// DBS for both members). Sentinels are skipped. Mirrors v1 isolation logic.
+/// Emit one unified mutation code per SNV (SBS, or DBS once for an isolated
+/// adjacent pair — the pair contributes a single DBS call, not one per
+/// member). Sentinels are skipped. Mirrors v1 isolation logic.
 pub fn emit_snv_codes(snvs: &[SnvCall], out: &mut impl FnMut(usize)) {
     let n = snvs.len();
     let mut j = 0;
@@ -48,6 +56,131 @@ pub fn emit_snv_codes(snvs: &[SnvCall], out: &mut impl FnMut(usize)) {
     #[allow(clippy::assertions_on_constants)]
     {
         debug_assert!(N_CODES == 257);
+    }
+}
+
+/// The four mutcat sidecar views for one contig, bundled so `count_contig`
+/// takes a single handle instead of four.
+pub struct Sidecars {
+    pub vk_snp: MutcatView,
+    pub vk_indel: MutcatView,
+    pub dense_snp: MutcatView,
+    pub dense_indel: MutcatView,
+}
+
+impl Sidecars {
+    /// Open all four mutcat sub-stream sidecars for `paths`'s contig. Any
+    /// sub-stream with no sidecar on disk opens as an empty `MutcatView`
+    /// (`open_sidecar`'s existing missing-file tolerance).
+    pub fn open(paths: &ContigPaths) -> std::io::Result<Sidecars> {
+        Ok(Sidecars {
+            vk_snp: open_sidecar(paths, MutcatSub::VkSnp)?,
+            vk_indel: open_sidecar(paths, MutcatSub::VkIndel)?,
+            dense_snp: open_sidecar(paths, MutcatSub::DenseSnp)?,
+            dense_indel: open_sidecar(paths, MutcatSub::DenseIndel)?,
+        })
+    }
+}
+
+/// Accumulate one contig's full mutation-count matrix into `acc`
+/// (`(n_samples, N_CODES)`).
+///
+/// Walks every flat `(sample, ploid)` column (`col = sample * ploidy +
+/// ploid`, matching `ContigReader::vk_slice`/`dense_carried`'s convention).
+/// For each column:
+/// 1. Gathers that hap's SNVs from `var_key/snp` (per-call, sidecar-indexed
+///    by the absolute call index) and `dense/snp` (per dense variant the hap
+///    carries, sidecar-indexed by the dense variant column), merges by
+///    position, dedups, and runs `emit_snv_codes` for on-the-fly DBS pairing.
+/// 2. Gathers that hap's indels from `var_key/indel` + `dense/indel`; each
+///    emits `ID83_OFFSET + code` directly (no pairing). A sentinel code
+///    (`UNCLASSIFIED`/`NOT_ANNOTATED`, both `>= N_ID83`) pushes the unified
+///    code past `N_CODES`, so the single `unified < N_CODES` bound filters
+///    both sentinels without naming them.
+/// 3. Accumulates into `acc[[sample, unified_code]]`: `per_sample` marks each
+///    code present at most once per sample (across all its ploids), else
+///    every hit increments by one.
+///
+/// Single-threaded (rayon parallelization is a later task).
+pub fn count_contig(
+    reader: &ContigReader,
+    sidecars: &Sidecars,
+    per_sample: bool,
+    acc: &mut Array2<i64>,
+) {
+    let ploidy = reader.ploidy;
+    for sample in 0..reader.n_samples {
+        // Presence-mode bookkeeping: at most one mark per (sample, code),
+        // even if the sample carries the same code on multiple ploids.
+        let mut seen = per_sample.then(|| vec![false; N_CODES]);
+        let mut bump = |code: usize| {
+            if let Some(seen) = seen.as_mut() {
+                if seen[code] {
+                    return;
+                }
+                seen[code] = true;
+            }
+            acc[[sample, code]] += 1;
+        };
+
+        for p in 0..ploidy {
+            let col = sample * ploidy + p;
+
+            // --- SNVs: var_key/snp + dense/snp, merged by position ---
+            let mut snvs: Vec<SnvCall> = Vec::new();
+            {
+                let vk_range = reader.vk_snp.column(col);
+                let (o0, o1) = (vk_range.start, vk_range.end);
+                let positions = &reader.vk_snp.positions()[o0..o1];
+                let keys = as_bytes(&reader.vk_snp.keys);
+                for (i, &pos) in positions.iter().enumerate() {
+                    let abs_i = o0 + i;
+                    snvs.push(SnvCall {
+                        pos,
+                        sbs: sidecars.vk_snp.code_at(abs_i),
+                        ref_i: sidecars.vk_snp.ref_at(abs_i),
+                        alt_i: unpack_snp_key_at(keys, abs_i),
+                    });
+                }
+            }
+            if let Some(dense) = reader.dense_view(DenseClass::Snp) {
+                let keys = as_bytes(&dense.keys);
+                for (dcol, &pos) in dense.positions().iter().enumerate() {
+                    if dense.carried(col, dcol) {
+                        snvs.push(SnvCall {
+                            pos,
+                            sbs: sidecars.dense_snp.code_at(dcol),
+                            ref_i: sidecars.dense_snp.ref_at(dcol),
+                            alt_i: unpack_snp_key_at(keys, dcol),
+                        });
+                    }
+                }
+            }
+            snvs.sort_by_key(|s| s.pos);
+            snvs.dedup_by_key(|s| s.pos);
+            emit_snv_codes(&snvs, &mut bump);
+
+            // --- indels: var_key/indel + dense/indel, each direct (no pairing) ---
+            {
+                let vk_range = reader.vk_indel.column(col);
+                for abs_i in vk_range {
+                    let unified = ID83_OFFSET + sidecars.vk_indel.code_at(abs_i) as usize;
+                    if unified < N_CODES {
+                        bump(unified);
+                    }
+                }
+            }
+            if let Some(dense) = reader.dense_view(DenseClass::Indel) {
+                for dcol in 0..dense.n_dense_variants {
+                    if dense.carried(col, dcol) {
+                        let unified = ID83_OFFSET + sidecars.dense_indel.code_at(dcol) as usize;
+                        if unified < N_CODES {
+                            bump(unified);
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/mutcat/count.rs
+++ b/src/mutcat/count.rs
@@ -1,0 +1,102 @@
+//! Streaming mutation-catalogue counting with on-the-fly DBS pairing.
+
+use crate::mutcat::classify::dbs78_code;
+use crate::mutcat::{DBS78_OFFSET, N_CODES, SBS96_OFFSET, UNCLASSIFIED};
+use svar2_codec::decode_snp_2bit;
+
+/// One SNV on a single haplotype (already position-sorted & deduped).
+#[derive(Debug, Clone, Copy)]
+pub struct SnvCall {
+    pub pos: u32,
+    pub sbs: u8,   // SBS96 class-local index or sentinel
+    pub ref_i: u8, // 2-bit ref base code
+    pub alt_i: u8, // 2-bit alt base code
+}
+
+/// Emit one unified mutation code per SNV (SBS or, for isolated adjacent pairs,
+/// DBS for both members). Sentinels are skipped. Mirrors v1 isolation logic.
+pub fn emit_snv_codes(snvs: &[SnvCall], out: &mut impl FnMut(usize)) {
+    let n = snvs.len();
+    let mut j = 0;
+    while j < n {
+        let v = snvs[j];
+        // try to pair v with the next SNV
+        if j + 1 < n && snvs[j + 1].pos == v.pos + 1 {
+            let w = snvs[j + 1];
+            // isolation: no adjacent SNV before v, none after w.
+            let before = j > 0 && snvs[j - 1].pos + 1 == v.pos;
+            let after = j + 2 < n && snvs[j + 2].pos == w.pos + 1;
+            if !before && !after {
+                let code = dbs78_code(
+                    decode_snp_2bit(v.ref_i),
+                    decode_snp_2bit(v.alt_i),
+                    decode_snp_2bit(w.ref_i),
+                    decode_snp_2bit(w.alt_i),
+                );
+                if code != UNCLASSIFIED {
+                    out(DBS78_OFFSET + code as usize);
+                    out(DBS78_OFFSET + code as usize);
+                    j += 2;
+                    continue;
+                }
+            }
+        }
+        if (v.sbs as usize) < 96 {
+            out(SBS96_OFFSET + v.sbs as usize);
+        }
+        j += 1;
+    }
+    #[allow(clippy::assertions_on_constants)]
+    {
+        debug_assert!(N_CODES == 257);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snv(pos: u32, ref_b: u8, alt_b: u8) -> SnvCall {
+        use crate::mutcat::classify::sbs96_code;
+        SnvCall {
+            pos,
+            sbs: sbs96_code(b'A', ref_b, alt_b, b'A'), // dummy flanks for the test
+            ref_i: svar2_codec::encode_snp_2bit(ref_b),
+            alt_i: svar2_codec::encode_snp_2bit(alt_b),
+        }
+    }
+
+    #[test]
+    fn isolated_pair_emits_two_dbs() {
+        let snvs = [snv(10, b'A', b'C'), snv(11, b'C', b'A')];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        // AC>CA is DBS index 0 → unified 96; both members contribute.
+        assert_eq!(codes, vec![96, 96]);
+    }
+
+    #[test]
+    fn run_of_three_stays_sbs() {
+        let snvs = [
+            snv(10, b'C', b'A'),
+            snv(11, b'C', b'A'),
+            snv(12, b'C', b'A'),
+        ];
+        let mut n_dbs = 0;
+        emit_snv_codes(&snvs, &mut |c| {
+            if c >= DBS78_OFFSET {
+                n_dbs += 1;
+            }
+        });
+        assert_eq!(n_dbs, 0, "runs of 3 must stay SBS");
+    }
+
+    #[test]
+    fn non_adjacent_snvs_are_sbs() {
+        let snvs = [snv(10, b'C', b'A'), snv(20, b'C', b'A')];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        assert!(codes.iter().all(|&c| c < DBS78_OFFSET));
+        assert_eq!(codes.len(), 2);
+    }
+}

--- a/src/mutcat/count.rs
+++ b/src/mutcat/count.rs
@@ -35,7 +35,6 @@ pub fn emit_snv_codes(snvs: &[SnvCall], out: &mut impl FnMut(usize)) {
                 );
                 if code != UNCLASSIFIED {
                     out(DBS78_OFFSET + code as usize);
-                    out(DBS78_OFFSET + code as usize);
                     j += 2;
                     continue;
                 }
@@ -67,12 +66,12 @@ mod tests {
     }
 
     #[test]
-    fn isolated_pair_emits_two_dbs() {
+    fn isolated_pair_emits_one_dbs() {
         let snvs = [snv(10, b'A', b'C'), snv(11, b'C', b'A')];
         let mut codes = vec![];
         emit_snv_codes(&snvs, &mut |c| codes.push(c));
-        // AC>CA is DBS index 0 → unified 96; both members contribute.
-        assert_eq!(codes, vec![96, 96]);
+        // AC>CA is DBS index 0 → unified 96; the doublet contributes exactly once.
+        assert_eq!(codes, vec![96]);
     }
 
     #[test]
@@ -82,13 +81,17 @@ mod tests {
             snv(11, b'C', b'A'),
             snv(12, b'C', b'A'),
         ];
-        let mut n_dbs = 0;
-        emit_snv_codes(&snvs, &mut |c| {
-            if c >= DBS78_OFFSET {
-                n_dbs += 1;
-            }
-        });
-        assert_eq!(n_dbs, 0, "runs of 3 must stay SBS");
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        assert_eq!(
+            codes.len(),
+            3,
+            "all three SNVs in the run must emit an SBS code"
+        );
+        assert!(
+            codes.iter().all(|&c| c < DBS78_OFFSET),
+            "runs of 3 must stay SBS"
+        );
     }
 
     #[test]

--- a/src/mutcat/count.rs
+++ b/src/mutcat/count.rs
@@ -1,6 +1,7 @@
 //! Streaming mutation-catalogue counting with on-the-fly DBS pairing.
 
 use ndarray::Array2;
+use rayon::prelude::*;
 
 use crate::dense::DenseClass;
 use crate::layout::{ContigPaths, MutcatSub};
@@ -82,12 +83,10 @@ impl Sidecars {
     }
 }
 
-/// Accumulate one contig's full mutation-count matrix into `acc`
-/// (`(n_samples, N_CODES)`).
-///
-/// Walks every flat `(sample, ploid)` column (`col = sample * ploidy +
-/// ploid`, matching `ContigReader::vk_slice`/`dense_carried`'s convention).
-/// For each column:
+/// Gather + classify one flat `(sample, ploid)` column's SNVs/indels
+/// (`col = sample * ploidy + ploid`, matching
+/// `ContigReader::vk_slice`/`dense_carried`'s convention), returning its raw
+/// `(N_CODES,)` count row:
 /// 1. Gathers that hap's SNVs from `var_key/snp` (per-call, sidecar-indexed
 ///    by the absolute call index) and `dense/snp` (per dense variant the hap
 ///    carries, sidecar-indexed by the dense variant column), merges by
@@ -97,11 +96,94 @@ impl Sidecars {
 ///    (`UNCLASSIFIED`/`NOT_ANNOTATED`, both `>= N_ID83`) pushes the unified
 ///    code past `N_CODES`, so the single `unified < N_CODES` bound filters
 ///    both sentinels without naming them.
-/// 3. Accumulates into `acc[[sample, unified_code]]`: `per_sample` marks each
-///    code present at most once per sample (across all its ploids), else
-///    every hit increments by one.
 ///
-/// Single-threaded (rayon parallelization is a later task).
+/// Every emitted code increments its slot by one (raw counts) — this column
+/// is independent of every other column, so it can run on its own thread;
+/// per-sample presence-clipping happens once, after `count_contig` reduces
+/// a sample's columns together.
+fn count_column(reader: &ContigReader, sidecars: &Sidecars, col: usize) -> Vec<i64> {
+    let mut row = vec![0i64; N_CODES];
+    let mut bump = |code: usize| {
+        row[code] += 1;
+    };
+
+    // --- SNVs: var_key/snp + dense/snp, merged by position ---
+    let mut snvs: Vec<SnvCall> = Vec::new();
+    {
+        let vk_range = reader.vk_snp.column(col);
+        let (o0, o1) = (vk_range.start, vk_range.end);
+        let positions = &reader.vk_snp.positions()[o0..o1];
+        let keys = as_bytes(&reader.vk_snp.keys);
+        for (i, &pos) in positions.iter().enumerate() {
+            let abs_i = o0 + i;
+            snvs.push(SnvCall {
+                pos,
+                sbs: sidecars.vk_snp.code_at(abs_i),
+                ref_i: sidecars.vk_snp.ref_at(abs_i),
+                alt_i: unpack_snp_key_at(keys, abs_i),
+            });
+        }
+    }
+    if let Some(dense) = reader.dense_view(DenseClass::Snp) {
+        let keys = as_bytes(&dense.keys);
+        for (dcol, &pos) in dense.positions().iter().enumerate() {
+            if dense.carried(col, dcol) {
+                snvs.push(SnvCall {
+                    pos,
+                    sbs: sidecars.dense_snp.code_at(dcol),
+                    ref_i: sidecars.dense_snp.ref_at(dcol),
+                    alt_i: unpack_snp_key_at(keys, dcol),
+                });
+            }
+        }
+    }
+    snvs.sort_by_key(|s| s.pos);
+    snvs.dedup_by_key(|s| s.pos);
+    emit_snv_codes(&snvs, &mut bump);
+
+    // --- indels: var_key/indel + dense/indel, each direct (no pairing) ---
+    {
+        let vk_range = reader.vk_indel.column(col);
+        for abs_i in vk_range {
+            let unified = ID83_OFFSET + sidecars.vk_indel.code_at(abs_i) as usize;
+            if unified < N_CODES {
+                bump(unified);
+            }
+        }
+    }
+    if let Some(dense) = reader.dense_view(DenseClass::Indel) {
+        for dcol in 0..dense.n_dense_variants {
+            if dense.carried(col, dcol) {
+                let unified = ID83_OFFSET + sidecars.dense_indel.code_at(dcol) as usize;
+                if unified < N_CODES {
+                    bump(unified);
+                }
+            }
+        }
+    }
+
+    row
+}
+
+/// Accumulate one contig's full mutation-count matrix into `acc`
+/// (`(n_samples, N_CODES)`).
+///
+/// Parallelized over flat `(sample, ploid)` columns with `rayon`:
+/// `count_column` gathers/classifies each column independently and returns
+/// its own raw (increment-only) `(N_CODES,)` row. `fold` sums each thread's
+/// columns into a private `(n_samples, N_CODES)` accumulator (a column's row
+/// lands in `local[[col / ploidy, ..]]`), and `reduce` sums those private
+/// accumulators together with elementwise `+`. Integer addition is
+/// associative & commutative, so the resulting per-sample sums are identical
+/// no matter how columns are split across threads.
+///
+/// `per_sample` (presence) semantics are applied AFTER that full
+/// column->sample reduce, by clipping each sample's row to `{0, 1}`: a code
+/// counts once if it occurred on ANY of that sample's ploidy columns. This
+/// exactly reproduces the single-threaded per-sample `seen` bitmap (which
+/// marked a code at most once per sample across all its ploids), and doing
+/// the clip once — post-reduce, on the fully-summed row — makes it
+/// independent of fold/column order too.
 pub fn count_contig(
     reader: &ContigReader,
     sidecars: &Sidecars,
@@ -109,79 +191,28 @@ pub fn count_contig(
     acc: &mut Array2<i64>,
 ) {
     let ploidy = reader.ploidy;
-    for sample in 0..reader.n_samples {
-        // Presence-mode bookkeeping: at most one mark per (sample, code),
-        // even if the sample carries the same code on multiple ploids.
-        let mut seen = per_sample.then(|| vec![false; N_CODES]);
-        let mut bump = |code: usize| {
-            if let Some(seen) = seen.as_mut() {
-                if seen[code] {
-                    return;
-                }
-                seen[code] = true;
-            }
-            acc[[sample, code]] += 1;
-        };
+    let n_samples = reader.n_samples;
+    let n_cols = n_samples * ploidy;
 
-        for p in 0..ploidy {
-            let col = sample * ploidy + p;
+    let mut sample_rows = (0..n_cols)
+        .into_par_iter()
+        .fold(
+            || Array2::<i64>::zeros((n_samples, N_CODES)),
+            |mut local, col| {
+                let sample = col / ploidy;
+                for (code, v) in count_column(reader, sidecars, col).into_iter().enumerate() {
+                    local[[sample, code]] += v;
+                }
+                local
+            },
+        )
+        .reduce(|| Array2::<i64>::zeros((n_samples, N_CODES)), |a, b| a + b);
 
-            // --- SNVs: var_key/snp + dense/snp, merged by position ---
-            let mut snvs: Vec<SnvCall> = Vec::new();
-            {
-                let vk_range = reader.vk_snp.column(col);
-                let (o0, o1) = (vk_range.start, vk_range.end);
-                let positions = &reader.vk_snp.positions()[o0..o1];
-                let keys = as_bytes(&reader.vk_snp.keys);
-                for (i, &pos) in positions.iter().enumerate() {
-                    let abs_i = o0 + i;
-                    snvs.push(SnvCall {
-                        pos,
-                        sbs: sidecars.vk_snp.code_at(abs_i),
-                        ref_i: sidecars.vk_snp.ref_at(abs_i),
-                        alt_i: unpack_snp_key_at(keys, abs_i),
-                    });
-                }
-            }
-            if let Some(dense) = reader.dense_view(DenseClass::Snp) {
-                let keys = as_bytes(&dense.keys);
-                for (dcol, &pos) in dense.positions().iter().enumerate() {
-                    if dense.carried(col, dcol) {
-                        snvs.push(SnvCall {
-                            pos,
-                            sbs: sidecars.dense_snp.code_at(dcol),
-                            ref_i: sidecars.dense_snp.ref_at(dcol),
-                            alt_i: unpack_snp_key_at(keys, dcol),
-                        });
-                    }
-                }
-            }
-            snvs.sort_by_key(|s| s.pos);
-            snvs.dedup_by_key(|s| s.pos);
-            emit_snv_codes(&snvs, &mut bump);
-
-            // --- indels: var_key/indel + dense/indel, each direct (no pairing) ---
-            {
-                let vk_range = reader.vk_indel.column(col);
-                for abs_i in vk_range {
-                    let unified = ID83_OFFSET + sidecars.vk_indel.code_at(abs_i) as usize;
-                    if unified < N_CODES {
-                        bump(unified);
-                    }
-                }
-            }
-            if let Some(dense) = reader.dense_view(DenseClass::Indel) {
-                for dcol in 0..dense.n_dense_variants {
-                    if dense.carried(col, dcol) {
-                        let unified = ID83_OFFSET + sidecars.dense_indel.code_at(dcol) as usize;
-                        if unified < N_CODES {
-                            bump(unified);
-                        }
-                    }
-                }
-            }
-        }
+    if per_sample {
+        sample_rows.mapv_inplace(|v| v.min(1));
     }
+
+    *acc += &sample_rows;
 }
 
 #[cfg(test)]

--- a/src/mutcat/count.rs
+++ b/src/mutcat/count.rs
@@ -83,32 +83,68 @@ impl Sidecars {
     }
 }
 
+/// Push `v` unless it duplicates the last-pushed position (the `dedup_by_key`
+/// half of the old sort+dedup, applied inline during the merge).
+#[inline]
+fn push_unique(out: &mut Vec<SnvCall>, v: SnvCall) {
+    if out.last().is_none_or(|l| l.pos != v.pos) {
+        out.push(v);
+    }
+}
+
+/// Merge two already-position-sorted SNV runs (`a` = var_key, `b` = dense) into
+/// `out`, deduped by position. O(len a + len b) — replaces sorting the
+/// concatenation. On an equal position the var_key call wins (matches the old
+/// stable-sort + `dedup_by_key`, which kept the first / var_key entry).
+fn merge_dedup(a: &[SnvCall], b: &[SnvCall], out: &mut Vec<SnvCall>) {
+    out.clear();
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < a.len() && j < b.len() {
+        if a[i].pos <= b[j].pos {
+            push_unique(out, a[i]);
+            i += 1;
+        } else {
+            push_unique(out, b[j]);
+            j += 1;
+        }
+    }
+    while i < a.len() {
+        push_unique(out, a[i]);
+        i += 1;
+    }
+    while j < b.len() {
+        push_unique(out, b[j]);
+        j += 1;
+    }
+}
+
 /// Gather + classify one flat `(sample, ploid)` column's SNVs/indels
-/// (`col = sample * ploidy + ploid`, matching
-/// `ContigReader::vk_slice`/`dense_carried`'s convention), returning its raw
-/// `(N_CODES,)` count row:
-/// 1. Gathers that hap's SNVs from `var_key/snp` (per-call, sidecar-indexed
-///    by the absolute call index) and `dense/snp` (per dense variant the hap
-///    carries, sidecar-indexed by the dense variant column), merges by
-///    position, dedups, and runs `emit_snv_codes` for on-the-fly DBS pairing.
+/// (`col = sample * ploidy + ploid`), accumulating raw (increment-only) counts
+/// into `row` (a `(N_CODES,)` slice, shared across the sample's ploidy columns):
+/// 1. Gathers that hap's SNVs from `var_key/snp` (per-call, sidecar-indexed by
+///    the absolute call index) and `dense/snp` (per carried dense variant),
+///    both already position-sorted; `merge_dedup` unions them in O(n) and
+///    `emit_snv_codes` runs on-the-fly DBS pairing over the merged run.
 /// 2. Gathers that hap's indels from `var_key/indel` + `dense/indel`; each
 ///    emits `ID83_OFFSET + code` directly (no pairing). A sentinel code
 ///    (`UNCLASSIFIED`/`NOT_ANNOTATED`, both `>= N_ID83`) pushes the unified
 ///    code past `N_CODES`, so the single `unified < N_CODES` bound filters
 ///    both sentinels without naming them.
 ///
-/// Every emitted code increments its slot by one (raw counts) — this column
-/// is independent of every other column, so it can run on its own thread;
-/// per-sample presence-clipping happens once, after `count_contig` reduces
-/// a sample's columns together.
-fn count_column(reader: &ContigReader, sidecars: &Sidecars, col: usize) -> Vec<i64> {
-    let mut row = vec![0i64; N_CODES];
-    let mut bump = |code: usize| {
-        row[code] += 1;
-    };
-
-    // --- SNVs: var_key/snp + dense/snp, merged by position ---
-    let mut snvs: Vec<SnvCall> = Vec::new();
+/// `vk`/`dn`/`merged` are caller-owned scratch buffers reused across columns so
+/// this does no per-column heap allocation.
+#[allow(clippy::too_many_arguments)]
+fn count_column_into(
+    reader: &ContigReader,
+    sidecars: &Sidecars,
+    col: usize,
+    row: &mut [i64],
+    vk: &mut Vec<SnvCall>,
+    dn: &mut Vec<SnvCall>,
+    merged: &mut Vec<SnvCall>,
+) {
+    // --- SNVs: var_key/snp (already position-sorted) ---
+    vk.clear();
     {
         let vk_range = reader.vk_snp.column(col);
         let (o0, o1) = (vk_range.start, vk_range.end);
@@ -116,7 +152,7 @@ fn count_column(reader: &ContigReader, sidecars: &Sidecars, col: usize) -> Vec<i
         let keys = as_bytes(&reader.vk_snp.keys);
         for (i, &pos) in positions.iter().enumerate() {
             let abs_i = o0 + i;
-            snvs.push(SnvCall {
+            vk.push(SnvCall {
                 pos,
                 sbs: sidecars.vk_snp.code_at(abs_i),
                 ref_i: sidecars.vk_snp.ref_at(abs_i),
@@ -124,22 +160,22 @@ fn count_column(reader: &ContigReader, sidecars: &Sidecars, col: usize) -> Vec<i
             });
         }
     }
+    // --- dense/snp (position-sorted); iterate only carried variants ---
+    dn.clear();
     if let Some(dense) = reader.dense_view(DenseClass::Snp) {
+        let positions = dense.positions();
         let keys = as_bytes(&dense.keys);
-        for (dcol, &pos) in dense.positions().iter().enumerate() {
-            if dense.carried(col, dcol) {
-                snvs.push(SnvCall {
-                    pos,
-                    sbs: sidecars.dense_snp.code_at(dcol),
-                    ref_i: sidecars.dense_snp.ref_at(dcol),
-                    alt_i: unpack_snp_key_at(keys, dcol),
-                });
-            }
-        }
+        dense.for_each_carried(col, |dcol| {
+            dn.push(SnvCall {
+                pos: positions[dcol],
+                sbs: sidecars.dense_snp.code_at(dcol),
+                ref_i: sidecars.dense_snp.ref_at(dcol),
+                alt_i: unpack_snp_key_at(keys, dcol),
+            });
+        });
     }
-    snvs.sort_by_key(|s| s.pos);
-    snvs.dedup_by_key(|s| s.pos);
-    emit_snv_codes(&snvs, &mut bump);
+    merge_dedup(vk, dn, merged);
+    emit_snv_codes(merged, &mut |code| row[code] += 1);
 
     // --- indels: var_key/indel + dense/indel, each direct (no pairing) ---
     {
@@ -147,43 +183,36 @@ fn count_column(reader: &ContigReader, sidecars: &Sidecars, col: usize) -> Vec<i
         for abs_i in vk_range {
             let unified = ID83_OFFSET + sidecars.vk_indel.code_at(abs_i) as usize;
             if unified < N_CODES {
-                bump(unified);
+                row[unified] += 1;
             }
         }
     }
     if let Some(dense) = reader.dense_view(DenseClass::Indel) {
-        for dcol in 0..dense.n_dense_variants {
-            if dense.carried(col, dcol) {
-                let unified = ID83_OFFSET + sidecars.dense_indel.code_at(dcol) as usize;
-                if unified < N_CODES {
-                    bump(unified);
-                }
+        dense.for_each_carried(col, |dcol| {
+            let unified = ID83_OFFSET + sidecars.dense_indel.code_at(dcol) as usize;
+            if unified < N_CODES {
+                row[unified] += 1;
             }
-        }
+        });
     }
-
-    row
 }
 
 /// Accumulate one contig's full mutation-count matrix into `acc`
 /// (`(n_samples, N_CODES)`).
 ///
-/// Parallelized over flat `(sample, ploid)` columns with `rayon`:
-/// `count_column` gathers/classifies each column independently and returns
-/// its own raw (increment-only) `(N_CODES,)` row. `fold` sums each thread's
-/// columns into a private `(n_samples, N_CODES)` accumulator (a column's row
-/// lands in `local[[col / ploidy, ..]]`), and `reduce` sums those private
-/// accumulators together with elementwise `+`. Integer addition is
-/// associative & commutative, so the resulting per-sample sums are identical
-/// no matter how columns are split across threads.
+/// Parallelized over **samples** with `rayon`: each sample owns one contiguous
+/// `N_CODES` row of `acc` and folds its `ploidy` columns straight into that row
+/// (`count_column_into`). Rows are disjoint, so no per-job full-matrix
+/// accumulator and no reduce step are needed — the old `fold`/`reduce`
+/// allocated and summed an `(n_samples, N_CODES)` matrix per rayon split-job,
+/// which dominated the runtime. `acc` is the accumulator, so counting straight
+/// into its rows IS `acc += this contig`. The result is still order-independent:
+/// each sample's counts come only from its own columns.
 ///
-/// `per_sample` (presence) semantics are applied AFTER that full
-/// column->sample reduce, by clipping each sample's row to `{0, 1}`: a code
-/// counts once if it occurred on ANY of that sample's ploidy columns. This
-/// exactly reproduces the single-threaded per-sample `seen` bitmap (which
-/// marked a code at most once per sample across all its ploids), and doing
-/// the clip once — post-reduce, on the fully-summed row — makes it
-/// independent of fold/column order too.
+/// `per_sample` (presence) semantics are applied per row AFTER its columns are
+/// summed, by clipping to `{0, 1}`: a code counts once if it occurred on ANY of
+/// that sample's ploidy columns — reproducing the single-threaded per-sample
+/// `seen` bitmap.
 pub fn count_contig(
     reader: &ContigReader,
     sidecars: &Sidecars,
@@ -191,28 +220,51 @@ pub fn count_contig(
     acc: &mut Array2<i64>,
 ) {
     let ploidy = reader.ploidy;
-    let n_samples = reader.n_samples;
-    let n_cols = n_samples * ploidy;
 
-    let mut sample_rows = (0..n_cols)
-        .into_par_iter()
-        .fold(
-            || Array2::<i64>::zeros((n_samples, N_CODES)),
-            |mut local, col| {
-                let sample = col / ploidy;
-                for (code, v) in count_column(reader, sidecars, col).into_iter().enumerate() {
-                    local[[sample, code]] += v;
+    // Write each sample's counts straight into its own `acc` row. `acc` is the
+    // accumulator (`acc += this contig`), so `count_column_into`'s `row[c] += 1`
+    // onto the acc row IS that accumulation — no intermediate matrix, no memset,
+    // no full-matrix add. Rows are disjoint chunks, so this parallelizes cleanly.
+    acc.as_slice_mut()
+        .expect("count matrix accumulator must be C-contiguous")
+        .par_chunks_mut(N_CODES)
+        .enumerate()
+        .for_each(|(sample, acc_row)| {
+            let mut vk = Vec::new();
+            let mut dn = Vec::new();
+            let mut merged = Vec::new();
+            if per_sample {
+                // Presence within THIS contig, then OR (add) into acc: count this
+                // sample's ploidy columns into a private row, clip to {0,1}, add.
+                let mut local = [0i64; N_CODES];
+                for p in 0..ploidy {
+                    count_column_into(
+                        reader,
+                        sidecars,
+                        sample * ploidy + p,
+                        &mut local,
+                        &mut vk,
+                        &mut dn,
+                        &mut merged,
+                    );
                 }
-                local
-            },
-        )
-        .reduce(|| Array2::<i64>::zeros((n_samples, N_CODES)), |a, b| a + b);
-
-    if per_sample {
-        sample_rows.mapv_inplace(|v| v.min(1));
-    }
-
-    *acc += &sample_rows;
+                for (a, &l) in acc_row.iter_mut().zip(local.iter()) {
+                    *a += l.min(1);
+                }
+            } else {
+                for p in 0..ploidy {
+                    count_column_into(
+                        reader,
+                        sidecars,
+                        sample * ploidy + p,
+                        acc_row,
+                        &mut vk,
+                        &mut dn,
+                        &mut merged,
+                    );
+                }
+            }
+        });
 }
 
 #[cfg(test)]

--- a/src/mutcat/mod.rs
+++ b/src/mutcat/mod.rs
@@ -1,0 +1,57 @@
+//! COSMIC mutation-catalogue code space and classifiers for SVAR2.
+//! Code-space layout MUST match python/genoray/_mutcat/codebook.py.
+
+use std::ops::Range;
+
+/// Class-local index counts (COSMIC codebook sizes).
+pub const N_SBS96: usize = 96;
+pub const N_DBS78: usize = 78;
+pub const N_ID83: usize = 83;
+
+/// Unified code-space offsets — mirror codebook.py exactly.
+pub const SBS96_OFFSET: usize = 0;
+pub const DBS78_OFFSET: usize = SBS96_OFFSET + N_SBS96; // 96
+pub const ID83_OFFSET: usize = DBS78_OFFSET + N_DBS78; // 174
+pub const N_CODES: usize = ID83_OFFSET + N_ID83; // 257
+
+/// Sidecar `u8` sentinels (unsigned; v1's negative int16 sentinels don't survive).
+pub const UNCLASSIFIED: u8 = 254;
+pub const NOT_ANNOTATED: u8 = 255;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Sbs96,
+    Dbs78,
+    Id83,
+}
+
+impl Kind {
+    /// Half-open unified-code range for this kind.
+    pub fn code_range(self) -> Range<usize> {
+        match self {
+            Kind::Sbs96 => SBS96_OFFSET..DBS78_OFFSET,
+            Kind::Dbs78 => DBS78_OFFSET..ID83_OFFSET,
+            Kind::Id83 => ID83_OFFSET..N_CODES,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_space_matches_codebook() {
+        assert_eq!(SBS96_OFFSET, 0);
+        assert_eq!(DBS78_OFFSET, 96);
+        assert_eq!(ID83_OFFSET, 174);
+        assert_eq!(N_CODES, 257);
+    }
+
+    #[test]
+    fn kind_ranges_are_contiguous_and_sized() {
+        assert_eq!(Kind::Sbs96.code_range(), 0..96);
+        assert_eq!(Kind::Dbs78.code_range(), 96..174);
+        assert_eq!(Kind::Id83.code_range(), 174..257);
+    }
+}

--- a/src/mutcat/mod.rs
+++ b/src/mutcat/mod.rs
@@ -1,6 +1,8 @@
 //! COSMIC mutation-catalogue code space and classifiers for SVAR2.
 //! Code-space layout MUST match python/genoray/_mutcat/codebook.py.
 
+pub mod classify;
+
 use std::ops::Range;
 
 /// Class-local index counts (COSMIC codebook sizes).

--- a/src/mutcat/mod.rs
+++ b/src/mutcat/mod.rs
@@ -1,6 +1,7 @@
 //! COSMIC mutation-catalogue code space and classifiers for SVAR2.
 //! Code-space layout MUST match python/genoray/_mutcat/codebook.py.
 
+pub mod annotate;
 pub mod classify;
 pub mod sidecar;
 

--- a/src/mutcat/mod.rs
+++ b/src/mutcat/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod annotate;
 pub mod classify;
+pub mod count;
 pub mod sidecar;
 
 use std::ops::Range;

--- a/src/mutcat/mod.rs
+++ b/src/mutcat/mod.rs
@@ -2,6 +2,7 @@
 //! Code-space layout MUST match python/genoray/_mutcat/codebook.py.
 
 pub mod classify;
+pub mod sidecar;
 
 use std::ops::Range;
 

--- a/src/mutcat/sidecar.rs
+++ b/src/mutcat/sidecar.rs
@@ -1,0 +1,117 @@
+//! Read/write the per-contig mutcat sidecar. `code.bin` is raw u8 (one per
+//! record); `ref.bin` (snp subs only) is 2-bit packed A/C/T/G ref bases.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use memmap2::Mmap;
+
+use crate::layout::{ContigPaths, MutcatSub};
+use crate::query::sidecar::mmap_file;
+use svar2_codec::{pack_snp_keys, unpack_snp_key_at};
+
+pub fn write_sidecar(
+    paths: &ContigPaths,
+    sub: MutcatSub,
+    codes: &[u8],
+    ref_codes: Option<&[u8]>,
+) -> std::io::Result<()> {
+    let dir = paths.mutcat_sub_dir(sub);
+    fs::create_dir_all(&dir)?;
+    write_bytes(&paths.mutcat_code(sub), codes)?;
+    if sub.has_ref() {
+        let refs = ref_codes.expect("snp sub-stream requires ref_codes");
+        debug_assert_eq!(refs.len(), codes.len());
+        let packed = pack_snp_keys(refs);
+        write_bytes(&paths.mutcat_ref(sub), &packed)?;
+    }
+    Ok(())
+}
+
+fn write_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let mut f = fs::File::create(path)?;
+    f.write_all(bytes)?;
+    f.flush()
+}
+
+pub struct MutcatView {
+    code: Option<Mmap>,
+    ref_packed: Option<Mmap>,
+    pub n: usize,
+}
+
+impl MutcatView {
+    /// Class-local mutation code at record `i` (u8; may be a sentinel).
+    #[inline]
+    pub fn code_at(&self, i: usize) -> u8 {
+        match &self.code {
+            Some(m) => m[i],
+            None => crate::mutcat::NOT_ANNOTATED,
+        }
+    }
+    /// 2-bit reference-base code at snp record `i` (`0–3`). Panics if no ref stream.
+    #[inline]
+    pub fn ref_at(&self, i: usize) -> u8 {
+        let m = self
+            .ref_packed
+            .as_ref()
+            .expect("ref_at on a stream with no ref.bin");
+        unpack_snp_key_at(&m[..], i)
+    }
+}
+
+pub fn open_sidecar(paths: &ContigPaths, sub: MutcatSub) -> std::io::Result<MutcatView> {
+    let code = mmap_file(&paths.mutcat_code(sub))?;
+    let n = code.as_ref().map(|m| m.len()).unwrap_or(0);
+    let ref_packed = if sub.has_ref() {
+        mmap_file(&paths.mutcat_ref(sub))?
+    } else {
+        None
+    };
+    Ok(MutcatView {
+        code,
+        ref_packed,
+        n,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snp_sidecar_round_trips_code_and_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let codes = [5u8, 95, 254, 0];
+        let refs = [1u8, 3, 0, 2]; // C,G(→ codec 3),A,T
+        write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs)).unwrap();
+        let v = open_sidecar(&paths, MutcatSub::VkSnp).unwrap();
+        assert_eq!(v.n, 4);
+        for i in 0..4 {
+            assert_eq!(v.code_at(i), codes[i]);
+            assert_eq!(v.ref_at(i), refs[i]);
+        }
+    }
+
+    #[test]
+    fn indel_sidecar_has_no_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let codes = [10u8, 82, 255];
+        write_sidecar(&paths, MutcatSub::VkIndel, &codes, None).unwrap();
+        let v = open_sidecar(&paths, MutcatSub::VkIndel).unwrap();
+        assert_eq!(v.n, 3);
+        assert_eq!(v.code_at(1), 82);
+    }
+
+    #[test]
+    fn missing_sidecar_opens_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let v = open_sidecar(&paths, MutcatSub::DenseSnp).unwrap();
+        assert_eq!(v.n, 0);
+        assert_eq!(v.code_at(0), crate::mutcat::NOT_ANNOTATED);
+    }
+}

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -54,6 +54,7 @@ pub fn process_chromosome(
     long_allele_capacity: usize,
     skip_out_of_scope: bool,
     processing_threads: usize,
+    signatures: bool,
 ) -> Result<u64, ConversionError> {
     // Directory Formatting: svar2/{contig}/var_key/{snp,indel}
     let paths = crate::layout::ContigPaths::new(base_out_dir, chrom);
@@ -175,7 +176,7 @@ pub fn process_chromosome(
         .spawn({
             move || {
                 let bank = LongAlleleTableWriter::new(tx_long, long_allele_capacity);
-                executor::run_compute_engine(rx_dense, tx_sparse, bank)
+                executor::run_compute_engine(rx_dense, tx_sparse, bank, signatures)
             }
         })
         .expect("spawn executor");
@@ -304,6 +305,24 @@ pub fn process_chromosome(
     // A pure scan of the finished indel key streams — decoupled from the merge.
     let contig_dir = std::path::Path::new(base_out_dir).join(chrom);
     crate::max_del::write_max_del(&contig_dir, samples.len(), ploidy)?;
+
+    // Optional M-signatures write-time annotation: classify SBS96/ID83 codes
+    // and store the mutcat sidecar now, while we're already in the
+    // conversion-gated write path. Requires a reference (checked in Python).
+    if signatures && let Some(fasta) = fasta_path {
+        let ref_seq = crate::vcf_reader::load_contig_seq(fasta, chrom)?;
+        let reader = crate::query::ContigReader::open(base_out_dir, chrom, samples.len(), ploidy)
+            .map_err(|e| ConversionError::Io {
+            context: format!("open ContigReader for mutcat annotate {chrom}"),
+            source: e,
+        })?;
+        crate::mutcat::annotate::annotate_contig(&reader, &paths, &ref_seq).map_err(|e| {
+            ConversionError::Io {
+                context: format!("annotate mutcat {chrom}"),
+                source: e,
+            }
+        })?;
+    }
 
     println!("[{}] Pipeline Execution Finished Successfully.", chrom);
 

--- a/src/py_mutcat.rs
+++ b/src/py_mutcat.rs
@@ -1,0 +1,44 @@
+//! Python-facing mutcat: post-hoc annotation + count-matrix on PyContigReader.
+
+use numpy::{PyArray2, PyReadonlyArray1, ToPyArray};
+use pyo3::prelude::*;
+
+use crate::layout::ContigPaths;
+use crate::mutcat::N_CODES;
+use crate::mutcat::annotate::annotate_contig;
+use crate::mutcat::count::{Sidecars, count_contig};
+use crate::py_query::PyContigReader;
+
+#[pymethods]
+impl PyContigReader {
+    /// Classify this contig's records against `ref_seq` and write the sidecar.
+    fn annotate_mutations(
+        &self,
+        base_out_dir: &str,
+        chrom: &str,
+        ref_seq: PyReadonlyArray1<u8>,
+    ) -> PyResult<()> {
+        let paths = ContigPaths::new(base_out_dir, chrom);
+        let seq = ref_seq.as_slice()?;
+        annotate_contig(&self.inner, &paths, seq)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("annotate {chrom}: {e}")))?;
+        Ok(())
+    }
+
+    /// Build the `(n_samples, N_CODES)` count matrix for this contig.
+    fn count_matrix<'py>(
+        &self,
+        py: Python<'py>,
+        base_out_dir: &str,
+        chrom: &str,
+        per_sample: bool,
+    ) -> PyResult<Bound<'py, PyArray2<i64>>> {
+        let paths = ContigPaths::new(base_out_dir, chrom);
+        let sidecars = Sidecars::open(&paths).map_err(|e| {
+            pyo3::exceptions::PyIOError::new_err(format!("open sidecar {chrom}: {e}"))
+        })?;
+        let mut acc = ndarray::Array2::<i64>::zeros((self.inner.n_samples, N_CODES));
+        count_contig(&self.inner, &sidecars, per_sample, &mut acc);
+        Ok(acc.to_pyarray(py))
+    }
+}

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use ndarray::Array2;
 
 use crate::dense::DenseClass;
-use crate::layout::{self, ContigPaths};
+use crate::layout::{self, ContigPaths, MutcatSub};
 use crate::nrvk::LongAlleleReader;
 use crate::rvk;
 use crate::search::{SearchTree, overlap_range};
@@ -285,5 +285,44 @@ impl ContigReader {
         let tree = SearchTree::new(positions);
         let (s, e) = overlap_range(&tree, &v_ends, self.dense_indel_max_del, q_start, q_end);
         s..e
+    }
+}
+
+impl ContigReader {
+    /// All var_key/snp records for this contig: absolute positions + the
+    /// packed 2-bit key bytes (index with `unpack_snp_key_at`, not `keys[i]`).
+    pub(crate) fn vk_snp_records(&self) -> (&[u32], &[u8]) {
+        (self.vk_snp.positions(), as_bytes(&self.vk_snp.keys))
+    }
+
+    /// All dense/snp records, if this contig has a dense-SNP table: absolute
+    /// positions + packed 2-bit key bytes (same indexing caveat as above).
+    pub(crate) fn dense_snp_records(&self) -> Option<(&[u32], &[u8])> {
+        self.dense_snp
+            .as_ref()
+            .map(|d| (d.positions(), as_bytes(&d.keys)))
+    }
+
+    /// All indel records for `sub` (`VkIndel`/`DenseIndel` only): absolute
+    /// positions + uniform u32 keys. `None` if the requested dense table is
+    /// absent from this contig.
+    pub(crate) fn indel_records(&self, sub: MutcatSub) -> Option<(&[u32], &[u32])> {
+        match sub {
+            MutcatSub::VkIndel => Some((self.vk_indel.positions(), as_u32(&self.vk_indel.keys))),
+            MutcatSub::DenseIndel => self
+                .dense_indel
+                .as_ref()
+                .map(|d| (d.positions(), as_u32(&d.keys))),
+            _ => None,
+        }
+    }
+
+    /// Long-allele bytes for a `Lookup` indel key's row. Panics if this
+    /// contig has no LUT (a `Lookup` key implies one exists).
+    pub(crate) fn lut_allele(&self, row: u32) -> Vec<u8> {
+        self.lut
+            .as_ref()
+            .expect("Lookup key implies a LUT")
+            .get_allele(row)
     }
 }

--- a/src/query/sidecar.rs
+++ b/src/query/sidecar.rs
@@ -87,6 +87,19 @@ impl DenseView {
     pub(crate) fn carried(&self, hap: usize, col: usize) -> bool {
         bits::get_bit(as_bytes(&self.genotypes), hap * self.n_dense_variants + col)
     }
+    /// Call `f(col)` for each dense variant `col` that `hap` carries, ascending.
+    /// The hap's carriage is a contiguous `n_dense_variants`-bit row at bit
+    /// `hap * n_dense_variants`; scanning it whole-byte (skipping zero bytes)
+    /// touches only carried variants, unlike a per-`col` `carried()` loop.
+    #[inline]
+    pub(crate) fn for_each_carried(&self, hap: usize, f: impl FnMut(usize)) {
+        bits::for_each_set_bit(
+            as_bytes(&self.genotypes),
+            hap * self.n_dense_variants,
+            self.n_dense_variants,
+            f,
+        );
+    }
 }
 
 /// Load a CSR `offsets.npy` (len `columns + 1`); a missing file means an empty

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -135,7 +135,11 @@ pub fn classify_variant(ilen: i32, alt_allele: &[u8], bank: &mut LongAlleleTable
 
 // The core Dense-to-Sparse Matrix Transposer.
 // Flips Row-Major VCF data into Column-Major (Sample-Major) Sparse Tensors.
-pub fn dense2sparse_vk(chunk: &DenseChunk, bank: &mut LongAlleleTableWriter) -> SparseChunk {
+pub fn dense2sparse_vk(
+    chunk: &DenseChunk,
+    bank: &mut LongAlleleTableWriter,
+    sidecar_bits_enabled: bool,
+) -> SparseChunk {
     let (v_variants, num_samples, ploidy) = chunk.genos.shape;
     let columns = num_samples * ploidy;
 
@@ -174,7 +178,15 @@ pub fn dense2sparse_vk(chunk: &DenseChunk, bank: &mut LongAlleleTableWriter) -> 
         };
         let x = chunk.genos.popcount_plane(v);
 
-        match choose_representation(class, num_samples, ploidy, x) {
+        let sidecar_bits = if sidecar_bits_enabled {
+            match class {
+                Class::Snp => crate::cost_model::SIDECAR_BITS_SNP,
+                Class::Indel => crate::cost_model::SIDECAR_BITS_INDEL,
+            }
+        } else {
+            0
+        };
+        match choose_representation(class, num_samples, ploidy, x, sidecar_bits) {
             Representation::VarKey => routes.push(Route::VarKey(vk)),
             Representation::Dense => {
                 let sub = dense.get_mut(dclass);
@@ -527,7 +539,7 @@ mod tests {
         // Zero variants, just shape edge case.
         let chunk = build_test_chunk(0, 2, 2, &[], &[], &[]);
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
         let indel = sparse.streams.get(StreamTag::VarKeyIndel);
         assert_eq!(snp.call_positions.len(), 0);
@@ -558,7 +570,7 @@ mod tests {
 
         let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bit_pattern);
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
         let indel = sparse.streams.get(StreamTag::VarKeyIndel);
 
@@ -594,7 +606,7 @@ mod tests {
         let chunk = build_test_chunk(3, 1, 2, &refs, &alts, &bit_pattern);
 
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
         let indel = sparse.streams.get(StreamTag::VarKeyIndel);
 
@@ -630,7 +642,7 @@ mod tests {
         let chunk = build_test_chunk(1, 2, 2, &refs, &alts, &bits);
 
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
 
         // var_key snp stream is empty (variant went dense)
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
@@ -660,7 +672,7 @@ mod tests {
         let chunk = build_test_chunk(1, n, 2, &refs, &alts, &bits);
 
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
         assert_eq!(
             sparse
                 .streams
@@ -697,7 +709,7 @@ mod tests {
             let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bit_pattern);
 
             let mut bank = make_bank();
-            let sparse = dense2sparse_vk(&chunk, &mut bank);
+            let sparse = dense2sparse_vk(&chunk, &mut bank, false);
             let snp = sparse.streams.get(StreamTag::VarKeySnp);
             let indel = sparse.streams.get(StreamTag::VarKeyIndel);
 
@@ -734,7 +746,7 @@ mod tests {
             let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bit_pattern);
 
             let mut bank = make_bank();
-            let sparse = dense2sparse_vk(&chunk, &mut bank);
+            let sparse = dense2sparse_vk(&chunk, &mut bank, false);
             let snp = sparse.streams.get(StreamTag::VarKeySnp);
 
             let np = n_samples * ploidy;
@@ -784,7 +796,7 @@ mod tests {
             let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bits);
 
             let mut bank = make_bank();
-            let sparse = dense2sparse_vk(&chunk, &mut bank);
+            let sparse = dense2sparse_vk(&chunk, &mut bank, false);
 
             let vk_calls: usize = sparse.streams.get(StreamTag::VarKeySnp)
                 .sample_lengths.iter().map(|&c| c as usize).sum::<usize>()

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -149,6 +149,46 @@ pub struct VcfChunkReader {
     next_seq: u64,
 }
 
+/// Load `chrom`'s full sequence from the FASTA at `fasta_path`, uppercased to
+/// ASCII (matching the classifiers'/normalizer's expectation). Shared by
+/// `VcfChunkReader::new` (validate_ref/left_align) and the orchestrator's
+/// write-time `signatures` annotation — keep both call sites byte-identical.
+pub(crate) fn load_contig_seq(fasta_path: &str, chrom: &str) -> Result<Vec<u8>, ConversionError> {
+    // A wrong reference path reaches Rust unchecked (Python does not validate
+    // it), so surface it as FileNotFoundError specifically.
+    if !std::path::Path::new(fasta_path).exists() {
+        return Err(ConversionError::MissingFile {
+            path: fasta_path.to_string(),
+        });
+    }
+    let fasta = rust_htslib::faidx::Reader::from_path(fasta_path).map_err(|e| {
+        ConversionError::Input(format!(
+            "Failed to open reference FASTA '{fasta_path}' (is there a .fai?): {e}"
+        ))
+    })?;
+    // htslib's faidx_seq_len returns -1 for an unknown contig, surfaced via
+    // rust-htslib as u64::MAX — check explicitly for a clear message.
+    let contig_len_raw = fasta.fetch_seq_len(chrom);
+    if contig_len_raw == u64::MAX {
+        return Err(ConversionError::Input(format!(
+            "Contig '{chrom}' not found in reference FASTA"
+        )));
+    }
+    let contig_len = contig_len_raw as usize;
+    let mut ref_seq = if contig_len == 0 {
+        Vec::new()
+    } else {
+        fasta
+            .fetch_seq(chrom, 0, contig_len - 1)
+            .map_err(|e| ConversionError::Io {
+                context: format!("fetching contig '{chrom}' from reference FASTA"),
+                source: std::io::Error::other(e.to_string()),
+            })?
+    };
+    ref_seq.make_ascii_uppercase();
+    Ok(ref_seq)
+}
+
 impl VcfChunkReader {
     // opens the file, applies the sample filter at the C-level, and jumps to the chromosome.
     pub fn new(
@@ -207,41 +247,7 @@ impl VcfChunkReader {
         // Reference is optional. With a FASTA, cache the full uppercased contig for
         // validate_ref/left_align; without one, leave it empty and skip both.
         let (ref_seq, has_reference) = match fasta_path {
-            Some(path) => {
-                // A wrong reference path reaches Rust unchecked (Python does not
-                // validate it), so surface it as FileNotFoundError specifically.
-                if !std::path::Path::new(path).exists() {
-                    return Err(ConversionError::MissingFile {
-                        path: path.to_string(),
-                    });
-                }
-                let fasta = rust_htslib::faidx::Reader::from_path(path).map_err(|e| {
-                    ConversionError::Input(format!(
-                        "Failed to open reference FASTA '{path}' (is there a .fai?): {e}"
-                    ))
-                })?;
-                // htslib's faidx_seq_len returns -1 for an unknown contig, surfaced
-                // via rust-htslib as u64::MAX — check explicitly for a clear message.
-                let contig_len_raw = fasta.fetch_seq_len(chrom);
-                if contig_len_raw == u64::MAX {
-                    return Err(ConversionError::Input(format!(
-                        "Contig '{chrom}' not found in reference FASTA"
-                    )));
-                }
-                let contig_len = contig_len_raw as usize;
-                let mut ref_seq = if contig_len == 0 {
-                    Vec::new()
-                } else {
-                    fasta
-                        .fetch_seq(chrom, 0, contig_len - 1)
-                        .map_err(|e| ConversionError::Io {
-                            context: format!("fetching contig '{chrom}' from reference FASTA"),
-                            source: std::io::Error::other(e.to_string()),
-                        })?
-                };
-                ref_seq.make_ascii_uppercase();
-                (ref_seq, true)
-            }
+            Some(path) => (load_contig_seq(path, chrom)?, true),
             None => (Vec::new(), false),
         };
 

--- a/tests/bench_mutcat.rs
+++ b/tests/bench_mutcat.rs
@@ -1,0 +1,241 @@
+//! Profiling harness for the mutcat hot paths (`count_contig`, `annotate_contig`).
+//! Not a correctness test — gated behind `#[ignore]` so it only runs when asked:
+//!
+//!   cargo test --release --no-default-features --features conversion \
+//!       --test bench_mutcat -- --ignored --nocapture
+//!
+//! Knobs via env: BENCH_SAMPLES, BENCH_PLOIDY, BENCH_RECORDS, BENCH_ITERS.
+
+mod common;
+
+use std::time::Instant;
+
+use common::{SynthRecord, build_contig};
+use genoray_core::layout::{ContigPaths, MutcatSub};
+use genoray_core::mutcat::count::{Sidecars, count_contig};
+use genoray_core::mutcat::sidecar::write_sidecar;
+use genoray_core::query::ContigReader;
+use ndarray::Array2;
+use svar2_codec::encode_snp_2bit;
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// A tiny deterministic LCG so the workload is reproducible without rand.
+struct Lcg(u64);
+impl Lcg {
+    fn next_u32(&mut self) -> u32 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (self.0 >> 33) as u32
+    }
+    fn below(&mut self, n: u32) -> u32 {
+        self.next_u32() % n
+    }
+}
+
+/// Owned buffers so `SynthRecord<'a>` can borrow them.
+struct Owned {
+    ref_a: Vec<u8>,
+    alt: Vec<u8>,
+    gt: Vec<i32>,
+    pos: i64,
+}
+
+fn make_workload(n_samples: usize, ploidy: usize, n_records: usize) -> Vec<Owned> {
+    const BASES: [u8; 4] = [b'A', b'C', b'G', b'T'];
+    let n_haps = n_samples * ploidy;
+    let mut rng = Lcg(0x9E3779B97F4A7C15);
+    let mut out = Vec::with_capacity(n_records);
+    let mut pos: i64 = 100;
+    let mut i = 0;
+    while i < n_records {
+        // ~15% indels, rest SNPs. Among SNPs, ~10% form an adjacent doublet
+        // (exercises the DBS pairing branch), ~30% are "common" (many carriers
+        // -> dense route), the rest rare (few carriers -> var_key route).
+        let roll = rng.below(100);
+        if roll < 15 {
+            // indel: half INS, half DEL, tail 1..4
+            let anchor = BASES[rng.below(4) as usize];
+            let tlen = 1 + rng.below(4) as usize;
+            let mut tail = Vec::with_capacity(tlen);
+            for _ in 0..tlen {
+                let mut b = BASES[rng.below(4) as usize];
+                if b == anchor {
+                    b = BASES[((anchor as usize) + 1) & 3];
+                }
+                tail.push(b);
+            }
+            let (ref_a, alt) = if rng.below(2) == 0 {
+                let mut a = vec![anchor];
+                a.extend_from_slice(&tail);
+                (vec![anchor], a) // INS
+            } else {
+                let mut r = vec![anchor];
+                r.extend_from_slice(&tail);
+                (r, vec![anchor]) // DEL
+            };
+            let carriers = 1 + rng.below(5) as usize;
+            let gt = random_gt(&mut rng, n_haps, carriers);
+            out.push(Owned {
+                ref_a,
+                alt,
+                gt,
+                pos,
+            });
+            pos += 20;
+            i += 1;
+        } else {
+            let anchor = BASES[rng.below(4) as usize];
+            let alt_b = BASES[((rng.below(3) as usize) + 1 + anchor as usize) & 3];
+            let common = rng.below(100) < 30;
+            let carriers = if common {
+                n_haps / 3 + rng.below((n_haps / 3).max(1) as u32) as usize
+            } else {
+                1 + rng.below(3) as usize
+            };
+            let gt = random_gt(&mut rng, n_haps, carriers);
+            out.push(Owned {
+                ref_a: vec![anchor],
+                alt: vec![alt_b],
+                gt,
+                pos,
+            });
+            // ~10% chance of an adjacent partner one base over (rare route).
+            if !common && rng.below(100) < 10 && i + 1 < n_records {
+                let anchor2 = BASES[rng.below(4) as usize];
+                let alt2 = BASES[((rng.below(3) as usize) + 1 + anchor2 as usize) & 3];
+                let carriers2 = 1 + rng.below(3) as usize;
+                let gt2 = random_gt(&mut rng, n_haps, carriers2);
+                out.push(Owned {
+                    ref_a: vec![anchor2],
+                    alt: vec![alt2],
+                    gt: gt2,
+                    pos: pos + 1,
+                });
+                i += 1;
+            }
+            pos += 20;
+            i += 1;
+        }
+    }
+    out
+}
+
+fn random_gt(rng: &mut Lcg, n_haps: usize, carriers: usize) -> Vec<i32> {
+    let mut gt = vec![0i32; n_haps];
+    let carriers = carriers.min(n_haps);
+    let mut placed = 0;
+    while placed < carriers {
+        let idx = rng.below(n_haps as u32) as usize;
+        if gt[idx] == 0 {
+            gt[idx] = 1;
+            placed += 1;
+        }
+    }
+    gt
+}
+
+/// Inject valid mutcat sidecars for whichever substreams got records, so
+/// `count_contig` sees real codes without needing a reference FASTA pass.
+fn inject_sidecars(out: &std::path::Path, chrom: &str) {
+    let paths = ContigPaths::new(out.to_str().unwrap(), chrom);
+    let cdir = out.join(chrom);
+    // var_key/snp + dense/snp: u8 code (SBS class-local, use a valid 0..96) + 2-bit ref.
+    for (sub, sub_dir) in [
+        (MutcatSub::VkSnp, cdir.join("var_key").join("snp")),
+        (MutcatSub::DenseSnp, cdir.join("dense").join("snp")),
+    ] {
+        let pth = sub_dir.join("positions.bin");
+        let n = if pth.exists() {
+            std::fs::metadata(&pth)
+                .map(|m| m.len() as usize / 4)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        if n > 0 {
+            let codes: Vec<u8> = (0..n).map(|i| (i % 96) as u8).collect();
+            let refs: Vec<u8> = (0..n).map(|_| encode_snp_2bit(b'C')).collect();
+            write_sidecar(&paths, sub, &codes, Some(&refs)).unwrap();
+        }
+    }
+    for (sub, sub_dir) in [
+        (MutcatSub::VkIndel, cdir.join("var_key").join("indel")),
+        (MutcatSub::DenseIndel, cdir.join("dense").join("indel")),
+    ] {
+        let pth = sub_dir.join("positions.bin");
+        let n = if pth.exists() {
+            std::fs::metadata(&pth)
+                .map(|m| m.len() as usize / 4)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        if n > 0 {
+            let codes: Vec<u8> = (0..n).map(|i| (i % 83) as u8).collect();
+            write_sidecar(&paths, sub, &codes, None).unwrap();
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn bench_count_contig() {
+    let n_samples = env_usize("BENCH_SAMPLES", 300);
+    let ploidy = env_usize("BENCH_PLOIDY", 2);
+    let n_records = env_usize("BENCH_RECORDS", 3000);
+    let iters = env_usize("BENCH_ITERS", 200);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    let owned = make_workload(n_samples, ploidy, n_records);
+    let records: Vec<SynthRecord> = owned
+        .iter()
+        .map(|o| SynthRecord {
+            pos: o.pos,
+            ref_allele: &o.ref_a,
+            alts: vec![&o.alt[..]],
+            gt: o.gt.clone(),
+        })
+        .collect();
+    let sample_names: Vec<String> = (0..n_samples).map(|i| format!("S{i}")).collect();
+    let sample_refs: Vec<&str> = sample_names.iter().map(|s| s.as_str()).collect();
+
+    let t = Instant::now();
+    build_contig(&out, "chr1", &sample_refs, ploidy, &records);
+    inject_sidecars(&out, "chr1");
+    eprintln!(
+        "[setup] built + annotated {n_records} records in {:?}",
+        t.elapsed()
+    );
+
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", n_samples, ploidy).unwrap();
+    let sidecars = Sidecars::open(&ContigPaths::new(out.to_str().unwrap(), "chr1")).unwrap();
+
+    // warm-up (page in mmaps)
+    let mut acc = Array2::<i64>::zeros((n_samples, genoray_core::mutcat::N_CODES));
+    count_contig(&reader, &sidecars, false, &mut acc);
+    let checksum: i64 = acc.sum();
+
+    let t = Instant::now();
+    let mut sink = 0i64;
+    for _ in 0..iters {
+        let mut acc = Array2::<i64>::zeros((n_samples, genoray_core::mutcat::N_CODES));
+        count_contig(&reader, &sidecars, false, &mut acc);
+        sink = sink.wrapping_add(acc[[0, 0]]);
+    }
+    let dt = t.elapsed();
+    eprintln!(
+        "[count_contig] {iters} iters in {dt:?} => {:.3} ms/iter (checksum={checksum}, sink={sink}, samples={n_samples} ploidy={ploidy} records={n_records})",
+        dt.as_secs_f64() * 1e3 / iters as f64
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -184,7 +184,8 @@ pub fn build_contig(
         1,    // htslib_threads
         4096, // long_allele_capacity
         false,
-        1, // processing_threads
+        1,     // processing_threads
+        false, // signatures
     )
     .expect("process_chromosome should succeed");
     write_max_del_fixture(&out.join(chrom), samples.len(), ploidy, records);

--- a/tests/test_convert_skip_e2e.rs
+++ b/tests/test_convert_skip_e2e.rs
@@ -51,7 +51,8 @@ fn convert(
         1,
         8 * 1024 * 1024,
         skip,
-        1, // processing_threads
+        1,     // processing_threads
+        false, // signatures
     )
 }
 

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -98,7 +98,8 @@ fn test_e2e_normalized_bcf_pipeline() {
         1,    // htslib_threads
         4096, // long_allele_capacity
         false,
-        1, // processing_threads
+        1,     // processing_threads
+        false, // signatures
     )
     .expect("process_chromosome should succeed");
 
@@ -187,7 +188,8 @@ fn test_e2e_max_del_postpass() {
         1,
         4096,
         false,
-        1, // processing_threads
+        1,     // processing_threads
+        false, // signatures
     )
     .expect("conversion");
 
@@ -260,7 +262,8 @@ fn test_e2e_dense_snp_roundtrip() {
         1,
         4096,
         false,
-        1, // processing_threads
+        1,     // processing_threads
+        false, // signatures
     )
     .expect("conversion");
 
@@ -332,7 +335,8 @@ fn test_e2e_mutation_conservation() {
         1,
         4096,
         false,
-        1, // processing_threads
+        1,     // processing_threads
+        false, // signatures
     )
     .expect("process_chromosome should succeed");
 
@@ -433,7 +437,8 @@ fn test_missing_chrom_returns_err() {
         1,
         1 << 20,
         false,
-        1, // processing_threads
+        1,     // processing_threads
+        false, // signatures
     );
 
     assert!(matches!(

--- a/tests/test_mutcat_count.rs
+++ b/tests/test_mutcat_count.rs
@@ -1,0 +1,98 @@
+//! Disk-integration test for Task 9's `count_contig`: a real `ContigReader`
+//! over a `build_contig` fixture, with an injected `VkSnp` mutcat sidecar
+//! (count_contig reads sidecar codes/refs, never the FASTA, so the sidecar
+//! fully controls classification) driving an isolated-adjacent-SNV DBS pair.
+
+mod common;
+
+use common::{SynthRecord, build_contig, read_u32_bin};
+use genoray_core::layout::{ContigPaths, MutcatSub};
+use genoray_core::mutcat::count::{Sidecars, count_contig};
+use genoray_core::mutcat::sidecar::write_sidecar;
+use genoray_core::mutcat::{DBS78_OFFSET, N_CODES, UNCLASSIFIED};
+use genoray_core::query::ContigReader;
+use ndarray::{Array2, s};
+use svar2_codec::encode_snp_2bit;
+use tempfile::tempdir;
+
+#[test]
+fn count_contig_pairs_adjacent_snvs_for_one_sample() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    // 1 sample, ploidy 1: at np=1 the cost model (`cost_model::choose_representation`)
+    // strictly prefers var_key over dense for a singly-carried SNP (34 bits vs 35),
+    // so both records land in var_key/snp, not dense/snp.
+    let samples = ["S0"];
+    let records = vec![
+        SynthRecord {
+            pos: 10,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1],
+        },
+        SynthRecord {
+            pos: 11,
+            ref_allele: b"C",
+            alts: vec![&b"A"[..]],
+            gt: vec![1],
+        },
+    ];
+    build_contig(&out, "chr1", &samples, 1, &records);
+
+    // Confirm routing + absolute index order before trusting the injected
+    // sidecar's alignment: both SNVs in var_key/snp, position-sorted, and
+    // nothing in dense/snp.
+    let vk_positions = read_u32_bin(
+        &out.join("chr1")
+            .join("var_key")
+            .join("snp")
+            .join("positions.bin"),
+    );
+    assert_eq!(
+        vk_positions,
+        vec![10, 11],
+        "expected both SNVs in var_key/snp, in order"
+    );
+    let dense_snp_positions_path = out
+        .join("chr1")
+        .join("dense")
+        .join("snp")
+        .join("positions.bin");
+    assert!(
+        !dense_snp_positions_path.exists() || read_u32_bin(&dense_snp_positions_path).is_empty(),
+        "expected no SNVs routed to dense/snp"
+    );
+
+    // Inject a VkSnp sidecar aligned to that absolute index order: record 0
+    // (pos 10) REF=A, record 1 (pos 11) REF=C. The real ALT alleles built
+    // above (C then A) come from var_key's packed key stream, so the doublet
+    // is REF "AC" -> ALT "CA": DBS78 label "AC>CA" is index 0 (see
+    // src/mutcat/classify.rs's DBS78_LABELS[0] and its `dbs78_literal_hit`
+    // test). The per-record SBS code is irrelevant here since a successfully
+    // paired doublet never falls back to it — set to UNCLASSIFIED.
+    let paths = ContigPaths::new(out.to_str().unwrap(), "chr1");
+    let codes = [UNCLASSIFIED, UNCLASSIFIED];
+    let refs = [encode_snp_2bit(b'A'), encode_snp_2bit(b'C')];
+    write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs)).unwrap();
+
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 1, 1).unwrap();
+    let sidecars = Sidecars::open(&paths).unwrap();
+
+    let mut acc = Array2::<i64>::zeros((1, N_CODES));
+    count_contig(&reader, &sidecars, false, &mut acc);
+
+    // Count-once fix (Task 8, commit 1bd79cd): an isolated adjacent pair
+    // contributes exactly ONE DBS call, not one per member.
+    assert_eq!(
+        acc[[0, DBS78_OFFSET]],
+        1,
+        "expected exactly one DBS78 index-0 call"
+    );
+    assert_eq!(
+        acc.slice(s![0, 0..96]).sum(),
+        0,
+        "the two SNVs that formed the doublet must not also show up as SBS96 calls"
+    );
+}

--- a/tests/test_mutcat_count.rs
+++ b/tests/test_mutcat_count.rs
@@ -12,6 +12,7 @@ use genoray_core::mutcat::sidecar::write_sidecar;
 use genoray_core::mutcat::{DBS78_OFFSET, N_CODES, UNCLASSIFIED};
 use genoray_core::query::ContigReader;
 use ndarray::{Array2, s};
+use rayon::ThreadPoolBuilder;
 use svar2_codec::encode_snp_2bit;
 use tempfile::tempdir;
 
@@ -95,4 +96,131 @@ fn count_contig_pairs_adjacent_snvs_for_one_sample() {
         0,
         "the two SNVs that formed the doublet must not also show up as SBS96 calls"
     );
+}
+
+/// Task 10: `count_contig`'s column loop now runs over `rayon`, each thread
+/// folding into a private per-sample accumulator that's later reduced with
+/// `+`. This must be bit-identical regardless of how many threads the pool
+/// has. 2 samples x ploidy 2 = 4 flat columns, each carrying exactly one
+/// non-adjacent SNV (so every column does real, independent work and no
+/// column is empty) — enough columns that thread count 4 actually puts one
+/// column per thread.
+#[test]
+fn count_is_thread_count_invariant() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+
+    // 2 samples, ploidy 2: 4 flat columns (col = sample*2 + p). Each SNV is
+    // carried by exactly one column and positions are far apart (no adjacent
+    // pairs), so each column's contribution is independent and unambiguous.
+    let samples = ["S0", "S1"];
+    let records = vec![
+        SynthRecord {
+            pos: 10,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0, 0, 0], // S0 hap0
+        },
+        SynthRecord {
+            pos: 20,
+            ref_allele: b"A",
+            alts: vec![&b"T"[..]],
+            gt: vec![0, 1, 0, 0], // S0 hap1
+        },
+        SynthRecord {
+            pos: 30,
+            ref_allele: b"A",
+            alts: vec![&b"G"[..]],
+            gt: vec![0, 0, 1, 0], // S1 hap0
+        },
+        SynthRecord {
+            pos: 40,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![0, 0, 0, 1], // S1 hap1
+        },
+    ];
+    build_contig(&out, "chr1", &samples, 2, &records);
+
+    // Inject sidecars covering both possible routes (var_key/snp and
+    // dense/snp) with the SAME dummy class-local code for every record, so
+    // classification doesn't depend on knowing the cost model's routing
+    // choice: whichever route(s) end up carrying records, `count_contig`
+    // will emit unified code `SBS96_OFFSET + 5` for each one.
+    let paths = ContigPaths::new(out.to_str().unwrap(), "chr1");
+    let dummy_code = 5u8;
+    let dummy_ref = encode_snp_2bit(b'A');
+
+    let vk_snp_positions = out
+        .join("chr1")
+        .join("var_key")
+        .join("snp")
+        .join("positions.bin");
+    let n_vk = if vk_snp_positions.exists() {
+        read_u32_bin(&vk_snp_positions).len()
+    } else {
+        0
+    };
+    if n_vk > 0 {
+        write_sidecar(
+            &paths,
+            MutcatSub::VkSnp,
+            &vec![dummy_code; n_vk],
+            Some(&vec![dummy_ref; n_vk]),
+        )
+        .unwrap();
+    }
+
+    let dense_snp_positions = out
+        .join("chr1")
+        .join("dense")
+        .join("snp")
+        .join("positions.bin");
+    let n_dense = if dense_snp_positions.exists() {
+        read_u32_bin(&dense_snp_positions).len()
+    } else {
+        0
+    };
+    if n_dense > 0 {
+        write_sidecar(
+            &paths,
+            MutcatSub::DenseSnp,
+            &vec![dummy_code; n_dense],
+            Some(&vec![dummy_ref; n_dense]),
+        )
+        .unwrap();
+    }
+    assert_eq!(
+        n_vk + n_dense,
+        4,
+        "all four SNVs must land in var_key/snp or dense/snp"
+    );
+
+    let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap();
+    let sidecars = Sidecars::open(&paths).unwrap();
+
+    let run_with_threads = |n_threads: usize| {
+        let pool = ThreadPoolBuilder::new()
+            .num_threads(n_threads)
+            .build()
+            .unwrap();
+        pool.install(|| {
+            let mut acc = Array2::<i64>::zeros((2, N_CODES));
+            count_contig(&reader, &sidecars, false, &mut acc);
+            acc
+        })
+    };
+
+    let acc_1 = run_with_threads(1);
+    let acc_4 = run_with_threads(4);
+
+    assert_eq!(
+        acc_1, acc_4,
+        "count_contig must be bit-identical regardless of rayon thread count"
+    );
+    // Sanity: each sample carries exactly 2 of the 4 SNVs, both classified as
+    // unified code SBS96_OFFSET + 5.
+    assert_eq!(acc_1[[0, 5]], 2, "S0 carries 2 of the 4 SNVs");
+    assert_eq!(acc_1[[1, 5]], 2, "S1 carries 2 of the 4 SNVs");
 }

--- a/tests/test_svar2_mutcat.py
+++ b/tests/test_svar2_mutcat.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import polars as pl
+import pysam
 import pytest
 
-from genoray import SparseVar2
+from genoray import SparseVar, SparseVar2
+from genoray._reference import Reference
 from tests.test_svar2_from_vcf import _write_ref, _write_vcf
 
 
@@ -38,3 +41,149 @@ def test_mutation_matrix_requires_annotation(tmp_path: Path):
     sv2 = SparseVar2(out)
     with pytest.raises(ValueError, match="not annotated"):
         sv2.mutation_matrix("SBS96")
+
+
+# ---------------------------------------------------------------------------
+# Task 14: v1 <-> SVAR2 parity + write-time/post-hoc round-trip
+# ---------------------------------------------------------------------------
+
+# 80bp non-repetitive reference so indel regions have a single unambiguous
+# left-aligned representation (no homopolymer/repeat context to shift).
+_PARITY_SEQ = (
+    "AAGCCCAATAAACCACTCTGACTGGCCGAATAGGGATATAGGCAACGACATGTGCGGCGACCCTTGCGACAGTGACGCTT"
+)
+
+
+def _write_parity_ref(d: Path) -> Path:
+    ref = d / "parity_ref.fa"
+    ref.write_text(f">chr1\n{_PARITY_SEQ}\n")
+    pysam.faidx(str(ref))
+    return ref
+
+
+def _write_parity_vcf(d: Path) -> Path:
+    """Build a shared VCF exercising SBS96, ID83, and DBS78 for both v1 and v2.
+
+    Variants (1-based POS, all against ``_PARITY_SEQ``):
+
+    - POS=10  A>G   isolated SNV on S0 (het)                       -> SBS96
+    - POS=30  A>C   \\ adjacent SNV pair on S1's hap0 (phased 1|0,  -> DBS78
+    - POS=31  T>A   /  1|0) -- the critical "count once" case
+    - POS=45  A>G   isolated SNV on S0 (het, other haplotype)      -> SBS96
+    - POS=50  A>AG  pure insertion on S0 (het)                     -> ID83
+    - POS=65  TG>T  pure deletion on S1 (het)                      -> ID83
+
+    All positions are spaced >=5bp apart except the intentional POS=30/31
+    doublet, so no other variant accidentally collapses into a DBS pair.
+    """
+    vcf_path = d / "parity_in.vcf"
+    h = pysam.VariantHeader()
+    h.add_line(f"##contig=<ID=chr1,length={len(_PARITY_SEQ)}>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+    h.add_sample("S0")
+    h.add_sample("S1")
+
+    # (0-based start, REF, ALT, {sample: (hap0, hap1)})
+    records = [
+        (9, "A", "G", {"S0": (0, 1), "S1": (0, 0)}),  # POS=10 isolated SNV
+        (29, "A", "C", {"S0": (0, 0), "S1": (1, 0)}),  # POS=30 doublet part 1
+        (30, "T", "A", {"S0": (0, 0), "S1": (1, 0)}),  # POS=31 doublet part 2
+        (44, "A", "G", {"S0": (1, 0), "S1": (0, 0)}),  # POS=45 isolated SNV
+        (49, "A", "AG", {"S0": (0, 1), "S1": (0, 0)}),  # POS=50 insertion
+        (64, "TG", "T", {"S0": (0, 0), "S1": (0, 1)}),  # POS=65 deletion
+    ]
+    with pysam.VariantFile(str(vcf_path), "w", header=h) as vf:
+        for start, ref, alt, gts in records:
+            r = h.new_record(contig="chr1", start=start, alleles=(ref, alt))
+            for s, gt in gts.items():
+                r.samples[s]["GT"] = gt
+                r.samples[s].phased = True
+            vf.write(r)
+
+    vcf_gz = d / "parity_in.vcf.gz"
+    with open(vcf_gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(vcf_path)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(vcf_gz)], check=True)
+    return vcf_gz
+
+
+def test_matrix_parity_with_v1(tmp_path: Path):
+    """v1 ``SparseVar`` and ``SparseVar2`` must classify+count identically.
+
+    Converts one shared VCF+FASTA both ways, annotates both, and checks
+    ``mutation_matrix`` for every kind x count combination is bit-for-bit
+    equal. The fixture includes an isolated SNV pair (SBS96 case), a pure
+    insertion and a pure deletion (ID83 case), and one ISOLATED adjacent-SNV
+    doublet on the same haplotype (DBS78 case) -- this last one is the
+    critical check that both stores count a doublet exactly ONCE (v1 via the
+    DBS_PARTNER sentinel, SVAR2 via its equivalent fix).
+    """
+    fa = _write_parity_ref(tmp_path)
+    vcf = _write_parity_vcf(tmp_path)
+
+    # v1: SparseVar.from_vcf takes a genoray.VCF wrapper (not a bare path) and
+    # a required max_mem; it has no reference= kwarg (v1 does not normalize
+    # against a reference at write time -- only annotate_mutations does).
+    from genoray import VCF as _V1VCF
+
+    v1_out = tmp_path / "v1.svar"
+    SparseVar.from_vcf(v1_out, _V1VCF(str(vcf)), max_mem="10m", overwrite=True)
+    v1 = SparseVar(v1_out)
+    v1.annotate_mutations(Reference.from_path(fa), write_back=True)
+
+    # v2
+    v2_out = tmp_path / "v2.svar2"
+    SparseVar2.from_vcf(v2_out, vcf, fa, overwrite=True, threads=1)
+    v2 = SparseVar2(v2_out)
+    v2.annotate_mutations(fa)
+
+    dbs_nonzero = False
+    for kind in ("SBS96", "ID83", "DBS78"):
+        for count in ("allele", "sample"):
+            a = v1.mutation_matrix(kind, count=count)
+            b = v2.mutation_matrix(kind, count=count)
+            cols = ["MutationType", *v2.available_samples]
+            a = a.select(cols)
+            b = b.select(cols)
+            assert a.equals(b), f"{kind}/{count} mismatch:\nv1:\n{a}\nv2:\n{b}"
+
+            total = a.select(v2.available_samples).sum().sum_horizontal().item()
+            assert total > 0, f"{kind}/{count} matrix is unexpectedly all-zero"
+            if kind == "DBS78":
+                dbs_nonzero = True
+
+    assert dbs_nonzero, "DBS78 comparison did not run"
+    # Explicitly confirm the doublet was counted exactly ONCE (not twice, not
+    # dropped) in both stores' allele-count matrices.
+    d1 = v1.mutation_matrix("DBS78", count="allele")
+    d2 = v2.mutation_matrix("DBS78", count="allele")
+    assert d1.select("S1").sum().item() == 1
+    assert d2.select("S1").sum().item() == 1
+
+
+def test_write_time_signatures_match_posthoc(tmp_path: Path):
+    """Write-time (`signatures=True`) and post-hoc `annotate_mutations` must
+    produce identical mutation matrices.
+
+    The two stores may differ in var_key/dense *routing* since write-time
+    signature classification is factored into the cost model that decides
+    routing, but `mutation_matrix` counts over the classified codes
+    irrespective of routing, so the matrices must match exactly.
+    """
+    fa = _write_parity_ref(tmp_path)
+    vcf = _write_parity_vcf(tmp_path)
+
+    a_out = tmp_path / "wtime.svar2"
+    SparseVar2.from_vcf(a_out, vcf, fa, signatures=True, overwrite=True, threads=1)
+    b_out = tmp_path / "posthoc.svar2"
+    SparseVar2.from_vcf(b_out, vcf, fa, overwrite=True, threads=1)
+    sb = SparseVar2(b_out)
+    sb.annotate_mutations(fa)
+    sa = SparseVar2(a_out)
+
+    for kind in ("SBS96", "ID83"):
+        ma = sa.mutation_matrix(kind)
+        mb = sb.mutation_matrix(kind)
+        assert ma.equals(mb), f"{kind} mismatch:\nwrite-time:\n{ma}\npost-hoc:\n{mb}"
+        total = ma.select(sa.available_samples).sum().sum_horizontal().item()
+        assert total > 0, f"{kind} matrix is unexpectedly all-zero"

--- a/tests/test_svar2_mutcat.py
+++ b/tests/test_svar2_mutcat.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from genoray import SparseVar2
+from tests.test_svar2_from_vcf import _write_ref, _write_vcf
+
+
+def test_mutation_matrix_shape_and_labels(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref)
+
+    meta = json.loads((out / "meta.json").read_text())
+    assert meta["mutcat_contigs"] == ["chr1"]
+
+    mm = sv2.mutation_matrix("SBS96", count="allele")
+    assert mm.columns[0] == "MutationType"
+    assert mm.height == 96
+    assert set(mm.columns[1:]) == set(sv2.available_samples)
+    assert mm.select(pl.exclude("MutationType")).to_numpy().dtype.kind in "iu"
+
+
+def test_mutation_matrix_requires_annotation(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store_unannotated.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+
+    sv2 = SparseVar2(out)
+    with pytest.raises(ValueError, match="not annotated"):
+        sv2.mutation_matrix("SBS96")

--- a/tests/test_svar2_mutcat.py
+++ b/tests/test_svar2_mutcat.py
@@ -161,6 +161,60 @@ def test_matrix_parity_with_v1(tmp_path: Path):
     assert d2.select("S1").sum().item() == 1
 
 
+def _write_parity_ref_softmasked(d: Path) -> Path:
+    """Same sequence as ``_write_parity_ref`` but entirely lower-case, simulating
+    a soft-masked reference (e.g. UCSC hg38, ~50% lower-case repeat-mask)."""
+    ref = d / "parity_ref_softmasked.fa"
+    ref.write_text(f">chr1\n{_PARITY_SEQ.lower()}\n")
+    pysam.faidx(str(ref))
+    return ref
+
+
+def test_annotate_handles_softmasked_reference(tmp_path: Path):
+    """Post-hoc ``annotate_mutations`` must classify identically whether the
+    reference FASTA is upper- or lower-case (soft-masked).
+
+    Regression for a bug where write-time ``from_vcf(signatures=True)``
+    uppercases the reference it loads (``load_contig_seq``) but post-hoc
+    ``annotate_mutations`` (via ``Reference._load_contig``, which only does
+    ``seq.encode("ascii")``) did not. The shared Rust classifiers'
+    ``base_index`` matches uppercase A/C/G/T only, so a soft-masked
+    reference would silently classify every SNV/indel in a lower-case region
+    as UNCLASSIFIED post-hoc while write-time counted them -- corrupting the
+    "post-hoc == write-time" invariant on any real (soft-masked) genome.
+
+    Builds two identical stores from the same VCF (using the upper-case
+    reference for conversion, so REF/ALT validation is unaffected), then
+    annotates one post-hoc with the upper-case reference and the other with
+    an all-lower-case version of the exact same sequence. Without the fix
+    the lower-case run returns all-UNCLASSIFIED/zero matrices; with the fix
+    the two matrices are bit-for-bit identical.
+    """
+    fa_upper = _write_parity_ref(tmp_path)
+    fa_soft = _write_parity_ref_softmasked(tmp_path)
+    vcf = _write_parity_vcf(tmp_path)
+
+    out_upper = tmp_path / "softmask_upper.svar2"
+    SparseVar2.from_vcf(out_upper, vcf, fa_upper, overwrite=True, threads=1)
+    sv_upper = SparseVar2(out_upper)
+    sv_upper.annotate_mutations(fa_upper)
+
+    out_soft = tmp_path / "softmask_lower.svar2"
+    SparseVar2.from_vcf(out_soft, vcf, fa_upper, overwrite=True, threads=1)
+    sv_soft = SparseVar2(out_soft)
+    sv_soft.annotate_mutations(fa_soft)
+
+    for kind in ("SBS96", "ID83"):
+        m_upper = sv_upper.mutation_matrix(kind)
+        m_soft = sv_soft.mutation_matrix(kind)
+        assert m_upper.equals(m_soft), (
+            f"{kind} mismatch between upper-case and soft-masked reference:\n"
+            f"upper:\n{m_upper}\nsoft-masked:\n{m_soft}"
+        )
+        total = m_upper.select(sv_upper.available_samples).sum().sum_horizontal().item()
+        assert total > 0, f"{kind} matrix is unexpectedly all-zero"
+
+
 def test_write_time_signatures_match_posthoc(tmp_path: Path):
     """Write-time (`signatures=True`) and post-hoc `annotate_mutations` must
     produce identical mutation matrices.


### PR DESCRIPTION
## Summary

Adds COSMIC mutational-signature support (SBS96, ID83, DBS78-via-adjacency) to `SparseVar2`, implemented in Rust with v1 feature parity and far lower memory.

A per-contig `mutcat/` sidecar stores one `u8` class-local mutation code per record (aligned to each existing sub-stream), plus a 2-bit reference base for SNPs. A single Rust classification pass writes it (at write time or post-hoc). `mutation_matrix` streams the mmap'd genotype sub-streams column-by-column, reclassifying adjacent same-haplotype SNV pairs into DBS78 on the fly — never materializing a per-entry code array. The existing numpy/scipy `fit_signatures` refit is reused unchanged.

## Public API (new — no breaking changes)

- `SparseVar2.annotate_mutations(reference, *, contigs=None)` — post-hoc classification → sidecar.
- `SparseVar2.mutation_matrix(kind, *, count="allele"|"sample")` → `pl.DataFrame` (`MutationType` + per-sample columns); `kind ∈ {SBS96, DBS78, ID83}`.
- `SparseVar2.assign_signatures(kind, ...)` — COSMIC refit via `fit_signatures`.
- `SparseVar2.from_vcf(..., signatures=True)` — classify during the write (factored into the var_key/dense cost model).

`SKILL.md` and docs updated.

## Implementation

- **Rust `src/mutcat/`:** code-space constants (mirrors `_mutcat/codebook.py`), pure classifiers (SBS96/ID83/DBS78), sidecar I/O (`u8` code + 2-bit ref), classification pass, and a rayon-parallel streaming count matrix with on-the-fly DBS pairing.
- Cost model (`choose_representation`) accounts for sidecar bits when signatures are on; wired through `run_conversion_pipeline` → orchestrator for write-time annotation.
- PyO3 bindings on `PyContigReader` (`annotate_mutations`, `count_matrix`).

## Correctness notes

- **DBS78 counts each isolated doublet once** (matching v1's `_entry_codes_kernel` / COSMIC event semantics). The design doc was internally contradictory on this; resolved to count-once and validated against v1.
- **Reference is uppercased at the shared classification choke point** so post-hoc and write-time annotation produce identical matrices on soft-masked references (e.g. UCSC hg38).

## Testing

- v1 ↔ SVAR2 parity across all `kind × count` combos, including an isolated adjacent-SNV doublet (DBS78 counted once, verified bit-for-bit equal to v1).
- Write-time (`signatures=True`) vs post-hoc annotation produce identical matrices (routing-invariant).
- Soft-masked-reference regression test; rayon thread-count-invariance; cost-model crossover shift; per-classifier unit tests cross-checked against the Python codebook.
- Full gate green: Rust suite 0 failures; `pytest tests` 563 passed / 2 skipped / 16 xfailed; ruff / cargo-fmt / clippy / pyrefly clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
