### PR TITLE
feat(svar2): write scalar-numeric INFO/FORMAT fields in from_vcf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
   for COSMIC mutational-signature workflows (SBS96/ID83/DBS78), implemented in
   Rust with a per-record sidecar and streaming count matrix. `from_vcf` gains a
   `signatures=` flag to classify during the write (factored into the cost model).
+- `SparseVar2.from_vcf` can extract scalar-numeric INFO/FORMAT fields into the
+  store via new `info_fields=`/`format_fields=` kwargs and `InfoField`/
+  `FormatField` config types (`genoray.InfoField`, `genoray.FormatField`).
+  Scoped to `Integer`/`Float`/`Flag` header types with `Number ∈ {1, A}` (plus
+  `Flag`'s `Number=0`); integer widths are losslessly auto-narrowed to the
+  observed range by default, `f16` is opt-in and lossy. FORMAT storage is
+  genotype-aligned — values at non-carrier genotypes are dropped, not stored
+  independently. Write-only in this release; a query/decode API for stored
+  fields is deferred to a follow-up.
 
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   share a common offset-derivation + tile-gather implementation. Field output
   is byte-identical to before. Internal-only (no public API change) —
   finalize's own instruction count drops ~13% (callgrind Ir, small workload)
-  and peak RSS on a 200-sample/50k-record conversion drops ~7% (498 MiB →
+  and peak RSS on a 200-sample/50k-record conversion drops ~7% (~487 MiB →
   ~452 MiB); end-to-end wall time is unchanged since conversion remains
   reader/htslib-bound, not finalize-bound.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@
   genotype-aligned — values at non-carrier genotypes are dropped, not stored
   independently. Write-only in this release; a query/decode API for stored
   fields is deferred to a follow-up.
+- SVAR2 field write internals: the finalize pass streams staged values
+  through `chunks_exact` (no intermediate `Vec<f64>` materialization) and
+  runs in parallel across fields/files; the var_key and pos/key merges now
+  share a common offset-derivation + tile-gather implementation. Field output
+  is byte-identical to before. Internal-only (no public API change) —
+  finalize's own instruction count drops ~13% (callgrind Ir, small workload)
+  and peak RSS on a 200-sample/50k-record conversion drops ~7% (498 MiB →
+  ~452 MiB); end-to-end wall time is unchanged since conversion remains
+  reader/htslib-bound, not finalize-bound.
 
 ### BREAKING CHANGES
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +372,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
+ "half",
  "memmap2",
  "ndarray",
  "ndarray-npy",
@@ -397,6 +404,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bytemuck = "1.25.0"
 crossbeam-channel = "0.5.15"
+half = "2"
 memmap2 = "0.9.10"
 ndarray = "0.17.2"
 ndarray-npy = "0.10.0"

--- a/docs/roadmap/data-model.md
+++ b/docs/roadmap/data-model.md
@@ -214,38 +214,80 @@ svar2/
     │   ├── snp/
     │   │   ├── positions.bin       # sidecar SNP-variant positions (sorted), u32 LE
     │   │   ├── alleles.bin         # 2-bit packed keys, one per SNP variant (no LUT), u8
-    │   │   ├── {field}.npy         # per-variant INFO/FORMAT fields
     │   │   └── genotypes.bin       # 1-bit (sample, ploid, snp_variant) matrix, C-order, u8
     │   └── indel/
     │       ├── positions.bin       # u32 LE
     │       ├── alleles.bin         # 32-bit keys, one per indel variant (points into shared LUT), u32 LE
-    │       ├── {field}.npy
     │       └── genotypes.bin       # 1-bit (sample, ploid, indel_variant) matrix, C-order, u8
     ├── pointer/                    # = SVAR 1.0 representation (longer-term, M11)
     │   ├── snp/
     │   │   ├── positions.npy
     │   │   ├── alleles.npy         # 2-bit packed variant table (no LUT)
-    │   │   ├── {field}.npy
     │   │   ├── pointers.npy        # u32/u64 pointers into the SNP variant table
     │   │   └── offsets.npy         # per (sample, ploid) ragged offsets into pointers
     │   └── indel/
     │       ├── positions.npy
     │       ├── alleles.npy         # 32-bit variant table (points into shared LUT)
-    │       ├── {field}.npy
     │       ├── pointers.npy
     │       └── offsets.npy
-    └── var_key/
-        ├── snp/
-        │   ├── positions.bin       # per-call SNP positions (sorted within each hap), u32 LE
-        │   ├── alleles.bin         # 2-bit packed ALT, 4 calls/byte (uint8), no LUT
-        │   ├── offsets.npy         # per (sample, ploid) ragged offsets into snp calls, u64
-        │   └── {field}.npy         # per-call INFO/FORMAT for SNP calls
-        └── indel/
-            ├── positions.bin       # per-call indel positions (sorted within each hap), u32 LE
-            ├── alleles.bin         # 32-bit keys, one per call (ragged, points into shared LUT), u32 LE
-            ├── offsets.npy         # per (sample, ploid) ragged offsets into alleles, u64
-            └── {field}.npy
+    ├── var_key/
+    │   ├── snp/
+    │   │   ├── positions.bin       # per-call SNP positions (sorted within each hap), u32 LE
+    │   │   ├── alleles.bin         # 2-bit packed ALT, 4 calls/byte (uint8), no LUT
+    │   │   └── offsets.npy         # per (sample, ploid) ragged offsets into snp calls, u64
+    │   └── indel/
+    │       ├── positions.bin       # per-call indel positions (sorted within each hap), u32 LE
+    │       ├── alleles.bin         # 32-bit keys, one per call (ragged, points into shared LUT), u32 LE
+    │       └── offsets.npy         # per (sample, ploid) ragged offsets into alleles, u64
+    └── fields/                     # INFO/FORMAT field values (see below); only present
+        └── {name}/                 # when `from_vcf(info_fields=, format_fields=)` is used
+            ├── var_key_snp/values.bin
+            ├── var_key_indel/values.bin
+            ├── dense_snp/values.bin
+            └── dense_indel/values.bin       # only the subs with records for this contig exist
 ```
+
+### INFO/FORMAT field storage
+
+`from_vcf(info_fields=, format_fields=)` extracts scalar-numeric INFO
+(per-variant) and FORMAT (per-call) fields, genotype-aligned to whichever
+representation (`var_key`/`dense`) each variant already routed to — see
+`docs/superpowers/specs/2026-07-11-svar2-info-format-fields-write-design.md`
+for the full design. Each requested field gets its own
+`{contig}/fields/{name}/{sub}/values.bin`, where `sub ∈ {var_key_snp,
+var_key_indel, dense_snp, dense_indel}` (only the subs that actually had
+records for that contig/representation are written). `values.bin` is a raw
+little-endian array in the field's resolved storage dtype:
+
+- **var_key**: one value per call (INFO values duplicated across a variant's
+  calls; FORMAT values one per carrier call) — parallel to that sub's
+  `offsets.npy`-indexed call stream.
+- **dense INFO**: one value per dense variant, parallel to `positions.bin`.
+- **dense FORMAT**: a full `n_samples`-long per-sample column per dense
+  variant (`n_samples · n_dense_variants` total); non-carrier sample slots
+  hold the field's `default`/sentinel, keeping FORMAT read semantics uniform
+  with var_key.
+
+No offsets are needed for field arrays — each is a fixed stride derived from
+the existing `n_samples`/variant-count/call-count already implied by the
+representation's genotype arrays.
+
+Each requested field's resolved dtype/category/default is recorded in the
+top-level `meta.json` under a `"fields"` array, one entry per field:
+
+```json
+"fields": [
+  {"name": "DS", "category": "format", "dtype": "f32", "default": 0.0},
+  {"name": "AC", "category": "info",   "dtype": "u8",  "default": null}
+]
+```
+
+`category` is `"info"` or `"format"`; `dtype` is the resolved (never `"auto"`)
+storage dtype string (e.g. `"f32"`, `"u8"`); `default` is the configured
+missing-fill value, or `null` when unset (falls back to the dtype's reserved
+sentinel). Note: as of this writing there is no reader/query API for these
+field values yet — writing is implemented, decode/output is a separate,
+deferred spec.
 
 `meta.json` carries the format version (so `SparseVar2` can negotiate), sample list,
 contig list, and ploidy. The per-stream maximum deletion length needed for overlap

--- a/docs/roadmap/data-model.md
+++ b/docs/roadmap/data-model.md
@@ -240,11 +240,12 @@ svar2/
     │       ├── alleles.bin         # 32-bit keys, one per call (ragged, points into shared LUT), u32 LE
     │       └── offsets.npy         # per (sample, ploid) ragged offsets into alleles, u64
     └── fields/                     # INFO/FORMAT field values (see below); only present
-        └── {name}/                 # when `from_vcf(info_fields=, format_fields=)` is used
-            ├── var_key_snp/values.bin
-            ├── var_key_indel/values.bin
-            ├── dense_snp/values.bin
-            └── dense_indel/values.bin       # only the subs with records for this contig exist
+        └── {category}/             # when `from_vcf(info_fields=, format_fields=)` is used
+            └── {name}/             # category ∈ {info, format}; same name may exist in both
+                ├── var_key_snp/values.bin
+                ├── var_key_indel/values.bin
+                ├── dense_snp/values.bin
+                └── dense_indel/values.bin       # only the subs with records for this contig exist
 ```
 
 ### INFO/FORMAT field storage
@@ -254,10 +255,13 @@ svar2/
 representation (`var_key`/`dense`) each variant already routed to — see
 `docs/superpowers/specs/2026-07-11-svar2-info-format-fields-write-design.md`
 for the full design. Each requested field gets its own
-`{contig}/fields/{name}/{sub}/values.bin`, where `sub ∈ {var_key_snp,
-var_key_indel, dense_snp, dense_indel}` (only the subs that actually had
-records for that contig/representation are written). `values.bin` is a raw
-little-endian array in the field's resolved storage dtype:
+`{contig}/fields/{category}/{name}/{sub}/values.bin`, where `category ∈
+{info, format}` (a name may be requested as both an INFO and a FORMAT field
+at once — the category segment keeps their `values.bin` files from
+colliding) and `sub ∈ {var_key_snp, var_key_indel, dense_snp, dense_indel}`
+(only the subs that actually had records for that contig/representation are
+written). `values.bin` is a raw little-endian array in the field's resolved
+storage dtype:
 
 - **var_key**: one value per call (INFO values duplicated across a variant's
   calls; FORMAT values one per carrier call) — parallel to that sub's

--- a/docs/superpowers/plans/2026-07-12-svar2-fields-followup-cleanup-optimization.md
+++ b/docs/superpowers/plans/2026-07-12-svar2-fields-followup-cleanup-optimization.md
@@ -1,0 +1,730 @@
+# SVAR2 fields — PR#100 follow-ups, cleanup & field-path optimization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close PR#100's three deferred follow-ups, DRY/clean the new field-write code, and cut the finalize pass's cost via a measurement-driven, byte-identical optimization.
+
+**Architecture:** Work lands as new commits on the open PR#100 branch `worktree-svar2-field-specs`. Tests come first (lock behavior), then the refactors run green, then a bracketed profile→optimize→re-profile pass scoped to the field-write code. The reader/htslib path is explicitly off-limits.
+
+**Tech Stack:** Rust (rust-htslib, rayon, bytemuck, ndarray-npy), PyO3, Python (pytest, vcfixture), `perf` + `valgrind --tool=callgrind` + `cargo asm` (cargo-show-asm) for profiling.
+
+## Global Constraints
+
+- **Commits:** Conventional Commits (`feat:`/`fix:`/`refactor:`/`test:`/`perf:`/`docs:`/`chore:`). End commit messages with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Rust tests:** always `pixi run bash -lc 'cargo test --no-default-features --features conversion ...'` — without `--no-default-features` the pyo3 test binary fails to link (`undefined symbol: _Py_Dealloc`).
+- **Python tests:** `pixi run pytest tests/<file>.py -v` for a single file; `pixi run test` for the full suite (it regenerates fixtures via `gen_from_vcf.sh`).
+- **prek hooks** are already installed in this repo's git-common-dir; commits/pushes run them.
+- **Byte-identical output:** the optimization must produce on-disk field `values.bin` bytes identical to pre-optimization. This is the acceptance bar for Tasks 7–8.
+- **No public API change:** nothing reachable from `import genoray` changes name/semantics; `skills/genoray-api/SKILL.md` needs no edit (confirmed at close-out).
+- **Off-limits:** the reader/htslib conversion path (known reader-bound; prior optimization round already done). Do not modify `vcf_reader.rs` for perf.
+- **Versioning:** do NOT bump the version or edit versioned `CHANGELOG.md` sections; accumulate entries under `## Unreleased` only.
+- Profiling artifacts (drivers, synthetic VCFs, callgrind out files) live under `$CLAUDE_JOB_DIR/tmp` and are NOT committed.
+
+---
+
+## Stage 1 — Tests first (follow-ups #2, #3)
+
+### Task 1: Rust unit test — `f32→f32` no-op finalize rewrite
+
+Covers the finalize path where a Float field already has an explicit concrete `f32` dtype, so `resolve_dtype` returns `F32` and `rewrite_file` re-encodes f32→f32 (no width change). Currently untested.
+
+**Files:**
+- Test: `src/field_finalize.rs` (append to the existing `#[cfg(test)] mod tests`, after the last test near line 690)
+
+**Interfaces:**
+- Consumes (existing test helpers in this module): `float_field(name: &str, dtype: StorageDtype, default: Option<f64>) -> FieldSpec` (field_finalize.rs:507), `write_f32_field(root: &Path, contig: &str, name: &str, sub: &str, values: &[f32])` (field_finalize.rs:481), `read_values_bin(path: &Path) -> Vec<u8>` (field_finalize.rs:493), `finalize_fields(output_dir: &Path, contigs: &[String], fields: &[FieldSpec]) -> Result<Vec<ResolvedField>, ConversionError>` (field_finalize.rs:84).
+- Produces: nothing consumed downstream (test only).
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `mod tests` in `src/field_finalize.rs`:
+
+```rust
+    #[test]
+    fn explicit_f32_rewrites_in_place_byte_identical() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let contig = "chr1";
+        let vals: [f32; 4] = [0.5, -1.25, 0.0, 3.5];
+        // stage under one var_key sub label
+        write_f32_field(root, contig, "DS", "var_key_snp", &vals);
+        let path = root
+            .join(contig)
+            .join("fields")
+            .join("format")
+            .join("DS")
+            .join("var_key_snp")
+            .join("values.bin");
+        let before = read_values_bin(&path);
+
+        let field = float_field("DS", StorageDtype::F32, None);
+        let resolved = finalize_fields(root, &[contig.to_string()], &[field]).unwrap();
+
+        assert_eq!(resolved[0].dtype, StorageDtype::F32);
+        let after = read_values_bin(&path);
+        // f32 staged -> f32 resolved: rewrite must reproduce the same 16 bytes.
+        assert_eq!(before, after, "f32->f32 finalize must be byte-identical");
+    }
+```
+
+Note: verify `float_field` builds a **format**-category field (the path uses `fields/format/DS`). If `float_field` defaults to INFO, either add a category arg inline or construct the `FieldSpec` literal in-test with `category: FieldCategory::Format`. Read field_finalize.rs:507 first and match the actual helper.
+
+- [ ] **Step 2: Run test to verify it fails (or reveals the helper's category)**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib field_finalize::tests::explicit_f32_rewrites_in_place_byte_identical -- --nocapture'`
+Expected: initially FAIL if the path/category is wrong (fix the fixture to match the helper), then compile+run.
+
+- [ ] **Step 3: Adjust fixture to the real helper signature**
+
+If `float_field` is INFO-only, replace its use with an explicit spec so the staged path matches `finalize`'s enumeration:
+
+```rust
+        let field = FieldSpec {
+            name: "DS".into(),
+            category: FieldCategory::Format,
+            htype: HtslibType::Float,
+            dtype: StorageDtype::F32,
+            default: None,
+        };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib field_finalize::tests::explicit_f32_rewrites_in_place_byte_identical'`
+Expected: PASS (`test result: ok. 1 passed`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/field_finalize.rs
+git commit -m "test(svar2): cover f32->f32 no-op finalize rewrite
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Python e2e — VarKeyIndel FORMAT field_calls + multi-field ordering
+
+Two behaviors the PR body flagged as untested, both exercised end-to-end through routing → merge → finalize:
+1. A rare indel (few carriers, small cohort) routes to the **var_key_indel** stream, and its FORMAT field's `var_key_indel/values.bin` is written non-empty.
+2. Multiple INFO and multiple FORMAT fields resolve to distinct, correct per-field files with no cross-contamination.
+
+Routing rationale (do not guess): `choose_representation` (src/cost_model.rs:60) makes an indel route to VarKey when `x*(64+info+format) <= 32+32+np + info + format*n_samples`. With 2 samples (np=4) and a single-carrier indel, `var_key ≈ 64 < dense ≈ 68`, so a rare indel is var_key deterministically.
+
+**Files:**
+- Test: `tests/test_svar2_fields.py` (append new tests + a fixture builder)
+
+**Interfaces:**
+- Consumes: `vcfixture` `VcfBuilder`, `Number`, `Seq`, `Type` (already imported at tests/test_svar2_fields.py:19); `genoray.SparseVar2.from_vcf(out, source, *, no_reference=True, info_fields=..., format_fields=...)`; `genoray._svar2_fields.FormatField` (imported at line 21).
+- Produces: nothing downstream (tests only).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_svar2_fields.py`:
+
+```python
+def _rare_indel_vcf(tmp_path: Path) -> Path:
+    """2 samples; a biallelic indel carried by exactly ONE call, plus a FORMAT
+    float DS. With np=4 and a single carrier call, choose_representation routes
+    the indel to var_key_indel (var_key ~64 bits < dense ~68), so DS must land
+    in fields/format/DS/var_key_indel/values.bin."""
+    doc = (
+        VcfBuilder(samples=["s0", "s1"], contigs=[("chr1", 100_000)])
+        .fmt("GT")
+        .fmt("DS", Number.ONE, Type.FLOAT)
+        .record(
+            "chr1",
+            100,
+            ref="AT",
+            alt=[Seq("A")],  # 1bp deletion (indel)
+            gt=["0|1", "0|0"],  # one carrier call total
+            DS=[[0.5], [0.0]],
+        )
+    )
+    return doc.write(tmp_path / "rare_indel.vcf.gz", bgzip=True, index=True)
+
+
+def test_from_vcf_varkey_indel_format_field_written(tmp_path: Path):
+    from genoray import SparseVar2
+
+    src = _rare_indel_vcf(tmp_path)
+    out = tmp_path / "store_vk_indel.svar2"
+    SparseVar2.from_vcf(
+        out, str(src), no_reference=True, format_fields=[FormatField("DS", default=0.0)]
+    )
+    import json
+
+    meta = json.loads((out / "meta.json").read_text())
+    contig = meta["contigs"][0]
+    vk_indel = out / contig / "fields" / "format" / "DS" / "var_key_indel" / "values.bin"
+    assert vk_indel.is_file(), "var_key_indel DS values.bin missing"
+    assert vk_indel.stat().st_size > 0, "var_key_indel DS field_calls not written"
+
+
+def _multifield_vcf(tmp_path: Path) -> Path:
+    """2 INFO + 2 FORMAT scalar fields with distinct values, to prove per-field
+    files don't cross-contaminate through routing/merge/finalize."""
+    doc = (
+        VcfBuilder(samples=["s0", "s1"], contigs=[("chr1", 100_000)])
+        .info("AC", Number.A, Type.INTEGER)
+        .info("AN", Number.ONE, Type.INTEGER)
+        .fmt("GT")
+        .fmt("DP", Number.ONE, Type.INTEGER)
+        .fmt("DS", Number.ONE, Type.FLOAT)
+        .record(
+            "chr1",
+            100,
+            ref="A",
+            alt=[Seq("C")],
+            gt=["0|1", "1|1"],
+            info={"AC": 3, "AN": 4},
+            DP=[[10], [20]],
+            DS=[[0.25], [0.75]],
+        )
+    )
+    return doc.write(tmp_path / "multifield.vcf.gz", bgzip=True, index=True)
+
+
+def test_from_vcf_multi_field_no_cross_contamination(tmp_path: Path):
+    import json
+
+    from genoray import SparseVar2
+
+    src = _multifield_vcf(tmp_path)
+    out = tmp_path / "store_multi.svar2"
+    SparseVar2.from_vcf(
+        out,
+        str(src),
+        no_reference=True,
+        info_fields=["AC", "AN"],
+        format_fields=["DP", "DS"],
+    )
+    meta = json.loads((out / "meta.json").read_text())
+    by_name = {f["name"]: f for f in meta["fields"]}
+    # Each field is recorded exactly once under its own category.
+    assert by_name["AC"]["category"] == "info"
+    assert by_name["AN"]["category"] == "info"
+    assert by_name["DP"]["category"] == "format"
+    assert by_name["DS"]["category"] == "format"
+    # DS is the only Float field -> f32; the ints auto-narrow to a sub-4b width.
+    assert by_name["DS"]["dtype"] == "f32"
+    assert by_name["DP"]["dtype"] in {"i8", "u8", "i16", "u16"}
+    contig = meta["contigs"][0]
+    # Every declared field has at least one non-empty values.bin, and int fields
+    # stay a whole number of their own resolved width (proves disjoint files).
+    width = {"bool": 1, "i8": 1, "u8": 1, "i16": 2, "u16": 2, "f16": 2, "f32": 4, "i32": 4, "u32": 4}
+    for name, spec in by_name.items():
+        cat = spec["category"]
+        files = list((out / contig / "fields" / cat / name).glob("*/values.bin"))
+        assert files, f"{cat}/{name} has no values.bin"
+        assert sum(p.stat().st_size for p in files) > 0, f"{cat}/{name} all empty"
+        w = width[spec["dtype"]]
+        assert all(p.stat().st_size % w == 0 for p in files), f"{cat}/{name} bad width"
+```
+
+- [ ] **Step 2: Run tests to verify they pass (behavior already implemented)**
+
+Run: `pixi run pytest tests/test_svar2_fields.py::test_from_vcf_varkey_indel_format_field_written tests/test_svar2_fields.py::test_from_vcf_multi_field_no_cross_contamination -v`
+Expected: both PASS. These lock existing behavior. If `var_key_indel` is empty, the indel routed dense — reduce carriers or raise sample count until routing flips (per the cost formula above); do not weaken the assertion to `>= 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_svar2_fields.py
+git commit -m "test(svar2): cover var_key_indel FORMAT calls + multi-field isolation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Python e2e — combined `signatures=True` + fields
+
+Confirms the mutcat write-time annotation and the INFO/FORMAT field pipeline compose (their cost terms are additive; this is the missing integration point). `signatures=True` requires a reference.
+
+**Files:**
+- Test: `tests/test_svar2_fields.py` (append)
+
+**Interfaces:**
+- Consumes: `SparseVar2.from_vcf(out, source, reference, *, signatures=True, info_fields=..., format_fields=...)`; a reference FASTA whose bases match the VCF REF alleles.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_svar2_fields.py`:
+
+```python
+def _ref_and_fields_vcf(tmp_path: Path) -> tuple[Path, Path]:
+    """A reference FASTA + a bgzipped/indexed VCF whose REF bases match it,
+    carrying one INFO int (AC) and one FORMAT float (DS). Reuses the 40bp
+    reference convention from tests/test_svar2_from_vcf.py (_REF)."""
+    import subprocess
+
+    ref_seq = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"  # POS3='A', POS7='C'
+    ref = tmp_path / "ref.fa"
+    ref.write_text(f">chr1\n{ref_seq}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    doc = (
+        VcfBuilder(samples=["s0", "s1"], contigs=[("chr1", 40)])
+        .info("AC", Number.A, Type.INTEGER)
+        .fmt("GT")
+        .fmt("DS", Number.ONE, Type.FLOAT)
+        .record("chr1", 3, ref="A", alt=[Seq("G")], gt=["1|0", "0|0"], info={"AC": 1}, DS=[[0.5], [0.0]])
+        .record("chr1", 7, ref="C", alt=[Seq("CAT")], gt=["0|1", "1|1"], info={"AC": 3}, DS=[[0.9], [0.2]])
+    )
+    vcf = doc.write(tmp_path / "ref_fields.vcf.gz", bgzip=True, index=True)
+    return vcf, ref
+
+
+def test_from_vcf_signatures_and_fields_compose(tmp_path: Path):
+    import json
+
+    from genoray import SparseVar2
+
+    vcf, ref = _ref_and_fields_vcf(tmp_path)
+    out = tmp_path / "store_sig_fields.svar2"
+    SparseVar2.from_vcf(
+        out,
+        str(vcf),
+        str(ref),
+        signatures=True,
+        info_fields=["AC"],
+        format_fields=[FormatField("DS", default=0.0)],
+        threads=1,
+    )
+    meta = json.loads((out / "meta.json").read_text())
+    names = {f["name"] for f in meta["fields"]}
+    assert {"AC", "DS"} <= names, "field manifest missing AC/DS under signatures=True"
+    contig = meta["contigs"][0]
+    # fields written
+    assert list((out / contig / "fields" / "info" / "AC").glob("*/values.bin"))
+    assert list((out / contig / "fields" / "format" / "DS").glob("*/values.bin"))
+    # mutcat sidecar written alongside (signatures path ran)
+    sidecar = list((out / contig).rglob("*sig*")) + list((out / contig).rglob("*mutcat*"))
+    assert sidecar, "signatures=True produced no mutcat sidecar next to fields"
+```
+
+- [ ] **Step 2: Run and adjust the sidecar assertion to the real artifact name**
+
+Run: `pixi run pytest tests/test_svar2_fields.py::test_from_vcf_signatures_and_fields_compose -v`
+If it fails only on the `sidecar` glob, inspect the store to find the real mutcat artifact name and tighten the assertion:
+
+Run: `pixi run pytest tests/test_svar2_fields.py::test_from_vcf_signatures_and_fields_compose -v -s` then, from a scratch run, list the contig dir. Cross-check the sidecar path against `src/mutcat/sidecar.rs` / `src/mutcat/mod.rs` and replace the `rglob` with the exact filename.
+Expected after fix: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_svar2_fields.py
+git commit -m "test(svar2): cover signatures=True composed with INFO/FORMAT fields
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Stage 2 — DRY & cleanup
+
+### Task 4: Replace stringly-typed `prefix: &str` with `FieldCategory` in dense field merge
+
+`merge_dense_field_values` (src/dense_merge.rs:120) takes `prefix: &str` and matches `"finfo"`/`"fformat"` at runtime with an error arm. Replace with the existing `FieldCategory` enum; select the chunk-path builder by variant. Removes the runtime error branch and its test.
+
+**Files:**
+- Modify: `src/dense_merge.rs:120` (signature + body + the `"bogus"` error test)
+- Modify: `src/orchestrator.rs:337-370` (call site — pass `field.category` instead of the `"finfo"`/`"fformat"` string; drop the `prefix` local)
+
+**Interfaces:**
+- Consumes: `crate::field::FieldCategory` (Info/Format), `layout::chunk_field_info` (layout.rs:121), `layout::chunk_field_format` (layout.rs:124).
+- Produces: `pub fn merge_dense_field_values(output_dir: &str, num_chunks: usize, dense_ledger: &[u32], category: FieldCategory, field_ix: usize, dest_values_bin: &Path) -> Result<(), ConversionError>`.
+
+- [ ] **Step 1: Change the signature and body**
+
+In `src/dense_merge.rs`, replace `prefix: &str` with `category: crate::field::FieldCategory` and the `match prefix { "finfo" => ..., "fformat" => ..., other => Err(...) }` block with:
+
+```rust
+        let path = match category {
+            crate::field::FieldCategory::Info => layout::chunk_field_info(dir, c, field_ix),
+            crate::field::FieldCategory::Format => layout::chunk_field_format(dir, c, field_ix),
+        };
+```
+
+Delete the now-impossible `other =>` error arm entirely.
+
+- [ ] **Step 2: Update the call site**
+
+In `src/orchestrator.rs`, in the dense merge loop (around 337-370), drop the `let (prefix, field_ix) = match field.category { ... "finfo" ... "fformat" ... }` string binding; keep the `info_ix`/`format_ix` counters for `field_ix`, and pass `field.category` directly:
+
+```rust
+            let field_ix = match field.category {
+                crate::field::FieldCategory::Info => {
+                    let ix = info_ix;
+                    info_ix += 1;
+                    ix
+                }
+                crate::field::FieldCategory::Format => {
+                    let ix = format_ix;
+                    format_ix += 1;
+                    ix
+                }
+            };
+            // ... dest_dir unchanged ...
+            crate::dense_merge::merge_dense_field_values(
+                dir.to_str().unwrap(),
+                num_chunks,
+                &ledger,
+                field.category,
+                field_ix,
+                &dest_values_bin,
+            )?;
+```
+
+- [ ] **Step 3: Fix the unit tests in dense_merge.rs**
+
+Update the two passing tests (dense_merge.rs:325, :358) to pass `FieldCategory::Info` / `FieldCategory::Format` instead of `"finfo"`/`"fformat"`. **Delete** the `"bogus"` error test (dense_merge.rs:378 area) — the invalid state is now unrepresentable, so the test no longer compiles. Add `use crate::field::FieldCategory;` to the test module if needed.
+
+- [ ] **Step 4: Build + run affected tests**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib dense_merge'`
+Expected: PASS, no `unknown prefix` references remain.
+
+- [ ] **Step 5: Full Rust + Python guard**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion'` then `pixi run pytest tests/test_svar2_fields.py -q`
+Expected: all PASS (the same-name INFO/FORMAT test still green — category routing unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/dense_merge.rs src/orchestrator.rs
+git commit -m "refactor(svar2): type dense field merge by FieldCategory, not str prefix
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Extract shared offset + tile-gather helper (follow-up #1)
+
+`merge_mini_sc` (src/merge.rs:25) and `merge_var_key_field_values` (src/merge.rs:294) share (a) Phase-A per-column/per-chunk offset derivation and (b) the adaptive-tile, parallel pread→interleave→pwrite gather. The only real difference: `merge_mini_sc` moves two payload streams per item (pos u32 = 4 bytes, key = `key_bytes`), the field merge moves one (`item_width`). Model both as a **list of byte-payload streams** sharing one offset/tile schedule.
+
+**Files:**
+- Modify: `src/merge.rs` (add a private helper; rewrite both fns to call it)
+
+**Interfaces:**
+- Produces (private to `merge.rs`):
+  - `struct Payload<'a> { item_width: usize, chunk_files: &'a [File], dest: &'a File }` (one per byte-stream).
+  - `fn derive_offsets(num_chunks: usize, total_columns: usize, ram_ledger: &[Vec<u32>]) -> (Vec<u64>, Vec<Vec<u32>>)` returning `(final_offsets, chunk_offsets)`.
+  - `fn gather_columns(total_columns: usize, num_chunks: usize, ram_ledger: &[Vec<u32>], final_offsets: &[u64], chunk_offsets: &[Vec<u32>], payloads: &[Payload]) -> Result<(), ConversionError>` — the tile loop, byte-generic: for each tile allocate one `Vec<u8>` per payload sized `tile_items * item_width`, pread each chunk's slice, interleave column-major via per-column write heads (in items × item_width bytes), pwrite each payload's tile to its byte range.
+- Consumes: `TILE_RAM_BUDGET_BYTES`, `layout::*`, `read_exact_at`/`write_all_at` (already used).
+
+Note on positions: `merge_mini_sc` currently casts pos bytes to `&[u32]` for the copy, but the copy is a straight `copy_from_slice`; treating positions as raw 4-byte items in `gather_columns` is byte-identical. The `offsets.npy` write and the Phase-C chunk-file cleanup stay in `merge_mini_sc` (they are pos/key-specific and not shared).
+
+- [ ] **Step 1: Add `derive_offsets` and unit-test it against the inline arithmetic**
+
+Add `derive_offsets` to `src/merge.rs`, then add a test asserting it reproduces the existing inline result for a small ledger:
+
+```rust
+    #[test]
+    fn derive_offsets_matches_inline() {
+        // 2 chunks, 3 columns
+        let ledger = vec![vec![2u32, 0, 1], vec![1u32, 3, 0]];
+        let (final_offsets, chunk_offsets) = derive_offsets(2, 3, &ledger);
+        assert_eq!(final_offsets, vec![0, 3, 6, 7]); // col totals 3,3,1
+        assert_eq!(chunk_offsets[0], vec![0, 2, 2, 3]);
+        assert_eq!(chunk_offsets[1], vec![0, 1, 4, 4]);
+    }
+```
+
+- [ ] **Step 2: Run the offset test**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib merge::tests::derive_offsets_matches_inline'`
+Expected: PASS.
+
+- [ ] **Step 3: Add `gather_columns` and route `merge_var_key_field_values` through it**
+
+Rewrite `merge_var_key_field_values` to: `derive_offsets(...)`, create+`set_len` the dest file, open chunk field files, then call `gather_columns` with a single `Payload { item_width, chunk_files: &field_files, dest: &dest_file }`. Keep its existing behavior (no offsets.npy, no chunk cleanup — those belong to the pos/key merge).
+
+- [ ] **Step 4: Verify var_key field merge tests still pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib merge'`
+Expected: PASS — including the existing `merge_var_key_field_values` test (merge.rs:659) and all `merge_mini_sc` tests (still on the old code path at this point).
+
+- [ ] **Step 5: Route `merge_mini_sc` through the shared helpers**
+
+Rewrite `merge_mini_sc`'s Phase A to `derive_offsets(...)`, keep the `offsets.npy` write, then replace its inline tile loop with `gather_columns` given two payloads: `Payload { item_width: 4, chunk_files: &pos_files, dest: &final_pos_file }` and `Payload { item_width: key_bytes, chunk_files: &key_files, dest: &final_key_file }`. Keep Phase-C cleanup (`remove_file` chunk pos/key) after the gather. This requires opening pos and key chunk files as two separate `Vec<File>` (they are currently a `Vec<(File, File)>` — split into two vecs so each becomes a payload's `chunk_files`).
+
+- [ ] **Step 6: Full merge + orchestrator round-trip**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion'`
+Expected: ALL PASS — the `merge_mini_sc` tests (merge.rs:504-735) verify the pos/key output byte-for-byte, so this proves the refactor preserved behavior.
+
+- [ ] **Step 7: Python e2e guard**
+
+Run: `pixi run pytest tests/test_svar2_fields.py tests/test_svar2_from_vcf.py -q`
+Expected: PASS — real conversions produce identical stores.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/merge.rs
+git commit -m "refactor(svar2): share offset derivation + tile gather across merges
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Stage 3 — Baseline profile
+
+### Task 6: Capture a fields-enabled baseline (perf + callgrind)
+
+Measurement only — **no code change, no commit**. Establishes the pre-optimization cost of the finalize pass on a workload big enough for it to register.
+
+**Files:**
+- Create (throwaway, under `$CLAUDE_JOB_DIR/tmp`, not committed): `gen_big_vcf.py`, `drive_convert.py`
+
+**Interfaces:** none (scripts).
+
+- [ ] **Step 1: Synthesize a moderately large fields-carrying VCF**
+
+Write `$CLAUDE_JOB_DIR/tmp/gen_big_vcf.py` that emits a bgzipped, indexed VCF: 1 contig, ~200 samples, ~50,000 biallelic records (mix ~10% indels), each with `FORMAT DS` (Float, Number=1), `FORMAT DP` (Integer, Number=1), and `INFO AC` (Integer, Number=A). Use `vcfixture.VcfBuilder` if it scales, else write the text VCF directly and `bgzip`/`bcftools index`. This makes finalize handle millions of staged FORMAT calls.
+
+Run: `pixi run python $CLAUDE_JOB_DIR/tmp/gen_big_vcf.py $CLAUDE_JOB_DIR/tmp/big.vcf.gz`
+Expected: `big.vcf.gz` + index produced.
+
+- [ ] **Step 2: Build the profiling extension**
+
+Run: `pixi run bash -lc 'RUSTFLAGS="-C force-frame-pointers=yes" maturin develop --profile profiling'`
+Expected: builds `genoray_core` with release opt + debuginfo.
+
+- [ ] **Step 3: Write the driver**
+
+Write `$CLAUDE_JOB_DIR/tmp/drive_convert.py`:
+
+```python
+import sys, shutil
+from pathlib import Path
+from genoray import SparseVar2
+from genoray._svar2_fields import FormatField
+
+src, out = sys.argv[1], Path(sys.argv[2])
+if out.exists():
+    shutil.rmtree(out)
+SparseVar2.from_vcf(
+    out, src, no_reference=True, threads=1,
+    info_fields=["AC"], format_fields=[FormatField("DS", default=0.0), "DP"],
+)
+```
+
+(`threads=1` keeps callgrind's serial model honest; the finalize parallelism win is measured separately via wall-time in Task 7.)
+
+- [ ] **Step 4: perf record + report**
+
+Run:
+```bash
+pixi run bash -lc 'cd $CLAUDE_JOB_DIR/tmp && perf record -g --call-graph fp -o perf.data -- python drive_convert.py big.vcf.gz store.svar2 && perf report -i perf.data --stdio | head -60'
+```
+Expected: a symbolized profile. Record the % of samples inside `finalize`, `read_staged`, `scan`, `rewrite_file`, `encode`, and `merge_dense_field_values`.
+
+- [ ] **Step 5: callgrind for instruction counts**
+
+Run:
+```bash
+pixi run bash -lc 'cd $CLAUDE_JOB_DIR/tmp && valgrind --tool=callgrind --callgrind-out-file=cg.baseline.out python drive_convert.py big.vcf.gz store_cg.svar2 && callgrind_annotate cg.baseline.out | head -60'
+```
+Expected: instruction-retired breakdown. Record `Ir` totals for the finalize functions above. (Callgrind is slow — a smaller VCF, e.g. 50 samples × 10k records, is acceptable for the instruction ratio; note the size used.)
+
+- [ ] **Step 6: Record baseline wall time + peak RSS**
+
+Run:
+```bash
+pixi run bash -lc 'cd $CLAUDE_JOB_DIR/tmp && /usr/bin/time -v python drive_convert.py big.vcf.gz store_t.svar2 2>&1 | grep -E "Elapsed|Maximum resident"'
+```
+Expected: baseline wall-clock + peak RSS. **Write all baseline numbers into `$CLAUDE_JOB_DIR/tmp/BASELINE.md`** for Task 9's before/after table. No commit.
+
+---
+
+## Stage 4 — Optimize (byte-identical, guarded)
+
+### Task 7: Streaming + parallel finalize
+
+Cut the finalize pass's cost per Task 6's profile. Three changes, all byte-identical:
+1. **No `Vec<f64>` materialization** — scan and encode iterate over the raw byte buffer via `chunks_exact(4)`, never collecting an intermediate `Vec<f64>`.
+2. **Parallelize** — scan files with rayon and reduce `ScanStats`; rewrite files with rayon; run fields concurrently.
+3. **(Profile-gated) single read** — if Task 6 shows disk-read (not decode/encode) dominates, retain each file's raw `Vec<u8>` from the scan pass and reuse it in rewrite to avoid the second `std::fs::read`. If page cache makes reads free (decode/encode dominate), skip this and keep two reads to bound memory to one file per thread.
+
+**Files:**
+- Modify: `src/field_finalize.rs` — `finalize_fields` (84), `finalize_one` (95), `scan` (176), `read_staged` (139), `rewrite_file` (359)
+
+**Interfaces:**
+- `finalize_fields`/`finalize_one`/`resolve_dtype`/`ResolvedField` signatures unchanged (public shape preserved).
+- Internal: replace `read_staged(...) -> Vec<f64>` usage with a byte-iterating helper, e.g. `fn decode_elem(chunk: [u8;4], is_float: bool) -> f64` applied inside `scan`/`rewrite` loops over `bytes.chunks_exact(4)`.
+
+- [ ] **Step 1: Lock byte-identity — add a pre-refactor golden test**
+
+Add a finalize test that stages a mixed field (values forcing an auto-narrow, plus a staged-missing sentinel), captures the finalized bytes, and asserts them against a hard-coded expected byte vector — so any behavior drift in the refactor fails loudly:
+
+```rust
+    #[test]
+    fn finalize_auto_narrow_byte_golden() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // i32 staged values incl. one MISSING sentinel; auto -> narrow.
+        write_i32_field(root, "chr1", "AC", "var_key_snp", &[0, 5, 127, i32::MIN, 3]);
+        let field = int_field("AC", StorageDtype::Auto, None);
+        let resolved = finalize_fields(root, &[String::from("chr1")], &[field]).unwrap();
+        let path = root.join("chr1").join("fields").join("info").join("AC")
+            .join("var_key_snp").join("values.bin");
+        let got = read_values_bin(&path);
+        // Record the ACTUAL bytes+dtype from a run BEFORE editing scan/rewrite,
+        // then hard-code them here so the optimization must reproduce them.
+        // (Fill `expected` and `resolved[0].dtype` from the pre-refactor output.)
+        // assert_eq!(resolved[0].dtype, StorageDtype::__);
+        // assert_eq!(got, vec![__]);
+        let _ = (resolved, got);
+    }
+```
+
+Run it once on current code (`... --lib field_finalize::tests::finalize_auto_narrow_byte_golden -- --nocapture`), read the produced dtype+bytes, fill in the `expected`/dtype asserts, and re-run to confirm it passes on the un-optimized code. Commit this test in this step so it guards the next steps.
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib field_finalize::tests::finalize_auto_narrow_byte_golden'`
+Expected: PASS on current code.
+
+```bash
+git add src/field_finalize.rs
+git commit -m "test(svar2): golden byte-level guard for finalize auto-narrow
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 2: Remove the `Vec<f64>` materialization**
+
+Rewrite `scan` to iterate `bytes.chunks_exact(4)` decoding each element inline (via a small `decode_elem` helper) and folding into `ScanStats`, without building a `Vec<f64>`. Rewrite `rewrite_file` to read the bytes, then iterate `chunks_exact(4)` decoding+`encode`-ing directly into `out`. Keep `read_staged` only if still used; otherwise delete it and its length-check into the new helper (preserve the "not a multiple of 4 bytes" error).
+
+- [ ] **Step 3: Verify byte-identity + all finalize tests**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib field_finalize'`
+Expected: PASS — golden test + f32-noop + all existing narrow/overflow tests.
+
+- [ ] **Step 4: Parallelize scan/rewrite/fields with rayon**
+
+`finalize_fields`: `fields.par_iter().map(...).collect()`. `scan`: `files.par_iter()` producing per-file `ScanStats`, reduced with a combine (min/max/has_missing/observe merge — add `ScanStats::merge`). `finalize_one` rewrite loop: `files.par_iter().try_for_each(rewrite_file)`. Add `use rayon::prelude::*;`.
+
+- [ ] **Step 5: (Profile-gated) retain bytes to drop the second read**
+
+Only if Task 6 flagged read I/O as dominant: have the scan pass return `(ScanStats, Vec<(PathBuf, Vec<u8>)>)` and feed the retained bytes into rewrite. Otherwise skip — note the decision in the commit body.
+
+- [ ] **Step 6: Full guard (Rust + Python)**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion'` then `pixi run pytest tests/test_svar2_fields.py tests/test_svar2_from_vcf.py -q`
+Expected: ALL PASS. Byte-identity holds (golden + round-trip asserts).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/field_finalize.rs
+git commit -m "perf(svar2): stream + parallelize finalize, drop f64 materialization
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: (Conditional) Stream `merge_dense_field_values`
+
+Only if Task 6's profile shows `merge_dense_field_values` (dense_merge.rs:120) is a meaningful share. It currently reads every chunk file fully into one growing `Vec<u8>` before writing. Replace with a buffered chunk→dest copy to bound peak memory.
+
+**Files:**
+- Modify: `src/dense_merge.rs:120`
+
+- [ ] **Step 1: Decide from the profile**
+
+If `merge_dense_field_values` is < a few % of instructions/RSS in Task 6, **skip this task** and note "dense field merge not a hotspot — skipped" in Task 9's writeup. Otherwise continue.
+
+- [ ] **Step 2: Stream the concatenation**
+
+Open `dest` once; for each non-empty chunk (per `dense_ledger`), open the chunk file and `std::io::copy` it into a `BufWriter<File>` over dest, then remove the chunk file (preserve the existing skip-empty + cleanup semantics). Do not hold all bytes in one `Vec`.
+
+- [ ] **Step 3: Verify**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --features conversion --lib dense_merge'` then `pixi run pytest tests/test_svar2_fields.py -q`
+Expected: PASS (dense field bytes identical).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/dense_merge.rs
+git commit -m "perf(svar2): stream dense field merge to bound peak memory
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Stage 5 — cargo asm, re-profile & document
+
+### Task 9: Inspect codegen, re-profile, and write it up
+
+**Files:**
+- Modify: `CHANGELOG.md` (append under `## Unreleased`)
+- Verify (no edit expected): `skills/genoray-api/SKILL.md`
+
+- [ ] **Step 1: `cargo asm` on the hot inner loops**
+
+Inspect generated assembly for the per-element encode and the field-routing loop to confirm no surprise bounds checks / spills after the refactor:
+
+```bash
+pixi run bash -lc 'cargo asm --no-default-features --features conversion --rust genoray_core::field_finalize::encode 2>&1 | head -80'
+pixi run bash -lc 'cargo asm --no-default-features --features conversion --rust genoray_core::rvk::dense2sparse_vk 2>&1 | head -120'
+```
+Expected: readable asm. If `cargo asm` can't resolve the path, list candidates with `cargo asm --no-default-features --features conversion 2>&1 | grep -iE "encode|dense2sparse"` and use the exact printed symbol. Note any bounds-check in the innermost encode loop; if present and cheap to remove (e.g. via `chunks_exact`/slice pre-slicing), do so and re-run Task 7 Step 6's guard.
+
+- [ ] **Step 2: Re-profile with the same Task 6 workload**
+
+Rebuild (`RUSTFLAGS="-C force-frame-pointers=yes" maturin develop --profile profiling`) and re-run the perf, callgrind, and `/usr/bin/time -v` commands from Task 6 against the same `big.vcf.gz`. Capture finalize `Ir`, wall time, and peak RSS.
+
+- [ ] **Step 3: Build the before/after table**
+
+Compare against `$CLAUDE_JOB_DIR/tmp/BASELINE.md`. Compute deltas for: finalize callgrind `Ir`, total wall time, peak RSS. Confirm no regression in the reader path's share.
+
+- [ ] **Step 4: CHANGELOG entry**
+
+Append a human-readable line under `## Unreleased` in `CHANGELOG.md`, e.g.:
+
+```markdown
+- SVAR2 field write: finalize pass streams staged values (no intermediate f64
+  materialization) and runs in parallel across fields/files; DRY'd the var_key
+  and pos/key merges onto a shared tile-gather. Field output is byte-identical.
+  (finalize: <X>% fewer instructions, peak RSS <Y>→<Z>.)
+```
+
+Fill `<X>/<Y>/<Z>` from Step 3.
+
+- [ ] **Step 5: Confirm no public API drift**
+
+Verify no `import genoray` name changed (all edits were private modules `merge`/`dense_merge`/`field_finalize`, internal-only). Confirm `skills/genoray-api/SKILL.md` needs no change:
+
+Run: `git diff --name-only main...HEAD -- python/ | grep -v '_' || echo 'no public python surface touched'`
+Expected: no public (non-underscore) module changes → SKILL.md untouched. State this explicitly in the commit body.
+
+- [ ] **Step 6: Commit + push + update PR**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(svar2): changelog for field finalize/merge cleanup + perf
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git push
+```
+
+Then post the before/after table as a PR#100 comment (`gh pr comment 100 --body ...`). Do not merge.
+
+---
+
+## Notes
+
+Two untracked doc files from the PR#100 session sit in the worktree
+(`docs/superpowers/specs/2026-07-11-svar1-to-svar2-conversion-design.md`,
+`docs/superpowers/plans/2026-07-11-svar2-info-format-fields-write.md`). Left
+untouched unless the user asks to commit them.

--- a/docs/superpowers/specs/2026-07-11-svar2-info-format-fields-write-design.md
+++ b/docs/superpowers/specs/2026-07-11-svar2-info-format-fields-write-design.md
@@ -1,0 +1,279 @@
+# SVAR2 — writing INFO/FORMAT fields (spec #1 of 3)
+
+Status: **design, ready for spec review.** This is spec **#1** of a three-part
+effort:
+
+1. **(this doc) Write INFO/FORMAT fields** into SVAR2 at conversion time.
+2. **Read/output** those fields on `SparseVar2` (query/decode path) — separate spec.
+3. **SVAR1 → SVAR2** conversion — separate spec
+   ([`2026-07-11-svar1-to-svar2-conversion-design.md`](2026-07-11-svar1-to-svar2-conversion-design.md),
+   partial; unblocks once #1/#2 land).
+
+Date: 2026-07-11
+
+## Problem / motivation
+
+SVAR2 stores genotype **presence** only. It has no way to carry per-variant
+(INFO) or per-sample (FORMAT) numeric annotations — dosages, VAF, CCF, DP, GQ,
+etc. SVAR1 supported a narrow slice of this (dosages + `Number=G` FORMAT
+fields); SVAR2 has nothing. This spec adds a **general, source-agnostic
+write mechanism** for scalar-numeric INFO and FORMAT fields, modeled on the
+existing mutcat sidecar. Dosage is the first concrete consumer (needed by spec
+#3's SVAR1→SVAR2 migration), but the mechanism is not dosage-specific.
+
+## Scope
+
+**In:**
+- Scalar-numeric **INFO** (per-variant) and **FORMAT** (per-call) fields.
+- `Integer` (logically `i32`), `Float` (`f32`), and `Flag` (`bool`, INFO-only)
+  header types; `Number=1` and biallelic-split `Number=A` arity.
+- Per-field storage-dtype selection with lossless integer auto-narrowing and an
+  opt-in lossy `f16`, both range-/type-validated at conversion time.
+- Extraction in `from_vcf` (Rust/htslib) and the storage/plumbing/merge layer.
+  The layer is source-agnostic so spec #3 can feed it from SVAR1 arrays.
+
+**Out (deferred):**
+- The **read/output** path (spec #2).
+- Multi-valued arities (`Number=R`, `Number=G`, `Number=.`) and
+  String/Character fields (need ragged offsets / a byte-bank — future).
+- The **independent/lossless FORMAT stream** (see §3, Option B) — deferred to
+  avoid downstream ripple; v1 is genotype-aligned only.
+
+## Background
+
+- **Sidecar precedent (mutcat)**: `src/mutcat/sidecar.rs` writes per-contig,
+  per-sub-stream SoA arrays positionally aligned to each sub-stream's records;
+  `src/layout.rs` owns all paths. Fields follow the same shape.
+- **Pipeline stages** (`src/orchestrator.rs`, `src/types.rs`): reader →
+  `DenseChunk (V,S,P)` → `dense2sparse_vk` (cost-routes each variant to var_key
+  or dense) → `SparseChunk { streams: var_key…, dense: DenseSubChunk… }` →
+  `merge_mini_sc` → writer. **Unlike mutcat, fields cannot be a post-pass** —
+  their values exist only in the source and must ride this pipeline to stay
+  aligned to the finalized records.
+- **var_key vs dense** (`src/cost_model.rs`): var_key stores per **call**
+  (sample-major: `SparseSubStream` with `call_positions` + per-hap
+  `sample_lengths`); dense stores a per-**variant** table + a hap-major 1-bit
+  genotype matrix. The cost model routes by carrier count `x`.
+
+## Design
+
+### 1. Public API
+
+`from_vcf` gains two parameters; a bare `str` uses inferred defaults, a config
+object overrides them:
+
+```python
+@dataclass(frozen=True)
+class InfoField:
+    name: str
+    dtype: FieldDtype | None = None   # None → auto (see §2)
+    default: float | int | None = None  # missing-fill value
+
+@dataclass(frozen=True)
+class FormatField:
+    name: str
+    dtype: FieldDtype | None = None
+    default: float | int | None = None  # missing-fill; genotype-aligned (§3)
+
+FieldDtype = Literal["bool","i8","u8","i16","u16","i32","u32","f16","f32"]
+
+@classmethod
+def from_vcf(cls, ...,
+    info_fields: Sequence[str | InfoField] | None = None,
+    format_fields: Sequence[str | FormatField] | None = None,
+) -> int: ...
+```
+
+Separate INFO/FORMAT lists (a name may exist in both). `default`, when set, is
+the value written for VCF-missing entries. (For FORMAT under the
+genotype-aligned model in §3, `default` is purely the missing-fill — it does
+**not** trigger omission in v1, since Option B is deferred.)
+
+### 2. Field typing, dtype selection, validation
+
+Storage dtype is resolved per field against the VCF header **and** the observed
+data:
+
+- **`dtype=None` (default):**
+  - Integer/Flag → **losslessly auto-narrowed**: chunks carry `i32`; a
+    **global finalize pass** (after all per-contig merges) observes the
+    field's global `[min,max]` across all contigs (and whether any missing
+    occurred) and writes the smallest width that fits the range plus a
+    reserved missing sentinel; per-contig storage is uniform because dtype is
+    global in `meta.json`. Integer narrowing is lossless, so it is safe to
+    automate.
+  - Float → **`f32`** (the source precision; never auto-downcast to `f16`).
+- **Explicit `dtype`:** validated on two axes at conversion time —
+  - *Header-type compat:* Integer → any int/`bool` width; Float → `f16`/`f32`;
+    Flag → `bool`/`u8`. Reject Float→int, int→Float, etc.
+  - *Observed-range compat:* every value is already scanned during extraction,
+    so overflow of the requested width (or a nonzero fraction stored to an int)
+    is an error (loud, not silent).
+- **`f16`** is the only lossy option and must be requested explicitly; overflow
+  of the `f16` range (~65504) errors.
+
+**Why not read BCF's adaptive int width?** BCF's int8/16/32 descriptor is
+**per record**, not per field, and rust-htslib's safe API decodes into a
+requested width rather than exposing the descriptor. It cannot yield a single
+columnar width. Observing the global range during our existing extraction scan
+gives the same "smallest int" result, authoritatively, at merge time.
+
+**Missing values:** map to the field's `default` if set, else to the width's
+reserved sentinel — `NaN` for `f16`/`f32`, `INT*_MIN` (per chosen width) for
+ints. Flag never missing (absent ⟺ `false`).
+
+### 3. Storage model — genotype-aligned (Option A)
+
+**Chosen: no independent field positions in either representation** — the field
+reuses whatever structure the genotype rep already has. This is what
+"genotype-aligned" means here, and it differs by representation:
+
+- **var_key:** FORMAT values ride the genotype *calls* — one value per call,
+  the per-sample value broadcast across that sample's carrier haplotypes (exactly
+  SVAR1's `broadcast(dosages)[genos==1]`). Array is parallel to `call_positions`,
+  no new positions.
+- **dense:** FORMAT is stored as a **full per-sample column** (`n_samples`
+  values per dense variant), O(1)-indexable by sample with no popcount/offsets,
+  matching how the dense genotype already stores a full `np`-bit "everyone"
+  mask. Non-carrier slots hold `default`, keeping read semantics uniform with
+  var_key. No positions needed — the column is dense.
+
+Both preserve the strictly sample-major layout and neither introduces a separate
+field position stream.
+
+Granularity, per representation:
+
+| | var_key (per call, sample-major) | dense |
+| --- | --- | --- |
+| **INFO** (per-variant) | value duplicated per call → `width·x` | 1 value / variant → `width` |
+| **FORMAT** (per-call) | 1 value / call → `width·n_calls` (`= width·x`) | full per-sample column → `width·n_samples` |
+
+**Deferred — Option B (independent/lossless FORMAT stream):** storing a FORMAT
+field as its *own* sample-major sparse sub-stream (per-hap positions + values,
+keyed on the field's non-`default` set rather than the carrier set) would be
+lossless for decoupled fields (e.g. imputed dosage nonzero at ref-genotype
+samples). It ripples through routing, merge, decode, and query, so it is
+**out of scope for v1**. Consequence documented for users: FORMAT values at
+non-carrier samples are dropped.
+
+### 4. Cost model
+
+Generalize the existing scalar `sidecar_bits` in `choose_representation`
+(`src/cost_model.rs`) to per-representation field sums:
+
+```
+var_key_bits = x·(POS+key) + Σ_info width_i·x + Σ_fmt width_f·x
+dense_bits   = POS+key+np  + Σ_info width_i   + Σ_fmt width_f·n_samples
+```
+
+- **INFO shifts the crossover toward dense** (`width_i·x` in var_key vs
+  `width_i` once in dense — real amortization).
+- **FORMAT also shifts toward dense for high-carrier variants** — var_key pays
+  `width_f·x` (per carrier call) while dense pays `width_f·n_samples` (full
+  column). It does **not** cancel: dense is chosen when `x` is large (up to
+  `np ≥ n_samples`), so FORMAT reinforces the genotype routing rather than being
+  neutral to it.
+
+So both an `info_bits` (per-variant amortizable) and a `format_bits`
+(`width·x` var_key / `width·n_samples` dense) term feed `choose_representation`,
+threaded through the pipeline as the existing sidecar-bits knob generalizes.
+
+### 5. On-disk layout + `meta.json`
+
+Under each contig, mirroring mutcat (`src/layout.rs` owns the paths):
+
+```
+{contig}/fields/{name}/var_key_snp/values.bin     # 1 / call   (INFO dup'd; FORMAT per call)
+{contig}/fields/{name}/var_key_indel/values.bin
+{contig}/fields/{name}/dense_snp/values.bin        # INFO: 1 / variant; FORMAT: full n_samples column / variant
+{contig}/fields/{name}/dense_indel/values.bin
+```
+
+`values.bin` is a raw little-endian array in the resolved storage dtype, its
+length and alignment determined by the sub-stream and category: **var_key** →
+one value per call (INFO duplicated; FORMAT per carrier call); **dense INFO** →
+one value per dense variant; **dense FORMAT** → an `n_samples`-long per-sample
+column per dense variant (`n_samples · n_dense_variants` total, sample-indexed,
+non-carrier slots = `default`). No offsets are needed for any scalar field —
+each is a fixed stride from `n_samples`/`n_dense_variants`/call counts already
+in the layout.
+
+`meta.json` gains a `fields` array (one entry per stored field), consumed by
+spec #2's reader:
+
+```json
+"fields": [
+  {"name": "DS", "category": "format", "dtype": "f32", "default": 0.0},
+  {"name": "AF", "category": "info",   "dtype": "f16", "default": null}
+]
+```
+
+### 6. Reader extraction (`from_vcf`, Rust/htslib)
+
+The VCF reader (`src/vcf_reader.rs`) reads the declared fields per record:
+- **INFO:** one scalar per variant. For biallelic-split `Number=A`, take the
+  split allele's element; `Number=1` is the scalar; Flag → bool presence.
+- **FORMAT:** the per-sample vector; `Number=1` → one scalar per sample, later
+  broadcast to that sample's carrier haps at routing. Missing → `default`/sentinel.
+- The header supplies `Type`/`Number` for validation (§2); a field absent from
+  the header, or non-scalar arity, errors before conversion starts.
+
+### 7. Pipeline plumbing (the bulk of the work)
+
+- **`DenseChunk`** (`src/types.rs`) gains typed field columns: INFO per-variant
+  (`len V`) and FORMAT per-sample-per-variant (`len V·n_samples`, source is
+  per-sample) for each requested field. Type-erased byte columns tagged by dtype.
+- **`dense2sparse_vk`** routes field values alongside genotypes in the existing
+  passes: on a var_key call push the call's field value(s); on a dense variant
+  push INFO once (per variant) and FORMAT as the full `n_samples`-long per-sample
+  column (carrier samples' values, `default` elsewhere). Arrays stay aligned by
+  construction.
+- **`SparseSubStream` / `DenseSubChunk`** gain parallel field arrays; the
+  **chunked writer** writes per-chunk field files; **`merge_mini_sc`**
+  generalizes to move field columns with their records (and performs the
+  integer auto-narrowing in §2, since it is the stage that sees the whole
+  contig).
+
+### 8. Memory
+
+htslib hands FORMAT out densely per record, so a per-chunk `V·n_samples·width`
+block per FORMAT field is materialized transiently (≈100 MB for
+`chunk_size=25k`, `n_samples=1000`, `f32`). Bounded but real: document it and
+auto-shrink `chunk_size` when `format_fields` is non-empty (or expose a knob).
+INFO adds only `V·width` per field — negligible.
+
+## Testing strategy
+
+- **Rust unit tests:** dtype resolution + validation (header-compat matrix,
+  range overflow errors, `f16` overflow, auto-narrow width selection incl.
+  sentinel reservation); routing unchanged by FORMAT bits, shifted by INFO bits
+  (`choose_representation` tests); field-array alignment through
+  `dense2sparse_vk` for mixed var_key/dense routing.
+- **e2e (`tests/test_e2e.rs` + a Python test):** `from_vcf(info_fields=…,
+  format_fields=…)` on a fixture writes `fields/…/values.bin` with the expected
+  lengths, dtypes, and values; missing → `default`/sentinel; FORMAT values match
+  the source at carriers and are absent at non-carriers (documented Option-A loss).
+- **Merge/auto-narrow:** integer field with values spanning multiple chunks
+  narrows to the correct global width; a wider-than-`u8` value forces `i16`; etc.
+- Read-side round-trip is deferred to spec #2's tests.
+
+## Documentation / housekeeping
+
+- `skills/genoray-api/SKILL.md` — new `InfoField`/`FormatField` public types and
+  the `from_vcf(info_fields=, format_fields=)` kwargs (mandatory per the
+  public-API rule in `CLAUDE.md`).
+- CHANGELOG entry under `## Unreleased` (Conventional Commits `feat:`).
+- Reconcile the SVAR2 roadmap/data-model docs with the new `fields/` layout and
+  `meta.json` schema.
+
+## Open questions (settle in the plan)
+
+- Exact `values.bin` file naming + whether `fields/` sits beside or under
+  `mutcat/` conventions (defer to `src/layout.rs`).
+- Type-erasure representation for field columns on `DenseChunk`/`SparseChunk`
+  (tagged enum vs trait object) — pick the one that keeps the hot routing loop
+  monomorphized.
+- Whether the missing-sentinel reservation shrinks the auto-narrow range only
+  when missing values are actually observed (measure) or always (simpler).
+- Interaction with `signatures=True` (both add per-record sidecars; confirm the
+  cost-model knobs compose).

--- a/docs/superpowers/specs/2026-07-12-svar2-fields-followup-cleanup-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-12-svar2-fields-followup-cleanup-optimization-design.md
@@ -1,0 +1,165 @@
+# SVAR2 INFO/FORMAT fields — PR#100 follow-ups, cleanup & field-path optimization
+
+**Date:** 2026-07-12
+**Branch:** `worktree-svar2-field-specs` (open PR #100)
+**Status:** Design approved; ready for implementation plan.
+
+## Context
+
+PR #100 added the **write path** for scalar-numeric INFO (per-variant) and FORMAT
+(per-call) fields to `SparseVar2.from_vcf` (spec #1 of the 3-part SVAR2 fields
+effort). It is functionally complete and green, but its PR body lists three
+deferred follow-ups, and a code survey surfaced a few concrete smells plus one
+clear field-specific performance target.
+
+This spec covers a single round of polish on that branch: close the follow-ups,
+DRY/clean the new code, and run a **measurement-driven** optimization pass scoped
+to the field-write code this PR newly adds. All work lands as new commits on the
+existing PR #100 branch.
+
+### Explicitly out of scope
+
+- **The reader/htslib path.** Prior profiling established VCF→SVAR2 conversion is
+  reader-bound (htslib inflate+parse ~78%), and that path already received a
+  GT-decode + per-word-pack + parallel-pack optimization round. We do not
+  re-open it here.
+- The read/query path for fields (that is spec #2 of the effort).
+- Any public API change. No new/renamed/removed names reachable from
+  `import genoray`; `skills/genoray-api/SKILL.md` is expected to need no change
+  (to be confirmed at close-out).
+
+## Sequencing
+
+Work is ordered so the risky stages (refactor, optimize) run under a test safety
+net, and so the optimization is bracketed by before/after measurements:
+
+1. **Lock behavior** — add the missing tests (follow-ups #2, #3).
+2. **DRY & cleanup** — follow-up #1 + surveyed smells, refactor kept green.
+3. **Baseline profile** — capture perf + callgrind on a fields-enabled run.
+4. **Optimize** — measurement-driven, output byte-identical, kept green.
+5. **Re-profile & document** — report before/after, update CHANGELOG.
+
+Each stage ends with both suites green:
+`cargo test --no-default-features --features conversion` and `pixi run test`.
+
+## Stage 1 — Tests first (follow-ups #2, #3)
+
+Add coverage the PR body flagged, *before* refactoring so it guards the changes:
+
+- **Combined `signatures=True` + fields e2e.** A `from_vcf` round-trip with
+  `signatures=True` and both `info_fields` and `format_fields` set. Cost terms are
+  additive/orthogonal; this confirms they compose end-to-end.
+- **`VarKeyIndel` `field_calls` path.** The var_key-indel sub-label is currently
+  untested; add a case that routes an indel through it and asserts stored values.
+- **Multi-field ordering.** ≥2 fields of each category; assert each field's
+  per-`values.bin` content is correct and fields do not cross-contaminate.
+- **`f32→f32` no-op rewrite.** Finalize on an already-concrete `f32` field
+  (the rewrite-to-same-dtype path).
+
+These are Rust unit/integration tests and/or Python e2e tests, matching where the
+existing field tests live (`field_finalize.rs` tests, `tests/`, and the Python
+`from_vcf` round-trip test).
+
+## Stage 2 — DRY & cleanup
+
+### Follow-up #1: DRY the two merges
+
+`merge_mini_sc` (`src/merge.rs:25`) and `merge_var_key_field_values`
+(`src/merge.rs:294`) share:
+
+- **Phase A** — global per-column offset derivation + per-chunk local offsets from
+  the RAM ledger (identical arithmetic; the code comment at merge.rs:307 flags the
+  deliberate duplication).
+- **Phase B** — the adaptive-tile, parallel pread→interleave→pwrite gather loop.
+
+Extract a shared helper parameterized by item width and the per-item transfer so
+both call sites use it. `merge_mini_sc` moves two payloads per item (pos u32 + key
+`key_bytes`), `merge_var_key_field_values` moves one (`item_width`); the helper
+must express that difference cleanly (e.g. a slice of `(src_file, item_width,
+dest_file)` payloads sharing one offset/tile schedule) rather than by widening to
+`Any`-style dynamic dispatch. Target: eliminate the ~110 duplicated lines while
+keeping the working pos/key merge behavior identical.
+
+### Stringly-typed prefix → enum
+
+`merge_dense_field_values` (`src/dense_merge.rs:120`) takes `prefix: &str` and
+matches `"finfo"`/`"fformat"` at runtime, returning a `ConversionError::Input` on
+anything else. Replace with the existing `FieldCategory` enum (`src/field.rs`),
+selecting the chunk-path builder by variant. Makes the invalid state
+unrepresentable and removes the runtime error branch.
+
+### Minor
+
+While in these files, audit remaining `&str` sub-labels / field naming and tidy
+only where it is a clear win. No speculative refactors, no gold-plating.
+
+## Stages 3–5 — Field-path optimization (measured)
+
+### Baseline (Stage 3)
+
+Build with the existing profiling profile:
+
+```
+RUSTFLAGS="-C force-frame-pointers=yes" maturin develop --profile profiling
+```
+
+Run `SparseVar2.from_vcf` with `info_fields`/`format_fields` enabled on the
+`gen_from_vcf.sh` test data, via a throwaway driver in `$CLAUDE_JOB_DIR/tmp`
+(no committed benchmark). Capture with `perf` (sampling / flamegraph) and
+`callgrind` (instruction-level). Record the field-code cost share as the baseline.
+
+### Prime target: `src/field_finalize.rs`
+
+The global finalize pass is the newest field-specific cost and is independent of
+the reader-bound story. Three concrete issues:
+
+1. **Double disk read.** `finalize_one` calls `scan(&files, …)` then, per file,
+   `rewrite_file(…)`, and both call `read_staged`, so every staged `values.bin` is
+   read from disk twice. Fuse to a single read (or `mmap` the file and make two
+   passes over one in-memory buffer).
+2. **Full `Vec<f64>` materialization.** `read_staged` collects the whole file into
+   a `Vec<f64>` (2× on-disk size) — for FORMAT fields that is O(total carrier
+   calls). Iterate over the byte buffer instead of collecting.
+3. **Serial.** `finalize_fields` maps over fields serially and each field's
+   file loop is serial, while the rest of the pipeline is rayon-parallel.
+   Parallelize across fields and/or files.
+
+Constraint: on-disk output must be **byte-for-byte identical** to the current
+finalize. The new multi-field/no-op tests plus the existing round-trip assertions
+verify this.
+
+### Secondary target: `merge_dense_field_values`
+
+Currently reads each chunk file fully into one growing `Vec<u8>` and writes the
+concatenation. Stream chunk→dest (buffered copy) to bound peak memory. Apply only
+if the baseline profile shows it is worth it.
+
+### `cargo asm`
+
+After the changes, inspect generated code for the hot inner loops — `encode`
+(`field_finalize.rs:399`) and the field-routing loop in `dense2sparse_vk` — to
+confirm codegen (no surprise bounds checks / spills) on the per-element path.
+
+### Close-out (Stage 5)
+
+- Re-profile the same fields-enabled run; report before/after: callgrind
+  instructions retired, wall-time, and peak RSS for the finalize stage.
+- Add a human-readable entry under `## Unreleased` in `CHANGELOG.md`.
+- Confirm no `skills/genoray-api/SKILL.md` change is required (no public surface
+  touched).
+
+## Guardrails & success criteria
+
+- Both test suites green at the end of every stage.
+- Optimization produces byte-identical SVAR2 field output vs. pre-optimization.
+- Measured, reported reduction in the field-code cost share of a fields-enabled
+  conversion (finalize instructions/RSS the headline metric); no regression in the
+  reader path.
+- No public API surface change.
+
+## Notes
+
+Two untracked doc files sit in the worktree from the PR #100 session
+(`docs/superpowers/specs/2026-07-11-svar1-to-svar2-conversion-design.md` and
+`docs/superpowers/plans/2026-07-11-svar2-info-format-fields-write.md`). Left
+untouched unless the user decides to commit them.

--- a/python/genoray/__init__.py
+++ b/python/genoray/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
     "Filter",
     "SparseVar",
     "SparseVar2",
+    "InfoField",
+    "FormatField",
     "exprs",
     "fit_signatures",
     "cosmic_signatures",
@@ -33,6 +35,8 @@ _LAZY: dict[str, tuple[str, str | None]] = {
     "Filter": ("genoray._vcf", "Filter"),
     "SparseVar": ("genoray._svar", "SparseVar"),
     "SparseVar2": ("genoray._svar2", "SparseVar2"),
+    "InfoField": ("genoray._svar2_fields", "InfoField"),
+    "FormatField": ("genoray._svar2_fields", "FormatField"),
     "exprs": ("genoray.exprs", None),
     "fit_signatures": ("genoray._signatures", "fit_signatures"),
     "cosmic_signatures": ("genoray._signatures", "cosmic_signatures"),
@@ -57,5 +61,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ._signatures import fit_signatures as fit_signatures
     from ._svar import SparseVar as SparseVar
     from ._svar2 import SparseVar2 as SparseVar2
+    from ._svar2_fields import FormatField as FormatField
+    from ._svar2_fields import InfoField as InfoField
     from ._vcf import Filter as Filter
     from ._vcf import VCF as VCF

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from natsort import natsorted
 
 import genoray._core as _core
 from genoray._svar2_batch import _BatchQueryMixin
 from genoray._svar2_decode import _DecodeMixin
+from genoray._svar2_fields import _resolve_fields
 from genoray._svar2_mutcat import _MutcatMixin
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from genoray._svar2_fields import FormatField, InfoField
 
 
 def _ensure_bgzipped(source: Path) -> None:
@@ -71,6 +78,8 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         overwrite: bool = False,
         long_allele_capacity: int = 8 * 1024 * 1024,
         signatures: bool = False,
+        info_fields: Sequence[str | InfoField] | None = None,
+        format_fields: Sequence[str | FormatField] | None = None,
     ) -> int:
         """Convert a bgzipped VCF or BCF to an SVAR2 store.
 
@@ -84,6 +93,15 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         signatures: if True, classify SBS96/ID83 codes during the write and
         store the mutcat sidecar (factored into the dense/var_key cost model).
         Requires a reference; raises if `no_reference=True`.
+
+        info_fields, format_fields: scalar-numeric (Integer/Float, and Flag for
+        INFO) header fields to carry through to the SVAR2 store. Each entry is
+        either a bare field name (dtype auto-narrowed from the header, no
+        default fill) or an :class:`InfoField`/:class:`FormatField` spec
+        (explicit `dtype`/`default`). `default` fills VCF-missing entries;
+        otherwise a reserved sentinel/NaN is written. FORMAT fields are
+        genotype-aligned: non-carrier values are dropped for var_key-routed
+        variants.
         """
         from cyvcf2 import VCF as _CyVCF
 
@@ -113,6 +131,9 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             raise ValueError(f"No variants found in {source}.")
 
         reference_path = None if no_reference else str(reference)
+        flds = _resolve_fields(str(source), info_fields, format_fields)
+        info = [t for t in flds if t[1] == "info"]
+        format_ = [t for t in flds if t[1] == "format"]
         return _core.run_conversion_pipeline(
             str(source),
             reference_path,
@@ -125,4 +146,6 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             long_allele_capacity,
             skip_out_of_scope,
             signatures,
+            info,
+            format_,
         )

--- a/python/genoray/_svar2_fields.py
+++ b/python/genoray/_svar2_fields.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from cyvcf2 import VCF as _CyVCF
+
+FieldDtype = Literal["bool", "i8", "u8", "i16", "u16", "i32", "u32", "f16", "f32"]
+
+_INT_DTYPES = {"bool", "i8", "u8", "i16", "u16", "i32", "u32"}
+_FLOAT_DTYPES = {"f16", "f32"}
+
+
+@dataclass(frozen=True)
+class InfoField:
+    """A per-variant INFO field to store in the SVAR2 output.
+
+    ``dtype=None`` infers storage from the header (Integer→lossless auto-narrow,
+    Float→f32, Flag→bool). ``default`` is the value written for VCF-missing
+    entries (else a reserved sentinel/NaN).
+    """
+
+    name: str
+    dtype: FieldDtype | None = None
+    default: float | int | None = None
+
+
+@dataclass(frozen=True)
+class FormatField:
+    """A per-sample FORMAT field to store in the SVAR2 output. Genotype-aligned:
+    only carrier calls (var_key) or a full per-sample dense column are stored;
+    non-carrier values in var_key-routed variants are dropped. Same ``dtype``/
+    ``default`` semantics as :class:`InfoField`.
+    """
+
+    name: str
+    dtype: FieldDtype | None = None
+    default: float | int | None = None
+
+
+def _htslib_type(header_type: str) -> str:
+    match header_type:
+        case "Integer":
+            return "int"
+        case "Float":
+            return "float"
+        case "Flag":
+            return "flag"
+        case other:
+            raise ValueError(
+                f"field Type={other!r} is unsupported (need Integer/Float/Flag)"
+            )
+
+
+def _check_dtype_compat(name: str, htype: str, dtype: str | None) -> None:
+    if dtype is None:
+        return
+    if htype in ("int", "flag") and dtype not in _INT_DTYPES:
+        raise ValueError(f"field {name!r} ({htype}) incompatible with dtype {dtype!r}")
+    if htype == "float" and dtype not in _FLOAT_DTYPES:
+        raise ValueError(f"field {name!r} (float) incompatible with dtype {dtype!r}")
+
+
+def _resolve_one(
+    vcf: _CyVCF, spec: str | InfoField | FormatField, category: str
+) -> tuple[str, str, str, str | None, float | None]:
+    field = spec if not isinstance(spec, str) else None
+    name = spec if isinstance(spec, str) else spec.name
+    try:
+        hdr = vcf.get_header_type(name)  # {'HeaderType','Type','Number',...}
+    except KeyError:
+        raise ValueError(f"field {name!r} not found in the VCF header") from None
+    number = str(hdr.get("Number"))
+    htype = _htslib_type(hdr["Type"])
+    if htype == "flag":
+        if category != "info":
+            raise ValueError(f"Flag field {name!r} is INFO-only")
+    elif number not in ("1", "A"):
+        raise ValueError(
+            f"field {name!r} has Number={number}; only scalar Number=1 or "
+            "biallelic-split Number=A are supported"
+        )
+    dtype = None if field is None else field.dtype
+    default = (
+        None
+        if field is None
+        else (None if field.default is None else float(field.default))
+    )
+    _check_dtype_compat(name, htype, dtype)
+    return (name, category, htype, dtype, default)
+
+
+def _resolve_fields(
+    vcf_path: str,
+    info_fields: Sequence[str | InfoField] | None,
+    format_fields: Sequence[str | FormatField] | None,
+) -> list[tuple[str, str, str, str | None, float | None]]:
+    vcf = _CyVCF(vcf_path)
+    try:
+        out: list[tuple[str, str, str, str | None, float | None]] = []
+        for spec in info_fields or []:
+            out.append(_resolve_one(vcf, spec, "info"))
+        for spec in format_fields or []:
+            out.append(_resolve_one(vcf, spec, "format"))
+        return out
+    finally:
+        vcf.close()

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -300,9 +300,10 @@ Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_ou
     range, raises `ValueError`. `f16` is the only lossy option and must be
     requested explicitly.
   - **`default`** — the value written for VCF-missing entries; otherwise a
-    reserved sentinel (`NaN` for float widths, the width-specific
-    `INT*_MIN` for ints). `Flag` fields are never missing (absent ⇒
-    `false`/`0`).
+    reserved sentinel at the extreme of the chosen width (`INT*_MIN` for
+    signed widths, `u*::MAX` for unsigned widths — auto-narrowing prefers
+    unsigned when the observed range is non-negative — and `NaN` for float
+    widths). `Flag` fields are never missing (absent ⇒ `false`/`0`).
   - **FORMAT is genotype-aligned, not independently lossless**: a FORMAT
     value is stored only where the genotype has a call — one value per
     carrier call in var_key-routed variants, or a full dense per-sample

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -17,7 +17,8 @@ description: Use when writing or modifying Python code that imports `genoray` to
 - `genoray.VCF` — VCF/BCF reader
 - `genoray.Filter` — VCF filter value object bundling a cyvcf2 record predicate (`record`) with its matching `.gvi` polars expression (`expr`)
 - `genoray.SparseVar` — sparse `.svar` reader/writer
-- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`)
+- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`; scalar-numeric INFO/FORMAT field extraction during the write via `from_vcf(info_fields=, format_fields=)`)
+- `genoray.InfoField` / `genoray.FormatField` — frozen dataclasses (`name`, `dtype=None`, `default=None`) configuring a single INFO/FORMAT field for `SparseVar2.from_vcf`; a bare `str` name uses inferred defaults instead
 - `genoray.exprs` — polars filter expressions for `.gvi` indexes
 - `genoray.cosmic_signatures` — fetch/cache COSMIC reference signatures
 - `genoray.fit_signatures` — sparse forward-selection signature refit
@@ -35,7 +36,8 @@ Prefer reading these over guessing:
 - `genoray/_vcf.py` — `VCF` class: constructor, `read`, `chunk`, mode constants near the top of the class; `get_record_info(contig=None, start=None, end=None, fields=None, info=None, lazy=False)` — non-FORMAT record-level fields (including INFO) for a range or the whole file, returns `pl.DataFrame` (or `pl.LazyFrame` when `lazy=True`)
 - `genoray/_pgen.py` — `PGEN` class: constructor, `read`, `chunk`, `read_ranges`, `chunk_ranges`, mode constants near the top of the class
 - `genoray/_svar.py` — `SparseVar`: `__init__`, `from_vcf`, `from_pgen`, `read_ranges`, `read_ranges_with_length(contig, starts=0, ends=POS_MAX, samples=None)` (length-guaranteed range read; returns the same type as `read_ranges` — a `Ragged` or fields-augmented record), `with_fields`, `annotate_mutations`, `mutation_matrix`, `assign_signatures`, `annotate_with_gtf(gtf, level_filter=1, write_back=True, *, strand_encoding=None, codon_null_token=None)` (GTF CDS annotation entry point, returns `pl.DataFrame` with `varID`/`gene_id`/`strand`/`codon_pos`), `cache_afs()` (computes and persists an `AF` column to the `.gvi` index; returns `None`)
-- `genoray/_svar2.py` — `SparseVar2`: `__init__`, `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode`, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
+- `genoray/_svar2.py` — `SparseVar2`: `__init__`, `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write, `info_fields=`/`format_fields=` extract scalar-numeric fields during the write); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode`, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
+- `genoray/_svar2_fields.py` — `InfoField`/`FormatField` dataclasses + `FieldDtype` and the header/dtype validation used by `from_vcf(info_fields=, format_fields=)` (no public read-side API yet)
 - `genoray/_cli/__main__.py` — the `genoray` CLI (`index`, `write` / `write svar1`, `view`)
 - `genoray/_signatures.py` — `cosmic_signatures`, `fit_signatures`
 - `genoray/_reference.py` — `Reference`: `from_path`, `fetch`, `contig_array`
@@ -244,7 +246,7 @@ dropped = SparseVar2.from_vcf(
 dropped = SparseVar2.from_vcf("out.svar2", "file.vcf.gz", no_reference=True)
 ```
 
-Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False) -> int`
+Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None) -> int`
 
 - `source` — a bgzipped VCF (`.vcf.gz`) or BCF (`.bcf`). **VCF/BCF only** — no PGEN
   source yet (roadmap M7). Auto-indexes (`.csi`) if no `.csi`/`.tbi` is found.
@@ -268,6 +270,50 @@ Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_ou
   `mutcat` sidecar yet (unlike `SparseVar.annotate_mutations`/
   `mutation_matrix`, below) — this flag only controls whether the sidecar is
   written.
+- `info_fields=`/`format_fields=` — `Sequence[str | InfoField]` /
+  `Sequence[str | FormatField]`, `None` by default. Extracts **scalar-numeric**
+  INFO/FORMAT fields into the store during the write:
+
+  ```python
+  from genoray import SparseVar2, InfoField, FormatField
+
+  SparseVar2.from_vcf(
+      "out.svar2", "file.vcf.gz", "ref.fa",
+      info_fields=["AC", InfoField("AF", dtype="f16")],
+      format_fields=[FormatField("DS", default=0.0)],
+  )
+  ```
+
+  - **Scope: scalar-numeric only.** Header `Type` must be `Integer`, `Float`,
+    or `Flag`; `Number` must be `1`, biallelic-split `A`, or `0` (`Flag`,
+    INFO-only). Anything else (`Number=R`/`G`/`.`, `String`/`Character`
+    fields) raises `ValueError` at config time, before conversion starts. A
+    bare `str` name uses inferred defaults (`dtype=None`, no `default`); pass
+    an `InfoField`/`FormatField` to override.
+  - **`dtype`** (`FieldDtype = Literal["bool","i8","u8","i16","u16","i32","u32","f16","f32"]`):
+    `None` (default) auto-resolves — `Integer`/`Flag` are **losslessly
+    auto-narrowed** to the smallest width fitting the observed global range
+    (plus a reserved missing sentinel); `Float` always resolves to `f32`
+    (never silently downcast). An explicit `dtype` is validated at
+    conversion time against both the header type (e.g. `Float` cannot target
+    an int width) and the observed range — overflow, or `f16`'s ~65504
+    range, raises `ValueError`. `f16` is the only lossy option and must be
+    requested explicitly.
+  - **`default`** — the value written for VCF-missing entries; otherwise a
+    reserved sentinel (`NaN` for float widths, the width-specific
+    `INT*_MIN` for ints). `Flag` fields are never missing (absent ⇒
+    `false`/`0`).
+  - **FORMAT is genotype-aligned, not independently lossless**: a FORMAT
+    value is stored only where the genotype has a call — one value per
+    carrier call in var_key-routed variants, or a full dense per-sample
+    column (non-carrier slots filled with `default`/sentinel) in
+    dense-routed variants. Non-carrier FORMAT values (e.g. an imputed
+    dosage at a ref/ref genotype) are **dropped by design** in this version;
+    an independent lossless FORMAT stream is deferred to a future spec.
+  - **No read path yet** — this only controls what gets written. Querying
+    stored field values back out (a decode/query API) is not implemented;
+    see `meta.json`'s `"fields"` array and `docs/roadmap/data-model.md` for
+    the on-disk layout if you need to inspect values directly.
 
 ### Range queries
 

--- a/src/cost_model.rs
+++ b/src/cost_model.rs
@@ -37,14 +37,23 @@ pub const SIDECAR_BITS_INDEL: u64 = 8; // 8-bit code
 
 /// Choose the cheaper representation for one variant with `x_calls` carriers.
 ///
-/// var_key = x · (POS_BITS + key_bits + sidecar_bits)  (position + key + sidecar inlined per call)
-/// dense   = POS_BITS + key_bits + np + sidecar_bits    (table row once + 1-bit-per-hap mask + sidecar once)
+/// var_key = x · (POS_BITS + key_bits + sidecar_bits + info_bits + format_bits)
+///           (position + key + sidecar + INFO + FORMAT inlined per call)
+/// dense   = POS_BITS + key_bits + np + sidecar_bits + info_bits + format_bits · n_samples
+///           (table row once + 1-bit-per-hap mask + sidecar once + INFO once +
+///           FORMAT per sample)
 ///
 /// `sidecar_bits` is the per-record mutational-signature sidecar cost (0 when
 /// signatures are disabled; see `SIDECAR_BITS_SNP`/`SIDECAR_BITS_INDEL`). It is
 /// paid once per carrier call in `var_key` (the sidecar rides along with each
 /// inlined call) but only once per variant in `dense` (the sidecar lives in
 /// the table row, not the per-hap mask).
+///
+/// `info_bits`/`format_bits` are the summed per-record storage widths (in
+/// bits) of the active INFO/FORMAT fields (0 when no fields are configured).
+/// INFO is amortized once per variant in `dense` but paid per carrier call in
+/// `var_key`; FORMAT is paid once per sample in `dense` (every sample gets a
+/// column entry) but per carrier call in `var_key`.
 ///
 /// Route to `Dense` iff strictly cheaper; ties break to `VarKey`.
 #[inline]
@@ -54,11 +63,19 @@ pub fn choose_representation(
     ploidy: usize,
     x_calls: usize,
     sidecar_bits: u64,
+    info_bits: u64,
+    format_bits: u64,
 ) -> Representation {
     let np = (n_samples as u64) * (ploidy as u64);
+    let x = x_calls as u64;
     let per_call = POS_BITS + key_bits(class) + sidecar_bits;
-    let var_key_bits = (x_calls as u64) * per_call;
-    let dense_bits = POS_BITS + key_bits(class) + np + sidecar_bits;
+    let var_key_bits = x * (per_call + info_bits + format_bits);
+    let dense_bits = POS_BITS
+        + key_bits(class)
+        + np
+        + sidecar_bits
+        + info_bits
+        + format_bits * (n_samples as u64);
     if dense_bits < var_key_bits {
         Representation::Dense
     } else {
@@ -75,7 +92,7 @@ mod tests {
     fn test_x_zero_is_var_key() {
         // No carriers: var_key costs 0, dense costs a full row — var_key wins.
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 0, 0),
+            choose_representation(Class::Snp, 1000, 2, 0, 0, 0, 0),
             Representation::VarKey
         );
     }
@@ -85,11 +102,11 @@ mod tests {
         // np=2000: dense=32+2+2000=2034; var_key=34x. Dense wins when 34x > 2034
         // → x >= 60 (34*59=2006 < 2034 → var_key; 34*60=2040 > 2034 → dense).
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 59, 0),
+            choose_representation(Class::Snp, 1000, 2, 59, 0, 0, 0),
             Representation::VarKey
         );
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 60, 0),
+            choose_representation(Class::Snp, 1000, 2, 60, 0, 0, 0),
             Representation::Dense
         );
     }
@@ -99,11 +116,11 @@ mod tests {
         // np=2000: dense=32+32+2000=2064; var_key=64x. Dense when 64x > 2064
         // → x >= 33 (64*32=2048 < 2064; 64*33=2112 > 2064).
         assert_eq!(
-            choose_representation(Class::Indel, 1000, 2, 32, 0),
+            choose_representation(Class::Indel, 1000, 2, 32, 0, 0, 0),
             Representation::VarKey
         );
         assert_eq!(
-            choose_representation(Class::Indel, 1000, 2, 33, 0),
+            choose_representation(Class::Indel, 1000, 2, 33, 0, 0, 0),
             Representation::Dense
         );
     }
@@ -121,7 +138,7 @@ mod tests {
         let np = 34u64 * 3 - 34; // = 68 → dense_bits = 34 + 68 = 102 = 34*3
         let n = np as usize; // ploidy 1
         assert_eq!(
-            choose_representation(Class::Snp, n, 1, 3, 0), // var_key = 34*3 = 102 == dense
+            choose_representation(Class::Snp, n, 1, 3, 0, 0, 0), // var_key = 34*3 = 102 == dense
             Representation::VarKey,
             "exact tie must resolve to VarKey"
         );
@@ -134,11 +151,11 @@ mod tests {
         // dense = 32+2+2000+10 = 2044; per_call = 34+10 = 44.
         // dense < 44x → x > 46.45 → dense at x>=47 (vs 60 without).
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 46, SIDECAR_BITS_SNP),
+            choose_representation(Class::Snp, 1000, 2, 46, SIDECAR_BITS_SNP, 0, 0),
             Representation::VarKey
         );
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 47, SIDECAR_BITS_SNP),
+            choose_representation(Class::Snp, 1000, 2, 47, SIDECAR_BITS_SNP, 0, 0),
             Representation::Dense
         );
     }
@@ -146,9 +163,40 @@ mod tests {
     #[test]
     fn zero_sidecar_matches_legacy() {
         assert_eq!(
-            choose_representation(Class::Snp, 1000, 2, 60, 0),
+            choose_representation(Class::Snp, 1000, 2, 60, 0, 0, 0),
             Representation::Dense
         );
+    }
+
+    #[test]
+    fn info_bits_shift_toward_dense() {
+        // np=2000, x=59 sits just below the (0-field) crossover (VarKey; see
+        // test_snp_crossover_np2000). INFO is amortized once per variant in
+        // dense (2034+32=2066) but paid on every one of the 59 carrier calls
+        // in var_key (59*(34+32)=3894), so a single 32-bit INFO field alone
+        // flips this variant from VarKey to Dense.
+        let base = choose_representation(Class::Snp, 1000, 2, 59, 0, 0, 0);
+        let with_info = choose_representation(Class::Snp, 1000, 2, 59, 0, 32, 0);
+        assert_eq!(base, Representation::VarKey);
+        assert_eq!(with_info, Representation::Dense);
+    }
+
+    #[test]
+    fn format_bits_do_not_cancel() {
+        // n_samples=10, ploidy=35 (np=350), x=11: baseline (0-field) dense=384
+        // vs var_key=374 -> VarKey. FORMAT costs format_bits*n_samples once in
+        // dense (paid per sample, genotype-aligned Option A) vs
+        // format_bits*x_calls in var_key (paid per carrier call); since
+        // x_calls(11) > n_samples(10) here, a 16-bit FORMAT field grows the
+        // var_key side faster than the dense side (550 vs 544), flipping this
+        // variant to Dense. (High ploidy is chosen purely to keep x_calls >
+        // n_samples while the 0-field baseline is still VarKey; see report
+        // for the algebra.)
+        let r = choose_representation(Class::Snp, 10, 35, 11, 0, 0, 16);
+        assert_eq!(r, Representation::Dense);
+
+        let base = choose_representation(Class::Snp, 10, 35, 11, 0, 0, 0);
+        assert_eq!(base, Representation::VarKey);
     }
 
     proptest::proptest! {
@@ -159,9 +207,9 @@ mod tests {
             ploidy in 1usize..3,
             x in 0usize..20000,
         ) {
-            let here = choose_representation(Class::Snp, n, ploidy, x, 0);
+            let here = choose_representation(Class::Snp, n, ploidy, x, 0, 0, 0);
             if here == Representation::Dense {
-                let more = choose_representation(Class::Snp, n, ploidy, x + 1, 0);
+                let more = choose_representation(Class::Snp, n, ploidy, x + 1, 0, 0, 0);
                 prop_assert_eq!(more, Representation::Dense);
             }
         }

--- a/src/dense_merge.rs
+++ b/src/dense_merge.rs
@@ -10,7 +10,7 @@ use crate::layout;
 use crate::rvk::pack_snp_keys;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn merge_dense_class(
     num_chunks: usize,
@@ -93,6 +93,68 @@ pub fn merge_dense_class(
         let _ = fs::remove_file(layout::chunk_pos(dir, c));
         let _ = fs::remove_file(layout::chunk_key(dir, c));
         let _ = fs::remove_file(layout::chunk_geno(dir, c));
+    }
+    Ok(())
+}
+
+/// Concatenate one dense field's per-chunk `chunk_{c}_{finfo|fformat}{field_ix}.bin`
+/// files, in chunk order, into `dest_values_bin`.
+///
+/// Dense field values are staged 1:1 with dense variants (no ragged ledger, no
+/// transpose — an INFO value is one value per dense variant; a FORMAT value is
+/// `n_dense_variants[c] * num_samples` values, variant-major), so this mirrors
+/// `merge_dense_class`'s positions/keys concat exactly: a pure chunk-order byte
+/// concatenation reproduces the final layout. Chunks with `dense_ledger[c] == 0`
+/// wrote no per-chunk field file (Task 7) and are skipped here too.
+///
+/// `prefix` selects which per-chunk file family to read: `"finfo"` for INFO
+/// fields (`layout::chunk_field_info`) or `"fformat"` for FORMAT fields
+/// (`layout::chunk_field_format`). `field_ix` is the per-category (INFO-only or
+/// FORMAT-only) field index Task 7 staged under.
+///
+/// The caller is responsible for creating `dest_values_bin`'s parent directory
+/// before calling this function (this function does not call `create_dir_all`),
+/// mirroring `merge::merge_var_key_field_values`'s contract.
+///
+/// On success, the consumed per-chunk field files are removed.
+pub fn merge_dense_field_values(
+    output_dir: &str,
+    num_chunks: usize,
+    dense_ledger: &[u32],
+    prefix: &str,
+    field_ix: usize,
+    dest_values_bin: &Path,
+) -> Result<(), ConversionError> {
+    debug_assert_eq!(
+        dense_ledger.len(),
+        num_chunks,
+        "dense_ledger must have exactly one row per chunk"
+    );
+    let dir = Path::new(output_dir);
+    let mut values: Vec<u8> = Vec::new();
+    let mut consumed: Vec<PathBuf> = Vec::new();
+    for (c, &count) in dense_ledger.iter().enumerate().take(num_chunks) {
+        if count == 0 {
+            continue;
+        }
+        let path = match prefix {
+            "finfo" => layout::chunk_field_info(dir, c, field_ix),
+            "fformat" => layout::chunk_field_format(dir, c, field_ix),
+            other => {
+                return Err(ConversionError::Input(format!(
+                    "merge_dense_field_values: unknown prefix {other:?}, expected \"finfo\" or \"fformat\""
+                )));
+            }
+        };
+        values.extend_from_slice(&fs::read(&path).map_err(|e| ConversionError::Io {
+            context: format!("reading {}", path.display()),
+            source: e,
+        })?);
+        consumed.push(path);
+    }
+    write_all(dest_values_bin, &values)?;
+    for path in consumed {
+        let _ = fs::remove_file(path);
     }
     Ok(())
 }
@@ -217,5 +279,103 @@ mod tests {
         merge_dense_class(1, 1, 1, 1, true, dir.to_str().unwrap(), vec![5]).unwrap();
         // pack_snp_keys([1,2,3,0,1]) == [0x39, 0x01] (see rvk.rs test)
         assert_eq!(fs::read(layout::alleles(dir)).unwrap(), vec![0x39u8, 0x01]);
+    }
+
+    fn read_i32(path: &Path) -> Vec<i32> {
+        let bytes = fs::read(path).unwrap();
+        bytes
+            .chunks_exact(4)
+            .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    fn read_f32(path: &Path) -> Vec<f32> {
+        let bytes = fs::read(path).unwrap();
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    #[test]
+    fn test_merge_dense_field_values_finfo_skips_empty_chunk() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path();
+        // chunk0: 2 dense variants -> finfo0 = [10, 20] (i32)
+        write_all(
+            &layout::chunk_field_info(dir, 0, 0),
+            bytemuck::cast_slice(&[10i32, 20]),
+        )
+        .unwrap();
+        // chunk1: 1 dense variant -> finfo0 = [30] (i32)
+        write_all(
+            &layout::chunk_field_info(dir, 1, 0),
+            bytemuck::cast_slice(&[30i32]),
+        )
+        .unwrap();
+        // chunk2: 0 dense variants -> Task 7 wrote NO finfo file for it.
+        let dense_ledger = vec![2u32, 1, 0];
+        let dest = dir
+            .join("fields")
+            .join("DP")
+            .join("dense_snp")
+            .join("values.bin");
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+
+        merge_dense_field_values(dir.to_str().unwrap(), 3, &dense_ledger, "finfo", 0, &dest)
+            .unwrap();
+
+        assert_eq!(read_i32(&dest), vec![10, 20, 30]);
+        // Consumed per-chunk field files are removed.
+        assert!(!layout::chunk_field_info(dir, 0, 0).exists());
+        assert!(!layout::chunk_field_info(dir, 1, 0).exists());
+    }
+
+    #[test]
+    fn test_merge_dense_field_values_fformat_concat() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path();
+        // num_samples=2, variant-major. chunk0: 1 dense variant -> 2 values.
+        write_all(
+            &layout::chunk_field_format(dir, 0, 1),
+            bytemuck::cast_slice(&[1.0f32, 2.0]),
+        )
+        .unwrap();
+        // chunk1: 2 dense variants -> 4 values.
+        write_all(
+            &layout::chunk_field_format(dir, 1, 1),
+            bytemuck::cast_slice(&[3.0f32, 4.0, 5.0, 6.0]),
+        )
+        .unwrap();
+        let dense_ledger = vec![1u32, 2];
+        let dest = dir
+            .join("fields")
+            .join("DS")
+            .join("dense_indel")
+            .join("values.bin");
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+
+        merge_dense_field_values(dir.to_str().unwrap(), 2, &dense_ledger, "fformat", 1, &dest)
+            .unwrap();
+
+        assert_eq!(read_f32(&dest), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        assert!(!layout::chunk_field_format(dir, 0, 1).exists());
+        assert!(!layout::chunk_field_format(dir, 1, 1).exists());
+    }
+
+    #[test]
+    fn test_merge_dense_field_values_unknown_prefix_errors() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path();
+        let dense_ledger = vec![1u32];
+        write_all(
+            &layout::chunk_field_info(dir, 0, 0),
+            bytemuck::cast_slice(&[1i32]),
+        )
+        .unwrap();
+        let dest = dir.join("values.bin");
+        let err =
+            merge_dense_field_values(dir.to_str().unwrap(), 1, &dense_ledger, "bogus", 0, &dest);
+        assert!(err.is_err());
     }
 }

--- a/src/dense_merge.rs
+++ b/src/dense_merge.rs
@@ -107,10 +107,10 @@ pub fn merge_dense_class(
 /// concatenation reproduces the final layout. Chunks with `dense_ledger[c] == 0`
 /// wrote no per-chunk field file (Task 7) and are skipped here too.
 ///
-/// `prefix` selects which per-chunk file family to read: `"finfo"` for INFO
-/// fields (`layout::chunk_field_info`) or `"fformat"` for FORMAT fields
-/// (`layout::chunk_field_format`). `field_ix` is the per-category (INFO-only or
-/// FORMAT-only) field index Task 7 staged under.
+/// `category` selects which per-chunk file family to read: `FieldCategory::Info`
+/// for INFO fields (`layout::chunk_field_info`) or `FieldCategory::Format` for
+/// FORMAT fields (`layout::chunk_field_format`). `field_ix` is the per-category
+/// (INFO-only or FORMAT-only) field index Task 7 staged under.
 ///
 /// The caller is responsible for creating `dest_values_bin`'s parent directory
 /// before calling this function (this function does not call `create_dir_all`),
@@ -121,7 +121,7 @@ pub fn merge_dense_field_values(
     output_dir: &str,
     num_chunks: usize,
     dense_ledger: &[u32],
-    prefix: &str,
+    category: crate::field::FieldCategory,
     field_ix: usize,
     dest_values_bin: &Path,
 ) -> Result<(), ConversionError> {
@@ -137,14 +137,9 @@ pub fn merge_dense_field_values(
         if count == 0 {
             continue;
         }
-        let path = match prefix {
-            "finfo" => layout::chunk_field_info(dir, c, field_ix),
-            "fformat" => layout::chunk_field_format(dir, c, field_ix),
-            other => {
-                return Err(ConversionError::Input(format!(
-                    "merge_dense_field_values: unknown prefix {other:?}, expected \"finfo\" or \"fformat\""
-                )));
-            }
+        let path = match category {
+            crate::field::FieldCategory::Info => layout::chunk_field_info(dir, c, field_ix),
+            crate::field::FieldCategory::Format => layout::chunk_field_format(dir, c, field_ix),
         };
         values.extend_from_slice(&fs::read(&path).map_err(|e| ConversionError::Io {
             context: format!("reading {}", path.display()),
@@ -179,6 +174,7 @@ fn write_all(path: &Path, bytes: &[u8]) -> Result<(), ConversionError> {
 mod tests {
     use super::*;
     use crate::bits::{get_bit, set_bit};
+    use crate::field::FieldCategory;
     use tempfile::tempdir;
 
     // Build a hap-major block (np rows × v_c cols) from a bool matrix
@@ -322,8 +318,15 @@ mod tests {
             .join("values.bin");
         fs::create_dir_all(dest.parent().unwrap()).unwrap();
 
-        merge_dense_field_values(dir.to_str().unwrap(), 3, &dense_ledger, "finfo", 0, &dest)
-            .unwrap();
+        merge_dense_field_values(
+            dir.to_str().unwrap(),
+            3,
+            &dense_ledger,
+            FieldCategory::Info,
+            0,
+            &dest,
+        )
+        .unwrap();
 
         assert_eq!(read_i32(&dest), vec![10, 20, 30]);
         // Consumed per-chunk field files are removed.
@@ -355,27 +358,18 @@ mod tests {
             .join("values.bin");
         fs::create_dir_all(dest.parent().unwrap()).unwrap();
 
-        merge_dense_field_values(dir.to_str().unwrap(), 2, &dense_ledger, "fformat", 1, &dest)
-            .unwrap();
+        merge_dense_field_values(
+            dir.to_str().unwrap(),
+            2,
+            &dense_ledger,
+            FieldCategory::Format,
+            1,
+            &dest,
+        )
+        .unwrap();
 
         assert_eq!(read_f32(&dest), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         assert!(!layout::chunk_field_format(dir, 0, 1).exists());
         assert!(!layout::chunk_field_format(dir, 1, 1).exists());
-    }
-
-    #[test]
-    fn test_merge_dense_field_values_unknown_prefix_errors() {
-        let tmp = tempdir().unwrap();
-        let dir = tmp.path();
-        let dense_ledger = vec![1u32];
-        write_all(
-            &layout::chunk_field_info(dir, 0, 0),
-            bytemuck::cast_slice(&[1i32]),
-        )
-        .unwrap();
-        let dest = dir.join("values.bin");
-        let err =
-            merge_dense_field_values(dir.to_str().unwrap(), 1, &dense_ledger, "bogus", 0, &dest);
-        assert!(err.is_err());
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -24,13 +24,14 @@ pub fn run_compute_engine(
     tx_sparse: Sender<SparseChunk>,
     mut bank: LongAlleleTableWriter,
     sidecar_bits_enabled: bool,
+    fields: &[crate::field::FieldSpec],
 ) -> Phase1Output {
     let mut var_key_ledgers: StreamMap<Vec<Vec<u32>>> =
         StreamMap::from_fn(|_| Vec::with_capacity(10_000));
     let mut dense_ledgers: DenseMap<Vec<u32>> = DenseMap::from_fn(|_| Vec::with_capacity(10_000));
 
     while let Ok(chunk) = rx_dense.recv() {
-        let sparse_chunk = dense2sparse_vk(&chunk, &mut bank, sidecar_bits_enabled);
+        let sparse_chunk = dense2sparse_vk(&chunk, &mut bank, sidecar_bits_enabled, fields);
 
         for (tag, sub) in sparse_chunk.streams.iter() {
             var_key_ledgers
@@ -93,7 +94,7 @@ mod tests {
         drop(tx_d);
 
         let bank = crate::nrvk::LongAlleleTableWriter::new(tx_l, 1 << 16);
-        let out = run_compute_engine(rx_d, tx_s, bank, false);
+        let out = run_compute_engine(rx_d, tx_s, bank, false, &[]);
 
         // one chunk processed → one ledger row per stream and per dense class
         assert_eq!(out.var_key_ledgers.get(StreamTag::VarKeySnp).len(), 1);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -79,6 +79,8 @@ mod tests {
             alt: b"C".to_vec(),
             alt_offsets: vec![0, 1],
             genos,
+            info_staged: Vec::new(),
+            format_staged: Vec::new(),
         }
     }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -63,6 +63,34 @@ impl StorageDtype {
             _ => return None,
         })
     }
+
+    /// Lowercase on-disk/`meta.json` name. `Auto` never reaches here in
+    /// practice (finalize always resolves it to a concrete dtype first), but
+    /// maps to `"auto"` rather than panicking so this stays a total function.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StorageDtype::Auto => "auto",
+            StorageDtype::Bool => "bool",
+            StorageDtype::I8 => "i8",
+            StorageDtype::U8 => "u8",
+            StorageDtype::I16 => "i16",
+            StorageDtype::U16 => "u16",
+            StorageDtype::I32 => "i32",
+            StorageDtype::U32 => "u32",
+            StorageDtype::F16 => "f16",
+            StorageDtype::F32 => "f32",
+        }
+    }
+}
+
+impl FieldCategory {
+    /// Lowercase on-disk/`meta.json` name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FieldCategory::Info => "info",
+            FieldCategory::Format => "format",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/field.rs
+++ b/src/field.rs
@@ -44,11 +44,6 @@ impl StorageDtype {
         })
     }
 
-    /// `true` iff the given htslib type should be staged as floating point.
-    pub fn stage_is_float(htype: HtslibType) -> bool {
-        htype == HtslibType::Float
-    }
-
     fn parse(s: &str) -> Option<Self> {
         Some(match s {
             "bool" => Self::Bool,

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,0 +1,150 @@
+//! Field-spec typing core for SVAR2 INFO/FORMAT field write support.
+//!
+//! Pure typing/validation over a manifest of `(name, category, htype, dtype,
+//! default)` tuples produced on the Python side. No I/O here — this module
+//! only maps user-facing strings to typed enums and validates them.
+
+use crate::error::ConversionError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldCategory {
+    Info,
+    Format,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HtslibType {
+    Int,
+    Float,
+    Flag,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageDtype {
+    Auto,
+    Bool,
+    I8,
+    U8,
+    I16,
+    U16,
+    I32,
+    U32,
+    F16,
+    F32,
+}
+
+impl StorageDtype {
+    /// Final on-disk width in bytes; `Auto` is undecided until finalize.
+    pub fn width_bytes(self) -> Option<usize> {
+        Some(match self {
+            StorageDtype::Auto => return None,
+            StorageDtype::Bool | StorageDtype::I8 | StorageDtype::U8 => 1,
+            StorageDtype::I16 | StorageDtype::U16 | StorageDtype::F16 => 2,
+            StorageDtype::I32 | StorageDtype::U32 | StorageDtype::F32 => 4,
+        })
+    }
+
+    /// `true` iff the given htslib type should be staged as floating point.
+    pub fn stage_is_float(htype: HtslibType) -> bool {
+        htype == HtslibType::Float
+    }
+
+    fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "bool" => Self::Bool,
+            "i8" => Self::I8,
+            "u8" => Self::U8,
+            "i16" => Self::I16,
+            "u16" => Self::U16,
+            "i32" => Self::I32,
+            "u32" => Self::U32,
+            "f16" => Self::F16,
+            "f32" => Self::F32,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldSpec {
+    pub name: String,
+    pub category: FieldCategory,
+    pub htype: HtslibType,
+    pub dtype: StorageDtype,
+    pub default: Option<f64>,
+}
+
+impl FieldSpec {
+    pub fn stage_is_float(&self) -> bool {
+        self.htype == HtslibType::Float
+    }
+}
+
+fn bad(ctx: &str) -> ConversionError {
+    ConversionError::Input(ctx.to_string())
+}
+
+#[allow(clippy::type_complexity)]
+pub fn parse_manifest(
+    raw: Vec<(String, String, String, Option<String>, Option<f64>)>,
+) -> Result<Vec<FieldSpec>, ConversionError> {
+    raw.into_iter()
+        .map(|(name, category, htype, dtype, default)| {
+            let category = match category.as_str() {
+                "info" => FieldCategory::Info,
+                "format" => FieldCategory::Format,
+                other => return Err(bad(&format!("bad field category {other:?}"))),
+            };
+            let htype = match htype.as_str() {
+                "int" => HtslibType::Int,
+                "float" => HtslibType::Float,
+                "flag" => HtslibType::Flag,
+                other => return Err(bad(&format!("bad htslib type {other:?}"))),
+            };
+            let dtype = match dtype {
+                None => StorageDtype::Auto,
+                Some(s) => StorageDtype::parse(&s)
+                    .ok_or_else(|| bad(&format!("bad storage dtype {s:?}")))?,
+            };
+            Ok(FieldSpec {
+                name,
+                category,
+                htype,
+                dtype,
+                default,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_manifest_maps_tuples() {
+        let raw = vec![
+            (
+                "DS".into(),
+                "format".into(),
+                "float".into(),
+                Some("f16".into()),
+                Some(0.0),
+            ),
+            ("AC".into(), "info".into(), "int".into(), None, None),
+        ];
+        let specs = parse_manifest(raw).unwrap();
+        assert_eq!(specs.len(), 2);
+        assert!(matches!(specs[0].category, FieldCategory::Format));
+        assert!(matches!(specs[0].dtype, StorageDtype::F16));
+        assert!(specs[0].stage_is_float());
+        assert!(matches!(specs[1].dtype, StorageDtype::Auto));
+        assert!(!specs[1].stage_is_float());
+    }
+
+    #[test]
+    fn parse_manifest_rejects_bad_category() {
+        let raw = vec![("X".into(), "bogus".into(), "int".into(), None, None)];
+        assert!(parse_manifest(raw).is_err());
+    }
+}

--- a/src/field.rs
+++ b/src/field.rs
@@ -78,6 +78,20 @@ impl FieldSpec {
     pub fn stage_is_float(&self) -> bool {
         self.htype == HtslibType::Float
     }
+
+    /// The sentinel a resolved field value falls back to when htslib reports
+    /// it missing and the spec has no explicit `default`: htslib's own
+    /// missing-int encoding for Int/Flag columns, NaN for Float columns
+    /// (mirrors htslib's float-missing encoding, which is itself a NaN bit
+    /// pattern). Also used as the non-carrier fill for genotype-aligned
+    /// dense FORMAT columns.
+    pub fn missing_sentinel(&self) -> f64 {
+        self.default.unwrap_or(if self.stage_is_float() {
+            f64::from(f32::NAN)
+        } else {
+            i32::MIN as f64
+        })
+    }
 }
 
 fn bad(ctx: &str) -> ConversionError {

--- a/src/field_finalize.rs
+++ b/src/field_finalize.rs
@@ -97,7 +97,7 @@ fn finalize_one(
     contigs: &[String],
     field: &FieldSpec,
 ) -> Result<ResolvedField, ConversionError> {
-    let files = field_files(output_dir, contigs, &field.name);
+    let files = field_files(output_dir, contigs, field.category.as_str(), &field.name);
     let stats = scan(&files, field)?;
     let dtype = resolve_dtype(field, &stats)?;
     for path in &files {
@@ -114,13 +114,14 @@ fn finalize_one(
 /// Enumerate the `values.bin` files that exist for `name`, across every
 /// contig and all four sub labels. Iterating the known sub labels directly
 /// (rather than globbing) is simpler and matches the fixed staging layout.
-fn field_files(output_dir: &Path, contigs: &[String], name: &str) -> Vec<PathBuf> {
+fn field_files(output_dir: &Path, contigs: &[String], category: &str, name: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
     for contig in contigs {
         for sub in SUB_LABELS {
             let path = output_dir
                 .join(contig)
                 .join("fields")
+                .join(category)
                 .join(name)
                 .join(sub)
                 .join("values.bin");
@@ -462,15 +463,28 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    // Test fields below always pair `write_i32_field` with `int_field`
+    // (category "info") and `write_f32_field` with `float_field` (category
+    // "format"), so the category segment is hardcoded here to match.
     fn write_i32_field(root: &Path, contig: &str, name: &str, sub: &str, values: &[i32]) {
-        let dir = root.join(contig).join("fields").join(name).join(sub);
+        let dir = root
+            .join(contig)
+            .join("fields")
+            .join("info")
+            .join(name)
+            .join(sub);
         fs::create_dir_all(&dir).unwrap();
         let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
         fs::write(dir.join("values.bin"), bytes).unwrap();
     }
 
     fn write_f32_field(root: &Path, contig: &str, name: &str, sub: &str, values: &[f32]) {
-        let dir = root.join(contig).join("fields").join(name).join(sub);
+        let dir = root
+            .join(contig)
+            .join("fields")
+            .join("format")
+            .join(name)
+            .join(sub);
         fs::create_dir_all(&dir).unwrap();
         let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
         fs::write(dir.join("values.bin"), bytes).unwrap();
@@ -514,11 +528,11 @@ mod tests {
         assert_eq!(resolved.len(), 1);
         assert!(matches!(resolved[0].dtype, StorageDtype::U8));
 
-        let path1 = root.join("chr1/fields/AC/var_key_snp/values.bin");
+        let path1 = root.join("chr1/fields/info/AC/var_key_snp/values.bin");
         let bytes1 = read_values_bin(&path1);
         assert_eq!(bytes1, vec![0u8, 50, 200]);
 
-        let path2 = root.join("chr2/fields/AC/var_key_snp/values.bin");
+        let path2 = root.join("chr2/fields/info/AC/var_key_snp/values.bin");
         let bytes2 = read_values_bin(&path2);
         assert_eq!(bytes2, vec![0u8, 5, 10]);
     }
@@ -538,7 +552,7 @@ mod tests {
 
         assert!(matches!(resolved[0].dtype, StorageDtype::U16));
 
-        let path = root.join("chr1/fields/DP/var_key_snp/values.bin");
+        let path = root.join("chr1/fields/info/DP/var_key_snp/values.bin");
         let bytes = read_values_bin(&path);
         let words: Vec<u16> = bytes
             .chunks_exact(2)
@@ -560,7 +574,7 @@ mod tests {
         let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
         assert!(matches!(resolved[0].dtype, StorageDtype::U8));
 
-        let path = root.join("chr1/fields/AF/var_key_snp/values.bin");
+        let path = root.join("chr1/fields/info/AF/var_key_snp/values.bin");
         let bytes = read_values_bin(&path);
         assert_eq!(bytes, vec![0u8, 200, u8::MAX]);
     }
@@ -576,7 +590,7 @@ mod tests {
         let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
         assert!(matches!(resolved[0].dtype, StorageDtype::F16));
 
-        let path = root.join("chr1/fields/DS/dense_snp/values.bin");
+        let path = root.join("chr1/fields/format/DS/dense_snp/values.bin");
         let bytes = read_values_bin(&path);
         assert_eq!(bytes.len(), 3 * 2);
         let words: Vec<half::f16> = bytes
@@ -631,7 +645,7 @@ mod tests {
             resolved[0].dtype
         );
 
-        let path = root.join("chr1/fields/SC/var_key_snp/values.bin");
+        let path = root.join("chr1/fields/info/SC/var_key_snp/values.bin");
         let bytes = read_values_bin(&path);
         let decoded: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
         assert_eq!(decoded, vec![-5i8, 0, 100]);
@@ -654,7 +668,7 @@ mod tests {
             resolved[0].dtype
         );
 
-        let path = root.join("chr1/fields/SC2/var_key_snp/values.bin");
+        let path = root.join("chr1/fields/info/SC2/var_key_snp/values.bin");
         let bytes = read_values_bin(&path);
         let decoded: Vec<i16> = bytes
             .chunks_exact(2)

--- a/src/field_finalize.rs
+++ b/src/field_finalize.rs
@@ -23,6 +23,7 @@
 
 use crate::error::ConversionError;
 use crate::field::{FieldCategory, FieldSpec, HtslibType, StorageDtype};
+use rayon::prelude::*;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -73,6 +74,21 @@ impl ScanStats {
             self.max = v;
         }
     }
+
+    /// Fold `other` (e.g. another file's stats) into `self`. Associative and
+    /// commutative — safe to use as a rayon reduction: `min`/`max` combine via
+    /// plain comparison (both start at +-infinity so an empty side is a
+    /// no-op), `has_missing`/`any_values` combine via `||`.
+    fn merge(&mut self, other: ScanStats) {
+        if other.min < self.min {
+            self.min = other.min;
+        }
+        if other.max > self.max {
+            self.max = other.max;
+        }
+        self.has_missing |= other.has_missing;
+        self.any_values |= other.any_values;
+    }
 }
 
 fn bad(msg: impl Into<String>) -> ConversionError {
@@ -87,7 +103,7 @@ pub fn finalize_fields(
     fields: &[FieldSpec],
 ) -> Result<Vec<ResolvedField>, ConversionError> {
     fields
-        .iter()
+        .par_iter()
         .map(|field| finalize_one(output_dir, contigs, field))
         .collect()
 }
@@ -100,9 +116,9 @@ fn finalize_one(
     let files = field_files(output_dir, contigs, field.category.as_str(), &field.name);
     let stats = scan(&files, field)?;
     let dtype = resolve_dtype(field, &stats)?;
-    for path in &files {
-        rewrite_file(path, field, dtype)?;
-    }
+    files
+        .par_iter()
+        .try_for_each(|path| rewrite_file(path, field, dtype))?;
     Ok(ResolvedField {
         name: field.name.clone(),
         category: field.category,
@@ -133,10 +149,9 @@ fn field_files(output_dir: &Path, contigs: &[String], category: &str, name: &str
     out
 }
 
-/// Read a staged `values.bin` as `f64` (exact for both `i32` and `f32`
-/// staged domains), decoding each 4-byte little-endian element per
-/// `is_float`.
-fn read_staged(path: &Path, is_float: bool) -> Result<Vec<f64>, ConversionError> {
+/// Read a staged `values.bin`'s raw bytes, validating the length is a whole
+/// number of 4-byte native-width (`i32`/`f32`) elements.
+fn read_staged_bytes(path: &Path) -> Result<Vec<u8>, ConversionError> {
     let bytes = std::fs::read(path).map_err(|e| ConversionError::Io {
         context: format!("reading {}", path.display()),
         source: e,
@@ -148,17 +163,17 @@ fn read_staged(path: &Path, is_float: bool) -> Result<Vec<f64>, ConversionError>
             bytes.len()
         )));
     }
-    Ok(bytes
-        .chunks_exact(4)
-        .map(|c| {
-            let arr: [u8; 4] = c.try_into().unwrap();
-            if is_float {
-                f32::from_le_bytes(arr) as f64
-            } else {
-                i32::from_le_bytes(arr) as f64
-            }
-        })
-        .collect())
+    Ok(bytes)
+}
+
+/// Decode one staged 4-byte little-endian element (exact as `f64` for both
+/// the `i32` and `f32` staged domains) per `is_float`.
+fn decode_elem(chunk: [u8; 4], is_float: bool) -> f64 {
+    if is_float {
+        f32::from_le_bytes(chunk) as f64
+    } else {
+        i32::from_le_bytes(chunk) as f64
+    }
 }
 
 /// `true` iff a staged element `v` represents the staged missing sentinel.
@@ -173,23 +188,43 @@ fn is_staged_missing(v: f64, is_float: bool) -> bool {
     }
 }
 
+/// Scan one file's staged bytes into `ScanStats`, decoding each 4-byte
+/// element inline via `chunks_exact` — no intermediate `Vec<f64>`.
+fn scan_file(
+    path: &Path,
+    is_float: bool,
+    treat_missing: bool,
+) -> Result<ScanStats, ConversionError> {
+    let bytes = read_staged_bytes(path)?;
+    let mut stats = ScanStats::empty();
+    for chunk in bytes.chunks_exact(4) {
+        let arr: [u8; 4] = chunk.try_into().unwrap();
+        let v = decode_elem(arr, is_float);
+        if treat_missing && is_staged_missing(v, is_float) {
+            stats.has_missing = true;
+        } else {
+            stats.observe(v);
+        }
+    }
+    Ok(stats)
+}
+
 fn scan(files: &[PathBuf], field: &FieldSpec) -> Result<ScanStats, ConversionError> {
     let is_float = field.stage_is_float();
     // A `default` was already substituted at staging time, so nothing in
     // the data can be the staged sentinel; treat nothing as missing (the
     // default value itself still flows into min/max via `observe`).
     let treat_missing = field.default.is_none();
-    let mut stats = ScanStats::empty();
-    for path in files {
-        for v in read_staged(path, is_float)? {
-            if treat_missing && is_staged_missing(v, is_float) {
-                stats.has_missing = true;
-            } else {
-                stats.observe(v);
-            }
-        }
-    }
-    Ok(stats)
+    // `ScanStats::merge` is associative/commutative (min/max via comparison,
+    // has_missing/any_values via `||`), so a parallel map+reduce over files
+    // is deterministic regardless of thread scheduling order.
+    files
+        .par_iter()
+        .map(|path| scan_file(path, is_float, treat_missing))
+        .try_reduce(ScanStats::empty, |mut a, b| {
+            a.merge(b);
+            Ok(a)
+        })
 }
 
 fn unsigned_bound(width: u32) -> u64 {
@@ -363,11 +398,14 @@ fn rewrite_file(
 ) -> Result<(), ConversionError> {
     let is_float = field.stage_is_float();
     let treat_missing = field.default.is_none();
-    let values = read_staged(path, is_float)?;
+    let bytes = read_staged_bytes(path)?;
 
     let width = dtype.width_bytes().unwrap_or(4);
-    let mut out = Vec::with_capacity(values.len() * width);
-    for v in values {
+    let n_elems = bytes.len() / 4;
+    let mut out = Vec::with_capacity(n_elems * width);
+    for chunk in bytes.chunks_exact(4) {
+        let arr: [u8; 4] = chunk.try_into().unwrap();
+        let v = decode_elem(arr, is_float);
         let is_missing = treat_missing && is_staged_missing(v, is_float);
         encode(&mut out, dtype, v, is_missing);
     }

--- a/src/field_finalize.rs
+++ b/src/field_finalize.rs
@@ -1,0 +1,631 @@
+//! Global finalize pass: resolves each field's on-disk dtype from data
+//! observed across every contig, then rewrites the staged `values.bin` files
+//! in place to that resolved width.
+//!
+//! Staging (Tasks 4/5/8a/8b) always writes fields as native-width `i32`
+//! (Int/Flag) or `f32` (Float), 4 bytes/element, little-endian. A staged
+//! missing sentinel (`i32::MIN` for int, `NaN` for float) is present ONLY
+//! when the field has no configured `default` — when a `default` is set,
+//! missing was already replaced by that default value at staging time, so no
+//! sentinel is ever written for that field. This pass:
+//!
+//!   1. Enumerates every `values.bin` file staged for a field, across all
+//!      contigs and the four genotype-aligned sub-streams
+//!      (`var_key_snp`/`var_key_indel`/`dense_snp`/`dense_indel`).
+//!   2. Scans them to find the field's global `[min, max]` and whether a
+//!      missing sentinel was observed.
+//!   3. Resolves the field's concrete `StorageDtype` — validating an
+//!      explicit user request against the observed range, or (for `Auto`)
+//!      choosing the smallest lossless width, reserving a sentinel slot iff
+//!      missing was observed.
+//!   4. Rewrites every file to the resolved width, remapping the staged
+//!      sentinel (if any) to the resolved dtype's own sentinel encoding.
+
+use crate::error::ConversionError;
+use crate::field::{FieldCategory, FieldSpec, HtslibType, StorageDtype};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// The four genotype-aligned sub-stream directory names a field's values may
+/// be staged under (mirrors `orchestrator.rs`'s `sub_label` computation:
+/// `spec.subdir.replace('/', "_")` over `"var_key/snp"`, `"var_key/indel"`,
+/// `"dense/snp"`, `"dense/indel"`).
+const SUB_LABELS: [&str; 4] = ["var_key_snp", "var_key_indel", "dense_snp", "dense_indel"];
+
+/// A field's globally-resolved on-disk representation, produced once all
+/// contigs have been staged and rewritten. `dtype` is always concrete
+/// (never `StorageDtype::Auto`).
+#[derive(Debug, Clone)]
+pub struct ResolvedField {
+    pub name: String,
+    pub category: FieldCategory,
+    pub dtype: StorageDtype,
+    pub default: Option<f64>,
+}
+
+/// Global `[min, max]` (kept as `f64`; exact for both the `i32` and `f32`
+/// staged domains) plus whether a missing sentinel was observed, across
+/// every file staged for one field.
+#[derive(Debug, Clone, Copy)]
+struct ScanStats {
+    min: f64,
+    max: f64,
+    has_missing: bool,
+    any_values: bool,
+}
+
+impl ScanStats {
+    fn empty() -> Self {
+        ScanStats {
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+            has_missing: false,
+            any_values: false,
+        }
+    }
+
+    fn observe(&mut self, v: f64) {
+        self.any_values = true;
+        if v < self.min {
+            self.min = v;
+        }
+        if v > self.max {
+            self.max = v;
+        }
+    }
+}
+
+fn bad(msg: impl Into<String>) -> ConversionError {
+    ConversionError::Input(msg.into())
+}
+
+/// Resolve and rewrite every field's `values.bin` files under `output_dir`,
+/// returning one `ResolvedField` per input `FieldSpec` (same order).
+pub fn finalize_fields(
+    output_dir: &Path,
+    contigs: &[String],
+    fields: &[FieldSpec],
+) -> Result<Vec<ResolvedField>, ConversionError> {
+    fields
+        .iter()
+        .map(|field| finalize_one(output_dir, contigs, field))
+        .collect()
+}
+
+fn finalize_one(
+    output_dir: &Path,
+    contigs: &[String],
+    field: &FieldSpec,
+) -> Result<ResolvedField, ConversionError> {
+    let files = field_files(output_dir, contigs, &field.name);
+    let stats = scan(&files, field)?;
+    let dtype = resolve_dtype(field, &stats)?;
+    for path in &files {
+        rewrite_file(path, field, dtype)?;
+    }
+    Ok(ResolvedField {
+        name: field.name.clone(),
+        category: field.category,
+        dtype,
+        default: field.default,
+    })
+}
+
+/// Enumerate the `values.bin` files that exist for `name`, across every
+/// contig and all four sub labels. Iterating the known sub labels directly
+/// (rather than globbing) is simpler and matches the fixed staging layout.
+fn field_files(output_dir: &Path, contigs: &[String], name: &str) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for contig in contigs {
+        for sub in SUB_LABELS {
+            let path = output_dir
+                .join(contig)
+                .join("fields")
+                .join(name)
+                .join(sub)
+                .join("values.bin");
+            if path.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// Read a staged `values.bin` as `f64` (exact for both `i32` and `f32`
+/// staged domains), decoding each 4-byte little-endian element per
+/// `is_float`.
+fn read_staged(path: &Path, is_float: bool) -> Result<Vec<f64>, ConversionError> {
+    let bytes = std::fs::read(path).map_err(|e| ConversionError::Io {
+        context: format!("reading {}", path.display()),
+        source: e,
+    })?;
+    if bytes.len() % 4 != 0 {
+        return Err(bad(format!(
+            "{}: staged values.bin length {} is not a multiple of 4 bytes",
+            path.display(),
+            bytes.len()
+        )));
+    }
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|c| {
+            let arr: [u8; 4] = c.try_into().unwrap();
+            if is_float {
+                f32::from_le_bytes(arr) as f64
+            } else {
+                i32::from_le_bytes(arr) as f64
+            }
+        })
+        .collect())
+}
+
+/// `true` iff a staged element `v` represents the staged missing sentinel.
+/// Only meaningful (and only ever actually observed) when the field has no
+/// `default` — a `default` means missing was already substituted at staging
+/// time, so no sentinel exists in the data regardless of what this returns.
+fn is_staged_missing(v: f64, is_float: bool) -> bool {
+    if is_float {
+        v.is_nan()
+    } else {
+        v as i64 == i32::MIN as i64
+    }
+}
+
+fn scan(files: &[PathBuf], field: &FieldSpec) -> Result<ScanStats, ConversionError> {
+    let is_float = field.stage_is_float();
+    // A `default` was already substituted at staging time, so nothing in
+    // the data can be the staged sentinel; treat nothing as missing (the
+    // default value itself still flows into min/max via `observe`).
+    let treat_missing = field.default.is_none();
+    let mut stats = ScanStats::empty();
+    for path in files {
+        for v in read_staged(path, is_float)? {
+            if treat_missing && is_staged_missing(v, is_float) {
+                stats.has_missing = true;
+            } else {
+                stats.observe(v);
+            }
+        }
+    }
+    Ok(stats)
+}
+
+fn unsigned_bound(width: u32) -> u64 {
+    match width {
+        1 => u8::MAX as u64,
+        2 => u16::MAX as u64,
+        4 => u32::MAX as u64,
+        _ => unreachable!("width must be 1, 2, or 4 bytes"),
+    }
+}
+
+fn signed_bounds(width: u32) -> (i64, i64) {
+    match width {
+        1 => (i8::MIN as i64, i8::MAX as i64),
+        2 => (i16::MIN as i64, i16::MAX as i64),
+        4 => (i32::MIN as i64, i32::MAX as i64),
+        _ => unreachable!("width must be 1, 2, or 4 bytes"),
+    }
+}
+
+fn unsigned_fits(width: u32, min: i64, max: i64, has_missing: bool) -> bool {
+    let reserved = if has_missing { 1 } else { 0 };
+    min >= 0 && max <= (unsigned_bound(width) as i64 - reserved)
+}
+
+fn signed_fits(width: u32, min: i64, max: i64, has_missing: bool) -> bool {
+    let reserved = if has_missing { 1 } else { 0 };
+    let (smin, smax) = signed_bounds(width);
+    min >= smin + reserved && max <= smax
+}
+
+#[derive(Debug, Clone, Copy)]
+enum IntChoice {
+    Unsigned(u32),
+    Signed(u32),
+}
+
+/// Smallest lossless integer width for `[min, max]`, reserving a sentinel
+/// slot iff `has_missing`. Prefers unsigned over signed at a given width
+/// whenever `min >= 0` (checked first below). Widths are tried smallest
+/// first; `i32` staging (with `i32::MIN` carved out as the sentinel, so real
+/// values are always `> i32::MIN`) guarantees the 4-byte signed case always
+/// fits as a last resort.
+fn choose_auto_int(min: i64, max: i64, has_missing: bool) -> IntChoice {
+    for width in [1u32, 2, 4] {
+        if unsigned_fits(width, min, max, has_missing) {
+            return IntChoice::Unsigned(width);
+        }
+        if signed_fits(width, min, max, has_missing) {
+            return IntChoice::Signed(width);
+        }
+    }
+    IntChoice::Signed(4)
+}
+
+fn int_choice_to_dtype(choice: IntChoice) -> StorageDtype {
+    match choice {
+        IntChoice::Unsigned(1) => StorageDtype::U8,
+        IntChoice::Unsigned(2) => StorageDtype::U16,
+        IntChoice::Unsigned(4) => StorageDtype::U32,
+        IntChoice::Signed(1) => StorageDtype::I8,
+        IntChoice::Signed(2) => StorageDtype::I16,
+        IntChoice::Signed(4) => StorageDtype::I32,
+        _ => unreachable!("choose_auto_int only emits width 1/2/4"),
+    }
+}
+
+/// Resolve a field's concrete `StorageDtype`: `Auto` chooses the narrowest
+/// lossless representation; an explicit request is range-checked against the
+/// observed data and returned as-is (or rejected with `ConversionError`).
+fn resolve_dtype(field: &FieldSpec, stats: &ScanStats) -> Result<StorageDtype, ConversionError> {
+    match field.dtype {
+        StorageDtype::Auto => {
+            if field.htype == HtslibType::Flag {
+                return Ok(StorageDtype::Bool);
+            }
+            if field.stage_is_float() {
+                return Ok(StorageDtype::F32);
+            }
+            if !stats.any_values {
+                // No data staged anywhere for this field; nothing to narrow.
+                return Ok(StorageDtype::U8);
+            }
+            let choice = choose_auto_int(stats.min as i64, stats.max as i64, stats.has_missing);
+            Ok(int_choice_to_dtype(choice))
+        }
+        explicit => {
+            validate_explicit(explicit, stats, &field.name)?;
+            Ok(explicit)
+        }
+    }
+}
+
+fn validate_explicit(
+    dtype: StorageDtype,
+    stats: &ScanStats,
+    field_name: &str,
+) -> Result<(), ConversionError> {
+    if !stats.any_values {
+        // No real values to range-check; a lone missing-only bool field has
+        // nowhere to put a sentinel, but that's an existing-data edge case
+        // we don't need to reject here (nothing conflicts with anything).
+        return Ok(());
+    }
+    let min_i = stats.min as i64;
+    let max_i = stats.max as i64;
+    match dtype {
+        StorageDtype::Bool => {
+            if stats.has_missing {
+                return Err(bad(format!(
+                    "field {field_name:?}: explicit dtype bool has no spare value to encode a missing sentinel"
+                )));
+            }
+            if min_i < 0 || max_i > 1 {
+                return Err(bad(format!(
+                    "field {field_name:?}: explicit dtype bool requires values in {{0,1}}, observed range [{}, {}]",
+                    stats.min, stats.max
+                )));
+            }
+        }
+        StorageDtype::I8 | StorageDtype::I16 | StorageDtype::I32 => {
+            let width = dtype.width_bytes().unwrap() as u32;
+            if !signed_fits(width, min_i, max_i, stats.has_missing) {
+                return Err(bad(format!(
+                    "field {field_name:?}: explicit dtype {:?} cannot hold observed range [{}, {}]{}",
+                    dtype,
+                    stats.min,
+                    stats.max,
+                    if stats.has_missing {
+                        " plus a reserved missing sentinel"
+                    } else {
+                        ""
+                    }
+                )));
+            }
+        }
+        StorageDtype::U8 | StorageDtype::U16 | StorageDtype::U32 => {
+            let width = dtype.width_bytes().unwrap() as u32;
+            if !unsigned_fits(width, min_i, max_i, stats.has_missing) {
+                return Err(bad(format!(
+                    "field {field_name:?}: explicit dtype {:?} cannot hold observed range [{}, {}]{}",
+                    dtype,
+                    stats.min,
+                    stats.max,
+                    if stats.has_missing {
+                        " plus a reserved missing sentinel"
+                    } else {
+                        ""
+                    }
+                )));
+            }
+        }
+        StorageDtype::F16 => {
+            if stats.max > 65504.0 || stats.min < -65504.0 {
+                return Err(bad(format!(
+                    "field {field_name:?}: explicit dtype f16 cannot hold observed range [{}, {}] (max magnitude 65504)",
+                    stats.min, stats.max
+                )));
+            }
+        }
+        StorageDtype::F32 => {}
+        StorageDtype::Auto => unreachable!("Auto is resolved separately, never validated here"),
+    }
+    Ok(())
+}
+
+fn rewrite_file(
+    path: &Path,
+    field: &FieldSpec,
+    dtype: StorageDtype,
+) -> Result<(), ConversionError> {
+    let is_float = field.stage_is_float();
+    let treat_missing = field.default.is_none();
+    let values = read_staged(path, is_float)?;
+
+    let width = dtype.width_bytes().unwrap_or(4);
+    let mut out = Vec::with_capacity(values.len() * width);
+    for v in values {
+        let is_missing = treat_missing && is_staged_missing(v, is_float);
+        encode(&mut out, dtype, v, is_missing);
+    }
+
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| ConversionError::Io {
+            context: format!("rewriting {}", path.display()),
+            source: e,
+        })?;
+    f.write_all(&out).map_err(|e| ConversionError::Io {
+        context: format!("writing {}", path.display()),
+        source: e,
+    })?;
+    f.flush().map_err(|e| ConversionError::Io {
+        context: format!("flushing {}", path.display()),
+        source: e,
+    })?;
+    Ok(())
+}
+
+/// Encode one resolved-dtype element into `out`. `v` is the staged value
+/// (already validated to fit `dtype`); `is_missing` selects the resolved
+/// sentinel encoding instead (`u*::MAX` for unsigned, `i*::MIN` for signed,
+/// `NaN` for float/`f16`) — only ever `true` when the field has no
+/// `default`, per the staging invariant.
+fn encode(out: &mut Vec<u8>, dtype: StorageDtype, v: f64, is_missing: bool) {
+    match dtype {
+        StorageDtype::Bool => {
+            out.push(if v != 0.0 { 1 } else { 0 });
+        }
+        StorageDtype::I8 => {
+            let x: i8 = if is_missing { i8::MIN } else { v as i64 as i8 };
+            out.push(x as u8);
+        }
+        StorageDtype::U8 => {
+            let x: u8 = if is_missing { u8::MAX } else { v as i64 as u8 };
+            out.push(x);
+        }
+        StorageDtype::I16 => {
+            let x: i16 = if is_missing {
+                i16::MIN
+            } else {
+                v as i64 as i16
+            };
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+        StorageDtype::U16 => {
+            let x: u16 = if is_missing {
+                u16::MAX
+            } else {
+                v as i64 as u16
+            };
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+        StorageDtype::I32 => {
+            let x: i32 = if is_missing {
+                i32::MIN
+            } else {
+                v as i64 as i32
+            };
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+        StorageDtype::U32 => {
+            let x: u32 = if is_missing {
+                u32::MAX
+            } else {
+                v as i64 as u32
+            };
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+        StorageDtype::F16 => {
+            let x = if is_missing {
+                half::f16::NAN
+            } else {
+                half::f16::from_f64(v)
+            };
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+        StorageDtype::F32 => {
+            let x: f32 = if is_missing { f32::NAN } else { v as f32 };
+            out.extend_from_slice(&x.to_le_bytes());
+        }
+        StorageDtype::Auto => unreachable!("dtype is resolved (concrete) before rewrite"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_i32_field(root: &Path, contig: &str, name: &str, sub: &str, values: &[i32]) {
+        let dir = root.join(contig).join("fields").join(name).join(sub);
+        fs::create_dir_all(&dir).unwrap();
+        let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        fs::write(dir.join("values.bin"), bytes).unwrap();
+    }
+
+    fn write_f32_field(root: &Path, contig: &str, name: &str, sub: &str, values: &[f32]) {
+        let dir = root.join(contig).join("fields").join(name).join(sub);
+        fs::create_dir_all(&dir).unwrap();
+        let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        fs::write(dir.join("values.bin"), bytes).unwrap();
+    }
+
+    fn read_values_bin(path: &Path) -> Vec<u8> {
+        fs::read(path).unwrap()
+    }
+
+    fn int_field(name: &str, dtype: StorageDtype, default: Option<f64>) -> FieldSpec {
+        FieldSpec {
+            name: name.to_string(),
+            category: FieldCategory::Info,
+            htype: HtslibType::Int,
+            dtype,
+            default,
+        }
+    }
+
+    fn float_field(name: &str, dtype: StorageDtype, default: Option<f64>) -> FieldSpec {
+        FieldSpec {
+            name: name.to_string(),
+            category: FieldCategory::Format,
+            htype: HtslibType::Float,
+            dtype,
+            default,
+        }
+    }
+
+    #[test]
+    fn auto_int_narrows_to_u8_no_missing() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_i32_field(root, "chr1", "AC", "var_key_snp", &[0, 50, 200]);
+        write_i32_field(root, "chr2", "AC", "var_key_snp", &[0, 5, 10]);
+
+        let contigs = vec!["chr1".to_string(), "chr2".to_string()];
+        let field = int_field("AC", StorageDtype::Auto, None);
+        let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
+
+        assert_eq!(resolved.len(), 1);
+        assert!(matches!(resolved[0].dtype, StorageDtype::U8));
+
+        let path1 = root.join("chr1/fields/AC/var_key_snp/values.bin");
+        let bytes1 = read_values_bin(&path1);
+        assert_eq!(bytes1, vec![0u8, 50, 200]);
+
+        let path2 = root.join("chr2/fields/AC/var_key_snp/values.bin");
+        let bytes2 = read_values_bin(&path2);
+        assert_eq!(bytes2, vec![0u8, 5, 10]);
+    }
+
+    #[test]
+    fn auto_int_with_missing_reserves_sentinel_and_may_bump_width() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // Values 0..=255 with a missing sentinel present: u8 can only carry
+        // 255 distinct non-sentinel values (0..=254), so the real value 255
+        // forces a bump to u16.
+        write_i32_field(root, "chr1", "DP", "var_key_snp", &[0, 254, 255, i32::MIN]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = int_field("DP", StorageDtype::Auto, None);
+        let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
+
+        assert!(matches!(resolved[0].dtype, StorageDtype::U16));
+
+        let path = root.join("chr1/fields/DP/var_key_snp/values.bin");
+        let bytes = read_values_bin(&path);
+        let words: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert_eq!(words, vec![0u16, 254, 255, u16::MAX]);
+    }
+
+    #[test]
+    fn auto_int_narrows_to_u8_with_missing_when_range_leaves_room() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // max 200 with missing: u8 needs only 201 slots (0..=200) plus one
+        // sentinel slot (255) — fits in u8 (max usable non-sentinel is 254).
+        write_i32_field(root, "chr1", "AF", "var_key_snp", &[0, 200, i32::MIN]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = int_field("AF", StorageDtype::Auto, None);
+        let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
+        assert!(matches!(resolved[0].dtype, StorageDtype::U8));
+
+        let path = root.join("chr1/fields/AF/var_key_snp/values.bin");
+        let bytes = read_values_bin(&path);
+        assert_eq!(bytes, vec![0u8, 200, u8::MAX]);
+    }
+
+    #[test]
+    fn explicit_f16_in_range_rewrites_to_two_bytes() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_f32_field(root, "chr1", "DS", "dense_snp", &[0.0, 65504.0, -100.5]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = float_field("DS", StorageDtype::F16, None);
+        let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
+        assert!(matches!(resolved[0].dtype, StorageDtype::F16));
+
+        let path = root.join("chr1/fields/DS/dense_snp/values.bin");
+        let bytes = read_values_bin(&path);
+        assert_eq!(bytes.len(), 3 * 2);
+        let words: Vec<half::f16> = bytes
+            .chunks_exact(2)
+            .map(|c| half::f16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert_eq!(words[0].to_f32(), 0.0);
+        assert_eq!(words[1].to_f32(), 65504.0);
+        assert_eq!(words[2].to_f32(), -100.5);
+    }
+
+    #[test]
+    fn explicit_f16_overflow_errors() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_f32_field(root, "chr1", "DS", "dense_snp", &[0.0, 70000.0]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = float_field("DS", StorageDtype::F16, None);
+        let err = finalize_fields(root, &contigs, &[field]).unwrap_err();
+        assert!(matches!(err, ConversionError::Input(_)));
+    }
+
+    #[test]
+    fn explicit_int_overflow_errors() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_i32_field(root, "chr1", "XX", "var_key_snp", &[0, 300]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = int_field("XX", StorageDtype::I8, None);
+        let err = finalize_fields(root, &contigs, &[field]).unwrap_err();
+        assert!(matches!(err, ConversionError::Input(_)));
+    }
+
+    #[test]
+    fn default_set_values_treated_as_non_missing() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // No i32::MIN sentinel is ever staged when `default` is set — every
+        // element (including substituted defaults) is a real value.
+        write_i32_field(root, "chr1", "GQ", "var_key_snp", &[0, 5, 0]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = int_field("GQ", StorageDtype::Auto, Some(0.0));
+        let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
+        // No missing observed (by construction), so u8 needs no reserved
+        // sentinel slot: max 5 fits trivially.
+        assert!(matches!(resolved[0].dtype, StorageDtype::U8));
+        assert_eq!(resolved[0].default, Some(0.0));
+    }
+}

--- a/src/field_finalize.rs
+++ b/src/field_finalize.rs
@@ -693,4 +693,30 @@ mod tests {
         assert!(matches!(resolved[0].dtype, StorageDtype::U8));
         assert_eq!(resolved[0].default, Some(0.0));
     }
+
+    #[test]
+    fn explicit_f32_rewrites_in_place_byte_identical() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let contig = "chr1";
+        let vals: [f32; 4] = [0.5, -1.25, 0.0, 3.5];
+        // stage under one var_key sub label
+        write_f32_field(root, contig, "DS", "var_key_snp", &vals);
+        let path = root
+            .join(contig)
+            .join("fields")
+            .join("format")
+            .join("DS")
+            .join("var_key_snp")
+            .join("values.bin");
+        let before = read_values_bin(&path);
+
+        let field = float_field("DS", StorageDtype::F32, None);
+        let resolved = finalize_fields(root, &[contig.to_string()], &[field]).unwrap();
+
+        assert_eq!(resolved[0].dtype, StorageDtype::F32);
+        let after = read_values_bin(&path);
+        // f32 staged -> f32 resolved: rewrite must reproduce the same 16 bytes.
+        assert_eq!(before, after, "f32->f32 finalize must be byte-identical");
+    }
 }

--- a/src/field_finalize.rs
+++ b/src/field_finalize.rs
@@ -695,6 +695,32 @@ mod tests {
     }
 
     #[test]
+    fn finalize_auto_narrow_byte_golden() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // i32 staged values incl. one MISSING sentinel; auto -> narrow.
+        write_i32_field(root, "chr1", "AC", "var_key_snp", &[0, 5, 127, i32::MIN, 3]);
+        let field = int_field("AC", StorageDtype::Auto, None);
+        let resolved = finalize_fields(root, &[String::from("chr1")], &[field]).unwrap();
+        let path = root
+            .join("chr1")
+            .join("fields")
+            .join("info")
+            .join("AC")
+            .join("var_key_snp")
+            .join("values.bin");
+        let got = read_values_bin(&path);
+        // Captured from a run on pre-refactor code (`cargo test --no-default-features
+        // --features conversion --lib field_finalize::tests::finalize_auto_narrow_byte_golden
+        // -- --nocapture`): values [0, 5, 127, i32::MIN, 3], no default => MIN is
+        // the staged-missing sentinel. max=127 with has_missing=true still fits
+        // u8 (0..=254 usable, sentinel reserved at 255) => resolves to U8, with
+        // the sentinel remapped to u8::MAX=255.
+        assert_eq!(resolved[0].dtype, StorageDtype::U8);
+        assert_eq!(got, vec![0u8, 5, 127, 255, 3]);
+    }
+
+    #[test]
     fn explicit_f32_rewrites_in_place_byte_identical() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();

--- a/src/field_finalize.rs
+++ b/src/field_finalize.rs
@@ -613,6 +613,57 @@ mod tests {
     }
 
     #[test]
+    fn auto_int_negative_min_narrows_to_signed_i8() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // min=-5, max=100, no missing: -5..100 fits i8's -128..=127 range, and
+        // a negative min forces the Signed branch (unsigned_fits requires
+        // min >= 0).
+        write_i32_field(root, "chr1", "SC", "var_key_snp", &[-5, 0, 100]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = int_field("SC", StorageDtype::Auto, None);
+        let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
+
+        assert!(
+            matches!(resolved[0].dtype, StorageDtype::I8),
+            "expected I8 (signed), got {:?}",
+            resolved[0].dtype
+        );
+
+        let path = root.join("chr1/fields/SC/var_key_snp/values.bin");
+        let bytes = read_values_bin(&path);
+        let decoded: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
+        assert_eq!(decoded, vec![-5i8, 0, 100]);
+    }
+
+    #[test]
+    fn auto_int_negative_min_out_of_i8_range_bumps_to_signed_i16() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // min=-200 doesn't fit i8 (-128..=127), forcing a bump to i16.
+        write_i32_field(root, "chr1", "SC2", "var_key_snp", &[-200, 0, 100]);
+
+        let contigs = vec!["chr1".to_string()];
+        let field = int_field("SC2", StorageDtype::Auto, None);
+        let resolved = finalize_fields(root, &contigs, &[field]).unwrap();
+
+        assert!(
+            matches!(resolved[0].dtype, StorageDtype::I16),
+            "expected I16 (signed), got {:?}",
+            resolved[0].dtype
+        );
+
+        let path = root.join("chr1/fields/SC2/var_key_snp/values.bin");
+        let bytes = read_values_bin(&path);
+        let decoded: Vec<i16> = bytes
+            .chunks_exact(2)
+            .map(|c| i16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        assert_eq!(decoded, vec![-200i16, 0, 100]);
+    }
+
+    #[test]
     fn default_set_values_treated_as_non_missing() {
         let tmp = tempdir().unwrap();
         let root = tmp.path();

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -115,6 +115,15 @@ pub fn offsets(dir: &Path) -> PathBuf {
 pub fn chunk_geno(dir: &Path, chunk_id: usize) -> PathBuf {
     dir.join(format!("chunk_{}_geno.bin", chunk_id))
 }
+pub fn chunk_field(dir: &Path, chunk_id: usize, field_ix: usize) -> PathBuf {
+    dir.join(format!("chunk_{}_field{}.bin", chunk_id, field_ix))
+}
+pub fn chunk_field_info(dir: &Path, chunk_id: usize, field_ix: usize) -> PathBuf {
+    dir.join(format!("chunk_{}_finfo{}.bin", chunk_id, field_ix))
+}
+pub fn chunk_field_format(dir: &Path, chunk_id: usize, field_ix: usize) -> PathBuf {
+    dir.join(format!("chunk_{}_fformat{}.bin", chunk_id, field_ix))
+}
 pub fn genotypes(dir: &Path) -> PathBuf {
     dir.join("genotypes.bin")
 }
@@ -186,6 +195,24 @@ mod tests {
         assert_eq!(
             genotypes(dir),
             Path::new("/out/chr1/dense/snp/genotypes.bin")
+        );
+    }
+
+    #[test]
+    fn test_chunk_field_names() {
+        let dir = Path::new("/out/chr1/var_key/snp");
+        assert_eq!(
+            chunk_field(dir, 3, 0),
+            Path::new("/out/chr1/var_key/snp/chunk_3_field0.bin")
+        );
+        let dense_dir = Path::new("/out/chr1/dense/snp");
+        assert_eq!(
+            chunk_field_info(dense_dir, 3, 1),
+            Path::new("/out/chr1/dense/snp/chunk_3_finfo1.bin")
+        );
+        assert_eq!(
+            chunk_field_format(dense_dir, 3, 2),
+            Path::new("/out/chr1/dense/snp/chunk_3_fformat2.bin")
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // src/lib.rs
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 #[cfg(feature = "conversion")]
 use rayon::prelude::*;
@@ -93,8 +94,9 @@ fn index_vcf(path: String) -> PyResult<()> {
 //The Python Wrapper and resource allocator
 #[cfg(feature = "conversion")]
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
 #[pyfunction]
-#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false))]
+#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new()))]
 fn run_conversion_pipeline(
     py: Python,
     vcf_path: String,
@@ -108,8 +110,15 @@ fn run_conversion_pipeline(
     long_allele_capacity: usize, // default 8MB — old 100MB rarely flushed mid-run, blocking executor at finalize
     skip_out_of_scope: bool,
     signatures: bool,
+    info_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
+    format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
 ) -> PyResult<usize> {
     let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
+
+    let mut raw = info_fields;
+    raw.extend(format_fields);
+    let fields =
+        crate::field::parse_manifest(raw).map_err(|e| PyValueError::new_err(e.to_string()))?;
 
     let results: Vec<Result<u64, crate::error::ConversionError>> = py.detach(|| {
         // Step 1 -> HW discovery/override and budgeting
@@ -176,6 +185,7 @@ fn run_conversion_pipeline(
                         skip_out_of_scope,
                         processing_threads,
                         signatures,
+                        &fields,
                     )
                 })
                 .collect::<Vec<_>>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod enum_map;
 pub mod error;
 #[cfg(feature = "conversion")]
 pub mod executor;
+pub mod field;
 pub mod layout;
 #[cfg(feature = "conversion")]
 pub mod max_del;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,9 +204,11 @@ fn run_conversion_pipeline(
 
     // All contigs staged — resolve each field's global on-disk dtype and
     // rewrite its staged values.bin files to that width.
-    let resolved_fields =
-        crate::field_finalize::finalize_fields(std::path::Path::new(&output_dir), &chroms, &fields)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let resolved_fields = crate::field_finalize::finalize_fields(
+        std::path::Path::new(&output_dir),
+        &chroms,
+        &fields,
+    )?;
     let _ = &resolved_fields; // consumed by write_meta in the next task
 
     // All contigs converted — write the top-level meta.json describing the cohort.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub mod error;
 #[cfg(feature = "conversion")]
 pub mod executor;
 pub mod field;
+#[cfg(feature = "conversion")]
+pub mod field_finalize;
 pub mod layout;
 #[cfg(feature = "conversion")]
 pub mod max_del;
@@ -199,6 +201,13 @@ fn run_conversion_pipeline(
     for r in results {
         total_dropped += r?; // ConversionError -> PyErr via From (category-aware)
     }
+
+    // All contigs staged — resolve each field's global on-disk dtype and
+    // rewrite its staged values.bin files to that width.
+    let resolved_fields =
+        crate::field_finalize::finalize_fields(std::path::Path::new(&output_dir), &chroms, &fields)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let _ = &resolved_fields; // consumed by write_meta in the next task
 
     // All contigs converted — write the top-level meta.json describing the cohort.
     crate::meta::write_meta(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,6 @@ fn run_conversion_pipeline(
         &chroms,
         &fields,
     )?;
-    let _ = &resolved_fields; // consumed by write_meta in the next task
 
     // All contigs converted — write the top-level meta.json describing the cohort.
     crate::meta::write_meta(
@@ -218,6 +217,7 @@ fn run_conversion_pipeline(
         &samples,
         &chroms,
         ploidy,
+        &resolved_fields,
     )
     .map_err(|e| pyo3::exceptions::PyOSError::new_err(format!("failed to write meta.json: {e}")))?;
 

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -269,6 +269,189 @@ pub fn merge_mini_sc(
     Ok(())
 }
 
+/// Merge one var_key field's per-chunk `chunk_{c}_field{field_ix}.bin` files into
+/// `dest_values_bin`, in the same column-major order as `alleles.bin`/`positions.bin`.
+///
+/// `item_width` is the staged per-value byte width (4 for the i32/f32 staged
+/// representation Task 7 writes — narrowing to a final storage dtype happens later,
+/// at finalize time, not here). `ram_ledger` is the SAME calls-per-(chunk, column)
+/// ledger `merge_mini_sc` uses for the pos/key streams — field values are staged
+/// 1:1 with calls, so the identical column-major reordering applies; only the
+/// per-item width differs.
+///
+/// This performs its own Phase A (offsets) + Phase B (parallel tile gather) local
+/// to this one field stream, mirroring `merge_mini_sc`'s tile arithmetic exactly
+/// but for a single flat byte buffer (no separate pos/key arrays, and no
+/// `offsets.npy` — the offsets already written by `merge_mini_sc` for this stream
+/// apply unchanged to every field, since fields share the same per-call ordering).
+///
+/// The caller is responsible for creating `dest_values_bin`'s parent directory
+/// before calling this function (this function does not call `create_dir_all`).
+///
+/// On success, the per-chunk `chunk_{c}_field{field_ix}.bin` source files are
+/// removed (Phase C cleanup), mirroring `merge_mini_sc`'s pos/key cleanup.
+#[allow(clippy::too_many_arguments)]
+pub fn merge_var_key_field_values(
+    output_dir: &str,
+    num_chunks: usize,
+    num_samples: usize,
+    ploidy: usize,
+    ram_ledger: &[Vec<u32>],
+    field_ix: usize,
+    item_width: usize,
+    dest_values_bin: &Path,
+) -> Result<(), ConversionError> {
+    let output_dir_path = Path::new(output_dir);
+    let total_columns = num_samples * ploidy;
+
+    // Phase A: derive global per-column offsets + per-chunk local offsets from
+    // the RAM Ledger. Identical arithmetic to merge_mini_sc — deliberately NOT
+    // shared as a helper to keep the working pos/key merge untouched; see the
+    // task report for the "replicate vs refactor" tradeoff.
+    let mut final_offsets = vec![0u64; total_columns + 1];
+    let mut chunk_offsets = vec![vec![0u32; total_columns + 1]; num_chunks];
+
+    for col in 0..total_columns {
+        let mut col_total = 0u64;
+        for chunk_id in 0..num_chunks {
+            let calls = ram_ledger[chunk_id][col];
+            chunk_offsets[chunk_id][col + 1] = chunk_offsets[chunk_id][col] + calls;
+            col_total += calls as u64;
+        }
+        final_offsets[col + 1] = final_offsets[col] + col_total;
+    }
+
+    let total_items: u64 = final_offsets[total_columns];
+    let total_bytes: u64 = total_items * item_width as u64;
+
+    // Pre-create the monolithic output at full size so worker pwrites land in
+    // disjoint byte ranges (sparse file — no disk space consumed until written).
+    let dest_file = File::create(dest_values_bin).map_err(|e| ConversionError::Io {
+        context: format!("creating {:?}", dest_values_bin),
+        source: e,
+    })?;
+    dest_file
+        .set_len(total_bytes)
+        .map_err(|e| ConversionError::Io {
+            context: format!("sizing {:?}", dest_values_bin),
+            source: e,
+        })?;
+
+    // Open every chunk's field file exactly once; pread() is stateless and safe
+    // to call concurrently from multiple rayon workers.
+    let chunk_files: Vec<File> = (0..num_chunks)
+        .map(|c| -> Result<File, ConversionError> {
+            File::open(layout::chunk_field(output_dir_path, c, field_ix)).map_err(|e| {
+                ConversionError::Io {
+                    context: format!("opening chunk_{c}_field{field_ix}.bin"),
+                    source: e,
+                }
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    // Adaptive tile size: target TILE_RAM_BUDGET per tile (one buffer per tile here,
+    // vs two in merge_mini_sc, so this tolerates a slightly larger tile — but we
+    // keep the same budget constant for a simple, predictable footprint).
+    let avg_calls_per_col =
+        std::cmp::max(1u64, total_items / std::cmp::max(1, total_columns) as u64);
+    let columns_per_tile = std::cmp::max(
+        1usize,
+        std::cmp::min(
+            total_columns.max(1),
+            (TILE_RAM_BUDGET_BYTES / (avg_calls_per_col * item_width as u64)) as usize,
+        ),
+    );
+
+    let tile_starts: Vec<usize> = (0..total_columns).step_by(columns_per_tile).collect();
+
+    let final_offsets_ref = &final_offsets;
+    let chunk_offsets_ref = &chunk_offsets;
+    let chunk_files_ref = &chunk_files;
+    let dest_ref = &dest_file;
+
+    tile_starts
+        .par_iter()
+        .try_for_each(|&tile_start_col| -> Result<(), ConversionError> {
+            let tile_end_col = std::cmp::min(tile_start_col + columns_per_tile, total_columns);
+            let tile_n_cols = tile_end_col - tile_start_col;
+            let tile_start_item = final_offsets_ref[tile_start_col] as usize;
+            let tile_end_item = final_offsets_ref[tile_end_col] as usize;
+            let tile_total_items = tile_end_item - tile_start_item;
+
+            if tile_total_items == 0 {
+                return Ok(());
+            }
+
+            let mut tile_buffer = vec![0u8; tile_total_items * item_width];
+
+            // per-column write head (offset within this tile buffer, in items)
+            let mut tile_write_heads = vec![0usize; tile_n_cols];
+            #[allow(clippy::needless_range_loop)]
+            for i in 0..tile_n_cols {
+                let col = tile_start_col + i;
+                tile_write_heads[i] = (final_offsets_ref[col] as usize) - tile_start_item;
+            }
+
+            // gather from chunks
+            for chunk_id in 0..num_chunks {
+                let chunk_start_item = chunk_offsets_ref[chunk_id][tile_start_col] as usize;
+                let chunk_end_item = chunk_offsets_ref[chunk_id][tile_end_col] as usize;
+                let chunk_items_to_read = chunk_end_item - chunk_start_item;
+
+                if chunk_items_to_read == 0 {
+                    continue;
+                }
+
+                let mut chunk_bytes = vec![0u8; chunk_items_to_read * item_width];
+                let byte_offset = (chunk_start_item * item_width) as u64;
+                chunk_files_ref[chunk_id]
+                    .read_exact_at(&mut chunk_bytes, byte_offset)
+                    .map_err(|e| ConversionError::Io {
+                        context: "pread chunk field".into(),
+                        source: e,
+                    })?;
+
+                let mut local_chunk_cursor = 0usize;
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..tile_n_cols {
+                    let col = tile_start_col + i;
+                    let calls = ram_ledger[chunk_id][col] as usize;
+                    if calls == 0 {
+                        continue;
+                    }
+
+                    let dest_start = tile_write_heads[i] * item_width;
+                    let src_start = local_chunk_cursor * item_width;
+                    tile_buffer[dest_start..dest_start + calls * item_width]
+                        .copy_from_slice(&chunk_bytes[src_start..src_start + calls * item_width]);
+
+                    tile_write_heads[i] += calls;
+                    local_chunk_cursor += calls;
+                }
+            }
+
+            let tile_byte_offset = (tile_start_item * item_width) as u64;
+            dest_ref
+                .write_all_at(&tile_buffer, tile_byte_offset)
+                .map_err(|e| ConversionError::Io {
+                    context: "pwrite field values.bin".into(),
+                    source: e,
+                })?;
+            Ok(())
+        })?;
+
+    // Drop file handles to flush metadata before cleanup
+    drop(chunk_files);
+    drop(dest_file);
+
+    for c in 0..num_chunks {
+        let _ = std::fs::remove_file(layout::chunk_field(output_dir_path, c, field_ix));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     // Test loops mirror the (column, chunk) ledger structure with explicit indices,
@@ -433,6 +616,65 @@ mod tests {
         assert_eq!(final_pos, vec![100, 200, 400, 300, 500, 600]);
         assert_eq!(final_key, vec![1, 2, 4, 3, 5, 6]);
         assert_eq!(final_off, vec![0u64, 3, 6]);
+    }
+
+    // Helper: stage one chunk's field values (raw i32 bytes) to disk in the
+    // layout merge_var_key_field_values expects.
+    fn write_chunk_field_file(dir: &Path, chunk_id: usize, field_ix: usize, values: &[i32]) {
+        let mut f = File::create(layout::chunk_field(dir, chunk_id, field_ix)).unwrap();
+        f.write_all(bytemuck::cast_slice(values)).unwrap();
+    }
+
+    fn read_i32_bin(path: &Path) -> Vec<i32> {
+        let bytes = std::fs::read(path).unwrap();
+        bytes
+            .chunks_exact(4)
+            .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    // Field values must interleave IDENTICALLY to the keys given the same
+    // ledger — mirrors test_merge_multi_chunk_interleave's scenario exactly,
+    // but for a single field's per-chunk staged i32 values instead of pos/key.
+    #[test]
+    fn test_merge_var_key_field_values_multi_chunk_interleave() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path();
+
+        // 2 samples x 1 ploidy = 2 columns. 2 chunks.
+        // Chunk 0: col0=2 calls (10, 20), col1=1 call (30)  -> [10, 20, 30]
+        // Chunk 1: col0=1 call (40),      col1=2 calls (50, 60) -> [40, 50, 60]
+        // Expected final column-major order:
+        //   col0: chunk0 (10, 20) + chunk1 (40)      -> 10, 20, 40
+        //   col1: chunk0 (30)     + chunk1 (50, 60)  -> 30, 50, 60
+        // -> [10, 20, 40, 30, 50, 60]
+        let ram_ledger = vec![vec![2u32, 1], vec![1u32, 2]];
+        write_chunk_field_file(dir, 0, 0, &[10, 20, 30]);
+        write_chunk_field_file(dir, 1, 0, &[40, 50, 60]);
+
+        let dest = dir.join("fields").join("DP").join("var_key_snp");
+        std::fs::create_dir_all(&dest).unwrap();
+        let dest_values_bin = dest.join("values.bin");
+
+        merge_var_key_field_values(
+            dir.to_str().unwrap(),
+            2,
+            2,
+            1,
+            &ram_ledger,
+            0,
+            4,
+            &dest_values_bin,
+        )
+        .unwrap();
+
+        let final_values = read_i32_bin(&dest_values_bin);
+        assert_eq!(final_values, vec![10, 20, 40, 30, 50, 60]);
+        assert_eq!(final_values.len() * 4, 6 * 4); // total_calls(6) * item_width(4)
+
+        // Phase C cleanup: per-chunk field files must be gone.
+        assert!(!layout::chunk_field(dir, 0, 0).exists());
+        assert!(!layout::chunk_field(dir, 1, 0).exists());
     }
 
     proptest! {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -78,8 +78,11 @@ fn gather_columns(
 ) -> Result<(), ConversionError> {
     let total_items: u64 = final_offsets[total_columns];
 
-    // Adaptive tile size: target TILE_RAM_BUDGET per tile, summed across all
-    // payload buffers live at once (e.g. pos + key for merge_mini_sc).
+    // Adaptive tile size: target TILE_RAM_BUDGET per tile. Payloads are
+    // gathered sequentially below (one tile_buffer live at a time), but we
+    // size against the sum of all payload item widths (e.g. pos + key for
+    // merge_mini_sc) as a conservative bound that keeps peak tile RAM under
+    // budget even if the gather were made concurrent.
     let bytes_per_item: u64 = payloads.iter().map(|p| p.item_width as u64).sum();
     let avg_calls_per_col =
         std::cmp::max(1u64, total_items / std::cmp::max(1, total_columns) as u64);

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,6 +1,5 @@
 use crate::error::ConversionError;
 use crate::layout;
-use bytemuck;
 use ndarray::Array1;
 use ndarray_npy::write_npy;
 use rayon::prelude::*;
@@ -12,6 +11,174 @@ use std::path::Path;
 // budget caps a tile at ~32M items. Workers run in parallel via rayon — peak
 // process RAM = TILE_RAM_BUDGET × rayon_threads.
 const TILE_RAM_BUDGET_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Phase A (shared): derive global per-column offsets and per-chunk local
+/// offsets from the RAM Ledger. Both `merge_mini_sc` and
+/// `merge_var_key_field_values` need the identical column-major schedule —
+/// field values are staged 1:1 with calls, so the same reordering applies
+/// regardless of per-item byte width.
+///
+/// Returns `(final_offsets, chunk_offsets)`:
+/// - `final_offsets[col]` is the global item index where column `col` starts
+///   (length `total_columns + 1`, monotonically increasing).
+/// - `chunk_offsets[chunk_id][col]` is the local item index within
+///   `chunk_id`'s own stream where column `col` starts.
+fn derive_offsets(
+    num_chunks: usize,
+    total_columns: usize,
+    ram_ledger: &[Vec<u32>],
+) -> (Vec<u64>, Vec<Vec<u32>>) {
+    let mut final_offsets = vec![0u64; total_columns + 1];
+    let mut chunk_offsets = vec![vec![0u32; total_columns + 1]; num_chunks];
+
+    for col in 0..total_columns {
+        let mut col_total = 0u64;
+
+        for chunk_id in 0..num_chunks {
+            let calls = ram_ledger[chunk_id][col];
+            chunk_offsets[chunk_id][col + 1] = chunk_offsets[chunk_id][col] + calls;
+            col_total += calls as u64;
+        }
+        final_offsets[col + 1] = final_offsets[col] + col_total;
+    }
+
+    (final_offsets, chunk_offsets)
+}
+
+/// One byte-payload stream sharing the offset/tile schedule computed by
+/// `derive_offsets`: per-chunk source files (opened once, read via stateless
+/// `pread`) and the pre-sized destination file (written via `pwrite`).
+struct Payload<'a> {
+    /// Byte width of one item in this stream (e.g. 4 for positions/staged
+    /// i32 field values, `key_bytes` for the allele-key stream).
+    item_width: usize,
+    chunk_files: &'a [File],
+    dest: &'a File,
+}
+
+/// Phase B (shared): adaptive-tile, parallel pread→interleave→pwrite gather.
+///
+/// Each rayon worker owns one tile (a contiguous run of columns). For every
+/// payload it allocates one `Vec<u8>` sized `tile_items * item_width`, reads
+/// each chunk's contributing slice via positional reads, scatters bytes
+/// column-major into the tile buffer via per-column write heads (tracked in
+/// items, applied in bytes), then `pwrite`s the assembled tile to its
+/// pre-computed byte range in the payload's destination file.
+///
+/// Per-column write heads depend only on `final_offsets`/`ram_ledger` (not on
+/// any payload's data), so they are identical across payloads for the same
+/// tile — computed once per tile and reused (cloned) for each payload.
+fn gather_columns(
+    total_columns: usize,
+    num_chunks: usize,
+    ram_ledger: &[Vec<u32>],
+    final_offsets: &[u64],
+    chunk_offsets: &[Vec<u32>],
+    payloads: &[Payload],
+) -> Result<(), ConversionError> {
+    let total_items: u64 = final_offsets[total_columns];
+
+    // Adaptive tile size: target TILE_RAM_BUDGET per tile, summed across all
+    // payload buffers live at once (e.g. pos + key for merge_mini_sc).
+    let bytes_per_item: u64 = payloads.iter().map(|p| p.item_width as u64).sum();
+    let avg_calls_per_col =
+        std::cmp::max(1u64, total_items / std::cmp::max(1, total_columns) as u64);
+    let columns_per_tile = std::cmp::max(
+        1usize,
+        std::cmp::min(
+            total_columns.max(1),
+            (TILE_RAM_BUDGET_BYTES / (avg_calls_per_col * bytes_per_item)) as usize,
+        ),
+    );
+
+    // Tile start columns — independent work units, parallelized across rayon.
+    let tile_starts: Vec<usize> = (0..total_columns).step_by(columns_per_tile).collect();
+
+    tile_starts
+        .par_iter()
+        .try_for_each(|&tile_start_col| -> Result<(), ConversionError> {
+            let tile_end_col = std::cmp::min(tile_start_col + columns_per_tile, total_columns);
+            let tile_n_cols = tile_end_col - tile_start_col;
+            let tile_start_item = final_offsets[tile_start_col] as usize;
+            let tile_end_item = final_offsets[tile_end_col] as usize;
+            let tile_total_items = tile_end_item - tile_start_item;
+
+            if tile_total_items == 0 {
+                return Ok(());
+            }
+
+            // per-column write head (offset within this tile buffer, in items).
+            // Identical for every payload — computed once, cloned per payload below.
+            let mut tile_write_heads_base = vec![0usize; tile_n_cols];
+            #[allow(clippy::needless_range_loop)]
+            for i in 0..tile_n_cols {
+                let col = tile_start_col + i;
+                tile_write_heads_base[i] = (final_offsets[col] as usize) - tile_start_item;
+            }
+
+            for payload in payloads {
+                let item_width = payload.item_width;
+                let mut tile_buffer = vec![0u8; tile_total_items * item_width];
+                let mut tile_write_heads = tile_write_heads_base.clone();
+
+                // gather from chunks
+                for chunk_id in 0..num_chunks {
+                    let chunk_start_item = chunk_offsets[chunk_id][tile_start_col] as usize;
+                    let chunk_end_item = chunk_offsets[chunk_id][tile_end_col] as usize;
+                    let chunk_items_to_read = chunk_end_item - chunk_start_item;
+
+                    if chunk_items_to_read == 0 {
+                        continue;
+                    }
+
+                    // Stateless positional read — multiple workers can read the
+                    // same File concurrently without locking or seek contention.
+                    let mut chunk_bytes = vec![0u8; chunk_items_to_read * item_width];
+                    let byte_offset = (chunk_start_item * item_width) as u64;
+                    payload.chunk_files[chunk_id]
+                        .read_exact_at(&mut chunk_bytes, byte_offset)
+                        .map_err(|e| ConversionError::Io {
+                            context: "pread chunk payload".into(),
+                            source: e,
+                        })?;
+
+                    // stitch this chunk's block into the main Tile buffer
+                    let mut local_chunk_cursor = 0usize;
+                    #[allow(clippy::needless_range_loop)]
+                    for i in 0..tile_n_cols {
+                        let col = tile_start_col + i;
+                        let calls = ram_ledger[chunk_id][col] as usize;
+                        if calls == 0 {
+                            continue;
+                        }
+
+                        let dest_start = tile_write_heads[i] * item_width;
+                        let src_start = local_chunk_cursor * item_width;
+                        tile_buffer[dest_start..dest_start + calls * item_width].copy_from_slice(
+                            &chunk_bytes[src_start..src_start + calls * item_width],
+                        );
+
+                        tile_write_heads[i] += calls;
+                        local_chunk_cursor += calls;
+                    }
+                }
+
+                // pwrite the assembled tile to its known byte range in the
+                // destination file. Tiles are disjoint by construction
+                // (final_offsets is monotonically increasing), so concurrent
+                // write_all_at calls touch non-overlapping regions.
+                let tile_byte_offset = (tile_start_item * item_width) as u64;
+                payload
+                    .dest
+                    .write_all_at(&tile_buffer, tile_byte_offset)
+                    .map_err(|e| ConversionError::Io {
+                        context: "pwrite payload".into(),
+                        source: e,
+                    })?;
+            }
+            Ok(())
+        })
+}
 
 /// Performs the Tile-Based Interleaving Merge.
 ///
@@ -37,19 +204,7 @@ pub fn merge_mini_sc(
     println!("Phase A -> Executing In-Memory Metadata Pass");
 
     // pre-compute global offsets and local chunk offsets using the RAM Ledger
-    let mut final_offsets = vec![0u64; total_columns + 1];
-    let mut chunk_offsets = vec![vec![0u32; total_columns + 1]; num_chunks];
-
-    for col in 0..total_columns {
-        let mut col_total = 0u64;
-
-        for chunk_id in 0..num_chunks {
-            let calls = ram_ledger[chunk_id][col];
-            chunk_offsets[chunk_id][col + 1] = chunk_offsets[chunk_id][col] + calls;
-            col_total += calls as u64;
-        }
-        final_offsets[col + 1] = final_offsets[col] + col_total;
-    }
+    let (final_offsets, chunk_offsets) = derive_offsets(num_chunks, total_columns, &ram_ledger);
 
     // save the global offsets array immediately
     let offsets_array = Array1::from_vec(final_offsets.clone());
@@ -95,167 +250,53 @@ pub fn merge_mini_sc(
         })?;
 
     // Open every chunk's pos/key file exactly once; pread() is stateless and
-    // safe to call concurrently from multiple rayon workers.
-    let chunk_files: Vec<(File, File)> = (0..num_chunks)
-        .map(|c| -> Result<(File, File), ConversionError> {
-            let pf = File::open(layout::chunk_pos(output_dir_path, c)).map_err(|e| {
-                ConversionError::Io {
-                    context: format!("opening chunk_{c}_pos.bin"),
-                    source: e,
-                }
-            })?;
-            let kf = File::open(layout::chunk_key(output_dir_path, c)).map_err(|e| {
-                ConversionError::Io {
-                    context: format!("opening chunk_{c}_key.bin"),
-                    source: e,
-                }
-            })?;
-            Ok((pf, kf))
+    // safe to call concurrently from multiple rayon workers. Split into two
+    // parallel Vec<File> so each stream becomes its own gather_columns Payload.
+    let pos_chunk_files: Vec<File> = (0..num_chunks)
+        .map(|c| -> Result<File, ConversionError> {
+            File::open(layout::chunk_pos(output_dir_path, c)).map_err(|e| ConversionError::Io {
+                context: format!("opening chunk_{c}_pos.bin"),
+                source: e,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let key_chunk_files: Vec<File> = (0..num_chunks)
+        .map(|c| -> Result<File, ConversionError> {
+            File::open(layout::chunk_key(output_dir_path, c)).map_err(|e| ConversionError::Io {
+                context: format!("opening chunk_{c}_key.bin"),
+                source: e,
+            })
         })
         .collect::<Result<_, _>>()?;
 
-    // Adaptive tile size: target TILE_RAM_BUDGET per tile.
-    // pos buffer (u32) + key buffer (key_bytes-wide) → (pos_size + key_bytes) bytes per item.
-    let bytes_per_item = (pos_size + key_bytes) as u64;
-    let avg_calls_per_col =
-        std::cmp::max(1u64, total_items / std::cmp::max(1, total_columns) as u64);
-    let columns_per_tile = std::cmp::max(
-        1usize,
-        std::cmp::min(
-            total_columns.max(1),
-            (TILE_RAM_BUDGET_BYTES / (avg_calls_per_col * bytes_per_item)) as usize,
-        ),
-    );
     println!(
-        "Tile size: {} columns ({} items, ~{} MB per tile)",
-        columns_per_tile,
-        columns_per_tile as u64 * avg_calls_per_col,
-        (columns_per_tile as u64 * avg_calls_per_col * bytes_per_item) / (1024 * 1024),
+        "Tile size target: {} MB per tile (adaptive; computed inside gather_columns)",
+        TILE_RAM_BUDGET_BYTES / (1024 * 1024),
     );
 
-    // Tile start columns — independent work units, parallelized across rayon.
-    let tile_starts: Vec<usize> = (0..total_columns).step_by(columns_per_tile).collect();
-
-    // All shared state below is read-only or via &File pwrite, which is Sync.
-    let final_offsets_ref = &final_offsets;
-    let chunk_offsets_ref = &chunk_offsets;
-    let ram_ledger_ref = &ram_ledger;
-    let chunk_files_ref = &chunk_files;
-    let final_pos_ref = &final_pos_file;
-    let final_key_ref = &final_key_file;
-
-    tile_starts
-        .par_iter()
-        .try_for_each(|&tile_start_col| -> Result<(), ConversionError> {
-            let tile_end_col = std::cmp::min(tile_start_col + columns_per_tile, total_columns);
-            let tile_n_cols = tile_end_col - tile_start_col;
-            let tile_start_item = final_offsets_ref[tile_start_col] as usize;
-            let tile_end_item = final_offsets_ref[tile_end_col] as usize;
-            let tile_total_items = tile_end_item - tile_start_item;
-
-            if tile_total_items == 0 {
-                return Ok(());
-            }
-
-            let mut tile_pos_buffer = vec![0u32; tile_total_items];
-            let mut tile_key_buffer = vec![0u8; tile_total_items * key_bytes];
-
-            // per-column write head (offset within this tile buffer)
-            let mut tile_write_heads = vec![0usize; tile_n_cols];
-            // index loop: `i` indexes tile_write_heads while `col` offsets into the global ledger.
-            #[allow(clippy::needless_range_loop)]
-            for i in 0..tile_n_cols {
-                let col = tile_start_col + i;
-                tile_write_heads[i] = (final_offsets_ref[col] as usize) - tile_start_item;
-            }
-
-            // gather from chunks
-            for chunk_id in 0..num_chunks {
-                let chunk_start_item = chunk_offsets_ref[chunk_id][tile_start_col] as usize;
-                let chunk_end_item = chunk_offsets_ref[chunk_id][tile_end_col] as usize;
-                let chunk_items_to_read = chunk_end_item - chunk_start_item;
-
-                if chunk_items_to_read == 0 {
-                    continue;
-                }
-
-                // Stateless positional reads — multiple workers can read the same File
-                // concurrently without locking or seek-state contention.
-                let mut chunk_pos_bytes = vec![0u8; chunk_items_to_read * pos_size];
-                let mut chunk_key_bytes = vec![0u8; chunk_items_to_read * key_bytes];
-                let pos_byte_offset = (chunk_start_item * pos_size) as u64;
-                let key_byte_offset = (chunk_start_item * key_bytes) as u64;
-                chunk_files_ref[chunk_id]
-                    .0
-                    .read_exact_at(&mut chunk_pos_bytes, pos_byte_offset)
-                    .map_err(|e| ConversionError::Io {
-                        context: "pread chunk pos".into(),
-                        source: e,
-                    })?;
-                chunk_files_ref[chunk_id]
-                    .1
-                    .read_exact_at(&mut chunk_key_bytes, key_byte_offset)
-                    .map_err(|e| ConversionError::Io {
-                        context: "pread chunk key".into(),
-                        source: e,
-                    })?;
-
-                // zero-copy cast back to typed slice (positions only — keys stay raw bytes)
-                let chunk_pos_u32: &[u32] = bytemuck::cast_slice(&chunk_pos_bytes);
-
-                // stitch this chunk's block into the main Tile buffer
-                let mut local_chunk_cursor = 0usize;
-                // index loop: `i` indexes tile-local write heads while `col` offsets the ledger.
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..tile_n_cols {
-                    let col = tile_start_col + i;
-                    let calls = ram_ledger_ref[chunk_id][col] as usize;
-                    if calls == 0 {
-                        continue;
-                    }
-
-                    let dest_start = tile_write_heads[i];
-                    let dest_end = dest_start + calls;
-
-                    tile_pos_buffer[dest_start..dest_end].copy_from_slice(
-                        &chunk_pos_u32[local_chunk_cursor..local_chunk_cursor + calls],
-                    );
-
-                    let key_dest_start = dest_start * key_bytes;
-                    let key_src_start = local_chunk_cursor * key_bytes;
-                    tile_key_buffer[key_dest_start..key_dest_start + calls * key_bytes]
-                        .copy_from_slice(
-                            &chunk_key_bytes[key_src_start..key_src_start + calls * key_bytes],
-                        );
-
-                    tile_write_heads[i] += calls;
-                    local_chunk_cursor += calls;
-                }
-            }
-
-            // pwrite the assembled tile to its known byte range in the final files.
-            // Tiles are disjoint by construction (final_offsets is monotonically increasing),
-            // so concurrent write_all_at calls touch non-overlapping regions.
-            let tile_pos_byte_offset = (tile_start_item * pos_size) as u64;
-            let tile_key_byte_offset = (tile_start_item * key_bytes) as u64;
-            let tile_pos_bytes: &[u8] = bytemuck::cast_slice(&tile_pos_buffer);
-            final_pos_ref
-                .write_all_at(tile_pos_bytes, tile_pos_byte_offset)
-                .map_err(|e| ConversionError::Io {
-                    context: "pwrite positions.bin".into(),
-                    source: e,
-                })?;
-            final_key_ref
-                .write_all_at(&tile_key_buffer, tile_key_byte_offset)
-                .map_err(|e| ConversionError::Io {
-                    context: "pwrite alleles.bin".into(),
-                    source: e,
-                })?;
-            Ok(())
-        })?;
+    gather_columns(
+        total_columns,
+        num_chunks,
+        &ram_ledger,
+        &final_offsets,
+        &chunk_offsets,
+        &[
+            Payload {
+                item_width: pos_size,
+                chunk_files: &pos_chunk_files,
+                dest: &final_pos_file,
+            },
+            Payload {
+                item_width: key_bytes,
+                chunk_files: &key_chunk_files,
+                dest: &final_key_file,
+            },
+        ],
+    )?;
 
     // Drop file handles to flush metadata before cleanup
-    drop(chunk_files);
+    drop(pos_chunk_files);
+    drop(key_chunk_files);
     drop(final_pos_file);
     drop(final_key_file);
 
@@ -279,11 +320,11 @@ pub fn merge_mini_sc(
 /// 1:1 with calls, so the identical column-major reordering applies; only the
 /// per-item width differs.
 ///
-/// This performs its own Phase A (offsets) + Phase B (parallel tile gather) local
-/// to this one field stream, mirroring `merge_mini_sc`'s tile arithmetic exactly
-/// but for a single flat byte buffer (no separate pos/key arrays, and no
-/// `offsets.npy` — the offsets already written by `merge_mini_sc` for this stream
-/// apply unchanged to every field, since fields share the same per-call ordering).
+/// This calls the same `derive_offsets` (Phase A) + `gather_columns` (Phase B)
+/// helpers `merge_mini_sc` uses, with a single `Payload` for the flat byte
+/// buffer (no separate pos/key arrays, and no `offsets.npy` — the offsets
+/// already written by `merge_mini_sc` for this stream apply unchanged to every
+/// field, since fields share the same per-call ordering).
 ///
 /// The caller is responsible for creating `dest_values_bin`'s parent directory
 /// before calling this function (this function does not call `create_dir_all`).
@@ -304,22 +345,11 @@ pub fn merge_var_key_field_values(
     let output_dir_path = Path::new(output_dir);
     let total_columns = num_samples * ploidy;
 
-    // Phase A: derive global per-column offsets + per-chunk local offsets from
-    // the RAM Ledger. Identical arithmetic to merge_mini_sc — deliberately NOT
-    // shared as a helper to keep the working pos/key merge untouched; see the
-    // task report for the "replicate vs refactor" tradeoff.
-    let mut final_offsets = vec![0u64; total_columns + 1];
-    let mut chunk_offsets = vec![vec![0u32; total_columns + 1]; num_chunks];
-
-    for col in 0..total_columns {
-        let mut col_total = 0u64;
-        for chunk_id in 0..num_chunks {
-            let calls = ram_ledger[chunk_id][col];
-            chunk_offsets[chunk_id][col + 1] = chunk_offsets[chunk_id][col] + calls;
-            col_total += calls as u64;
-        }
-        final_offsets[col + 1] = final_offsets[col] + col_total;
-    }
+    // Phase A (shared): derive global per-column offsets + per-chunk local
+    // offsets from the RAM Ledger. Identical schedule merge_mini_sc uses for
+    // the pos/key streams — field values are staged 1:1 with calls, so the
+    // same column-major reordering applies.
+    let (final_offsets, chunk_offsets) = derive_offsets(num_chunks, total_columns, ram_ledger);
 
     let total_items: u64 = final_offsets[total_columns];
     let total_bytes: u64 = total_items * item_width as u64;
@@ -350,96 +380,19 @@ pub fn merge_var_key_field_values(
         })
         .collect::<Result<_, _>>()?;
 
-    // Adaptive tile size: target TILE_RAM_BUDGET per tile (one buffer per tile here,
-    // vs two in merge_mini_sc, so this tolerates a slightly larger tile — but we
-    // keep the same budget constant for a simple, predictable footprint).
-    let avg_calls_per_col =
-        std::cmp::max(1u64, total_items / std::cmp::max(1, total_columns) as u64);
-    let columns_per_tile = std::cmp::max(
-        1usize,
-        std::cmp::min(
-            total_columns.max(1),
-            (TILE_RAM_BUDGET_BYTES / (avg_calls_per_col * item_width as u64)) as usize,
-        ),
-    );
-
-    let tile_starts: Vec<usize> = (0..total_columns).step_by(columns_per_tile).collect();
-
-    let final_offsets_ref = &final_offsets;
-    let chunk_offsets_ref = &chunk_offsets;
-    let chunk_files_ref = &chunk_files;
-    let dest_ref = &dest_file;
-
-    tile_starts
-        .par_iter()
-        .try_for_each(|&tile_start_col| -> Result<(), ConversionError> {
-            let tile_end_col = std::cmp::min(tile_start_col + columns_per_tile, total_columns);
-            let tile_n_cols = tile_end_col - tile_start_col;
-            let tile_start_item = final_offsets_ref[tile_start_col] as usize;
-            let tile_end_item = final_offsets_ref[tile_end_col] as usize;
-            let tile_total_items = tile_end_item - tile_start_item;
-
-            if tile_total_items == 0 {
-                return Ok(());
-            }
-
-            let mut tile_buffer = vec![0u8; tile_total_items * item_width];
-
-            // per-column write head (offset within this tile buffer, in items)
-            let mut tile_write_heads = vec![0usize; tile_n_cols];
-            #[allow(clippy::needless_range_loop)]
-            for i in 0..tile_n_cols {
-                let col = tile_start_col + i;
-                tile_write_heads[i] = (final_offsets_ref[col] as usize) - tile_start_item;
-            }
-
-            // gather from chunks
-            for chunk_id in 0..num_chunks {
-                let chunk_start_item = chunk_offsets_ref[chunk_id][tile_start_col] as usize;
-                let chunk_end_item = chunk_offsets_ref[chunk_id][tile_end_col] as usize;
-                let chunk_items_to_read = chunk_end_item - chunk_start_item;
-
-                if chunk_items_to_read == 0 {
-                    continue;
-                }
-
-                let mut chunk_bytes = vec![0u8; chunk_items_to_read * item_width];
-                let byte_offset = (chunk_start_item * item_width) as u64;
-                chunk_files_ref[chunk_id]
-                    .read_exact_at(&mut chunk_bytes, byte_offset)
-                    .map_err(|e| ConversionError::Io {
-                        context: "pread chunk field".into(),
-                        source: e,
-                    })?;
-
-                let mut local_chunk_cursor = 0usize;
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..tile_n_cols {
-                    let col = tile_start_col + i;
-                    let calls = ram_ledger[chunk_id][col] as usize;
-                    if calls == 0 {
-                        continue;
-                    }
-
-                    let dest_start = tile_write_heads[i] * item_width;
-                    let src_start = local_chunk_cursor * item_width;
-                    tile_buffer[dest_start..dest_start + calls * item_width]
-                        .copy_from_slice(&chunk_bytes[src_start..src_start + calls * item_width]);
-
-                    tile_write_heads[i] += calls;
-                    local_chunk_cursor += calls;
-                }
-            }
-
-            let tile_byte_offset = (tile_start_item * item_width) as u64;
-            dest_ref
-                .write_all_at(&tile_buffer, tile_byte_offset)
-                .map_err(|e| ConversionError::Io {
-                    context: "pwrite field values.bin".into(),
-                    source: e,
-                })?;
-            Ok(())
-        })?;
+    // Phase B (shared): parallel tile gather — a single byte-payload stream.
+    gather_columns(
+        total_columns,
+        num_chunks,
+        ram_ledger,
+        &final_offsets,
+        &chunk_offsets,
+        &[Payload {
+            item_width,
+            chunk_files: &chunk_files,
+            dest: &dest_file,
+        }],
+    )?;
 
     // Drop file handles to flush metadata before cleanup
     drop(chunk_files);
@@ -486,6 +439,16 @@ mod tests {
     fn read_offsets_npy(path: &Path) -> Vec<u64> {
         let arr: ndarray::Array1<u64> = ndarray_npy::read_npy(path).unwrap();
         arr.to_vec()
+    }
+
+    #[test]
+    fn derive_offsets_matches_inline() {
+        // 2 chunks, 3 columns
+        let ledger = vec![vec![2u32, 0, 1], vec![1u32, 3, 0]];
+        let (final_offsets, chunk_offsets) = derive_offsets(2, 3, &ledger);
+        assert_eq!(final_offsets, vec![0, 3, 6, 7]); // col totals 3,3,1
+        assert_eq!(chunk_offsets[0], vec![0, 2, 2, 3]);
+        assert_eq!(chunk_offsets[1], vec![0, 1, 4, 4]);
     }
 
     // Single chunk passthrough: with one chunk the final files should byte-equal

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -18,12 +18,25 @@ pub fn write_meta(
     samples: &[String],
     contigs: &[String],
     ploidy: usize,
+    fields: &[crate::field_finalize::ResolvedField],
 ) -> std::io::Result<()> {
+    let fields: Vec<_> = fields
+        .iter()
+        .map(|f| {
+            json!({
+                "name": f.name,
+                "category": f.category.as_str(),
+                "dtype": f.dtype.as_str(),
+                "default": f.default,
+            })
+        })
+        .collect();
     let meta = json!({
         "format_version": format_version,
         "samples": samples,
         "contigs": contigs,
         "ploidy": ploidy,
+        "fields": fields,
     });
     // Serializing a plain serde_json::Value effectively cannot fail (no custom
     // Serialize), but propagate rather than panic to keep the io::Result contract
@@ -35,6 +48,8 @@ pub fn write_meta(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::field::{FieldCategory, StorageDtype};
+    use crate::field_finalize::ResolvedField;
     use serde_json::Value;
     use tempfile::tempdir;
 
@@ -44,7 +59,7 @@ mod tests {
         let samples = vec!["s1".to_string(), "s2".to_string()];
         let contigs = vec!["chr1".to_string(), "chr2".to_string()];
 
-        write_meta(tmp.path(), FORMAT_VERSION, &samples, &contigs, 2).unwrap();
+        write_meta(tmp.path(), FORMAT_VERSION, &samples, &contigs, 2, &[]).unwrap();
 
         let text = std::fs::read_to_string(tmp.path().join("meta.json")).unwrap();
         let v: Value = serde_json::from_str(&text).unwrap();
@@ -52,5 +67,41 @@ mod tests {
         assert_eq!(v["samples"], serde_json::json!(["s1", "s2"]));
         assert_eq!(v["contigs"], serde_json::json!(["chr1", "chr2"]));
         assert_eq!(v["ploidy"], 2);
+        assert_eq!(v["fields"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_write_meta_fields_manifest_round_trip() {
+        let tmp = tempdir().unwrap();
+        let samples = vec!["s1".to_string()];
+        let contigs = vec!["chr1".to_string()];
+        let fields = vec![
+            ResolvedField {
+                name: "DS".to_string(),
+                category: FieldCategory::Format,
+                dtype: StorageDtype::F32,
+                default: Some(0.0),
+            },
+            ResolvedField {
+                name: "AC".to_string(),
+                category: FieldCategory::Info,
+                dtype: StorageDtype::U8,
+                default: None,
+            },
+        ];
+
+        write_meta(tmp.path(), FORMAT_VERSION, &samples, &contigs, 2, &fields).unwrap();
+
+        let text = std::fs::read_to_string(tmp.path().join("meta.json")).unwrap();
+        let v: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            v["fields"][0],
+            serde_json::json!({"name": "DS", "category": "format", "dtype": "f32", "default": 0.0})
+        );
+        assert_eq!(
+            v["fields"][1],
+            serde_json::json!({"name": "AC", "category": "info", "dtype": "u8", "default": null})
+        );
+        assert!(v["fields"][1]["default"].is_null());
     }
 }

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -174,12 +174,13 @@ pub fn process_chromosome(
         .expect("spawn reader");
 
     // Step 2 -> The Executor
+    let fields_exec: Vec<crate::field::FieldSpec> = fields.to_vec();
     let executor_thread = thread::Builder::new()
         .name(format!("exec-{}", chrom))
         .spawn({
             move || {
                 let bank = LongAlleleTableWriter::new(tx_long, long_allele_capacity);
-                executor::run_compute_engine(rx_dense, tx_sparse, bank, signatures)
+                executor::run_compute_engine(rx_dense, tx_sparse, bank, signatures, &fields_exec)
             }
         })
         .expect("spawn executor");

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -285,6 +285,7 @@ pub fn process_chromosome(
             let dest_dir = std::path::Path::new(base_out_dir)
                 .join(chrom)
                 .join("fields")
+                .join(field.category.as_str())
                 .join(&field.name)
                 .join(&sub_label);
             fs::create_dir_all(&dest_dir).map_err(|e| ConversionError::Io {
@@ -351,6 +352,7 @@ pub fn process_chromosome(
             let dest_dir = std::path::Path::new(base_out_dir)
                 .join(chrom)
                 .join("fields")
+                .join(field.category.as_str())
                 .join(&field.name)
                 .join(&sub_label);
             fs::create_dir_all(&dest_dir).map_err(|e| ConversionError::Io {

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -55,7 +55,9 @@ pub fn process_chromosome(
     skip_out_of_scope: bool,
     processing_threads: usize,
     signatures: bool,
+    fields: &[crate::field::FieldSpec],
 ) -> Result<u64, ConversionError> {
+    let _ = fields; // unused until Task 5 wires field extraction into the pipeline
     // Directory Formatting: svar2/{contig}/var_key/{snp,indel}
     let paths = crate::layout::ContigPaths::new(base_out_dir, chrom);
 

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -57,7 +57,6 @@ pub fn process_chromosome(
     signatures: bool,
     fields: &[crate::field::FieldSpec],
 ) -> Result<u64, ConversionError> {
-    let _ = fields; // unused until Task 5 wires field extraction into the pipeline
     // Directory Formatting: svar2/{contig}/var_key/{snp,indel}
     let paths = crate::layout::ContigPaths::new(base_out_dir, chrom);
 
@@ -147,6 +146,7 @@ pub fn process_chromosome(
             // Convert references into owned Strings that can safely live forever in the thread
             let s_owned: Vec<String> = samples.iter().map(|&s| s.to_string()).collect();
             let pool = Arc::clone(&processing_pool);
+            let fields_owned: Vec<crate::field::FieldSpec> = fields.to_vec();
 
             move || -> Result<u64, ConversionError> {
                 // passing the thread budget down to HTSLib
@@ -159,6 +159,7 @@ pub fn process_chromosome(
                     htslib_threads,
                     ploidy,
                     skip_out_of_scope,
+                    &fields_owned,
                 )?;
                 let mut chunk_id = 0;
                 while let Some(dense_chunk) =

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -325,6 +325,49 @@ pub fn process_chromosome(
             .join(chrom)
             .join(spec.subdir);
         let ledger = std::mem::take(dense_ledgers.get_mut(spec.class));
+
+        // Dense field values are staged 1:1 with dense variants under this
+        // class, so they need only chunk-order concatenation (no ledger-driven
+        // reordering). Merge every field FIRST (borrowing the ledger) — the
+        // per-chunk field files (chunk_{c}_finfo{i}.bin / chunk_{c}_fformat{j}.bin)
+        // are disjoint from the pos/key/geno files merge_dense_class consumes
+        // right after, so ordering between the two doesn't matter for correctness.
+        let sub_label = spec.subdir.replace('/', "_");
+        let mut info_ix = 0usize;
+        let mut format_ix = 0usize;
+        for field in fields.iter() {
+            let (prefix, field_ix) = match field.category {
+                crate::field::FieldCategory::Info => {
+                    let ix = info_ix;
+                    info_ix += 1;
+                    ("finfo", ix)
+                }
+                crate::field::FieldCategory::Format => {
+                    let ix = format_ix;
+                    format_ix += 1;
+                    ("fformat", ix)
+                }
+            };
+            let dest_dir = std::path::Path::new(base_out_dir)
+                .join(chrom)
+                .join("fields")
+                .join(&field.name)
+                .join(&sub_label);
+            fs::create_dir_all(&dest_dir).map_err(|e| ConversionError::Io {
+                context: format!("create_dir_all {:?}", dest_dir),
+                source: e,
+            })?;
+            let dest_values_bin = dest_dir.join("values.bin");
+            crate::dense_merge::merge_dense_field_values(
+                dir.to_str().unwrap(),
+                num_chunks,
+                &ledger,
+                prefix,
+                field_ix,
+                &dest_values_bin,
+            )?;
+        }
+
         crate::dense_merge::merge_dense_class(
             num_chunks,
             samples.len(),

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -337,16 +337,16 @@ pub fn process_chromosome(
         let mut info_ix = 0usize;
         let mut format_ix = 0usize;
         for field in fields.iter() {
-            let (prefix, field_ix) = match field.category {
+            let field_ix = match field.category {
                 crate::field::FieldCategory::Info => {
                     let ix = info_ix;
                     info_ix += 1;
-                    ("finfo", ix)
+                    ix
                 }
                 crate::field::FieldCategory::Format => {
                     let ix = format_ix;
                     format_ix += 1;
-                    ("fformat", ix)
+                    ix
                 }
             };
             let dest_dir = std::path::Path::new(base_out_dir)
@@ -364,7 +364,7 @@ pub fn process_chromosome(
                 dir.to_str().unwrap(),
                 num_chunks,
                 &ledger,
-                prefix,
+                field.category,
                 field_ix,
                 &dest_values_bin,
             )?;

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -273,6 +273,37 @@ pub fn process_chromosome(
     let mut ledgers = ledgers; // make mutable to move rows out
     for spec in &REGISTRY {
         let dir = stream_dirs.get(spec.tag).clone();
+
+        // Var_key field values are staged 1:1 with calls, so they share the
+        // ledger's column-major reordering with the pos/key streams merged
+        // below. Merge every field FIRST (borrowing the ledger) — merge_mini_sc
+        // moves the ledger out right after, and the two merges touch disjoint
+        // per-chunk files (chunk_{c}_field*.bin vs chunk_{c}_pos/key.bin), so
+        // ordering between them doesn't matter for correctness.
+        let sub_label = spec.subdir.replace('/', "_");
+        for (field_ix, field) in fields.iter().enumerate() {
+            let dest_dir = std::path::Path::new(base_out_dir)
+                .join(chrom)
+                .join("fields")
+                .join(&field.name)
+                .join(&sub_label);
+            fs::create_dir_all(&dest_dir).map_err(|e| ConversionError::Io {
+                context: format!("create_dir_all {:?}", dest_dir),
+                source: e,
+            })?;
+            let dest_values_bin = dest_dir.join("values.bin");
+            merge::merge_var_key_field_values(
+                dir.to_str().unwrap(),
+                num_chunks,
+                samples.len(),
+                ploidy,
+                ledgers.get(spec.tag),
+                field_ix,
+                4, // staged width (i32/f32); narrowed to final dtype at finalize (Task 9)
+                &dest_values_bin,
+            )?;
+        }
+
         let ledger = std::mem::take(ledgers.get_mut(spec.tag));
         merge::merge_mini_sc(
             spec.key_bytes,

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -2,10 +2,13 @@ use crate::cost_model::{Class, Representation, choose_representation};
 use crate::dense::{DenseClass, DenseMap};
 use crate::enum_map::EnumKey;
 use crate::error::ConversionError;
+use crate::field::{FieldCategory, FieldSpec};
 use crate::layout;
 use crate::nrvk::LongAlleleTableWriter;
 use crate::streams::StreamTag;
-use crate::types::{DenseChunk, DenseSubChunk, MAX_INLINE_ALT_LEN, SparseChunk, SparseSubStream};
+use crate::types::{
+    DenseChunk, DenseSubChunk, MAX_INLINE_ALT_LEN, SparseChunk, SparseSubStream, StagedColumn,
+};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
@@ -139,6 +142,7 @@ pub fn dense2sparse_vk(
     chunk: &DenseChunk,
     bank: &mut LongAlleleTableWriter,
     sidecar_bits_enabled: bool,
+    fields: &[FieldSpec],
 ) -> SparseChunk {
     let (v_variants, num_samples, ploidy) = chunk.genos.shape;
     let columns = num_samples * ploidy;
@@ -150,11 +154,73 @@ pub fn dense2sparse_vk(
         Dense { class: DenseClass, col: u32 },
     }
 
+    // Read a staged column's value back as `f64` (the common currency for
+    // field resolution). `Int` also carries Flag columns (staged as 0/1).
+    #[inline(always)]
+    fn staged_f64(col: &StagedColumn, idx: usize) -> f64 {
+        match col {
+            StagedColumn::Int(v) => v[idx] as f64,
+            StagedColumn::Float(v) => v[idx] as f64,
+        }
+    }
+
+    // Map each flat index in `fields` to (is_format, per-category index) so
+    // both routing branches can index straight into `chunk.info_staged` /
+    // `chunk.format_staged` without re-filtering `fields` per variant/call.
+    // INVARIANT (reader-side): `info_staged`/`format_staged` are ordered to
+    // match the INFO/FORMAT-filtered order of `fields` (see types.rs).
+    let per_cat: Vec<(bool, usize)> = {
+        let mut info_i = 0usize;
+        let mut fmt_i = 0usize;
+        fields
+            .iter()
+            .map(|f| match f.category {
+                FieldCategory::Info => {
+                    let idx = info_i;
+                    info_i += 1;
+                    (false, idx)
+                }
+                FieldCategory::Format => {
+                    let idx = fmt_i;
+                    fmt_i += 1;
+                    (true, idx)
+                }
+            })
+            .collect()
+    };
+    let format_specs: Vec<&FieldSpec> = fields
+        .iter()
+        .filter(|f| f.category == FieldCategory::Format)
+        .collect();
+
+    // Genotype-aligned carrier test: sample `s` carries variant `v` iff any
+    // of its ploidy bits are set in `chunk.genos`. Used only for the dense
+    // FORMAT per-sample fill (Option A semantics) — not the hot bit-test in
+    // the transpose loop below, which walks bits directly for speed.
+    let is_carrier = |v: usize, s: usize| -> bool {
+        (0..ploidy).any(|p| {
+            let flat_idx = v * columns + s * ploidy + p;
+            (chunk.genos.words[flat_idx >> 6] >> (flat_idx & 63)) & 1 == 1
+        })
+    };
+
     // Dense per-class tables accumulate positions + keys as we discover dense
     // variants; geno_bits is sized after the pre-pass (n_dense known). This
     // also ensures a long insertion is pushed to the bank a single time, not
     // once per carrying haplotype.
     let mut dense = DenseMap::from_fn(|c| DenseSubChunk::empty(c.key_bytes()));
+    for (_c, sub) in dense.iter_mut() {
+        sub.field_info = fields
+            .iter()
+            .filter(|f| f.category == FieldCategory::Info)
+            .map(|f| StagedColumn::with_capacity(f.stage_is_float(), v_variants))
+            .collect();
+        sub.field_format = fields
+            .iter()
+            .filter(|f| f.category == FieldCategory::Format)
+            .map(|f| StagedColumn::with_capacity(f.stage_is_float(), v_variants * num_samples))
+            .collect();
+    }
     let mut routes: Vec<Route> = Vec::with_capacity(v_variants);
 
     for v in 0..v_variants {
@@ -201,6 +267,27 @@ pub fn dense2sparse_vk(
                     VarKey::Indel(key) => sub.keys.extend_from_slice(&key.to_le_bytes()),
                 }
                 sub.n_dense_variants += 1;
+
+                // Genotype-aligned (Option A) dense field push: INFO once per
+                // dense variant; FORMAT as a full per-sample column, with
+                // non-carrier samples filled with the field's sentinel/default.
+                for &(is_format, idx) in &per_cat {
+                    if is_format {
+                        let default_val = format_specs[idx].missing_sentinel();
+                        for s in 0..num_samples {
+                            let val = if is_carrier(v, s) {
+                                staged_f64(&chunk.format_staged[idx], v * num_samples + s)
+                            } else {
+                                default_val
+                            };
+                            sub.field_format[idx].push_f64(val);
+                        }
+                    } else {
+                        let val = staged_f64(&chunk.info_staged[idx], v);
+                        sub.field_info[idx].push_f64(val);
+                    }
+                }
+
                 routes.push(Route::Dense { class: dclass, col });
             }
         }
@@ -217,6 +304,12 @@ pub fn dense2sparse_vk(
         let spec = &crate::streams::REGISTRY[tag.index()];
         SparseSubStream::with_capacity(spec.key_bytes, estimated_nnz, columns)
     });
+    for (_tag, st) in streams.iter_mut() {
+        st.field_calls = fields
+            .iter()
+            .map(|f| StagedColumn::with_capacity(f.stage_is_float(), estimated_nnz))
+            .collect();
+    }
 
     let words: &[u64] = &chunk.genos.words;
 
@@ -255,9 +348,19 @@ pub fn dense2sparse_vk(
                             VarKey::Indel(key) => (StreamTag::VarKeyIndel, key.to_le_bytes()),
                         };
                         let spec = &crate::streams::REGISTRY[tag.index()];
-                        streams
-                            .get_mut(tag)
-                            .push_call(pos, &key_le[..spec.key_bytes]);
+                        let st = streams.get_mut(tag);
+                        st.push_call(pos, &key_le[..spec.key_bytes]);
+                        // Genotype-aligned (Option A) per-call field push,
+                        // aligned to call order: INFO uses the variant's
+                        // single value; FORMAT uses the calling sample's.
+                        for (i, &(is_format, idx)) in per_cat.iter().enumerate() {
+                            let val = if is_format {
+                                staged_f64(&chunk.format_staged[idx], v * num_samples + s)
+                            } else {
+                                staged_f64(&chunk.info_staged[idx], v)
+                            };
+                            st.field_calls[i].push_f64(val);
+                        }
                         *counts.get_mut(tag) += 1;
                     }
                     Route::Dense { class, col } => {
@@ -541,7 +644,7 @@ mod tests {
         // Zero variants, just shape edge case.
         let chunk = build_test_chunk(0, 2, 2, &[], &[], &[]);
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
         let indel = sparse.streams.get(StreamTag::VarKeyIndel);
         assert_eq!(snp.call_positions.len(), 0);
@@ -572,7 +675,7 @@ mod tests {
 
         let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bit_pattern);
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
         let indel = sparse.streams.get(StreamTag::VarKeyIndel);
 
@@ -608,7 +711,7 @@ mod tests {
         let chunk = build_test_chunk(3, 1, 2, &refs, &alts, &bit_pattern);
 
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
         let indel = sparse.streams.get(StreamTag::VarKeyIndel);
 
@@ -644,7 +747,7 @@ mod tests {
         let chunk = build_test_chunk(1, 2, 2, &refs, &alts, &bits);
 
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
 
         // var_key snp stream is empty (variant went dense)
         let snp = sparse.streams.get(StreamTag::VarKeySnp);
@@ -674,7 +777,7 @@ mod tests {
         let chunk = build_test_chunk(1, n, 2, &refs, &alts, &bits);
 
         let mut bank = make_bank();
-        let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
         assert_eq!(
             sparse
                 .streams
@@ -711,7 +814,7 @@ mod tests {
             let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bit_pattern);
 
             let mut bank = make_bank();
-            let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+            let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
             let snp = sparse.streams.get(StreamTag::VarKeySnp);
             let indel = sparse.streams.get(StreamTag::VarKeyIndel);
 
@@ -748,7 +851,7 @@ mod tests {
             let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bit_pattern);
 
             let mut bank = make_bank();
-            let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+            let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
             let snp = sparse.streams.get(StreamTag::VarKeySnp);
 
             let np = n_samples * ploidy;
@@ -798,7 +901,7 @@ mod tests {
             let chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bits);
 
             let mut bank = make_bank();
-            let sparse = dense2sparse_vk(&chunk, &mut bank, false);
+            let sparse = dense2sparse_vk(&chunk, &mut bank, false, &[]);
 
             let vk_calls: usize = sparse.streams.get(StreamTag::VarKeySnp)
                 .sample_lengths.iter().map(|&c| c as usize).sum::<usize>()
@@ -810,6 +913,128 @@ mod tests {
                 dense_calls += sub.geno_bits.iter().map(|b| b.count_ones() as usize).sum::<usize>();
             }
             prop_assert_eq!(vk_calls + dense_calls, true_count, "lost or double-counted a call");
+        }
+    }
+
+    // Genotype-aligned (Option A) field routing: one INFO (Int) + one FORMAT
+    // (Float) field, engineered so v0 stays var_key (single carrier) and v1
+    // routes dense (4/6 haps carry, well over the 34*x<=34+np crossover),
+    // with v1 leaving sample 2 a genuine non-carrier (both ploidy bits unset)
+    // to exercise the default-fill path.
+    #[test]
+    fn test_dense2sparse_routes_field_values_option_a() {
+        use crate::field::{HtslibType, StorageDtype};
+
+        let refs: Vec<&[u8]> = vec![b"A", b"A"];
+        let alts: Vec<&[u8]> = vec![b"C", b"G"];
+        let n_variants = 2;
+        let n_samples = 3;
+        let ploidy = 2;
+        let columns = n_samples * ploidy; // 6, np = 6
+
+        #[rustfmt::skip]
+        let bit_pattern = vec![
+            // v0: only s0p0 carries -> x=1, var_key (34*1 <= 34+6=40)
+            true, false, false, false, false, false,
+            // v1: s0(p0,p1) + s1(p0,p1) carry, s2 fully absent -> x=4, dense
+            true, true, true, true, false, false,
+        ];
+        assert_eq!(bit_pattern.len(), n_variants * columns);
+
+        let mut chunk = build_test_chunk(n_variants, n_samples, ploidy, &refs, &alts, &bit_pattern);
+        chunk.info_staged = vec![StagedColumn::Int(vec![10, 20])];
+        chunk.format_staged = vec![StagedColumn::Float(vec![
+            1.5, 2.5, 3.5, // v0: s0,s1,s2
+            10.5, 20.5, 30.5, // v1: s0,s1,s2
+        ])];
+
+        let fields = vec![
+            FieldSpec {
+                name: "AF".into(),
+                category: FieldCategory::Info,
+                htype: HtslibType::Int,
+                dtype: StorageDtype::Auto,
+                default: None,
+            },
+            FieldSpec {
+                name: "DS".into(),
+                category: FieldCategory::Format,
+                htype: HtslibType::Float,
+                dtype: StorageDtype::Auto,
+                default: Some(-1.0),
+            },
+        ];
+
+        let mut bank = make_bank();
+        let sparse = dense2sparse_vk(&chunk, &mut bank, false, &fields);
+
+        // Routing sanity, asserted before trusting the field data below.
+        let vk = sparse.streams.get(StreamTag::VarKeySnp);
+        assert_eq!(vk.call_positions.len(), 1, "v0 must stay var_key");
+        let d = sparse.dense.get(DenseClass::Snp);
+        assert_eq!(d.n_dense_variants, 1, "v1 must route dense");
+
+        // var_key: field_calls aligned to the single call (v0, hap s0p0).
+        assert_eq!(vk.field_calls.len(), 2);
+        match &vk.field_calls[0] {
+            StagedColumn::Int(v) => {
+                assert_eq!(v.len(), vk.call_positions.len());
+                assert_eq!(v[0], 10, "INFO value is the variant's single value");
+            }
+            other => panic!(
+                "expected Int INFO field_calls[0], got {:?}",
+                other_kind(other)
+            ),
+        }
+        match &vk.field_calls[1] {
+            StagedColumn::Float(v) => {
+                assert_eq!(v.len(), vk.call_positions.len());
+                assert_eq!(v[0], 1.5, "FORMAT value is the calling sample's value");
+            }
+            other => panic!(
+                "expected Float FORMAT field_calls[1], got {:?}",
+                other_kind(other)
+            ),
+        }
+
+        // dense: field_info one-per-variant.
+        assert_eq!(d.field_info.len(), 1);
+        match &d.field_info[0] {
+            StagedColumn::Int(v) => {
+                assert_eq!(v.len(), d.n_dense_variants);
+                assert_eq!(
+                    v[0], 20,
+                    "dense INFO value matches the dense variant's staged value"
+                );
+            }
+            other => panic!(
+                "expected Int dense field_info[0], got {:?}",
+                other_kind(other)
+            ),
+        }
+
+        // dense: field_format is a full per-sample column; carriers get the
+        // read value, the non-carrier gets the field's default.
+        assert_eq!(d.field_format.len(), 1);
+        match &d.field_format[0] {
+            StagedColumn::Float(v) => {
+                assert_eq!(v.len(), d.n_dense_variants * n_samples);
+                assert_eq!(v[0], 10.5, "carrier sample 0 keeps its staged value");
+                assert_eq!(v[1], 20.5, "carrier sample 1 keeps its staged value");
+                assert_eq!(v[2], -1.0, "non-carrier sample 2 gets the field default");
+            }
+            other => panic!(
+                "expected Float dense field_format[0], got {:?}",
+                other_kind(other)
+            ),
+        }
+    }
+
+    // Debug helper for panic messages above (StagedColumn has no Debug impl).
+    fn other_kind(col: &StagedColumn) -> &'static str {
+        match col {
+            StagedColumn::Int(_) => "Int",
+            StagedColumn::Float(_) => "Float",
         }
     }
 }

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -340,6 +340,8 @@ mod tests {
             alt: alt_buf,
             alt_offsets,
             genos,
+            info_staged: Vec::new(),
+            format_staged: Vec::new(),
         }
     }
 

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -223,6 +223,21 @@ pub fn dense2sparse_vk(
     }
     let mut routes: Vec<Route> = Vec::with_capacity(v_variants);
 
+    // Summed per-record storage width (bits) of the active INFO/FORMAT
+    // fields, computed once outside the per-variant loop. `Auto` dtype has
+    // no fixed width yet, so it's estimated at the 4-byte (32-bit) staged
+    // i32/f32 width used during staging.
+    let info_bits: u64 = fields
+        .iter()
+        .filter(|f| f.category == FieldCategory::Info)
+        .map(|f| f.dtype.width_bytes().unwrap_or(4) as u64 * 8)
+        .sum();
+    let format_bits: u64 = fields
+        .iter()
+        .filter(|f| f.category == FieldCategory::Format)
+        .map(|f| f.dtype.width_bytes().unwrap_or(4) as u64 * 8)
+        .sum();
+
     for v in 0..v_variants {
         // SAFETY: `v` ranges over `0..v_variants` and `chunk.ilens.len() ==
         // v_variants` (one entry per variant), so `ilens[v]` is in bounds.
@@ -252,7 +267,15 @@ pub fn dense2sparse_vk(
         } else {
             0
         };
-        match choose_representation(class, num_samples, ploidy, x, sidecar_bits) {
+        match choose_representation(
+            class,
+            num_samples,
+            ploidy,
+            x,
+            sidecar_bits,
+            info_bits,
+            format_bits,
+        ) {
             Representation::VarKey => routes.push(Route::VarKey(vk)),
             Representation::Dense => {
                 let sub = dense.get_mut(dclass);

--- a/src/types.rs
+++ b/src/types.rs
@@ -92,6 +92,32 @@ impl BitGrid3 {
     }
 }
 
+// A single staged INFO/FORMAT field column, monomorphic per column so the hot
+// reader path never boxes/dyn-dispatches per value. `Int` also carries Flag
+// columns (staged as 0/1). Values are always produced from `f64` (the common
+// currency `FieldSpec` resolution works in) and narrowed on push.
+pub enum StagedColumn {
+    Int(Vec<i32>),
+    Float(Vec<f32>),
+}
+
+impl StagedColumn {
+    pub fn with_capacity(is_float: bool, n: usize) -> Self {
+        if is_float {
+            StagedColumn::Float(Vec::with_capacity(n))
+        } else {
+            StagedColumn::Int(Vec::with_capacity(n))
+        }
+    }
+
+    pub fn push_f64(&mut self, v: f64) {
+        match self {
+            StagedColumn::Int(x) => x.push(v as i32),
+            StagedColumn::Float(x) => x.push(v as f32),
+        }
+    }
+}
+
 // Defines DenseChunk and SparseChunk structs. All other files import from here.
 
 // The struct produced by the VCF Reader and consumed by the Compute Thread (variant key)
@@ -108,6 +134,15 @@ pub struct DenseChunk {
 
     // Dense Genotype Tensor - Shape (Variants, Samples, Ploidy), bit-packed
     pub genos: BitGrid3, // (V, S, P)
+
+    // Staged INFO/FORMAT field columns, one per requested `FieldSpec`, in the
+    // same relative order as they appear (filtered by category) in the
+    // `fields` slice passed to `VcfChunkReader::new`. Empty when no fields
+    // were requested. `info_staged[i].len() == v`;
+    // `format_staged[j].len() == v * num_samples`, laid out variant-major
+    // then sample-minor: index `variant * num_samples + sample`.
+    pub info_staged: Vec<StagedColumn>,
+    pub format_staged: Vec<StagedColumn>,
 }
 
 // One position-sorted sub-stream of calls with byte-erased keys (`key_bytes`

--- a/src/types.rs
+++ b/src/types.rs
@@ -155,6 +155,12 @@ pub struct SparseSubStream {
     // Calls per (sample, ploid) in THIS sub-stream. Length == samples * ploidy.
     pub sample_lengths: Vec<u32>,
     pub key_bytes: usize,
+    // Genotype-aligned (Option A) per-call field values: one `StagedColumn`
+    // per field in FLAT `fields` order (INFO and FORMAT interleaved as they
+    // appear in the `fields` slice passed to `dense2sparse_vk`), each pushed
+    // in lockstep with `push_call` — `field_calls[i].len() ==
+    // call_positions.len()`. Empty when no fields were requested.
+    pub field_calls: Vec<StagedColumn>,
 }
 
 impl SparseSubStream {
@@ -164,6 +170,7 @@ impl SparseSubStream {
             call_keys: Vec::with_capacity(nnz * key_bytes),
             sample_lengths: Vec::with_capacity(columns),
             key_bytes,
+            field_calls: Vec::new(),
         }
     }
     #[inline(always)]
@@ -185,6 +192,14 @@ pub struct DenseSubChunk {
     // Hap-major bit block, shape (S, P, n_dense_variants), variant fastest.
     // Bit (hap h, dense col d) at flat index h*n_dense_variants + d.
     pub geno_bits: Vec<u8>,
+    // Genotype-aligned (Option A) dense field columns. `field_info[i]` is one
+    // per INFO field, `len() == n_dense_variants`. `field_format[j]` is one
+    // per FORMAT field, a FULL per-sample column: `len() == n_dense_variants
+    // * num_samples`; carrier samples get the read value, non-carrier
+    // samples get the field's default/sentinel. Both empty when no fields
+    // were requested.
+    pub field_info: Vec<StagedColumn>,
+    pub field_format: Vec<StagedColumn>,
 }
 
 impl DenseSubChunk {
@@ -195,6 +210,8 @@ impl DenseSubChunk {
             positions: Vec::new(),
             keys: Vec::new(),
             geno_bits: Vec::new(),
+            field_info: Vec::new(),
+            field_format: Vec::new(),
         }
     }
 }

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -1,9 +1,11 @@
 use crate::error::ConversionError;
+use crate::field::{FieldCategory, FieldSpec, HtslibType};
 use crate::normalize::atomize_record;
-use crate::types::{BitGrid3, DenseChunk};
+use crate::types::{BitGrid3, DenseChunk, StagedColumn};
 use rayon::prelude::*;
 use rust_htslib::bcf::record::Record;
 use rust_htslib::bcf::{IndexedReader, Read};
+use rust_htslib::errors::Error as HtslibError;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::Arc;
@@ -17,6 +19,14 @@ struct PendingAtom {
     source_alt_index: u16,
     gt: Arc<Vec<i32>>, // len = num_samples * ploidy; allele index per column (-1 = missing)
     seq: u64,          // stable tiebreak for equal positions
+
+    // Resolved field values for THIS atom (already indexed by source_alt_index
+    // where the underlying VCF field is Number=A). Populated in
+    // `decompose_current_record`, gathered into `DenseChunk::{info,format}_staged`
+    // in `read_next_chunk`'s sequential metadata pass. Empty when no fields of
+    // that category were requested.
+    info_vals: Vec<f64>,   // len == VcfChunkReader::info_fields.len()
+    format_vals: Vec<f64>, // len == VcfChunkReader::format_fields.len() * num_samples, field-major then sample: field*num_samples + sample
 }
 
 impl PartialEq for PendingAtom {
@@ -125,6 +135,133 @@ fn pack_presence_par(
     });
 }
 
+// The sentinel a resolved field value falls back to when htslib reports it
+// missing and the spec has no explicit `default`: htslib's own missing-int
+// encoding for Int/Flag columns, NaN for Float columns (mirrors htslib's
+// float-missing encoding, which is itself a NaN bit pattern).
+fn sentinel_default(spec: &FieldSpec) -> f64 {
+    spec.default.unwrap_or(if spec.stage_is_float() {
+        f64::from(f32::NAN)
+    } else {
+        i32::MIN as f64
+    })
+}
+
+// htslib missing-value detection on an already-widened f64: floats use NaN
+// (covers both htslib's MISSING and VECTOR_END float encodings, which are
+// distinct NaN bit patterns); ints use MISSING (i32::MIN) or VECTOR_END
+// (i32::MIN + 1) — the round-trip through f64 is exact for both since they're
+// in i32 range.
+fn is_htslib_missing(raw_val: f64, is_float: bool) -> bool {
+    if is_float {
+        raw_val.is_nan()
+    } else {
+        let iv = raw_val as i32;
+        iv == i32::MIN || iv == i32::MIN + 1
+    }
+}
+
+// Resolve one atom's value from a record-level raw buffer (already widened to
+// f64): `None` (field absent from the record/sample) or an out-of-range
+// Number=A index falls back to the spec's sentinel/default; a length-1 buffer
+// is a Number=1 scalar, otherwise indexed by `source_alt_index` (Number=A).
+fn resolve_scalar(vals: Option<&[f64]>, source_alt_index: u16, spec: &FieldSpec) -> f64 {
+    let default_val = sentinel_default(spec);
+    let Some(vals) = vals else {
+        return default_val;
+    };
+    if vals.is_empty() {
+        return default_val;
+    }
+    let raw_val = if vals.len() == 1 {
+        vals[0]
+    } else {
+        match vals.get(source_alt_index as usize) {
+            Some(&v) => v,
+            None => return default_val,
+        }
+    };
+    if is_htslib_missing(raw_val, spec.stage_is_float()) {
+        default_val
+    } else {
+        raw_val
+    }
+}
+
+// Decode one INFO field for the CURRENT record, once. `Ok(None)` means the
+// field is absent from this record (a normal, expected occurrence — NOT an
+// error); a genuine htslib read failure (bad type, corrupt buffer) surfaces
+// as `ConversionError::Input`, matching the GT-decode error style.
+fn decode_info_raw(record: &Record, spec: &FieldSpec) -> Result<Option<Vec<f64>>, ConversionError> {
+    let pos = record.pos();
+    match spec.htype {
+        HtslibType::Flag => {
+            // A Flag is never "missing": absent ⇒ false ⇒ 0.0.
+            let present = record.info(spec.name.as_bytes()).flag().map_err(|e| {
+                ConversionError::Input(format!(
+                    "Failed to read INFO/{} flag at pos {pos}: {e}",
+                    spec.name
+                ))
+            })?;
+            Ok(Some(vec![if present { 1.0 } else { 0.0 }]))
+        }
+        HtslibType::Int => match record.info(spec.name.as_bytes()).integer() {
+            Ok(Some(buf)) => Ok(Some(buf.iter().map(|&v| v as f64).collect())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(ConversionError::Input(format!(
+                "Failed to read INFO/{} at pos {pos}: {e}",
+                spec.name
+            ))),
+        },
+        HtslibType::Float => match record.info(spec.name.as_bytes()).float() {
+            Ok(Some(buf)) => Ok(Some(buf.iter().map(|&v| v as f64).collect())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(ConversionError::Input(format!(
+                "Failed to read INFO/{} at pos {pos}: {e}",
+                spec.name
+            ))),
+        },
+    }
+}
+
+// Decode one FORMAT field for the CURRENT record, once, for every VCF sample
+// in the header (not just the selected ones — matches the GT-decode idiom,
+// which indexes into the full per-header-sample buffer via
+// `self.sample_indices`). `Ok(None)` means the field is absent from this
+// record for all samples (htslib reports this as `BcfMissingTag`, a normal,
+// expected per-record occurrence, NOT an error). Any other htslib error is a
+// genuine read failure and surfaces as `ConversionError::Input`.
+//
+// FORMAT Flag is not valid VCF (Flag is INFO-only); defensively treated as Int.
+fn decode_format_raw(
+    record: &Record,
+    spec: &FieldSpec,
+) -> Result<Option<Vec<Vec<f64>>>, ConversionError> {
+    let pos = record.pos();
+    let result = match spec.htype {
+        HtslibType::Float => record.format(spec.name.as_bytes()).float().map(|bb| {
+            bb.iter()
+                .map(|s| s.iter().map(|&v| v as f64).collect())
+                .collect::<Vec<Vec<f64>>>()
+        }),
+        HtslibType::Int | HtslibType::Flag => {
+            record.format(spec.name.as_bytes()).integer().map(|bb| {
+                bb.iter()
+                    .map(|s| s.iter().map(|&v| v as f64).collect())
+                    .collect::<Vec<Vec<f64>>>()
+            })
+        }
+    };
+    match result {
+        Ok(v) => Ok(Some(v)),
+        Err(HtslibError::BcfMissingTag { .. }) => Ok(None),
+        Err(e) => Err(ConversionError::Input(format!(
+            "Failed to read FORMAT/{} at pos {pos}: {e}",
+            spec.name
+        ))),
+    }
+}
+
 pub struct VcfChunkReader {
     inner_reader: IndexedReader,
     num_samples: usize,
@@ -140,6 +277,13 @@ pub struct VcfChunkReader {
     skip_out_of_scope: bool,
     // Running count of out-of-scope ALTs dropped across this contig.
     dropped_out_of_scope: u64,
+
+    // Requested field specs, partitioned by category (order preserved within
+    // each partition). Index i into `info_fields`/`format_fields` matches
+    // index i into `PendingAtom::info_vals`/`format_vals` and
+    // `DenseChunk::info_staged`/`format_staged`.
+    info_fields: Vec<FieldSpec>,
+    format_fields: Vec<FieldSpec>,
 
     // Reorder state, persisted across read_next_chunk calls.
     record: Record,
@@ -191,6 +335,7 @@ pub(crate) fn load_contig_seq(fasta_path: &str, chrom: &str) -> Result<Vec<u8>, 
 
 impl VcfChunkReader {
     // opens the file, applies the sample filter at the C-level, and jumps to the chromosome.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         vcf_path: &str,
         fasta_path: Option<&str>,
@@ -199,6 +344,7 @@ impl VcfChunkReader {
         htslib_threads: usize,
         ploidy: usize,
         skip_out_of_scope: bool,
+        fields: &[FieldSpec],
     ) -> Result<Self, ConversionError> {
         // A wrong VCF path reaches Rust when the file was removed after Python's
         // upstream indexing/open; surface it as FileNotFoundError, not a ".tbi?" Input.
@@ -253,6 +399,17 @@ impl VcfChunkReader {
 
         let record = reader.empty_record();
 
+        let info_fields: Vec<FieldSpec> = fields
+            .iter()
+            .filter(|f| f.category == FieldCategory::Info)
+            .cloned()
+            .collect();
+        let format_fields: Vec<FieldSpec> = fields
+            .iter()
+            .filter(|f| f.category == FieldCategory::Format)
+            .cloned()
+            .collect();
+
         Ok(Self {
             inner_reader: reader,
             num_samples: samples.len(),
@@ -262,6 +419,8 @@ impl VcfChunkReader {
             has_reference,
             skip_out_of_scope,
             dropped_out_of_scope: 0,
+            info_fields,
+            format_fields,
             record,
             heap: BinaryHeap::new(),
             frontier: 0,
@@ -335,6 +494,20 @@ impl VcfChunkReader {
         )?;
         self.dropped_out_of_scope += dropped as u64;
 
+        // Decode each requested field's raw buffer ONCE for this record (position-
+        // independent of atomize_record's per-ALT split); per-atom resolution below
+        // only differs in which `source_alt_index` a Number=A buffer is indexed by.
+        let info_raw: Vec<Option<Vec<f64>>> = self
+            .info_fields
+            .iter()
+            .map(|spec| decode_info_raw(&self.record, spec))
+            .collect::<Result<_, _>>()?;
+        let format_raw: Vec<Option<Vec<Vec<f64>>>> = self
+            .format_fields
+            .iter()
+            .map(|spec| decode_format_raw(&self.record, spec))
+            .collect::<Result<_, _>>()?;
+
         for atom in atoms {
             // Left-align only when a reference is available; otherwise store the atom
             // at its as-given (right-trimmed) position.
@@ -343,6 +516,22 @@ impl VcfChunkReader {
             } else {
                 atom
             };
+
+            let info_vals: Vec<f64> = self
+                .info_fields
+                .iter()
+                .zip(info_raw.iter())
+                .map(|(spec, raw)| resolve_scalar(raw.as_deref(), atom.source_alt_index, spec))
+                .collect();
+
+            let mut format_vals = Vec::with_capacity(self.format_fields.len() * self.num_samples);
+            for (spec, raw) in self.format_fields.iter().zip(format_raw.iter()) {
+                for &vcf_idx in &self.sample_indices {
+                    let sample_vals = raw.as_ref().map(|v| v[vcf_idx].as_slice());
+                    format_vals.push(resolve_scalar(sample_vals, atom.source_alt_index, spec));
+                }
+            }
+
             let seq = self.next_seq;
             self.next_seq += 1;
             self.heap.push(Reverse(PendingAtom {
@@ -352,6 +541,8 @@ impl VcfChunkReader {
                 source_alt_index: atom.source_alt_index,
                 gt: Arc::clone(&gt),
                 seq,
+                info_vals,
+                format_vals,
             }));
         }
         Ok(())
@@ -427,6 +618,18 @@ impl VcfChunkReader {
         alt_offsets.push(0u32);
         let mut genos = BitGrid3::zeros(v, self.num_samples, self.ploidy);
 
+        let num_samples = self.num_samples;
+        let mut info_staged: Vec<StagedColumn> = self
+            .info_fields
+            .iter()
+            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v))
+            .collect();
+        let mut format_staged: Vec<StagedColumn> = self
+            .format_fields
+            .iter()
+            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v * num_samples))
+            .collect();
+
         // Sequential metadata pass (cheap, ordering-preserving).
         let mut off = 0u32;
         for a in atoms.iter() {
@@ -435,6 +638,15 @@ impl VcfChunkReader {
             alt.extend_from_slice(&a.alt);
             off += a.alt.len() as u32;
             alt_offsets.push(off);
+
+            for (i, col) in info_staged.iter_mut().enumerate() {
+                col.push_f64(a.info_vals[i]);
+            }
+            for (j, col) in format_staged.iter_mut().enumerate() {
+                for s in 0..num_samples {
+                    col.push_f64(a.format_vals[j * num_samples + s]);
+                }
+            }
         }
 
         // Presence packing: parallel over word-aligned variant blocks when a
@@ -455,6 +667,8 @@ impl VcfChunkReader {
             alt,
             alt_offsets,
             genos,
+            info_staged,
+            format_staged,
         }))
     }
 }
@@ -485,6 +699,8 @@ mod tests {
             source_alt_index: src,
             gt: std::sync::Arc::new(gt),
             seq: 0,
+            info_vals: Vec::new(),
+            format_vals: Vec::new(),
         }
     }
 

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -135,16 +135,10 @@ fn pack_presence_par(
     });
 }
 
-// The sentinel a resolved field value falls back to when htslib reports it
-// missing and the spec has no explicit `default`: htslib's own missing-int
-// encoding for Int/Flag columns, NaN for Float columns (mirrors htslib's
-// float-missing encoding, which is itself a NaN bit pattern).
+// Delegates to `FieldSpec::missing_sentinel` — single source of truth shared
+// with `dense2sparse_vk`'s genotype-aligned non-carrier fill (src/rvk.rs).
 fn sentinel_default(spec: &FieldSpec) -> f64 {
-    spec.default.unwrap_or(if spec.stage_is_float() {
-        f64::from(f32::NAN)
-    } else {
-        i32::MIN as f64
-    })
+    spec.missing_sentinel()
 }
 
 // htslib missing-value detection on an already-widened f64: floats use NaN

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -164,7 +164,10 @@ fn is_htslib_missing(raw_val: f64, is_float: bool) -> bool {
 // Resolve one atom's value from a record-level raw buffer (already widened to
 // f64): `None` (field absent from the record/sample) or an out-of-range
 // Number=A index falls back to the spec's sentinel/default; a length-1 buffer
-// is a Number=1 scalar, otherwise indexed by `source_alt_index` (Number=A).
+// is a Number=1 scalar, otherwise indexed by `source_alt_index - 1` (Number=A):
+// `source_alt_index` is 1-based (ALT1 → 1, matching BCF GT allele codes; see
+// `normalize::atomize_record`), but htslib's Number=A buffer is 0-based
+// per-ALT (ALT1's value lives at `vals[0]`).
 fn resolve_scalar(vals: Option<&[f64]>, source_alt_index: u16, spec: &FieldSpec) -> f64 {
     let default_val = sentinel_default(spec);
     let Some(vals) = vals else {
@@ -176,7 +179,8 @@ fn resolve_scalar(vals: Option<&[f64]>, source_alt_index: u16, spec: &FieldSpec)
     let raw_val = if vals.len() == 1 {
         vals[0]
     } else {
-        match vals.get(source_alt_index as usize) {
+        // source_alt_index is 1-based; htslib Number=A buffers are 0-based per-ALT.
+        match vals.get(source_alt_index.saturating_sub(1) as usize) {
             Some(&v) => v,
             None => return default_val,
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -28,6 +28,9 @@ pub fn run_io_writer(
                 bytemuck::cast_slice(&sub.call_positions),
             )?;
             write_bin(&layout::chunk_key(dir, id), &sub.call_keys)?; // already bytes
+            for (i, col) in sub.field_calls.iter().enumerate() {
+                write_bin(&layout::chunk_field(dir, id, i), staged_bytes(col))?;
+            }
         }
 
         // dense per-class matrix + table (only classes with dense variants)
@@ -43,6 +46,12 @@ pub fn run_io_writer(
             )?;
             write_bin(&layout::chunk_key(dir, id), &sub.keys)?;
             write_bin(&layout::chunk_geno(dir, id), &sub.geno_bits)?;
+            for (i, col) in sub.field_info.iter().enumerate() {
+                write_bin(&layout::chunk_field_info(dir, id, i), staged_bytes(col))?;
+            }
+            for (i, col) in sub.field_format.iter().enumerate() {
+                write_bin(&layout::chunk_field_format(dir, id, i), staged_bytes(col))?;
+            }
         }
     }
 
@@ -82,6 +91,15 @@ pub fn run_long_allele_writer(
         chrom_label
     );
     Ok(())
+}
+
+/// View a staged field column as raw bytes for a flat write, matching the
+/// element type's native representation (`i32`/`f32`).
+fn staged_bytes(col: &crate::types::StagedColumn) -> &[u8] {
+    match col {
+        crate::types::StagedColumn::Int(v) => bytemuck::cast_slice(v),
+        crate::types::StagedColumn::Float(v) => bytemuck::cast_slice(v),
+    }
 }
 
 fn write_bin(path: &Path, bytes: &[u8]) -> Result<(), ConversionError> {
@@ -180,5 +198,73 @@ mod tests {
         assert_eq!(geno, vec![0b0000_1011u8]);
         // indel had 0 dense variants → no files written
         assert!(!indel_dir.join("chunk_0_geno.bin").exists());
+    }
+
+    #[test]
+    fn test_writer_persists_field_chunk_files() {
+        let tmp = tempdir().unwrap();
+
+        let vk_snp = tmp.path().join("var_key/snp");
+        let vk_indel = tmp.path().join("var_key/indel");
+        std::fs::create_dir_all(&vk_snp).unwrap();
+        std::fs::create_dir_all(&vk_indel).unwrap();
+
+        let snp_dir = tmp.path().join("dense/snp");
+        let indel_dir = tmp.path().join("dense/indel");
+        std::fs::create_dir_all(&snp_dir).unwrap();
+        std::fs::create_dir_all(&indel_dir).unwrap();
+
+        // var_key/snp stream: 3 calls, one staged Float field.
+        let mut streams = StreamMap::from_fn(|tag| {
+            let kb = crate::streams::REGISTRY[tag.index()].key_bytes;
+            SparseSubStream::with_capacity(kb, 0, 0)
+        });
+        let snp_stream = streams.get_mut(StreamTag::VarKeySnp);
+        snp_stream.call_positions = vec![10, 20, 30];
+        snp_stream.call_keys = vec![1u8, 2u8, 3u8];
+        snp_stream.field_calls = vec![crate::types::StagedColumn::Float(vec![0.5, 1.5, 2.5])];
+
+        // dense/snp class: 2 dense variants, one INFO field + one FORMAT field.
+        let mut dense = DenseMap::from_fn(|c| DenseSubChunk::empty(c.key_bytes()));
+        let snp_dense = dense.get_mut(DenseClass::Snp);
+        snp_dense.n_dense_variants = 2;
+        snp_dense.positions = vec![100, 200];
+        snp_dense.keys = vec![1u8, 2u8];
+        snp_dense.geno_bits = vec![0u8];
+        snp_dense.field_info = vec![crate::types::StagedColumn::Int(vec![7, 8])];
+        snp_dense.field_format = vec![crate::types::StagedColumn::Float(vec![1.0, 2.0, 3.0, 4.0])];
+
+        let chunk = SparseChunk {
+            chunk_id: 0,
+            streams,
+            dense,
+        };
+
+        let (tx, rx) = bounded(1);
+        tx.send(chunk).unwrap();
+        drop(tx);
+
+        let dirs = StreamMap::from_fn(|tag| match tag {
+            StreamTag::VarKeySnp => vk_snp.clone(),
+            StreamTag::VarKeyIndel => vk_indel.clone(),
+        });
+        let dense_dirs = DenseMap::from_fn(|c| match c {
+            DenseClass::Snp => snp_dir.clone(),
+            DenseClass::Indel => indel_dir.clone(),
+        });
+
+        run_io_writer(rx, dirs, dense_dirs).unwrap();
+
+        // var_key/snp field0: 3 f32 = 12 bytes.
+        let field0 = std::fs::read(vk_snp.join("chunk_0_field0.bin")).unwrap();
+        assert_eq!(field0.len(), 12);
+
+        // dense/snp finfo0: 2 i32 = 8 bytes.
+        let finfo0 = std::fs::read(snp_dir.join("chunk_0_finfo0.bin")).unwrap();
+        assert_eq!(finfo0.len(), 8);
+
+        // dense/snp fformat0: 4 f32 = 16 bytes.
+        let fformat0 = std::fs::read(snp_dir.join("chunk_0_fformat0.bin")).unwrap();
+        assert_eq!(fformat0.len(), 16);
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -186,6 +186,7 @@ pub fn build_contig(
         false,
         1,     // processing_threads
         false, // signatures
+        &[],   // fields
     )
     .expect("process_chromosome should succeed");
     write_max_del_fixture(&out.join(chrom), samples.len(), ploidy, records);

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -27,6 +27,7 @@ fn drain_reader(
         1,
         ploidy,
         false,
+        &[],
     )
     .unwrap();
     let columns = samples.len() * ploidy;

--- a/tests/test_convert_skip_e2e.rs
+++ b/tests/test_convert_skip_e2e.rs
@@ -53,6 +53,7 @@ fn convert(
         skip,
         1,     // processing_threads
         false, // signatures
+        &[],   // fields
     )
 }
 

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -100,6 +100,7 @@ fn test_e2e_normalized_bcf_pipeline() {
         false,
         1,     // processing_threads
         false, // signatures
+        &[],   // fields
     )
     .expect("process_chromosome should succeed");
 
@@ -190,6 +191,7 @@ fn test_e2e_max_del_postpass() {
         false,
         1,     // processing_threads
         false, // signatures
+        &[],   // fields
     )
     .expect("conversion");
 
@@ -264,6 +266,7 @@ fn test_e2e_dense_snp_roundtrip() {
         false,
         1,     // processing_threads
         false, // signatures
+        &[],   // fields
     )
     .expect("conversion");
 
@@ -337,6 +340,7 @@ fn test_e2e_mutation_conservation() {
         false,
         1,     // processing_threads
         false, // signatures
+        &[],   // fields
     )
     .expect("process_chromosome should succeed");
 
@@ -439,6 +443,7 @@ fn test_missing_chrom_returns_err() {
         false,
         1,     // processing_threads
         false, // signatures
+        &[],   // fields
     );
 
     assert!(matches!(

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -373,6 +373,125 @@ fn test_e2e_mutation_conservation() {
     );
 }
 
+// Task 4: INFO/FORMAT field extraction into DenseChunk. Builds a DEDICATED
+// small BCF (not the shared SynthRecord/build_bcf_with_index helper, which
+// has no INFO/FORMAT beyond GT) with an INFO/AC (Number=1, Integer) and a
+// FORMAT/DS (Number=1, Float) field over 2 samples, 3 strictly-increasing
+// biallelic SNP positions (no indels ⇒ atom order == record order, so
+// per-variant assertions stay stable). AC is left unset on the last record to
+// exercise the missing → sentinel path (no `default` set on the FieldSpec).
+#[test]
+fn test_reader_extracts_info_format_fields() {
+    use genoray_core::field::{FieldCategory, FieldSpec, HtslibType, StorageDtype};
+    use genoray_core::types::StagedColumn;
+    use rust_htslib::bcf::record::GenotypeAllele;
+    use rust_htslib::bcf::{Format as BcfFormat, Header, Writer};
+
+    let tmp = tempdir().unwrap();
+    let bcf_path = tmp.path().join("fields.bcf");
+
+    let samples = ["S0", "S1"];
+    let num_samples = samples.len();
+    let ploidy = 2;
+
+    // (pos, ref, alt, ac (None = leave INFO/AC unset), ds per sample, gt per hap)
+    #[allow(clippy::type_complexity)]
+    let records: Vec<(i64, &[u8], &[u8], Option<i32>, [f32; 2], [i32; 4])> = vec![
+        (100, b"A", b"C", Some(5), [0.1, 0.2], [1, 0, 0, 1]),
+        (200, b"G", b"T", Some(7), [0.3, 0.4], [0, 1, 1, 0]),
+        (300, b"C", b"A", None, [0.5, 0.6], [1, 1, 0, 0]),
+    ];
+
+    {
+        let mut header = Header::new();
+        header.push_record(b"##contig=<ID=chr1,length=10000>");
+        header.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+        header.push_record(b"##INFO=<ID=AC,Number=1,Type=Integer,Description=\"Allele count\">");
+        header.push_record(b"##FORMAT=<ID=DS,Number=1,Type=Float,Description=\"Dosage\">");
+        for s in &samples {
+            header.push_sample(s.as_bytes());
+        }
+
+        let mut writer =
+            Writer::from_path(&bcf_path, &header, false, BcfFormat::Bcf).expect("open BCF writer");
+        for (pos, r, a, ac, ds, gt) in &records {
+            let mut record = writer.empty_record();
+            record.set_rid(Some(0));
+            record.set_pos(*pos);
+            record.set_alleles(&[r, a]).expect("set alleles");
+            let gt_alleles: Vec<GenotypeAllele> =
+                gt.iter().map(|&i| GenotypeAllele::Phased(i)).collect();
+            record.push_genotypes(&gt_alleles).expect("push genotypes");
+            if let Some(ac) = ac {
+                record.push_info_integer(b"AC", &[*ac]).expect("push AC");
+            }
+            record.push_format_float(b"DS", ds).expect("push DS");
+            writer.write(&record).expect("write record");
+        }
+    }
+    rust_htslib::bcf::index::build(&bcf_path, None, 0, rust_htslib::bcf::index::Type::Csi(14))
+        .expect("build BCF index");
+
+    let info = vec![FieldSpec {
+        name: "AC".to_string(),
+        category: FieldCategory::Info,
+        htype: HtslibType::Int,
+        dtype: StorageDtype::Auto,
+        default: None,
+    }];
+    let fmt = vec![FieldSpec {
+        name: "DS".to_string(),
+        category: FieldCategory::Format,
+        htype: HtslibType::Float,
+        dtype: StorageDtype::Auto,
+        default: None,
+    }];
+    let mut all = info.clone();
+    all.extend(fmt.clone());
+
+    let sample_refs: Vec<&str> = samples.to_vec();
+    // fasta_path = None: skip validate_ref/left_align, so positions stay put
+    // and atom order == record order (all SNPs, no atomize splitting).
+    let mut reader = VcfChunkReader::new(
+        bcf_path.to_str().unwrap(),
+        None,
+        "chr1",
+        &sample_refs,
+        1,
+        ploidy,
+        false,
+        &all,
+    )
+    .unwrap();
+    let chunk = reader
+        .read_next_chunk(100, 0, None)
+        .expect("chunk should succeed")
+        .expect("chunk should succeed");
+
+    assert_eq!(chunk.pos, vec![100, 200, 300]);
+
+    let ds = match &chunk.format_staged[0] {
+        StagedColumn::Float(v) => v,
+        _ => panic!("DS should stage as Float"),
+    };
+    assert_eq!(ds.len(), chunk.pos.len() * num_samples);
+    // variant 0 (pos 100), sample 1 (S1) → index 0*2 + 1
+    assert!((ds[1] - 0.2).abs() < 1e-6);
+    // variant 1 (pos 200), sample 0 (S0) → index 1*2 + 0
+    assert!((ds[2] - 0.3).abs() < 1e-6);
+    // variant 2 (pos 300), sample 1 (S1) → index 2*2 + 1
+    assert!((ds[5] - 0.6).abs() < 1e-6);
+
+    let ac = match &chunk.info_staged[0] {
+        StagedColumn::Int(v) => v,
+        _ => panic!("AC should stage as Int"),
+    };
+    assert_eq!(ac.len(), chunk.pos.len());
+    assert_eq!(ac[0], 5);
+    assert_eq!(ac[1], 7);
+    assert_eq!(ac[2], i32::MIN, "missing AC (no default) → sentinel");
+}
+
 // Sanity: a clean, properly atomized DEL (alt_len=1) passes the reader.
 #[test]
 fn test_reader_accepts_pure_del() {
@@ -397,6 +516,7 @@ fn test_reader_accepts_pure_del() {
         1,
         2,
         false,
+        &[],
     )
     .unwrap();
     let chunk = reader
@@ -468,6 +588,7 @@ fn test_missing_vcf_returns_missing_file() {
         1,
         2,
         false,
+        &[],
     );
 
     assert!(matches!(

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -492,6 +492,203 @@ fn test_reader_extracts_info_format_fields() {
     assert_eq!(ac[2], i32::MIN, "missing AC (no default) → sentinel");
 }
 
+// Regression (Task 4 code review, Critical): `resolve_scalar` must index a
+// Number=A htslib buffer by `source_alt_index - 1` (0-based per-ALT), not
+// `source_alt_index` directly (1-based). Biallelic records can't catch this —
+// a single-ALT Number=A buffer has length 1 and hits the `vals.len() == 1`
+// scalar branch regardless of index. Only a MULTIALLELIC record exercises the
+// `vals.get(idx)` arm: on unpatched code ALT1 (source_alt_index=1) reads
+// ALT2's slot and ALT2 (source_alt_index=2) reads out of bounds → sentinel.
+//
+// Builds one low-pos biallelic SNP (ordering sanity) then a 2-ALT record
+// ref="A", alt=["C","G"] with INFO/AC=[10,20] (Number=A Integer) and
+// FORMAT/DS Number=A Float, sample-major per htslib layout:
+// sample0=[0.1(ALT_C), 0.2(ALT_G)], sample1=[0.3(ALT_C), 0.4(ALT_G)] →
+// push_format_float(&[0.1, 0.2, 0.3, 0.4]). `atomize_record` pushes ALTs in
+// order (C=source_alt_index 1, G=source_alt_index 2) and the reorder heap
+// tiebreaks equal positions by insertion sequence, so the multiallelic
+// record's two atoms come out ALT-C then ALT-G. fasta_path=None skips
+// left-align, so positions/ordering stay exactly as written.
+#[test]
+fn test_reader_extracts_multiallelic_number_a_fields() {
+    use genoray_core::field::{FieldCategory, FieldSpec, HtslibType, StorageDtype};
+    use genoray_core::types::StagedColumn;
+    use rust_htslib::bcf::record::GenotypeAllele;
+    use rust_htslib::bcf::{Format as BcfFormat, Header, Writer};
+
+    let tmp = tempdir().unwrap();
+    let bcf_path = tmp.path().join("multiallelic_fields.bcf");
+
+    let samples = ["S0", "S1"];
+    let num_samples = samples.len();
+    let ploidy = 2;
+
+    {
+        let mut header = Header::new();
+        header.push_record(b"##contig=<ID=chr1,length=10000>");
+        header.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+        header.push_record(b"##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count\">");
+        header.push_record(b"##FORMAT=<ID=DS,Number=A,Type=Float,Description=\"Dosage\">");
+        for s in &samples {
+            header.push_sample(s.as_bytes());
+        }
+
+        let mut writer =
+            Writer::from_path(&bcf_path, &header, false, BcfFormat::Bcf).expect("open BCF writer");
+
+        // Record 0: biallelic SNP at a lower pos, ordering sanity only.
+        {
+            let mut record = writer.empty_record();
+            record.set_rid(Some(0));
+            record.set_pos(50);
+            record.set_alleles(&[b"T", b"A"]).expect("set alleles");
+            let gt_alleles = vec![
+                GenotypeAllele::Phased(1),
+                GenotypeAllele::Phased(0),
+                GenotypeAllele::Phased(0),
+                GenotypeAllele::Phased(0),
+            ];
+            record.push_genotypes(&gt_alleles).expect("push genotypes");
+            record.push_info_integer(b"AC", &[1]).expect("push AC");
+            record
+                .push_format_float(b"DS", &[0.9, 0.9])
+                .expect("push DS");
+            writer.write(&record).expect("write record");
+        }
+
+        // Record 1: MULTIALLELIC SNP, ref="A", alt=["C","G"].
+        {
+            let mut record = writer.empty_record();
+            record.set_rid(Some(0));
+            record.set_pos(200);
+            record
+                .set_alleles(&[b"A", b"C", b"G"])
+                .expect("set alleles");
+            // S0: hap0=ALT1(C), hap1=ALT2(G); S1: hom ref.
+            let gt_alleles = vec![
+                GenotypeAllele::Phased(1),
+                GenotypeAllele::Phased(2),
+                GenotypeAllele::Phased(0),
+                GenotypeAllele::Phased(0),
+            ];
+            record.push_genotypes(&gt_alleles).expect("push genotypes");
+            record.push_info_integer(b"AC", &[10, 20]).expect("push AC");
+            // Number=A, 2 samples, sample-major: [s0_altC, s0_altG, s1_altC, s1_altG].
+            record
+                .push_format_float(b"DS", &[0.1, 0.2, 0.3, 0.4])
+                .expect("push DS");
+            writer.write(&record).expect("write record");
+        }
+    }
+    rust_htslib::bcf::index::build(&bcf_path, None, 0, rust_htslib::bcf::index::Type::Csi(14))
+        .expect("build BCF index");
+
+    let info = vec![FieldSpec {
+        name: "AC".to_string(),
+        category: FieldCategory::Info,
+        htype: HtslibType::Int,
+        dtype: StorageDtype::Auto,
+        default: None,
+    }];
+    let fmt = vec![FieldSpec {
+        name: "DS".to_string(),
+        category: FieldCategory::Format,
+        htype: HtslibType::Float,
+        dtype: StorageDtype::Auto,
+        default: None,
+    }];
+    let mut all = info.clone();
+    all.extend(fmt.clone());
+
+    let sample_refs: Vec<&str> = samples.to_vec();
+    let mut reader = VcfChunkReader::new(
+        bcf_path.to_str().unwrap(),
+        None,
+        "chr1",
+        &sample_refs,
+        1,
+        ploidy,
+        false,
+        &all,
+    )
+    .unwrap();
+    let chunk = reader
+        .read_next_chunk(100, 0, None)
+        .expect("chunk should succeed")
+        .expect("chunk should succeed");
+
+    // 3 atoms total: 1 (pos 50) + 2 (pos 200, the multiallelic split).
+    assert_eq!(chunk.pos, vec![50, 200, 200]);
+    assert_eq!(chunk.ilens, vec![0, 0, 0], "all SNPs, no ilen shift");
+
+    // Identify the two multiallelic atoms by pos, then confirm which is which
+    // via their actual ALT bytes (don't just assume emission order) — this is
+    // the "non-vacuous" check: it fails loudly if atomize/heap ordering ever
+    // changes instead of silently comparing the wrong atom.
+    let multi_idxs: Vec<usize> = chunk
+        .pos
+        .iter()
+        .enumerate()
+        .filter(|&(_, &p)| p == 200)
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(multi_idxs.len(), 2, "expected exactly 2 split atoms @200");
+    let atom_alt = |i: usize| -> Vec<u8> {
+        let start = chunk.alt_offsets[i] as usize;
+        let end = chunk.alt_offsets[i + 1] as usize;
+        chunk.alt[start..end].to_vec()
+    };
+    let idx_c = *multi_idxs
+        .iter()
+        .find(|&&i| atom_alt(i) == b"C")
+        .expect("an atom with ALT=C must exist");
+    let idx_g = *multi_idxs
+        .iter()
+        .find(|&&i| atom_alt(i) == b"G")
+        .expect("an atom with ALT=G must exist");
+    assert_ne!(idx_c, idx_g);
+
+    let ac = match &chunk.info_staged[0] {
+        StagedColumn::Int(v) => v,
+        _ => panic!("AC should stage as Int"),
+    };
+    assert_eq!(ac.len(), chunk.pos.len());
+    assert_eq!(
+        ac[idx_c], 10,
+        "ALT=C (source_alt_index=1) must read AC[0]=10, not AC[1]=20"
+    );
+    assert_eq!(
+        ac[idx_g], 20,
+        "ALT=G (source_alt_index=2) must read AC[1]=20, not out-of-bounds/sentinel"
+    );
+
+    let ds = match &chunk.format_staged[0] {
+        StagedColumn::Float(v) => v,
+        _ => panic!("DS should stage as Float"),
+    };
+    assert_eq!(ds.len(), chunk.pos.len() * num_samples);
+    assert!(
+        (ds[idx_c * num_samples] - 0.1).abs() < 1e-6,
+        "ALT=C sample0 DS should be 0.1, got {}",
+        ds[idx_c * num_samples]
+    );
+    assert!(
+        (ds[idx_c * num_samples + 1] - 0.3).abs() < 1e-6,
+        "ALT=C sample1 DS should be 0.3, got {}",
+        ds[idx_c * num_samples + 1]
+    );
+    assert!(
+        (ds[idx_g * num_samples] - 0.2).abs() < 1e-6,
+        "ALT=G sample0 DS should be 0.2, got {}",
+        ds[idx_g * num_samples]
+    );
+    assert!(
+        (ds[idx_g * num_samples + 1] - 0.4).abs() < 1e-6,
+        "ALT=G sample1 DS should be 0.4, got {}",
+        ds[idx_g * num_samples + 1]
+    );
+}
+
 // Sanity: a clean, properly atomized DEL (alt_len=1) passes the reader.
 #[test]
 fn test_reader_accepts_pure_del() {

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -32,6 +32,7 @@ fn drain(bcf: &Path, fasta: &Path, chrom: &str, samples: &[&str]) -> Vec<(u32, i
         1,
         2,
         false,
+        &[],
     )
     .unwrap();
     let mut out = Vec::new();
@@ -241,6 +242,7 @@ fn left_shifts_stay_sorted_across_chunk_boundaries() {
         1,
         2,
         false,
+        &[],
     )
     .unwrap();
     let mut positions = Vec::new();
@@ -307,6 +309,7 @@ proptest! {
             1,
             2,
             false,
+            &[],
         )
         .unwrap();
         let mut positions = Vec::new();

--- a/tests/test_svar2_fields.py
+++ b/tests/test_svar2_fields.py
@@ -191,3 +191,114 @@ def test_from_vcf_same_name_info_and_format(tmp_path: Path):
     assert all(p.stat().st_size % format_width == 0 for p in format_vals)
     assert sum(p.stat().st_size for p in info_vals) > 0
     assert sum(p.stat().st_size for p in format_vals) > 0
+
+
+def _rare_indel_vcf(tmp_path: Path) -> Path:
+    """2 samples; a biallelic indel carried by exactly ONE call, plus a FORMAT
+    float DS. With np=4 and a single carrier call, choose_representation routes
+    the indel to var_key_indel (var_key ~64 bits < dense ~68), so DS must land
+    in fields/format/DS/var_key_indel/values.bin."""
+    doc = (
+        VcfBuilder(samples=["s0", "s1"], contigs=[("chr1", 100_000)])
+        .fmt("GT")
+        .fmt("DS", Number.ONE, Type.FLOAT)
+        .record(
+            "chr1",
+            100,
+            ref="AT",
+            alt=[Seq("A")],  # 1bp deletion (indel)
+            gt=["0|1", "0|0"],  # one carrier call total
+            DS=[[0.5], [0.0]],
+        )
+    )
+    return doc.write(tmp_path / "rare_indel.vcf.gz", bgzip=True, index=True)
+
+
+def test_from_vcf_varkey_indel_format_field_written(tmp_path: Path):
+    from genoray import SparseVar2
+
+    src = _rare_indel_vcf(tmp_path)
+    out = tmp_path / "store_vk_indel.svar2"
+    SparseVar2.from_vcf(
+        out, str(src), no_reference=True, format_fields=[FormatField("DS", default=0.0)]
+    )
+    import json
+
+    meta = json.loads((out / "meta.json").read_text())
+    contig = meta["contigs"][0]
+    vk_indel = (
+        out / contig / "fields" / "format" / "DS" / "var_key_indel" / "values.bin"
+    )
+    assert vk_indel.is_file(), "var_key_indel DS values.bin missing"
+    assert vk_indel.stat().st_size > 0, "var_key_indel DS field_calls not written"
+
+
+def _multifield_vcf(tmp_path: Path) -> Path:
+    """2 INFO + 2 FORMAT scalar fields with distinct values, to prove per-field
+    files don't cross-contaminate through routing/merge/finalize."""
+    doc = (
+        VcfBuilder(samples=["s0", "s1"], contigs=[("chr1", 100_000)])
+        .info("AC", Number.A, Type.INTEGER)
+        .info("AN", Number.ONE, Type.INTEGER)
+        .fmt("GT")
+        .fmt("DP", Number.ONE, Type.INTEGER)
+        .fmt("DS", Number.ONE, Type.FLOAT)
+        .record(
+            "chr1",
+            100,
+            ref="A",
+            alt=[Seq("C")],
+            gt=["0|1", "1|1"],
+            info={"AC": 3, "AN": 4},
+            DP=[[10], [20]],
+            DS=[[0.25], [0.75]],
+        )
+    )
+    return doc.write(tmp_path / "multifield.vcf.gz", bgzip=True, index=True)
+
+
+def test_from_vcf_multi_field_no_cross_contamination(tmp_path: Path):
+    import json
+
+    from genoray import SparseVar2
+
+    src = _multifield_vcf(tmp_path)
+    out = tmp_path / "store_multi.svar2"
+    SparseVar2.from_vcf(
+        out,
+        str(src),
+        no_reference=True,
+        info_fields=["AC", "AN"],
+        format_fields=["DP", "DS"],
+    )
+    meta = json.loads((out / "meta.json").read_text())
+    by_name = {f["name"]: f for f in meta["fields"]}
+    # Each field is recorded exactly once under its own category.
+    assert by_name["AC"]["category"] == "info"
+    assert by_name["AN"]["category"] == "info"
+    assert by_name["DP"]["category"] == "format"
+    assert by_name["DS"]["category"] == "format"
+    # DS is the only Float field -> f32; the ints auto-narrow to a sub-4b width.
+    assert by_name["DS"]["dtype"] == "f32"
+    assert by_name["DP"]["dtype"] in {"i8", "u8", "i16", "u16"}
+    contig = meta["contigs"][0]
+    # Every declared field has at least one non-empty values.bin, and int fields
+    # stay a whole number of their own resolved width (proves disjoint files).
+    width = {
+        "bool": 1,
+        "i8": 1,
+        "u8": 1,
+        "i16": 2,
+        "u16": 2,
+        "f16": 2,
+        "f32": 4,
+        "i32": 4,
+        "u32": 4,
+    }
+    for name, spec in by_name.items():
+        cat = spec["category"]
+        files = list((out / contig / "fields" / cat / name).glob("*/values.bin"))
+        assert files, f"{cat}/{name} has no values.bin"
+        assert sum(p.stat().st_size for p in files) > 0, f"{cat}/{name} all empty"
+        w = width[spec["dtype"]]
+        assert all(p.stat().st_size % w == 0 for p in files), f"{cat}/{name} bad width"

--- a/tests/test_svar2_fields.py
+++ b/tests/test_svar2_fields.py
@@ -105,7 +105,7 @@ def test_from_vcf_writes_dosage_field(tmp_path: Path):
     ds = next(f for f in meta["fields"] if f["name"] == "DS")
     assert ds["category"] == "format" and ds["dtype"] == "f32"
     contig = meta["contigs"][0]
-    vals = list((out / contig / "fields" / "DS").glob("*/values.bin"))
+    vals = list((out / contig / "fields" / "format" / "DS").glob("*/values.bin"))
     assert vals and all(p.stat().st_size % 4 == 0 for p in vals)
 
 
@@ -118,3 +118,76 @@ def test_from_vcf_with_no_fields_writes_empty_fields_list(tmp_path: Path):
     SparseVar2.from_vcf(out, "tests/data/biallelic.vcf.gz", no_reference=True)
     meta = json.loads((out / "meta.json").read_text())
     assert meta["fields"] == []
+
+
+def _dup_name_vcf(tmp_path: Path) -> Path:
+    """A VCF where `DP` is declared as BOTH an INFO field (site depth) and a
+    FORMAT field (per-sample depth) — a supported `from_vcf` input per the
+    design spec ("a name may exist in both"). Regression fixture for the
+    fields/{name}/ collision bug: without a category segment in the on-disk
+    path, INFO DP and FORMAT DP would merge/finalize into the same
+    `values.bin`, corrupting one or both.
+    """
+    doc = (
+        VcfBuilder(samples=["s0", "s1"], contigs=[("chr1", 100_000)])
+        .info("DP", Number.ONE, Type.INTEGER)
+        .fmt("GT")
+        .fmt("DP", Number.ONE, Type.INTEGER)
+        .record(
+            "chr1",
+            100,
+            ref="A",
+            alt=[Seq("C")],
+            gt=["0|1", "1|1"],
+            info={"DP": 30},
+            DP=[[10], [20]],
+        )
+        .record(
+            "chr1",
+            200,
+            ref="G",
+            alt=[Seq("T")],
+            gt=["1|0", "0|1"],
+            info={"DP": 40},
+            DP=[[15], [25]],
+        )
+    )
+    return doc.write(tmp_path / "dup.vcf.gz", bgzip=True, index=True)
+
+
+def test_from_vcf_same_name_info_and_format(tmp_path: Path):
+    import json
+
+    from genoray import SparseVar2
+
+    src = _dup_name_vcf(tmp_path)
+    out = tmp_path / "store_dup.svar2"
+    SparseVar2.from_vcf(
+        out, str(src), no_reference=True, info_fields=["DP"], format_fields=["DP"]
+    )
+    meta = json.loads((out / "meta.json").read_text())
+    dps = [f for f in meta["fields"] if f["name"] == "DP"]
+    # Both the INFO and FORMAT DP specs must survive finalize independently
+    # (no clobber, no double-finalize on a shared file).
+    assert {f["category"] for f in dps} == {"info", "format"}
+    contig = meta["contigs"][0]
+    info_vals = list((out / contig / "fields" / "info" / "DP").glob("*/values.bin"))
+    format_vals = list((out / contig / "fields" / "format" / "DP").glob("*/values.bin"))
+    assert info_vals
+    assert format_vals
+    # Auto-narrowing may resolve DP to a sub-4-byte width, and unrouted subs
+    # legitimately finalize to empty (0-byte) files, so just require: every
+    # file is a whole number of its own category's resolved dtype width
+    # (proves each category's rewrite used its own width, undisturbed by the
+    # other category sharing the name), and each category wrote SOME data.
+    byte_width = {"bool": 1, "i8": 1, "u8": 1, "i16": 2, "u16": 2, "f16": 2}
+    info_width = byte_width.get(
+        next(f["dtype"] for f in dps if f["category"] == "info"), 4
+    )
+    format_width = byte_width.get(
+        next(f["dtype"] for f in dps if f["category"] == "format"), 4
+    )
+    assert all(p.stat().st_size % info_width == 0 for p in info_vals)
+    assert all(p.stat().st_size % format_width == 0 for p in format_vals)
+    assert sum(p.stat().st_size for p in info_vals) > 0
+    assert sum(p.stat().st_size for p in format_vals) > 0

--- a/tests/test_svar2_fields.py
+++ b/tests/test_svar2_fields.py
@@ -1,0 +1,78 @@
+"""Tests for `genoray._svar2_fields`: `InfoField`/`FormatField` config and
+VCF-header validation (`_resolve_fields`).
+
+The fixture used here is a small, self-contained VCF built inline with
+`vcfixture` (not the shared `tests/data` fixtures, which lack the INFO/Flag
+fields these tests need). It declares:
+
+- `INFO AC` (Number=A, Integer)   -> bare-str inference + int htslib_type
+- `INFO DB` (Number=0, Flag)      -> flag htslib_type
+- `FORMAT DS` (Number=1, Float)   -> dtype/default override + int-rejection
+- `FORMAT AD` (Number=R, Integer) -> non-scalar Number rejection
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from vcfixture import Number, Seq, Type, VcfBuilder
+
+from genoray._svar2_fields import FormatField, _resolve_fields
+
+
+@pytest.fixture(scope="module")
+def vcf_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    tmp_path = tmp_path_factory.mktemp("svar2_fields")
+    doc = (
+        VcfBuilder(samples=["s1", "s2"], contigs=[("chr1", None)])
+        .fmt("GT")
+        .info("AC", Number.A, Type.INTEGER)
+        .info("DB", Number.FLAG, Type.FLAG)
+        .fmt("DS", Number.ONE, Type.FLOAT)
+        .fmt("AD", Number.R, Type.INTEGER)
+        .record(
+            "chr1",
+            1000,
+            ref="A",
+            alt=[Seq("T")],
+            gt=["0|1", "1|1"],
+            info={"AC": 1, "DB": True},
+            DS=[[0.5], [0.9]],
+            AD=[[10, 5], [2, 8]],
+        )
+    )
+    return doc.write(tmp_path / "fix.vcf.gz", bgzip=True, index=True)
+
+
+def test_resolve_bare_str_infers(vcf_path: Path):
+    out = _resolve_fields(str(vcf_path), ["AC"], ["DS"])
+    assert ("AC", "info", "int", None, None) in out
+    assert ("DS", "format", "float", None, None) in out
+
+
+def test_resolve_flag_info(vcf_path: Path):
+    out = _resolve_fields(str(vcf_path), ["DB"], [])
+    assert ("DB", "info", "flag", None, None) in out
+
+
+def test_resolve_dtype_and_default_override(vcf_path: Path):
+    out = _resolve_fields(
+        str(vcf_path), [], [FormatField("DS", dtype="f16", default=0.0)]
+    )
+    assert ("DS", "format", "float", "f16", 0.0) in out
+
+
+def test_reject_unknown_field(vcf_path: Path):
+    with pytest.raises(ValueError, match="not found in the VCF header"):
+        _resolve_fields(str(vcf_path), ["NOPE"], [])
+
+
+def test_reject_float_stored_as_int(vcf_path: Path):
+    with pytest.raises(ValueError, match="incompatible"):
+        _resolve_fields(str(vcf_path), [], [FormatField("DS", dtype="i16")])
+
+
+def test_reject_nonscalar_number(vcf_path: Path):
+    with pytest.raises(ValueError, match="Number"):
+        _resolve_fields(str(vcf_path), [], [FormatField("AD")])

--- a/tests/test_svar2_fields.py
+++ b/tests/test_svar2_fields.py
@@ -76,3 +76,45 @@ def test_reject_float_stored_as_int(vcf_path: Path):
 def test_reject_nonscalar_number(vcf_path: Path):
     with pytest.raises(ValueError, match="Number"):
         _resolve_fields(str(vcf_path), [], [FormatField("AD")])
+
+
+# --- end-to-end: from_vcf -> _core.run_conversion_pipeline -> meta.json/on-disk files ---
+
+
+def test_import_field_specs_from_package():
+    from genoray import FormatField as _FF
+    from genoray import InfoField as _IF
+
+    assert _IF.__name__ == "InfoField"
+    assert _FF is FormatField
+
+
+def test_from_vcf_writes_dosage_field(tmp_path: Path):
+    import json
+
+    from genoray import SparseVar2
+
+    out = tmp_path / "store.svar2"
+    SparseVar2.from_vcf(
+        out,
+        "tests/data/biallelic.vcf.gz",
+        no_reference=True,
+        format_fields=[FormatField("DS", default=0.0)],
+    )
+    meta = json.loads((out / "meta.json").read_text())
+    ds = next(f for f in meta["fields"] if f["name"] == "DS")
+    assert ds["category"] == "format" and ds["dtype"] == "f32"
+    contig = meta["contigs"][0]
+    vals = list((out / contig / "fields" / "DS").glob("*/values.bin"))
+    assert vals and all(p.stat().st_size % 4 == 0 for p in vals)
+
+
+def test_from_vcf_with_no_fields_writes_empty_fields_list(tmp_path: Path):
+    import json
+
+    from genoray import SparseVar2
+
+    out = tmp_path / "store_nofields.svar2"
+    SparseVar2.from_vcf(out, "tests/data/biallelic.vcf.gz", no_reference=True)
+    meta = json.loads((out / "meta.json").read_text())
+    assert meta["fields"] == []

--- a/tests/test_svar2_fields.py
+++ b/tests/test_svar2_fields.py
@@ -302,3 +302,72 @@ def test_from_vcf_multi_field_no_cross_contamination(tmp_path: Path):
         assert sum(p.stat().st_size for p in files) > 0, f"{cat}/{name} all empty"
         w = width[spec["dtype"]]
         assert all(p.stat().st_size % w == 0 for p in files), f"{cat}/{name} bad width"
+
+
+def _ref_and_fields_vcf(tmp_path: Path) -> tuple[Path, Path]:
+    """A reference FASTA + a bgzipped/indexed VCF whose REF bases match it,
+    carrying one INFO int (AC) and one FORMAT float (DS). Reuses the 40bp
+    reference convention from tests/test_svar2_from_vcf.py (_REF)."""
+    import subprocess
+
+    ref_seq = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"  # POS3='A', POS7='C'
+    ref = tmp_path / "ref.fa"
+    ref.write_text(f">chr1\n{ref_seq}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    doc = (
+        VcfBuilder(samples=["s0", "s1"], contigs=[("chr1", 40)])
+        .info("AC", Number.A, Type.INTEGER)
+        .fmt("GT")
+        .fmt("DS", Number.ONE, Type.FLOAT)
+        .record(
+            "chr1",
+            3,
+            ref="A",
+            alt=[Seq("G")],
+            gt=["1|0", "0|0"],
+            info={"AC": 1},
+            DS=[[0.5], [0.0]],
+        )
+        .record(
+            "chr1",
+            7,
+            ref="C",
+            alt=[Seq("CAT")],
+            gt=["0|1", "1|1"],
+            info={"AC": 3},
+            DS=[[0.9], [0.2]],
+        )
+    )
+    vcf = doc.write(tmp_path / "ref_fields.vcf.gz", bgzip=True, index=True)
+    return vcf, ref
+
+
+def test_from_vcf_signatures_and_fields_compose(tmp_path: Path):
+    import json
+
+    from genoray import SparseVar2
+
+    vcf, ref = _ref_and_fields_vcf(tmp_path)
+    out = tmp_path / "store_sig_fields.svar2"
+    SparseVar2.from_vcf(
+        out,
+        str(vcf),
+        str(ref),
+        signatures=True,
+        info_fields=["AC"],
+        format_fields=[FormatField("DS", default=0.0)],
+        threads=1,
+    )
+    meta = json.loads((out / "meta.json").read_text())
+    names = {f["name"] for f in meta["fields"]}
+    assert {"AC", "DS"} <= names, "field manifest missing AC/DS under signatures=True"
+    contig = meta["contigs"][0]
+    # fields written
+    assert list((out / contig / "fields" / "info" / "AC").glob("*/values.bin"))
+    assert list((out / contig / "fields" / "format" / "DS").glob("*/values.bin"))
+    # mutcat sidecar written alongside (signatures path ran)
+    sidecar = list((out / contig).rglob("*sig*")) + list(
+        (out / contig).rglob("*mutcat*")
+    )
+    assert sidecar, "signatures=True produced no mutcat sidecar next to fields"


### PR DESCRIPTION
## Summary

Adds scalar-numeric **INFO** (per-variant) and **FORMAT** (per-call) field extraction to `SparseVar2.from_vcf`, so annotations like dosage (DS), depth (DP), and flags ride the conversion pipeline and are stored alongside the genotype streams in the SVAR2 store. Implements spec #1 of the 3-part SVAR2 fields effort (`docs/superpowers/specs/2026-07-11-svar2-info-format-fields-write-design.md`).

**This is the write path only** — the read/query path is deferred to spec #2 (intentionally out of scope here).

## What's new (public API)

- `genoray.InfoField` / `genoray.FormatField` — frozen dataclasses `(name, dtype=None, default=None)`.
- `SparseVar2.from_vcf(..., info_fields=None, format_fields=None)` — accept bare field names (inferred dtype) or `InfoField`/`FormatField` configs.
- Scope: `Type ∈ {Integer, Float, Flag}`, `Number ∈ {1, A}` (+ Flag, INFO-only); anything else is rejected at config time.
- dtype: `None` → Integer/Flag losslessly auto-narrowed to the smallest width; Float → `f32`. Explicit dtype is range-validated (`f16` is opt-in/lossy). `default` is the missing-fill; otherwise a reserved sentinel.
- Genotype-aligned (Option A): FORMAT values are stored per carrier call; non-carrier FORMAT values in var_key-routed variants are dropped by design.

## How it works

Field values are staged at `i32`/`f32` and ride the existing pipeline (reader → `DenseChunk` → `dense2sparse_vk` routing → per-chunk write → per-contig merge). A global **finalize pass** then resolves each field's on-disk dtype (lossless int auto-narrow / explicit `f16`) and rewrites the staged `values.bin` files. Resolved dtype/category/default is recorded in `meta.json` under `"fields"`.

On-disk layout: `{contig}/fields/{category}/{name}/{sub}/values.bin` where `category ∈ {info, format}` and `sub ∈ {var_key_snp, var_key_indel, dense_snp, dense_indel}`.

## Testing

- Rust: `cargo test --no-default-features --features conversion` — 0 failed (per-module unit tests for typing, reader extraction, routing, cost model, writer, both merges, and finalize).
- Python: `pixi run test` — **573 passed, 0 failed** (includes an end-to-end `from_vcf` round-trip and a same-name INFO+FORMAT regression test).

## How this was built

Executed task-by-task via subagent-driven-development: a fresh implementer per task (TDD), a spec+quality review after each, and a final whole-branch review on the most capable model. Notable bugs caught and fixed in-flight:
- **Number=A off-by-one** (1-based `source_alt_index` indexed into 0-based htslib buffers) — fixed + multiallelic regression test.
- **Same-name INFO/FORMAT collision** (final review): a name in both lists (e.g. `DP`) collided on disk → now namespaced by category.

## Deferred follow-ups (non-blocking)

- `merge_var_key_field_values` duplicates ~110 lines of `merge_mini_sc`'s tile-gather; a shared offset helper could DRY it.
- No combined `signatures=True` + fields e2e test (the cost terms are orthogonal/additive; low risk).
- Minor test-coverage gaps (VarKeyIndel field_calls, multi-field ordering, f32→f32 no-op rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
