### PR TITLE
feat(svar2): read INFO/FORMAT fields (Rust API + Python decode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,27 @@
   `Flag`'s `Number=0`); integer widths are losslessly auto-narrowed to the
   observed range by default, `f16` is opt-in and lossy. FORMAT storage is
   genotype-aligned — values at non-carrier genotypes are dropped, not stored
-  independently. Write-only in this release; a query/decode API for stored
-  fields is deferred to a follow-up.
+  independently. A read/decode API for these stored fields is added below
+  (`SparseVar2.available_fields`/`with_fields`/`fields=`).
+- **SVAR2: read INFO/FORMAT fields.** `SparseVar2(path, fields=…)` /
+  `SparseVar2.with_fields(…)` / `SparseVar2.available_fields` opt a reader
+  into decoding fields written by `from_vcf(info_fields=, format_fields=)`;
+  fields are **not** decoded by default (each one costs extra I/O).
+  `SparseVar2.decode()` now attaches one `Ragged` per selected field to its
+  result, sharing the same variant-axis offsets object as `pos`/`ilen`/
+  `allele` (access via `rag["KEY"]`). Values come back in the dtype they are
+  stored as (no widening — an auto-narrowed field may be `int8`); missing
+  entries keep the store's `default` or its reserved sentinel
+  (`NaN`/`iinfo.min`/`iinfo.max`), returned as-is. Field keys are the bare
+  name when unique across INFO/FORMAT, else bcftools-style `INFO/DP` /
+  `FORMAT/DP` when a name is used by both categories. New `StoredField`
+  dataclass (`genoray._svar2_fields`) is the manifest entry type
+  `available_fields` returns.
+- **Public Rust read API** for consumers that do their own channel merge
+  (e.g. GenVarLoader): `query::FieldView` (mmap reader over a field's
+  `values.bin`), `vk_src` provenance on `BatchResult`/`BatchResultSplit` via
+  `query::gather_haps_readbound_src` / `query::overlap_batch_src`, plus
+  `query::dense_abs_row`.
 - SVAR2 field write internals: the finalize pass streams staged values
   through `chunks_exact` (no intermediate `Vec<f64>` materialization) and
   runs in parallel across fields/files; the var_key and pos/key merges now

--- a/docs/superpowers/plans/2026-07-12-svar2-fields-read.md
+++ b/docs/superpowers/plans/2026-07-12-svar2-fields-read.md
@@ -1,0 +1,2124 @@
+# SVAR2 Field Read Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let consumers read the INFO/FORMAT fields SVAR2 already writes — GenVarLoader via a public Rust `FieldView` + record provenance, and Python via `SparseVar2.decode(fields=…)`.
+
+**Architecture:** gvl runs its *own* var_key⋈dense merge and already holds the source channel + index when it emits a record, so genoray never gathers or materializes field values. It exposes (a) `FieldView`, an mmap over `values.bin` whose element width comes from `meta.json`, and (b) `vk_src`, the one index destroyed when var_key snp+indel are merged by position. Dense provenance is free (absolute row = arithmetic on the retained window ranges). Provenance is a monomorphized generic so the no-fields path stays byte-identical and zero-cost.
+
+**Tech Stack:** Rust (pyo3, memmap2, bytemuck, half), Python (numpy, seqpro.rag.Ragged), pixi, pytest, cargo.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-svar2-fields-read-design.md`
+
+## Global Constraints
+
+- **Rust tests MUST use `--no-default-features`**, else the pyo3 test binary fails to link with `undefined symbol: _Py_Dealloc`. Always: `pixi run bash -lc 'cargo test --no-default-features <args>'`.
+- **Element width is NOT in `values.bin`.** It comes only from `meta.json`'s `fields[].dtype`. Never infer width from file length.
+- **Dense FORMAT is indexed by the ORIGINAL cohort sample index**, never the selected subset slot. Index is `dense_row * n_samples + orig_sample`, where `n_samples` is the cohort width.
+- **On-disk field path:** `{contig}/fields/{info|format}/{name}/{var_key_snp|var_key_indel|dense_snp|dense_indel}/values.bin`.
+- **Missing sentinels:** `i*::MIN` / `u*::MAX` / `NaN`. A sentinel exists **only** when the field's `default` is `None`. Never translate or widen — preserve the stored dtype end to end.
+- **`vk_src` packing:** bit 31 = sub-stream tag (0 = snp, 1 = indel), bits 0..=30 = absolute call index. Ceiling 2^31, enforced by a **hard assert** that lives ONLY in the provenance-carrying code path.
+- **Zero-cost rule:** a no-fields gather must produce byte-identical output to today. Provenance is added via monomorphized generics, not runtime branches in the hot loop.
+- Commits follow Conventional Commits (`feat:`, `test:`, `refactor:`, `docs:`).
+- **Public-API rule (CLAUDE.md):** any change reachable from `import genoray` without an underscore MUST update `skills/genoray-api/SKILL.md` in the same PR.
+
+## File Structure
+
+**Milestone 1 — Rust read primitive + provenance (unblocks gvl)**
+
+| File | Responsibility |
+| --- | --- |
+| `src/layout.rs` (modify) | Add `FieldSub` enum + `ContigPaths::field_values(cat, name, sub)`. Single source of truth for field paths (today they are built inline in `orchestrator.rs`/`field_finalize.rs`). |
+| `src/field.rs` (modify) | Make `StorageDtype::parse` public; add `StorageDtype::from_meta_str`. |
+| `src/query/field.rs` (create) | `FieldView` — mmap + dtype; `value_at`, `format_at`, `as_slice`. Mirrors `src/mutcat/sidecar.rs`. |
+| `src/spine.rs` (modify) | `VkElem` trait, `SrcKeyRef`, `pack_vk_src`/`unpack_vk_src` (+ assert), generic `merge_by_position` and `gather_keys`. `merge_keys` becomes a thin alias. |
+| `src/query/reader.rs` (modify) | `vk_slice` becomes generic over `VkElem`; add `open_field`. |
+| `src/query/gather.rs` (modify) | `gather_vk` generic; `BatchResultSplit.vk_src`; `gather_haps_readbound_src`. |
+| `src/query/mod.rs` (modify) | Export `FieldView`, `SrcKeyRef`, `pack_vk_src`, `unpack_vk_src`, `gather_haps_readbound_src`. |
+
+**Milestone 2 — Python decode surface**
+
+| File | Responsibility |
+| --- | --- |
+| `src/py_query_decode.rs` (modify) | `decode_batch_fields` — gather field bytes per decoded record; return raw bytes + itemsize (Python applies dtype, as it already does for `allele`). |
+| `python/genoray/_svar2_fields.py` (modify) | Read the `meta.json` manifest; canonical field keys; dtype mapping. |
+| `python/genoray/_svar2.py` (modify) | `SparseVar2(fields=…)`, `with_fields`, `available_fields`. |
+| `python/genoray/_svar2_decode.py` (modify) | `decode()` attaches field arrays sharing the genotype offsets. |
+| `tests/test_svar2_fields_read.py` (create) | e2e read tests. |
+
+---
+
+## Task 1: Field paths in `layout.rs`
+
+**Files:**
+- Modify: `src/layout.rs`
+- Test: `src/layout.rs` (inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub enum FieldSub { VkSnp, VkIndel, DenseSnp, DenseIndel }` with `pub fn dir_name(self) -> &'static str`; `ContigPaths::field_values(&self, category: &str, name: &str, sub: FieldSub) -> PathBuf`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing `#[cfg(test)] mod tests` in `src/layout.rs`:
+
+```rust
+    #[test]
+    fn test_field_values_paths() {
+        let paths = ContigPaths::new("/out", "chr1");
+        assert_eq!(
+            paths.field_values("format", "DS", FieldSub::VkSnp),
+            Path::new("/out/chr1/fields/format/DS/var_key_snp/values.bin")
+        );
+        assert_eq!(
+            paths.field_values("info", "AF", FieldSub::DenseIndel),
+            Path::new("/out/chr1/fields/info/AF/dense_indel/values.bin")
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features test_field_values_paths'`
+Expected: FAIL — `cannot find type FieldSub in this scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/layout.rs` (after the `MutcatSub` block):
+
+```rust
+/// The four sub-streams a field sidecar mirrors. Same four directories as
+/// `MutcatSub`, but kept separate: field dirs live under `fields/{category}/`
+/// and gain no `has_ref` notion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldSub {
+    VkSnp,
+    VkIndel,
+    DenseSnp,
+    DenseIndel,
+}
+
+impl FieldSub {
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            FieldSub::VkSnp => "var_key_snp",
+            FieldSub::VkIndel => "var_key_indel",
+            FieldSub::DenseSnp => "dense_snp",
+            FieldSub::DenseIndel => "dense_indel",
+        }
+    }
+    /// Every sub-stream, in a fixed order (for iteration at open/finalize time).
+    pub fn all() -> [FieldSub; 4] {
+        [
+            FieldSub::VkSnp,
+            FieldSub::VkIndel,
+            FieldSub::DenseSnp,
+            FieldSub::DenseIndel,
+        ]
+    }
+}
+```
+
+And inside `impl ContigPaths`:
+
+```rust
+    /// `{out}/{contig}/fields/{category}/{name}/{sub}/values.bin`.
+    /// `category` is `"info"` or `"format"` (see `FieldCategory::as_str`).
+    pub fn field_values(&self, category: &str, name: &str, sub: FieldSub) -> PathBuf {
+        Path::new(&self.base_out_dir)
+            .join(&self.chrom)
+            .join("fields")
+            .join(category)
+            .join(name)
+            .join(sub.dir_name())
+            .join("values.bin")
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features test_field_values_paths'`
+Expected: PASS.
+
+- [ ] **Step 5: Verify no regression in the write path**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: all existing tests PASS (this task only adds; it does not yet rewire `orchestrator.rs`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/layout.rs
+git commit -m "feat(svar2): field values.bin paths in layout"
+```
+
+---
+
+## Task 2: Public `StorageDtype` parsing
+
+**Files:**
+- Modify: `src/field.rs`
+- Test: `src/field.rs` (inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: existing `StorageDtype` (`src/field.rs`) with its private `fn parse(s: &str) -> Option<Self>` and `pub fn width_bytes(self) -> Option<usize>` / `pub fn as_str(self) -> &'static str`.
+- Produces: `pub fn StorageDtype::from_meta_str(s: &str) -> Option<StorageDtype>` — parses a `meta.json` `fields[].dtype` string. `Auto` is rejected (returns `None`): finalize always resolves it, so `Auto` on disk means a corrupt store.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `#[cfg(test)] mod tests` in `src/field.rs` (create the module if absent):
+
+```rust
+    #[test]
+    fn test_from_meta_str_rejects_auto() {
+        assert_eq!(StorageDtype::from_meta_str("f16"), Some(StorageDtype::F16));
+        assert_eq!(StorageDtype::from_meta_str("i8"), Some(StorageDtype::I8));
+        assert_eq!(StorageDtype::from_meta_str("bool"), Some(StorageDtype::Bool));
+        // `auto` is never a finalized on-disk dtype.
+        assert_eq!(StorageDtype::from_meta_str("auto"), None);
+        assert_eq!(StorageDtype::from_meta_str("nonsense"), None);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features test_from_meta_str_rejects_auto'`
+Expected: FAIL — `no function or associated item named from_meta_str`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add inside `impl StorageDtype` in `src/field.rs`:
+
+```rust
+    /// Parse a finalized `meta.json` `fields[].dtype` string. Returns `None` for
+    /// `"auto"` — finalize always resolves `Auto` to a concrete dtype, so `auto`
+    /// on disk means the store is corrupt or was never finalized.
+    pub fn from_meta_str(s: &str) -> Option<Self> {
+        match Self::parse(s) {
+            Some(Self::Auto) | None => None,
+            Some(d) => Some(d),
+        }
+    }
+```
+
+Note: `Self::parse` never returns `Auto` today (it has no `"auto"` arm), but the
+match is written to be total so a future `parse` change cannot leak `Auto`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features test_from_meta_str_rejects_auto'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/field.rs
+git commit -m "feat(svar2): public StorageDtype::from_meta_str"
+```
+
+---
+
+## Task 3: `FieldView` — the mmap read primitive
+
+**Files:**
+- Create: `src/query/field.rs`
+- Modify: `src/query/mod.rs` (add `pub mod field;` and re-export)
+- Test: `src/query/field.rs` (inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `layout::{ContigPaths, FieldSub}` (Task 1), `StorageDtype::from_meta_str` (Task 2), `crate::query::sidecar::mmap_file` (existing, `pub(crate)`), `memmap2::Mmap`, `bytemuck`, `half::f16`.
+- Produces:
+  - `pub enum FieldValue { Bool(bool), I8(i8), U8(u8), I16(i16), U16(u16), I32(i32), U32(u32), F16(f16), F32(f32) }`
+  - `pub struct FieldView` with `pub fn open(paths: &ContigPaths, category: &str, name: &str, sub: FieldSub, dtype: StorageDtype, n_samples: usize) -> std::io::Result<FieldView>`
+  - `pub fn value_at(&self, i: usize) -> FieldValue`
+  - `pub fn format_at(&self, dense_row: usize, orig_sample: usize) -> FieldValue`
+  - `pub fn as_slice<T: bytemuck::Pod>(&self) -> Option<&[T]>`
+  - `pub fn dtype(&self) -> StorageDtype`, `pub fn len(&self) -> usize`, `pub fn is_empty(&self) -> bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/query/field.rs` with ONLY the test module for now:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::StorageDtype;
+    use crate::layout::{ContigPaths, FieldSub};
+    use std::fs;
+
+    fn write_field(paths: &ContigPaths, cat: &str, name: &str, sub: FieldSub, bytes: &[u8]) {
+        let p = paths.field_values(cat, name, sub);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, bytes).unwrap();
+    }
+
+    #[test]
+    fn value_at_reads_each_dtype() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+
+        let vals: [i16; 3] = [-5, 0, 300];
+        write_field(&paths, "info", "AC", FieldSub::VkSnp, bytemuck::cast_slice(&vals));
+        let v = FieldView::open(&paths, "info", "AC", FieldSub::VkSnp, StorageDtype::I16, 2).unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.value_at(0), FieldValue::I16(-5));
+        assert_eq!(v.value_at(2), FieldValue::I16(300));
+
+        let f: [f32; 2] = [0.5, 1.25];
+        write_field(&paths, "info", "AF", FieldSub::DenseSnp, bytemuck::cast_slice(&f));
+        let v = FieldView::open(&paths, "info", "AF", FieldSub::DenseSnp, StorageDtype::F32, 2).unwrap();
+        assert_eq!(v.value_at(1), FieldValue::F32(1.25));
+    }
+
+    #[test]
+    fn format_at_strides_by_original_cohort_sample() {
+        // 3 dense variants x 4 cohort samples, variant-major.
+        // value = row*10 + sample
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let n_samples = 4usize;
+        let mut vals: Vec<i32> = Vec::new();
+        for row in 0..3i32 {
+            for s in 0..4i32 {
+                vals.push(row * 10 + s);
+            }
+        }
+        write_field(&paths, "format", "DP", FieldSub::DenseSnp, bytemuck::cast_slice(&vals));
+        let v = FieldView::open(
+            &paths, "format", "DP", FieldSub::DenseSnp, StorageDtype::I32, n_samples,
+        )
+        .unwrap();
+        // Must use the ORIGINAL cohort sample index, not a selected slot.
+        assert_eq!(v.format_at(0, 0), FieldValue::I32(0));
+        assert_eq!(v.format_at(2, 3), FieldValue::I32(23));
+        assert_eq!(v.format_at(1, 2), FieldValue::I32(12));
+    }
+
+    #[test]
+    fn missing_file_opens_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let v =
+            FieldView::open(&paths, "info", "NOPE", FieldSub::VkIndel, StorageDtype::F32, 2).unwrap();
+        assert!(v.is_empty());
+        assert_eq!(v.len(), 0);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Add `pub mod field;` to `src/query/mod.rs` (next to the existing `pub mod decode;` etc.), then:
+
+Run: `pixi run bash -lc 'cargo test --no-default-features query::field'`
+Expected: FAIL — `cannot find type FieldView in this scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `src/query/field.rs` (above the test module):
+
+```rust
+//! Read the per-contig INFO/FORMAT field sidecars written by the conversion
+//! pipeline. Mirrors `crate::mutcat::sidecar`: an mmap per (field, sub-stream)
+//! plus indexed accessors.
+//!
+//! Two things this reader must get right, both of which the file itself cannot
+//! tell you:
+//!  * The element width comes ONLY from `meta.json`'s `fields[].dtype` — values
+//!    are staged as 4-byte i32/f32 and rewritten in place at finalize.
+//!  * Dense FORMAT is indexed by the ORIGINAL cohort sample index, never a
+//!    selected subset slot.
+
+use half::f16;
+use memmap2::Mmap;
+
+use crate::field::StorageDtype;
+use crate::layout::{ContigPaths, FieldSub};
+use crate::query::sidecar::mmap_file;
+
+/// One field element, in the dtype it is stored as. Never widened or converted.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FieldValue {
+    Bool(bool),
+    I8(i8),
+    U8(u8),
+    I16(i16),
+    U16(u16),
+    I32(i32),
+    U32(u32),
+    F16(f16),
+    F32(f32),
+}
+
+/// An mmap'd `values.bin` for one (field, sub-stream), plus the dtype needed to
+/// interpret it. A missing/empty file is a legal empty sub-stream.
+pub struct FieldView {
+    values: Option<Mmap>,
+    dtype: StorageDtype,
+    /// Cohort sample count — the stride for dense FORMAT columns.
+    n_samples: usize,
+    /// Element count (bytes / width).
+    n: usize,
+}
+
+impl FieldView {
+    pub fn open(
+        paths: &ContigPaths,
+        category: &str,
+        name: &str,
+        sub: FieldSub,
+        dtype: StorageDtype,
+        n_samples: usize,
+    ) -> std::io::Result<Self> {
+        let values = mmap_file(&paths.field_values(category, name, sub))?;
+        let width = dtype.width_bytes().ok_or_else(|| {
+            std::io::Error::other(format!(
+                "field {name:?} has unresolved dtype {:?}; the store was never finalized",
+                dtype.as_str()
+            ))
+        })?;
+        let n = values.as_ref().map(|m| m.len() / width).unwrap_or(0);
+        Ok(Self {
+            values,
+            dtype,
+            n_samples,
+            n,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> StorageDtype {
+        self.dtype
+    }
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.n
+    }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.n == 0
+    }
+
+    /// Zero-copy typed slice. `None` if the stored dtype's width does not match
+    /// `T`, or the sub-stream is empty. mmap pages are page-aligned, so
+    /// `bytemuck`'s alignment check always passes.
+    pub fn as_slice<T: bytemuck::Pod>(&self) -> Option<&[T]> {
+        let m = self.values.as_ref()?;
+        if self.dtype.width_bytes()? != std::mem::size_of::<T>() {
+            return None;
+        }
+        Some(bytemuck::cast_slice(&m[..]))
+    }
+
+    /// Element `i`: a var_key **call** index, or a dense INFO **variant row**.
+    /// Panics if `i >= len()` (an out-of-range index means the caller's
+    /// provenance disagrees with the store — a bug, not bad input).
+    #[inline]
+    pub fn value_at(&self, i: usize) -> FieldValue {
+        let m = self
+            .values
+            .as_ref()
+            .expect("value_at on an empty field sub-stream");
+        let w = self
+            .dtype
+            .width_bytes()
+            .expect("open() rejected unresolved dtypes");
+        let b = &m[i * w..(i + 1) * w];
+        match self.dtype {
+            StorageDtype::Bool => FieldValue::Bool(b[0] != 0),
+            StorageDtype::I8 => FieldValue::I8(b[0] as i8),
+            StorageDtype::U8 => FieldValue::U8(b[0]),
+            StorageDtype::I16 => FieldValue::I16(i16::from_le_bytes([b[0], b[1]])),
+            StorageDtype::U16 => FieldValue::U16(u16::from_le_bytes([b[0], b[1]])),
+            StorageDtype::I32 => FieldValue::I32(i32::from_le_bytes([b[0], b[1], b[2], b[3]])),
+            StorageDtype::U32 => FieldValue::U32(u32::from_le_bytes([b[0], b[1], b[2], b[3]])),
+            StorageDtype::F16 => FieldValue::F16(f16::from_le_bytes([b[0], b[1]])),
+            StorageDtype::F32 => FieldValue::F32(f32::from_le_bytes([b[0], b[1], b[2], b[3]])),
+            StorageDtype::Auto => unreachable!("open() rejects Auto"),
+        }
+    }
+
+    /// Dense FORMAT element for `(dense_row, orig_sample)`.
+    /// `orig_sample` MUST be the original cohort sample index.
+    #[inline]
+    pub fn format_at(&self, dense_row: usize, orig_sample: usize) -> FieldValue {
+        debug_assert!(
+            orig_sample < self.n_samples,
+            "orig_sample {orig_sample} >= cohort n_samples {}",
+            self.n_samples
+        );
+        self.value_at(dense_row * self.n_samples + orig_sample)
+    }
+
+    /// Raw little-endian bytes for element `i` (width = `dtype().width_bytes()`).
+    /// Used by the Python decode path, which applies the dtype numpy-side.
+    #[inline]
+    pub fn bytes_at(&self, i: usize) -> &[u8] {
+        let m = self
+            .values
+            .as_ref()
+            .expect("bytes_at on an empty field sub-stream");
+        let w = self
+            .dtype
+            .width_bytes()
+            .expect("open() rejected unresolved dtypes");
+        &m[i * w..(i + 1) * w]
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features query::field'`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/query/field.rs src/query/mod.rs
+git commit -m "feat(svar2): FieldView mmap reader for INFO/FORMAT sidecars"
+```
+
+---
+
+## Task 4: `vk_src` provenance — packing + the generic merge
+
+**Files:**
+- Modify: `src/spine.rs`
+- Test: `src/spine.rs` (inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: existing `KeyRef { position: u32, key: u32 }`, existing `gather_keys`, existing `merge_keys`.
+- Produces:
+  - `pub struct SrcKeyRef { pub key: KeyRef, pub src: u32 }`
+  - `pub trait VkElem: Copy { fn make(position: u32, key: u32, is_indel: bool, call_idx: usize) -> Self; fn position(&self) -> u32; }` — implemented for `KeyRef` (ignores provenance entirely; **no assert**) and `SrcKeyRef` (packs + asserts).
+  - `pub const VK_SRC_INDEL_BIT: u32 = 1 << 31;`
+  - `pub fn pack_vk_src(is_indel: bool, call_idx: usize) -> u32`
+  - `pub fn unpack_vk_src(src: u32) -> (bool, usize)`
+  - `pub fn merge_by_position<T: VkElem>(runs: Vec<Vec<T>>) -> Vec<T>`
+  - `pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef>` (now an alias — signature unchanged, all existing callers keep working)
+  - `gather_keys` gains two params: `is_indel: bool`, `abs_base: usize`, and is generic over `T: VkElem`.
+
+**Why `make` takes `is_indel`/`call_idx` rather than a pre-packed `u32`:** the 2^31
+assert must not run on the no-fields path. `KeyRef::make` ignores both args, so
+the packing and its assert are dead code and compile away. Passing a pre-packed
+`u32` would force the assert to execute even when provenance is discarded.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `#[cfg(test)] mod tests` in `src/spine.rs`:
+
+```rust
+    #[test]
+    fn pack_unpack_vk_src_round_trips() {
+        assert_eq!(unpack_vk_src(pack_vk_src(false, 0)), (false, 0));
+        assert_eq!(unpack_vk_src(pack_vk_src(true, 0)), (true, 0));
+        assert_eq!(unpack_vk_src(pack_vk_src(false, 12345)), (false, 12345));
+        assert_eq!(
+            unpack_vk_src(pack_vk_src(true, (1 << 31) - 1)),
+            (true, (1 << 31) - 1)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds the 2^31 vk_src ceiling")]
+    fn pack_vk_src_asserts_on_overflow() {
+        pack_vk_src(false, 1 << 31);
+    }
+
+    #[test]
+    fn merge_by_position_carries_src_and_keeps_snp_tie_break() {
+        // snp run at positions 10, 20 (calls 0, 1); indel run at 10, 15 (calls 7, 8).
+        // Ties at position 10 must keep the SNP first (run 0 wins).
+        let snp: Vec<SrcKeyRef> = vec![
+            SrcKeyRef { key: KeyRef { position: 10, key: 100 }, src: pack_vk_src(false, 0) },
+            SrcKeyRef { key: KeyRef { position: 20, key: 200 }, src: pack_vk_src(false, 1) },
+        ];
+        let indel: Vec<SrcKeyRef> = vec![
+            SrcKeyRef { key: KeyRef { position: 10, key: 300 }, src: pack_vk_src(true, 7) },
+            SrcKeyRef { key: KeyRef { position: 15, key: 400 }, src: pack_vk_src(true, 8) },
+        ];
+        let out = merge_by_position(vec![snp, indel]);
+        let got: Vec<(u32, bool, usize)> = out
+            .iter()
+            .map(|e| {
+                let (is_indel, idx) = unpack_vk_src(e.src);
+                (e.key.position, is_indel, idx)
+            })
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                (10, false, 0), // snp wins the tie
+                (10, true, 7),
+                (15, true, 8),
+                (20, false, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_keys_is_unchanged_for_bare_keyrefs() {
+        let a = vec![KeyRef { position: 1, key: 10 }, KeyRef { position: 5, key: 50 }];
+        let b = vec![KeyRef { position: 1, key: 99 }, KeyRef { position: 3, key: 30 }];
+        let out = merge_keys(vec![a, b]);
+        assert_eq!(
+            out,
+            vec![
+                KeyRef { position: 1, key: 10 }, // stable: earlier run first
+                KeyRef { position: 1, key: 99 },
+                KeyRef { position: 3, key: 30 },
+                KeyRef { position: 5, key: 50 },
+            ]
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features spine::'`
+Expected: FAIL — `cannot find function pack_vk_src`, `cannot find type SrcKeyRef`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/spine.rs`, add after the `KeyRef` definition:
+
+```rust
+/// Bit 31 of a packed `vk_src`: 0 = `var_key/snp`, 1 = `var_key/indel`.
+pub const VK_SRC_INDEL_BIT: u32 = 1 << 31;
+
+/// Pack a var_key record's provenance: sub-stream tag in bit 31, absolute call
+/// index in bits 0..=30.
+///
+/// The assert is deliberate and load-bearing: a silent overflow here would
+/// return values from the WRONG record, which is far worse than a panic. It is
+/// unreachable on any real store (2^31 calls in a single contig sub-stream), and
+/// it never runs on the no-provenance path (`KeyRef::make` ignores its args).
+#[inline]
+pub fn pack_vk_src(is_indel: bool, call_idx: usize) -> u32 {
+    assert!(
+        call_idx < (1usize << 31),
+        "var_key call index {call_idx} exceeds the 2^31 vk_src ceiling"
+    );
+    (call_idx as u32) | if is_indel { VK_SRC_INDEL_BIT } else { 0 }
+}
+
+/// Inverse of [`pack_vk_src`]: `(is_indel, call_idx)`.
+#[inline]
+pub fn unpack_vk_src(src: u32) -> (bool, usize) {
+    (
+        src & VK_SRC_INDEL_BIT != 0,
+        (src & !VK_SRC_INDEL_BIT) as usize,
+    )
+}
+
+/// A `KeyRef` plus the provenance needed to index a field sidecar: which
+/// var_key sub-stream it came from and its absolute call index there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SrcKeyRef {
+    pub key: KeyRef,
+    /// Packed via [`pack_vk_src`].
+    pub src: u32,
+}
+
+/// The element type a var_key gather emits. Monomorphizing over this is what
+/// keeps the no-fields path zero-cost: `KeyRef::make` discards the provenance
+/// args, so the packing (and its assert) is dead code and compiles away.
+pub trait VkElem: Copy {
+    fn make(position: u32, key: u32, is_indel: bool, call_idx: usize) -> Self;
+    fn position(&self) -> u32;
+}
+
+impl VkElem for KeyRef {
+    #[inline]
+    fn make(position: u32, key: u32, _is_indel: bool, _call_idx: usize) -> Self {
+        KeyRef { position, key }
+    }
+    #[inline]
+    fn position(&self) -> u32 {
+        self.position
+    }
+}
+
+impl VkElem for SrcKeyRef {
+    #[inline]
+    fn make(position: u32, key: u32, is_indel: bool, call_idx: usize) -> Self {
+        SrcKeyRef {
+            key: KeyRef { position, key },
+            src: pack_vk_src(is_indel, call_idx),
+        }
+    }
+    #[inline]
+    fn position(&self) -> u32 {
+        self.key.position
+    }
+}
+```
+
+Replace `merge_keys` with the generic merge plus a compatibility alias. **The body
+is byte-for-byte the old one with `.position` → `.position()`:**
+
+```rust
+/// K-way merge of already position-sorted runs into one position-sorted list.
+/// Stable across ties (earlier run wins). `O(total × n_runs)` with `n_runs`
+/// small (2 within a channel; more only if M11 adds a `pointer` sub-stream).
+///
+/// `query::gather_haps_readbound` hand-inlines a 2-run (snp_run, indel_run)
+/// equivalent of this merge for allocation reasons — any change to this
+/// function's ordering or tie-break MUST be mirrored there. That twin now
+/// carries the same `VkElem` payload, so the mirroring covers `src` too.
+pub fn merge_by_position<T: VkElem>(runs: Vec<Vec<T>>) -> Vec<T> {
+    let total: usize = runs.iter().map(|r| r.len()).sum();
+    let mut heads = vec![0usize; runs.len()];
+    let mut out = Vec::with_capacity(total);
+    for _ in 0..total {
+        let mut best: Option<usize> = None;
+        for r in 0..runs.len() {
+            if heads[r] >= runs[r].len() {
+                continue;
+            }
+            match best {
+                // Keep `best` on ties so the earlier run emits first (stable).
+                Some(b) if runs[b][heads[b]].position() <= runs[r][heads[r]].position() => {}
+                _ => best = Some(r),
+            }
+        }
+        let b = best.expect("total accounts for every remaining element");
+        out.push(runs[b][heads[b]]);
+        heads[b] += 1;
+    }
+    out
+}
+
+/// Bare-`KeyRef` merge — the pre-existing signature, now a thin alias so every
+/// existing caller is untouched and provably unchanged.
+pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
+    merge_by_position(runs)
+}
+```
+
+Make `gather_keys` generic. Replace its signature and push site:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub fn gather_keys<T: VkElem>(
+    positions: &[u32],
+    max_region_length: u32,
+    q_start: u32,
+    q_end: u32,
+    del_len: impl Fn(usize) -> u32,
+    carried: impl Fn(usize) -> bool,
+    to_key: impl Fn(usize) -> u32,
+    /// Sub-stream tag for provenance (`false` = snp, `true` = indel).
+    is_indel: bool,
+    /// Absolute index of `positions[0]` in the sub-stream's packed buffer, so
+    /// the absolute call index of element `i` is `abs_base + i`.
+    abs_base: usize,
+    out: &mut Vec<T>,
+) {
+    if positions.is_empty() {
+        return;
+    }
+    let v_ends: Vec<u32> = positions
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| p + 1 + del_len(i))
+        .collect();
+    let tree = SearchTree::new(positions);
+    let (s_idx, e_idx) = overlap_range(&tree, &v_ends, max_region_length, q_start, q_end);
+    for (i, &position) in positions.iter().enumerate().take(e_idx).skip(s_idx) {
+        if carried(i) && q_start < v_ends[i] {
+            out.push(T::make(position, to_key(i), is_indel, abs_base + i));
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Fix the two existing `gather_keys` call sites**
+
+`src/query/reader.rs::vk_slice` calls `gather_keys` twice. Add the two new args
+(the snp block already has `o0` in scope; so does the indel block):
+
+- snp block: after the `to_key` closure argument, insert `false, o0,`
+- indel block: after the `to_key` closure argument, insert `true, o0,`
+
+(Task 5 makes `vk_slice` itself generic; for now it still builds `Vec<KeyRef>`, so
+`T` infers to `KeyRef` and the provenance args are discarded.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: PASS — the 4 new spine tests plus every existing test (the whole suite
+must be green: `merge_keys`'s behaviour is unchanged by construction).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/spine.rs src/query/reader.rs
+git commit -m "feat(svar2): vk_src provenance packing + generic merge_by_position"
+```
+
+---
+
+## Task 5: Thread provenance through all three var_key gathers
+
+There are **three** producers of the `vk` channel and every one merges snp+indel,
+destroying provenance. All three must become generic over `VkElem`:
+
+1. `ContigReader::vk_slice` (`src/query/reader.rs:119`) → used by `overlap_batch`
+2. `gather_vk` (`src/query/gather.rs:126`) → used by `gather_ranges`
+3. the hand-inlined merge in `gather_haps_readbound` (`src/query/gather.rs:545-598`)
+
+**Files:**
+- Modify: `src/query/reader.rs`, `src/query/gather.rs`
+- Test: `src/query/gather.rs` (inline `#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `spine::{VkElem, SrcKeyRef, KeyRef, merge_by_position, pack_vk_src, unpack_vk_src}` (Task 4).
+- Produces:
+  - `ContigReader::vk_slice<T: VkElem>(...) -> Vec<T>`
+  - `gather_vk<T: VkElem>(reader, vk_snp_range, vk_indel_range, q_start) -> Vec<T>`
+  - `BatchResultSplit` gains `pub vk_src: Vec<u32>` (empty on the no-provenance path, one entry per `vk` record otherwise).
+  - `pub fn gather_haps_readbound_src(reader: &ContigReader, rb: &HapRanges<'_>) -> BatchResultSplit` — fills `vk_src`.
+  - `gather_haps_readbound` keeps its exact signature and leaves `vk_src` empty.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `#[cfg(test)] mod tests` in `src/query/gather.rs`:
+
+```rust
+    /// `vk_src` must be aligned 1:1 with `vk`, and each entry must point at the
+    /// record that actually produced it — including through the position-merge
+    /// of snp+indel and through the overlap FILTER that drops records (the
+    /// filter is why the index can't be recovered from run position afterwards).
+    #[test]
+    fn vk_src_is_aligned_with_vk_and_survives_the_merge() {
+        let (dir, n_samples, ploidy) = super::tests_support::tiny_store_with_snps_and_indels();
+        let reader =
+            ContigReader::open(dir.path().to_str().unwrap(), "chr1", n_samples, ploidy).unwrap();
+
+        let regions = [(0u32, 1_000u32)];
+        let rb = find_ranges(&reader, &regions, None);
+
+        // Build the equivalent HapRanges for the readbound path (1 region x all samples).
+        let region_starts: Vec<u32> = (0..n_samples).map(|_| regions[0].0).collect();
+        let orig_samples: Vec<usize> = (0..n_samples).collect();
+        let hr = HapRanges::new(
+            &region_starts,
+            &orig_samples,
+            &rb.vk_snp_range,
+            &rb.vk_indel_range,
+            &rb.dense_snp_range.repeat(n_samples),
+            &rb.dense_indel_range.repeat(n_samples),
+            ploidy,
+        );
+
+        let plain = gather_haps_readbound(&reader, &hr);
+        let with_src = gather_haps_readbound_src(&reader, &hr);
+
+        // The no-provenance path is unchanged, and provenance is purely additive.
+        assert!(plain.vk_src.is_empty(), "plain path must not populate vk_src");
+        assert_eq!(plain.vk, with_src.vk, "adding provenance must not change vk");
+        assert_eq!(plain.vk_off, with_src.vk_off);
+        assert_eq!(with_src.vk_src.len(), with_src.vk.len());
+
+        // Every vk_src must resolve to the record that produced its key.
+        let snp_pos = reader.vk_snp.positions();
+        let indel_pos = reader.vk_indel.positions();
+        for (i, kr) in with_src.vk.iter().enumerate() {
+            let (is_indel, idx) = spine::unpack_vk_src(with_src.vk_src[i]);
+            let pos = if is_indel { indel_pos[idx] } else { snp_pos[idx] };
+            assert_eq!(
+                pos, kr.position,
+                "vk_src[{i}] points at position {pos} but vk[{i}] is at {}",
+                kr.position
+            );
+        }
+    }
+```
+
+Add a small fixture helper module in the same `#[cfg(test)]` block. It builds a
+store with BOTH snp and indel var_key records so the merge and the tie-break are
+actually exercised:
+
+```rust
+    pub(super) mod tests_support {
+        use tempfile::TempDir;
+
+        /// Build a minimal on-disk contig with var_key snp + indel records for
+        /// 2 samples at ploidy 2. Reuses the crate's existing conversion test
+        /// helper so the store is a real, finalized one.
+        pub fn tiny_store_with_snps_and_indels() -> (TempDir, usize, usize) {
+            crate::testutil::tiny_svar2_store()
+        }
+    }
+```
+
+> **If `crate::testutil::tiny_svar2_store()` does not exist**, find the helper the
+> existing gather/readbound tests already use to build a store (grep the
+> `#[cfg(test)]` blocks in `src/query/gather.rs` and `tests/test_readbound_gather.rs`
+> for `ContigReader::open`) and call that instead. Do **not** hand-roll a new
+> fixture — reuse the existing one so this test exercises a real finalized store.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features vk_src_is_aligned'`
+Expected: FAIL — `cannot find function gather_haps_readbound_src`; `no field vk_src on BatchResultSplit`.
+
+- [ ] **Step 3: Make `vk_slice` and `gather_vk` generic**
+
+In `src/query/reader.rs`, change the `vk_slice` signature and its final merge:
+
+```rust
+    pub(crate) fn vk_slice<T: spine::VkElem>(
+        &self,
+        col: usize,
+        sample: usize,
+        p: usize,
+        q_start: u32,
+        q_end: u32,
+    ) -> Vec<T> {
+        let mut runs: Vec<Vec<T>> = Vec::with_capacity(2);
+```
+
+…leaving both `gather_keys` blocks as edited in Task 4 (they now push `T`), and
+ending with:
+
+```rust
+        spine::merge_by_position(runs)
+    }
+```
+
+In `src/query/gather.rs`, make `gather_vk` generic. Body is unchanged except the
+element construction and the merge:
+
+```rust
+pub(crate) fn gather_vk<T: spine::VkElem>(
+    reader: &ContigReader,
+    vk_snp_range: Range<usize>,
+    vk_indel_range: Range<usize>,
+    q_start: u32,
+) -> Vec<T> {
+    let snp_positions = reader.vk_snp.positions();
+    let snp_keys = as_bytes(&reader.vk_snp.keys);
+    let indel_positions = reader.vk_indel.positions();
+    let indel_keys = as_u32(&reader.vk_indel.keys);
+
+    let (ss, se) = (vk_snp_range.start, vk_snp_range.end);
+    let mut snp_run: Vec<T> = Vec::new();
+    for (j, &pos) in snp_positions.iter().enumerate().take(se).skip(ss) {
+        if q_start < pos + 1 {
+            // snp v_end = pos + 1
+            snp_run.push(T::make(
+                pos,
+                rvk::snp_code_to_key(rvk::unpack_snp_key_at(snp_keys, j)),
+                false,
+                j,
+            ));
+        }
+    }
+
+    let (is_, ie_) = (vk_indel_range.start, vk_indel_range.end);
+    let mut indel_run: Vec<T> = Vec::new();
+    for j in is_..ie_ {
+        let pos = indel_positions[j];
+        let v_end = pos + 1 + rvk::deletion_len(indel_keys[j]);
+        if q_start < v_end {
+            indel_run.push(T::make(pos, indel_keys[j], true, j));
+        }
+    }
+
+    spine::merge_by_position(vec![snp_run, indel_run])
+}
+```
+
+`overlap_batch` and `gather_ranges` call these with no turbofish; `T` infers to
+`KeyRef` from the `Vec<KeyRef>` they extend. No behaviour change.
+
+- [ ] **Step 4: Add `vk_src` to `BatchResultSplit` and split the readbound gather**
+
+In `src/query/gather.rs`, add the field to `BatchResultSplit` (after `vk_off`):
+
+```rust
+    /// Absolute var_key provenance per `vk` record, packed by
+    /// `spine::pack_vk_src` (bit 31 = sub-stream, bits 0..=30 = call index).
+    /// **Empty** unless produced by `gather_haps_readbound_src` — the plain
+    /// gather does not pay for it.
+    pub vk_src: Vec<u32>,
+```
+
+Add `vk_src: Vec::new(),` to every existing `BatchResultSplit { … }` literal (the
+one in `gather_haps_readbound` and the one in `src/query/oracle.rs:188`).
+
+Now make the readbound gather generic. Rename the existing
+`pub fn gather_haps_readbound` body to a private generic
+`fn gather_haps_readbound_impl<T: spine::VkElem>(reader, rb) -> (Vec<T>, Vec<usize>, /* rest of BatchResultSplit fields */)`.
+The mechanical change inside the hot loop is exactly three edits:
+
+```rust
+            // was: let mut snp_run: Vec<KeyRef> = Vec::with_capacity(...)
+            let mut snp_run: Vec<T> = Vec::with_capacity(ve.saturating_sub(vs));
+            for (k, &pos) in snp_positions[vs..ve].iter().enumerate() {
+                let j = vs + k;
+                if qs < pos + 1 {
+                    // was: snp_run.push(KeyRef { position: pos, key: ... });
+                    snp_run.push(T::make(
+                        pos,
+                        rvk::snp_code_to_key(rvk::unpack_snp_key_at(snp_keys, j)),
+                        false,
+                        j,
+                    ));
+                }
+            }
+
+            // indel run — RE-ADD the absolute index the zip previously dropped:
+            let mut indel_run: Vec<T> = Vec::with_capacity(vie.saturating_sub(vis));
+            for (k, (&pos, &key)) in indel_positions[vis..vie]
+                .iter()
+                .zip(&indel_keys[vis..vie])
+                .enumerate()
+            {
+                let j = vis + k;
+                let v_end = pos + 1 + rvk::deletion_len(key);
+                if qs < v_end {
+                    // was: indel_run.push(KeyRef { position: pos, key });
+                    indel_run.push(T::make(pos, key, true, j));
+                }
+            }
+```
+
+and the hand-inlined 2-way merge, which now compares via the trait:
+
+```rust
+            // Specialized 2-way merge, provably byte-identical to
+            // `spine::merge_by_position(vec![snp_run, indel_run])`: that generic
+            // k-way merge picks `best = Some(0)` (snp_run) on the first scan and
+            // only switches to run 1 (indel_run) when
+            // `!(snp_run[h0].position() <= indel_run[h1].position())`, i.e.
+            // exactly the `<=` two-pointer comparison below (ties still favor
+            // snp_run). The `VkElem` payload rides along unchanged, so this stays
+            // a mirror of the generic merge for `SrcKeyRef` as well as `KeyRef`.
+            let (mut si, mut ii) = (0usize, 0usize);
+            while si < snp_run.len() && ii < indel_run.len() {
+                if snp_run[si].position() <= indel_run[ii].position() {
+                    vk.push(snp_run[si]);
+                    si += 1;
+                } else {
+                    vk.push(indel_run[ii]);
+                    ii += 1;
+                }
+            }
+            vk.extend_from_slice(&snp_run[si..]);
+            vk.extend_from_slice(&indel_run[ii..]);
+            vk_off.push(vk.len());
+```
+
+(`vk` is `Vec<T>`. Keep the existing long comment block above the merge — extend
+it with the `VkElem` sentence as shown. `use crate::spine::VkElem;` must be in
+scope for `.position()`.)
+
+Then the two public entry points, which differ only in `T` and in how they
+project `vk`:
+
+```rust
+/// Flat per-query read-bound gather (see `gather_haps_readbound_impl`). Does NOT
+/// populate `vk_src` — the no-provenance path, byte-identical to pre-field
+/// behaviour and zero-cost (`KeyRef::make` discards the provenance args).
+pub fn gather_haps_readbound(reader: &ContigReader, rb: &HapRanges<'_>) -> BatchResultSplit {
+    gather_haps_readbound_impl::<KeyRef>(reader, rb)
+}
+
+/// As `gather_haps_readbound`, but also populates `vk_src` so a consumer can map
+/// each merged var_key record back to its `(sub-stream, absolute call index)` and
+/// index a `FieldView`. This is the entry point gvl uses to read fields.
+pub fn gather_haps_readbound_src(reader: &ContigReader, rb: &HapRanges<'_>) -> BatchResultSplit {
+    gather_haps_readbound_impl::<SrcKeyRef>(reader, rb)
+}
+```
+
+`gather_haps_readbound_impl<T>` builds `vk: Vec<T>` and, at the end, splits it:
+
+```rust
+    // Project the generic element back into the frozen (vk, vk_src) contract.
+    // For T = KeyRef, `src_of` is `None` and vk_src stays empty.
+    let (vk, vk_src) = T::split(vk);
+```
+
+Add to the `VkElem` trait in `src/spine.rs` (and its two impls):
+
+```rust
+    /// Split a merged run into the frozen `(keys, src)` contract. `KeyRef`
+    /// yields an empty `src`; `SrcKeyRef` yields one entry per key.
+    fn split(v: Vec<Self>) -> (Vec<KeyRef>, Vec<u32>);
+```
+
+```rust
+// in impl VkElem for KeyRef
+    #[inline]
+    fn split(v: Vec<Self>) -> (Vec<KeyRef>, Vec<u32>) {
+        (v, Vec::new())
+    }
+
+// in impl VkElem for SrcKeyRef
+    #[inline]
+    fn split(v: Vec<Self>) -> (Vec<KeyRef>, Vec<u32>) {
+        let mut keys = Vec::with_capacity(v.len());
+        let mut src = Vec::with_capacity(v.len());
+        for e in v {
+            keys.push(e.key);
+            src.push(e.src);
+        }
+        (keys, src)
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features vk_src_is_aligned'`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite — the zero-cost / no-regression gate**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: ALL PASS. In particular `tests/test_readbound_gather.rs` (the
+readbound-vs-union oracle) must still pass unchanged — that is the proof that
+`gather_haps_readbound`'s output is byte-identical to before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/spine.rs src/query/reader.rs src/query/gather.rs src/query/oracle.rs
+git commit -m "feat(svar2): thread vk_src provenance through the var_key gathers"
+```
+
+---
+
+## Task 6: Export the public Rust API + dense-provenance helper
+
+**Files:**
+- Modify: `src/query/mod.rs`, `src/lib.rs`
+- Test: `tests/test_field_read.rs` (create — an integration test, proving the API is reachable from *outside* the crate exactly as gvl reaches it)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces (the public surface gvl consumes):
+  - `genoray::query::{FieldView, FieldValue}`
+  - `genoray::query::{SrcKeyRef, pack_vk_src, unpack_vk_src, VK_SRC_INDEL_BIT}`
+  - `genoray::query::gather_haps_readbound_src`
+  - `genoray::layout::FieldSub`, `genoray::field::StorageDtype`
+  - `pub fn dense_abs_row(window_range: &Range<usize>, out_range: &Range<usize>, i: usize) -> usize` — documents the dense arithmetic so consumers don't re-derive it.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/test_field_read.rs`:
+
+```rust
+//! Proves the field-read API is reachable from OUTSIDE the crate — the same way
+//! GenVarLoader consumes it (Cargo path-dep, `default-features = false`).
+
+use genoray::field::StorageDtype;
+use genoray::layout::{ContigPaths, FieldSub};
+use genoray::query::{FieldValue, FieldView, pack_vk_src, unpack_vk_src};
+
+#[test]
+fn field_view_is_publicly_constructible() {
+    let tmp = tempfile::tempdir().unwrap();
+    let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+    let p = paths.field_values("format", "DS", FieldSub::VkSnp);
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    let vals: [f32; 3] = [0.0, 1.5, 2.0];
+    std::fs::write(&p, bytemuck::cast_slice(&vals)).unwrap();
+
+    let v = FieldView::open(&paths, "format", "DS", FieldSub::VkSnp, StorageDtype::F32, 1).unwrap();
+    assert_eq!(v.len(), 3);
+    assert_eq!(v.value_at(1), FieldValue::F32(1.5));
+    assert_eq!(v.as_slice::<f32>().unwrap(), &vals[..]);
+}
+
+#[test]
+fn vk_src_helpers_are_public() {
+    let s = pack_vk_src(true, 42);
+    assert_eq!(unpack_vk_src(s), (true, 42));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --test test_field_read'`
+Expected: FAIL — `module query is private` / unresolved imports.
+
+- [ ] **Step 3: Add the exports**
+
+In `src/query/mod.rs`, alongside the existing `pub use` block:
+
+```rust
+pub mod field;
+
+pub use field::{FieldValue, FieldView};
+pub use crate::spine::{SrcKeyRef, VK_SRC_INDEL_BIT, VkElem, pack_vk_src, unpack_vk_src};
+pub use gather::gather_haps_readbound_src;
+```
+
+Add `dense_abs_row` to `src/query/gather.rs` and export it:
+
+```rust
+/// Absolute dense **variant row** for entry `i` of a `BatchResultSplit` dense
+/// window — the index a `dense_snp`/`dense_indel` field `values.bin` is aligned
+/// to (INFO: `value_at(row)`; FORMAT: `format_at(row, orig_sample)`).
+///
+/// Dense provenance needs no extra state: each per-region window is a contiguous
+/// copy of the on-disk slice, so the absolute row is pure arithmetic.
+/// `on_disk` is `HapRanges::dense_*_range[q]`; `out` is
+/// `BatchResultSplit::dense_*_range[q]`; `i` indexes into `out`.
+#[inline]
+pub fn dense_abs_row(on_disk: &Range<usize>, out: &Range<usize>, i: usize) -> usize {
+    debug_assert!(out.contains(&i), "i must index into the output window");
+    on_disk.start + (i - out.start)
+}
+```
+
+Ensure `src/lib.rs` exposes the modules the test imports (`pub mod query;`,
+`pub mod layout;`, `pub mod field;` — add whichever are not already `pub`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features --test test_field_read'`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/query/mod.rs src/query/gather.rs src/lib.rs tests/test_field_read.rs
+git commit -m "feat(svar2): export FieldView + vk_src provenance as public Rust API"
+```
+
+**MILESTONE 1 COMPLETE — gvl is unblocked.** gvl can now call
+`gather_haps_readbound_src`, index a `FieldView` by `unpack_vk_src(vk_src[i])`
+for var_key records and by `dense_abs_row(...)` for dense records, and push the
+value next to `pos`/`ilen` in its own merge. Spec #3 (SVAR1→SVAR2) is unblocked.
+
+---
+
+## Task 7: Python — read the `meta.json` field manifest
+
+**Files:**
+- Modify: `python/genoray/_svar2_fields.py`
+- Test: `tests/test_svar2_fields_read.py` (create)
+
+**Interfaces:**
+- Consumes: `meta.json`'s `fields` array — `[{"name","category","dtype","default"}]` (written by `src/meta.rs:23-33`).
+- Produces:
+  - `NP_DTYPE: dict[str, np.dtype]` mapping the 9 storage dtypes to numpy.
+  - `@dataclass(frozen=True) class StoredField: name: str; category: Literal["info","format"]; dtype: np.dtype; default: float | None; key: str`
+  - `def _load_field_manifest(meta: dict) -> dict[str, StoredField]` — keyed by **canonical key**: the bare name when unique across categories, else bcftools-style `INFO/<name>` / `FORMAT/<name>`.
+  - `def _resolve_read_fields(requested: Sequence[str] | None, available: dict[str, StoredField]) -> list[StoredField]` — `None` → `[]` (opt in explicitly); unknown key → `ValueError` naming the available keys.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_svar2_fields_read.py`:
+
+```python
+import numpy as np
+import pytest
+
+from genoray._svar2_fields import (
+    StoredField,
+    _load_field_manifest,
+    _resolve_read_fields,
+)
+
+
+def test_canonical_keys_are_bare_when_unique():
+    meta = {
+        "fields": [
+            {"name": "AF", "category": "info", "dtype": "f32", "default": None},
+            {"name": "DS", "category": "format", "dtype": "f16", "default": 0.0},
+        ]
+    }
+    avail = _load_field_manifest(meta)
+    assert set(avail) == {"AF", "DS"}
+    assert avail["AF"].dtype == np.dtype("float32")
+    assert avail["DS"].dtype == np.dtype("float16")
+    assert avail["DS"].default == 0.0
+    assert avail["AF"].default is None
+
+
+def test_colliding_names_are_qualified_bcftools_style():
+    meta = {
+        "fields": [
+            {"name": "DP", "category": "info", "dtype": "i32", "default": None},
+            {"name": "DP", "category": "format", "dtype": "i16", "default": None},
+        ]
+    }
+    avail = _load_field_manifest(meta)
+    assert set(avail) == {"INFO/DP", "FORMAT/DP"}
+    assert avail["INFO/DP"].dtype == np.dtype("int32")
+    assert avail["FORMAT/DP"].dtype == np.dtype("int16")
+
+
+def test_resolve_rejects_unknown_field():
+    avail = _load_field_manifest(
+        {"fields": [{"name": "AF", "category": "info", "dtype": "f32", "default": None}]}
+    )
+    assert _resolve_read_fields(None, avail) == []
+    assert _resolve_read_fields(["AF"], avail) == [avail["AF"]]
+    with pytest.raises(ValueError, match="NOPE"):
+        _resolve_read_fields(["NOPE"], avail)
+
+
+def test_no_fields_in_meta_is_empty_not_an_error():
+    assert _load_field_manifest({}) == {}
+    assert _load_field_manifest({"fields": []}) == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar2_fields_read.py -v`
+Expected: FAIL — `ImportError: cannot import name 'StoredField'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `python/genoray/_svar2_fields.py`:
+
+```python
+import numpy as np
+
+#: Storage dtype (meta.json `fields[].dtype`) -> numpy dtype. The 9 dtypes the
+#: writer can resolve to; `bool` is stored as one byte per element.
+NP_DTYPE: dict[str, np.dtype] = {
+    "bool": np.dtype("bool"),
+    "i8": np.dtype("int8"),
+    "u8": np.dtype("uint8"),
+    "i16": np.dtype("int16"),
+    "u16": np.dtype("uint16"),
+    "i32": np.dtype("int32"),
+    "u32": np.dtype("uint32"),
+    "f16": np.dtype("float16"),
+    "f32": np.dtype("float32"),
+}
+
+
+@dataclass(frozen=True)
+class StoredField:
+    """A field present in a finished SVAR2 store, as declared by ``meta.json``.
+
+    ``key`` is the canonical name callers use: the bare ``name`` when it is
+    unique across categories, else bcftools-style ``INFO/<name>`` /
+    ``FORMAT/<name>``. ``default`` is the fill written for VCF-missing entries;
+    when it is ``None`` the store instead uses a reserved sentinel
+    (``iinfo.min`` / ``iinfo.max`` / ``NaN``), which is returned as-is.
+    """
+
+    name: str
+    category: Literal["info", "format"]
+    dtype: np.dtype
+    default: float | None
+    key: str
+
+
+def _load_field_manifest(meta: dict) -> dict[str, StoredField]:
+    """Parse ``meta.json``'s ``fields`` array into canonical-key -> StoredField.
+
+    A store written before fields existed simply has no ``fields`` key; that is
+    an empty manifest, not an error.
+    """
+    entries = meta.get("fields") or []
+    counts: dict[str, int] = {}
+    for e in entries:
+        counts[e["name"]] = counts.get(e["name"], 0) + 1
+
+    out: dict[str, StoredField] = {}
+    for e in entries:
+        name = e["name"]
+        category = e["category"]
+        dtype_str = e["dtype"]
+        if dtype_str not in NP_DTYPE:
+            raise ValueError(
+                f"field {name!r} has unsupported stored dtype {dtype_str!r}; "
+                "the store may be corrupt or written by a newer genoray"
+            )
+        key = name if counts[name] == 1 else f"{category.upper()}/{name}"
+        out[key] = StoredField(
+            name=name,
+            category=category,
+            dtype=NP_DTYPE[dtype_str],
+            default=e.get("default"),
+            key=key,
+        )
+    return out
+
+
+def _resolve_read_fields(
+    requested: "Sequence[str] | None", available: dict[str, StoredField]
+) -> list[StoredField]:
+    """Validate a field selection against the store's manifest.
+
+    ``None`` selects nothing (fields are opt-in — decoding them costs I/O).
+    """
+    if requested is None:
+        return []
+    out: list[StoredField] = []
+    for key in requested:
+        if key not in available:
+            raise ValueError(
+                f"field {key!r} is not in this store; available fields: "
+                f"{sorted(available)}"
+            )
+        out.append(available[key])
+    return out
+```
+
+Ensure the module's imports include `from typing import Literal` (already
+present) and `from dataclasses import dataclass` (already present).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run pytest tests/test_svar2_fields_read.py -v`
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_svar2_fields.py tests/test_svar2_fields_read.py
+git commit -m "feat(svar2): parse the meta.json field manifest for reads"
+```
+
+---
+
+## Task 8: Rust — gather field bytes per decoded record
+
+`decode_batch` (`src/py_query_decode.rs`) emits one record per `(region, sample,
+ploid, variant)`. This task makes it also emit, per requested field, one **raw
+little-endian element** per record. Python applies the dtype — exactly the trick
+already used for `allele` (`d["allele"].view("S1")`), so Rust needs no numpy
+dtype dispatch.
+
+**Files:**
+- Modify: `src/query/gather.rs` (`BatchResult` gains `vk_src`; `decode_hap` gains a provenance-emitting twin), `src/py_query_decode.rs`
+- Test: `src/query/gather.rs` (inline)
+
+**Interfaces:**
+- Consumes: `FieldView` (Task 3), `SrcKeyRef`/`unpack_vk_src` (Task 4), generic `vk_slice` (Task 5).
+- Produces:
+  - `BatchResult` gains `pub vk_src: Vec<u32>` (empty unless requested), by the same `VkElem` split as Task 5.
+  - `pub struct RecordSrc { pub is_dense: bool, pub is_indel: bool, pub idx: usize }` — provenance of one decoded record. For var_key, `idx` is the absolute call index; for dense, the absolute dense variant row.
+  - `BatchResult::decode_hap_src(&self, reader, r, s, p) -> (HapCalls, Vec<RecordSrc>)` — as `decode_hap`, but also returns per-record provenance in the same order.
+  - `PyContigReader::decode_batch_fields(regions, fields) -> PyDict` where `fields: Vec<(String, String, String)>` is `(category, name, dtype_str)`. Adds one key per field: `field_<key>` → `PyArray1<u8>` of `n_records * itemsize` raw bytes, plus `field_itemsize_<key>` → `usize`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `#[cfg(test)] mod tests` in `src/query/gather.rs`:
+
+```rust
+    /// `decode_hap_src` must emit exactly one provenance entry per decoded
+    /// record, in the same order, and each must resolve to the record's position.
+    #[test]
+    fn decode_hap_src_is_aligned_with_decoded_records() {
+        let (dir, n_samples, ploidy) = super::tests_support::tiny_store_with_snps_and_indels();
+        let reader =
+            ContigReader::open(dir.path().to_str().unwrap(), "chr1", n_samples, ploidy).unwrap();
+        let regions = [(0u32, 1_000u32)];
+        let br = overlap_batch_src(&reader, &regions);
+
+        let snp_pos = reader.vk_snp.positions();
+        let indel_pos = reader.vk_indel.positions();
+
+        for s in 0..n_samples {
+            for p in 0..ploidy {
+                let (hc, srcs) = br.decode_hap_src(&reader, 0, s, p);
+                assert_eq!(hc.positions.len(), srcs.len(), "one src per decoded record");
+                for (i, src) in srcs.iter().enumerate() {
+                    if !src.is_dense {
+                        let pos = if src.is_indel {
+                            indel_pos[src.idx]
+                        } else {
+                            snp_pos[src.idx]
+                        };
+                        assert_eq!(pos, hc.positions[i]);
+                    }
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features decode_hap_src_is_aligned'`
+Expected: FAIL — `cannot find function overlap_batch_src`.
+
+- [ ] **Step 3: Implement `vk_src` on `BatchResult` + `decode_hap_src`**
+
+In `src/query/gather.rs`:
+
+Add to `BatchResult` (after `vk_off`):
+
+```rust
+    /// As `BatchResultSplit::vk_src`. Empty unless produced by `overlap_batch_src`.
+    pub vk_src: Vec<u32>,
+```
+
+Add `vk_src: Vec::new(),` to the existing `BatchResult { … }` literals in
+`overlap_batch` and `gather_ranges`, then generalize `overlap_batch` the same way
+as Task 5 (private `overlap_batch_impl<T: VkElem>`, with `overlap_batch` =
+`::<KeyRef>` and a new `pub fn overlap_batch_src` = `::<SrcKeyRef>`; the only
+change inside is `reader.vk_slice::<T>(...)` and the final `T::split(vk)`).
+
+Add `RecordSrc` and `decode_hap_src`:
+
+```rust
+/// Where one decoded record came from, so a consumer can index a `FieldView`.
+/// var_key: `idx` is the absolute call index in `var_key/{snp,indel}`.
+/// dense: `idx` is the absolute dense variant row in `dense/{snp,indel}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordSrc {
+    pub is_dense: bool,
+    pub is_indel: bool,
+    pub idx: usize,
+}
+
+impl BatchResult {
+    /// As `decode_hap`, but also returns one `RecordSrc` per decoded record, in
+    /// the same order. Requires a `BatchResult` built by `overlap_batch_src`
+    /// (i.e. with `vk_src` populated); panics otherwise, since silently
+    /// returning wrong provenance would return wrong field values.
+    pub fn decode_hap_src(
+        &self,
+        reader: &ContigReader,
+        r: usize,
+        s: usize,
+        p: usize,
+    ) -> (HapCalls, Vec<RecordSrc>) {
+        assert_eq!(
+            self.vk_src.len(),
+            self.vk.len(),
+            "decode_hap_src requires a BatchResult from overlap_batch_src"
+        );
+        let h = (r * self.n_samples + s) * self.ploidy + p;
+
+        // var_key run for this hap, carrying provenance.
+        let (lo, hi) = (self.vk_off[h], self.vk_off[h + 1]);
+        let vk_run: Vec<(KeyRef, RecordSrc)> = (lo..hi)
+            .map(|i| {
+                let (is_indel, idx) = spine::unpack_vk_src(self.vk_src[i]);
+                (
+                    self.vk[i],
+                    RecordSrc {
+                        is_dense: false,
+                        is_indel,
+                        idx,
+                    },
+                )
+            })
+            .collect();
+
+        // Dense run: present entries of this region's window. `dense.src[j]`
+        // already holds `(class, per-class row)` — the index dense field
+        // values.bin is aligned to.
+        let dense = reader.dense_union();
+        let (ds, de) = (self.dense_range[r].start, self.dense_range[r].end);
+        let bit0 = self.dense_present_off[h];
+        let mut dn_run: Vec<(KeyRef, RecordSrc)> = Vec::new();
+        for (k, j) in (ds..de).enumerate() {
+            if bits::get_bit(&self.dense_present, bit0 + k) {
+                let (class, dcol) = dense.src[j];
+                dn_run.push((
+                    self.dense[j],
+                    RecordSrc {
+                        is_dense: true,
+                        is_indel: matches!(class, crate::dense::DenseClass::Indel),
+                        idx: dcol,
+                    },
+                ));
+            }
+        }
+
+        // Merge by position with the SAME stable tie-break as `decode_hap`
+        // (var_key run first on ties).
+        let mut merged: Vec<(KeyRef, RecordSrc)> = Vec::with_capacity(vk_run.len() + dn_run.len());
+        let (mut a, mut b) = (0usize, 0usize);
+        while a < vk_run.len() && b < dn_run.len() {
+            if vk_run[a].0.position <= dn_run[b].0.position {
+                merged.push(vk_run[a]);
+                a += 1;
+            } else {
+                merged.push(dn_run[b]);
+                b += 1;
+            }
+        }
+        merged.extend_from_slice(&vk_run[a..]);
+        merged.extend_from_slice(&dn_run[b..]);
+
+        let lut = reader.lut.as_ref();
+        let mut hc = HapCalls::default();
+        let mut srcs = Vec::with_capacity(merged.len());
+        for (kr, src) in merged {
+            let c = decode_keyref(kr, lut);
+            hc.positions.push(c.position);
+            hc.ilens.push(c.ilen);
+            hc.alts.push(c.alt);
+            srcs.push(src);
+        }
+        (hc, srcs)
+    }
+}
+```
+
+> **Ordering invariant:** `decode_hap` merges via
+> `spine::merge_keys(vec![vk_slice, dn])`, which is stable with the earlier run
+> (var_key) winning ties. The two-pointer merge above reproduces exactly that.
+> A test in Step 5 pins `decode_hap_src`'s record order to `decode_hap`'s.
+
+- [ ] **Step 4: Add the pyo3 binding**
+
+In `src/py_query_decode.rs`, add to the `#[pymethods] impl PyContigReader` block:
+
+```rust
+    /// As `decode_batch`, plus one raw-bytes buffer per requested field, aligned
+    /// 1:1 with the decoded records. `fields` is `(category, name, dtype_str)`.
+    /// Values are returned as little-endian bytes + an itemsize; Python applies
+    /// the numpy dtype (same trick as `allele`), so Rust does no dtype dispatch.
+    #[pyo3(signature = (regions, fields, base_dir, contig))]
+    pub fn decode_batch_fields<'py>(
+        &self,
+        py: Python<'py>,
+        regions: Vec<(u32, u32)>,
+        fields: Vec<(String, String, String)>,
+        base_dir: &str,
+        contig: &str,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        use crate::field::StorageDtype;
+        use crate::layout::{ContigPaths, FieldSub};
+        use crate::query::{FieldView, gather::overlap_batch_src};
+
+        let br = overlap_batch_src(&self.inner, &regions);
+        let paths = ContigPaths::new(base_dir, contig);
+        let n_samples_cohort = self.inner.n_samples();
+
+        // Open the four sub-stream views per field up front.
+        struct OpenField {
+            key: String,
+            is_format: bool,
+            width: usize,
+            views: [FieldView; 4], // indexed by FieldSub::all() order
+        }
+        let mut open: Vec<OpenField> = Vec::with_capacity(fields.len());
+        for (category, name, dtype_str) in &fields {
+            let dtype = StorageDtype::from_meta_str(dtype_str).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "field {name:?} has unresolved/unknown dtype {dtype_str:?}"
+                ))
+            })?;
+            let width = dtype
+                .width_bytes()
+                .expect("from_meta_str rejects unresolved dtypes");
+            let mut views = Vec::with_capacity(4);
+            for sub in FieldSub::all() {
+                views.push(
+                    FieldView::open(&paths, category, name, sub, dtype, n_samples_cohort)
+                        .map_err(|e| pyo3::exceptions::PyOSError::new_err(e.to_string()))?,
+                );
+            }
+            open.push(OpenField {
+                key: format!("{category}/{name}"),
+                is_format: category == "format",
+                width,
+                views: views.try_into().map_err(|_| ()).expect("exactly 4 subs"),
+            });
+        }
+
+        let mut pos: Vec<i32> = Vec::new();
+        let mut ilen: Vec<i32> = Vec::new();
+        let mut allele: Vec<u8> = Vec::new();
+        let mut str_off: Vec<i64> = vec![0];
+        let mut off: Vec<i64> = vec![0];
+        let mut fbytes: Vec<Vec<u8>> = vec![Vec::new(); open.len()];
+
+        for r in 0..br.n_regions {
+            for s in 0..br.n_samples {
+                for p in 0..br.ploidy {
+                    let (hc, srcs) = br.decode_hap_src(&self.inner, r, s, p);
+                    for i in 0..hc.positions.len() {
+                        pos.push(hc.positions[i] as i32);
+                        ilen.push(hc.ilens[i]);
+                        allele.extend_from_slice(&hc.alts[i]);
+                        str_off.push(allele.len() as i64);
+
+                        let src = srcs[i];
+                        // FieldSub::all() order: VkSnp, VkIndel, DenseSnp, DenseIndel
+                        let sub_ix = match (src.is_dense, src.is_indel) {
+                            (false, false) => 0,
+                            (false, true) => 1,
+                            (true, false) => 2,
+                            (true, true) => 3,
+                        };
+                        for (fi, f) in open.iter().enumerate() {
+                            let view = &f.views[sub_ix];
+                            // Dense FORMAT strides by the ORIGINAL cohort sample
+                            // index. `s` here is already the cohort index because
+                            // `overlap_batch_src` runs over the whole cohort.
+                            let elem = if src.is_dense && f.is_format {
+                                view.bytes_at(src.idx * n_samples_cohort + s)
+                            } else {
+                                view.bytes_at(src.idx)
+                            };
+                            debug_assert_eq!(elem.len(), f.width);
+                            fbytes[fi].extend_from_slice(elem);
+                        }
+                    }
+                    off.push(pos.len() as i64);
+                }
+            }
+        }
+
+        let d = PyDict::new(py);
+        d.set_item("pos", i32_to_pyarray(py, &pos))?;
+        d.set_item("ilen", i32_to_pyarray(py, &ilen))?;
+        d.set_item("allele", u8_to_pyarray(py, &allele))?;
+        d.set_item("str_off", PyArray1::from_slice(py, &str_off))?;
+        d.set_item("off", PyArray1::from_slice(py, &off))?;
+        d.set_item("n_regions", br.n_regions)?;
+        d.set_item("n_samples", br.n_samples)?;
+        d.set_item("ploidy", br.ploidy)?;
+        for (fi, f) in open.iter().enumerate() {
+            d.set_item(format!("field_{}", f.key), u8_to_pyarray(py, &fbytes[fi]))?;
+            d.set_item(format!("field_itemsize_{}", f.key), f.width)?;
+        }
+        Ok(d)
+    }
+```
+
+If `ContigReader::n_samples()` is not a public accessor, add one:
+
+```rust
+    #[inline]
+    pub fn n_samples(&self) -> usize {
+        self.n_samples
+    }
+```
+
+- [ ] **Step 5: Add the ordering-parity test**
+
+Append to `#[cfg(test)] mod tests` in `src/query/gather.rs`:
+
+```rust
+    /// `decode_hap_src` must return records in EXACTLY the order `decode_hap`
+    /// does — otherwise field values would be attached to the wrong variants.
+    #[test]
+    fn decode_hap_src_matches_decode_hap_order() {
+        let (dir, n_samples, ploidy) = super::tests_support::tiny_store_with_snps_and_indels();
+        let reader =
+            ContigReader::open(dir.path().to_str().unwrap(), "chr1", n_samples, ploidy).unwrap();
+        let regions = [(0u32, 1_000u32)];
+        let plain = overlap_batch(&reader, &regions);
+        let with_src = overlap_batch_src(&reader, &regions);
+        for s in 0..n_samples {
+            for p in 0..ploidy {
+                let a = plain.decode_hap(&reader, 0, s, p);
+                let (b, srcs) = with_src.decode_hap_src(&reader, 0, s, p);
+                assert_eq!(a.positions, b.positions);
+                assert_eq!(a.ilens, b.ilens);
+                assert_eq!(a.alts, b.alts);
+                assert_eq!(srcs.len(), b.positions.len());
+            }
+        }
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: ALL PASS, including the two new decode tests.
+
+- [ ] **Step 7: Build the extension so Python can call it**
+
+Run: `pixi run maturin develop --release`
+Expected: build succeeds. (This is a long foreground build — do NOT background it.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/query/gather.rs src/query/reader.rs src/py_query_decode.rs
+git commit -m "feat(svar2): decode_batch_fields — field bytes per decoded record"
+```
+
+---
+
+## Task 9: Python — `SparseVar2(fields=…)` and `decode()`
+
+**Files:**
+- Modify: `python/genoray/_svar2.py`, `python/genoray/_svar2_decode.py`
+- Test: `tests/test_svar2_fields_read.py` (extend)
+
+**Interfaces:**
+- Consumes: `_load_field_manifest`, `_resolve_read_fields`, `StoredField` (Task 7); `decode_batch_fields` (Task 8).
+- Produces:
+  - `SparseVar2.__init__(path, *, fields: Sequence[str] | None = None)`
+  - `SparseVar2.available_fields -> dict[str, StoredField]`
+  - `SparseVar2.with_fields(fields: Sequence[str]) -> SparseVar2`
+  - `SparseVar2.decode(contig, regions)` — the `Ragged` gains one entry per selected field, sharing the variant-axis offsets with `pos`/`ilen`/`allele`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Append to `tests/test_svar2_fields_read.py`:
+
+```python
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from genoray import SparseVar2
+from genoray._svar2_fields import FormatField, InfoField
+
+
+@pytest.fixture
+def store_with_fields(tmp_path: Path) -> SparseVar2:
+    """Convert the shared test VCF carrying one INFO and one FORMAT field."""
+    vcf = Path(__file__).parent / "data" / "biallelic.vcf.gz"
+    out = tmp_path / "fields.svar2"
+    SparseVar2.from_vcf(
+        out,
+        vcf,
+        no_reference=True,
+        info_fields=[InfoField("AF", dtype="f32")],
+        format_fields=[FormatField("DS", dtype="f32", default=0.0)],
+    )
+    return SparseVar2(out)
+
+
+def test_available_fields_reports_canonical_keys(store_with_fields):
+    avail = store_with_fields.available_fields
+    assert set(avail) == {"AF", "DS"}
+    assert avail["AF"].category == "info"
+    assert avail["DS"].category == "format"
+
+
+def test_decode_without_fields_is_unchanged(store_with_fields):
+    rag = store_with_fields.decode("chr1", [(0, 1_000_000)])
+    assert set(rag.fields) == {"pos", "ilen", "allele"}
+
+
+def test_decode_with_fields_shares_offsets_and_preserves_dtype(store_with_fields):
+    sv = store_with_fields.with_fields(["AF", "DS"])
+    rag = sv.decode("chr1", [(0, 1_000_000)])
+    assert set(rag.fields) == {"pos", "ilen", "allele", "AF", "DS"}
+
+    pos = rag.fields["pos"]
+    af = rag.fields["AF"]
+    ds = rag.fields["DS"]
+
+    # Stored dtype is preserved end to end — no widening.
+    assert af.data.dtype == np.dtype("float32")
+    assert ds.data.dtype == np.dtype("float32")
+
+    # One field value per decoded record, on the SAME offsets object.
+    assert af.data.shape == pos.data.shape
+    assert ds.data.shape == pos.data.shape
+    np.testing.assert_array_equal(af.offsets, pos.offsets)
+    np.testing.assert_array_equal(ds.offsets, pos.offsets)
+
+
+def test_decode_rejects_unknown_field(store_with_fields):
+    with pytest.raises(ValueError, match="NOPE"):
+        store_with_fields.with_fields(["NOPE"])
+```
+
+> The fixture uses `tests/data/biallelic.vcf.gz`. If that file has no `AF`/`DS`
+> declared in its header, the conversion will raise "field not found in the VCF
+> header" — in that case, generate a fixture that HAS them by extending
+> `tests/data/gen_from_vcf.sh` / `tests/data/gen_svar.py` (which already build
+> the test corpus), and use that path instead. Do not weaken the assertions.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar2_fields_read.py -v -k "decode or available"`
+Expected: FAIL — `SparseVar2.__init__() got an unexpected keyword argument 'fields'`.
+
+- [ ] **Step 3: Wire fields into `SparseVar2`**
+
+In `python/genoray/_svar2.py`, replace `__init__` and add the two members:
+
+```python
+    def __init__(
+        self, path: str | Path, *, fields: "Sequence[str] | None" = None
+    ) -> None:
+        self.path = Path(path)
+        meta = json.loads((self.path / "meta.json").read_text())
+        self.format_version: int = meta["format_version"]
+        self.available_samples: list[str] = list(meta["samples"])
+        self.contigs: list[str] = list(meta["contigs"])
+        self.ploidy: int = meta["ploidy"]
+        self.available_fields: dict[str, StoredField] = _load_field_manifest(meta)
+        #: The fields this reader decodes. Empty unless opted into via
+        #: ``fields=`` / :meth:`with_fields` — decoding a field costs extra I/O.
+        self._fields: list[StoredField] = _resolve_read_fields(
+            fields, self.available_fields
+        )
+        self._readers: dict[str, _core.PyContigReader] = {
+            contig: _core.PyContigReader(
+                str(self.path), contig, len(self.available_samples), self.ploidy
+            )
+            for contig in self.contigs
+        }
+
+    def with_fields(self, fields: "Sequence[str]") -> "SparseVar2":
+        """A new reader over the same store that also decodes ``fields``.
+
+        Keys are those of :attr:`available_fields`: the bare field name when it
+        is unique across INFO/FORMAT, else bcftools-style ``INFO/DP`` /
+        ``FORMAT/DP``.
+        """
+        return SparseVar2(self.path, fields=fields)
+```
+
+Update the import at the top of `_svar2.py`. It currently reads
+`from genoray._svar2_fields import _resolve_fields` (the write-path helper —
+keep it). Replace with:
+
+```python
+from genoray._svar2_fields import (
+    StoredField,
+    _load_field_manifest,
+    _resolve_fields,
+    _resolve_read_fields,
+)
+```
+
+`Sequence` is already imported under `TYPE_CHECKING` in this module.
+
+- [ ] **Step 4: Attach fields in `decode()`**
+
+In `python/genoray/_svar2_decode.py`, replace `decode`:
+
+```python
+    # Provided by the concrete SparseVar2 host class.
+    _fields: list[Any]
+    path: Any
+
+    def decode(self, contig: str, regions: Iterable[tuple[int, int]]) -> "Ragged":
+        """Materialize overlapping variants for ``contig`` into a record ``Ragged``.
+
+        Fields ``pos`` (i32), ``ilen`` (i32), ``allele`` (opaque-string ALT bytes),
+        plus one entry per selected INFO/FORMAT field (see
+        :meth:`SparseVar2.with_fields`) — every one sharing a single variant-axis
+        offsets object, shape ``(R, S, P, None)``, the same layout as gvl's
+        ``RaggedVariants``. Pure-deletion ALT is empty.
+
+        Field values come back in the dtype they are STORED as (SVAR2
+        losslessly auto-narrows integers), and VCF-missing entries carry the
+        store's ``default`` or its reserved sentinel (``NaN`` for floats,
+        ``iinfo.min``/``iinfo.max`` for ints) — neither is translated.
+        """
+        import numpy as np
+        from seqpro.rag import Ragged
+
+        reg = [(int(s), int(e)) for s, e in regions]
+        reader = self._readers[contig]
+        if not self._fields:
+            d = reader.decode_batch(reg)
+        else:
+            d = reader.decode_batch_fields(
+                reg,
+                [(f.category, f.name, _META_DTYPE[f.dtype]) for f in self._fields],
+                str(self.path),
+                contig,
+            )
+
+        shape = (d["n_regions"], d["n_samples"], d["ploidy"], None)
+        off = d["off"]
+        pos = Ragged.from_offsets(d["pos"], shape, off)
+        ilen = Ragged.from_offsets(d["ilen"], shape, off)
+        allele = Ragged.from_offsets(
+            d["allele"].view("S1"), shape, off, str_offsets=d["str_off"]
+        )
+        # If a consumer hits an error reading `.lengths` on a (2, N) offsets
+        # layout, call `.to_packed()` first — a known seqpro slicing quirk.
+        rec: dict[str, Ragged] = {"pos": pos, "ilen": ilen, "allele": allele}
+        for f in self._fields:
+            # Rust hands back raw little-endian bytes + an itemsize; the dtype is
+            # applied here (same trick as `allele`), so Rust does no dtype
+            # dispatch. `.view` is zero-copy.
+            raw: np.ndarray = d[f"field_{f.category}/{f.name}"]
+            itemsize = d[f"field_itemsize_{f.category}/{f.name}"]
+            if itemsize != f.dtype.itemsize:
+                # A width/dtype disagreement would silently reinterpret the
+                # bytes into wrong values — fail loudly instead.
+                raise ValueError(
+                    f"field {f.key!r}: store wrote {itemsize}-byte elements but "
+                    f"meta.json declares {f.dtype} ({f.dtype.itemsize} bytes)"
+                )
+            vals = raw.view(f.dtype)
+            rec[f.key] = Ragged.from_offsets(vals, shape, off)
+        return Ragged.from_fields(rec)
+```
+
+Add the reverse dtype map to `python/genoray/_svar2_fields.py`:
+
+```python
+#: numpy dtype -> the `meta.json` storage-dtype string the Rust side expects.
+_META_DTYPE: dict[np.dtype, str] = {v: k for k, v in NP_DTYPE.items()}
+```
+
+…and import it in `_svar2_decode.py`:
+
+```python
+from genoray._svar2_fields import _META_DTYPE
+```
+
+- [ ] **Step 5: Rebuild and run the tests**
+
+Run: `pixi run maturin develop --release`
+Then: `pixi run pytest tests/test_svar2_fields_read.py -v`
+Expected: ALL PASS.
+
+- [ ] **Step 6: Run the full Python suite (no-regression gate)**
+
+Run: `pixi run pytest -m "not network"`
+Expected: ALL PASS — in particular the existing `tests/test_svar2_decode.py`,
+which pins the no-fields `decode()` output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add python/genoray/_svar2.py python/genoray/_svar2_decode.py python/genoray/_svar2_fields.py tests/test_svar2_fields_read.py
+git commit -m "feat(svar2): SparseVar2.decode(fields=...) returns fields on shared offsets"
+```
+
+---
+
+## Task 10: Public-API docs + changelog
+
+**Files:**
+- Modify: `skills/genoray-api/SKILL.md`, `CHANGELOG.md`
+
+This is **mandatory**, not optional — `CLAUDE.md` requires the same PR that changes
+a public name to update the skill doc. New public names: `SparseVar2(fields=…)`,
+`SparseVar2.available_fields`, `SparseVar2.with_fields`, `SparseVar2.decode`'s
+field entries, and `StoredField`.
+
+- [ ] **Step 1: Update the skill doc**
+
+In `skills/genoray-api/SKILL.md`, in the `SparseVar2` section, add:
+
+````markdown
+### Reading INFO/FORMAT fields (SVAR2)
+
+Fields written by `from_vcf(info_fields=…, format_fields=…)` are read back by
+opting in. They are **not** decoded by default (each one costs extra I/O).
+
+```python
+sv = SparseVar2(path)
+sv.available_fields          # {"AF": StoredField(...), "DS": StoredField(...)}
+
+sv = sv.with_fields(["AF", "DS"])      # or SparseVar2(path, fields=["AF", "DS"])
+rag = sv.decode("chr1", [(0, 10_000)])
+rag.fields["DS"]             # Ragged, sharing offsets with pos/ilen/allele
+```
+
+**Field keys** are the bare field name when it is unique across INFO and FORMAT,
+and bcftools-style `INFO/DP` / `FORMAT/DP` when a name appears in both. Use
+whatever `available_fields` reports.
+
+**Dtype is preserved as stored.** SVAR2 losslessly auto-narrows integer fields,
+so an `AC` field may come back as `int8`. Nothing is widened.
+
+**Missing values** are the field's `default` if one was set at write time, else a
+reserved sentinel — `NaN` for floats, `iinfo.min`/`iinfo.max` for ints. They are
+returned as-is, never translated.
+
+**FORMAT caveat (inherited from the write path):** FORMAT values are
+genotype-aligned, so values at non-carrier samples are not stored. `decode()`
+only ever emits carrier records, so this is invisible on this surface.
+````
+
+- [ ] **Step 2: Update the changelog**
+
+Under `## Unreleased` in `CHANGELOG.md`:
+
+```markdown
+### Added
+
+- **SVAR2: read INFO/FORMAT fields.** `SparseVar2(fields=…)` /
+  `SparseVar2.with_fields(…)` / `SparseVar2.available_fields`, and
+  `SparseVar2.decode()` now returns each selected field as a `Ragged` sharing the
+  variant-axis offsets with `pos`/`ilen`/`allele`. Values come back in the dtype
+  they are stored as; missing entries keep the store's `default` or sentinel.
+  Field keys are bare names, or bcftools-style `INFO/DP` / `FORMAT/DP` when a
+  name is used by both categories.
+- **Public Rust read API** for consumers that do their own channel merge (gvl):
+  `query::FieldView` (mmap over a field's `values.bin`), `query::vk_src`
+  provenance on `BatchResult`/`BatchResultSplit` via
+  `query::gather_haps_readbound_src` / `overlap_batch_src`, plus
+  `query::dense_abs_row`.
+```
+
+- [ ] **Step 3: Verify the docs match the code**
+
+Run: `pixi run pytest tests/test_svar2_fields_read.py -v`
+Expected: PASS (the snippets in the doc mirror these tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/genoray-api/SKILL.md CHANGELOG.md
+git commit -m "docs(svar2): document the field-read API"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Full Rust suite**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: ALL PASS.
+
+- [ ] **Step 2: Full Python suite**
+
+Run: `pixi run test`
+Expected: ALL PASS.
+
+- [ ] **Step 3: Lint**
+
+Run: `pixi run bash -lc 'cargo clippy --no-default-features -- -D warnings && cargo fmt --check'`
+Then: `ruff check genoray tests && ruff format --check genoray tests`
+Expected: clean.
+
+- [ ] **Step 4: Confirm the zero-cost claim held**
+
+The no-fields paths must be untouched. Confirm `tests/test_readbound_gather.rs`
+and `tests/test_svar2_decode.py` pass **without modification** — if either needed
+editing, the provenance work changed existing behaviour and must be revisited.
+
+Run: `git diff main --stat -- tests/test_readbound_gather.rs tests/test_svar2_decode.py`
+Expected: **no output** (neither file changed).
+
+- [ ] **Step 5: Push**
+
+```bash
+git push
+```
+
+---
+
+## Spec Coverage Check
+
+| Spec section | Task |
+| --- | --- |
+| §1 `FieldView` (public, mmap, dtype from meta.json, `value_at`/`format_at`/`as_slice`) | 1, 2, 3, 6 |
+| §2 `vk_src` packing + hard 2^31 assert | 4 |
+| §3 One generic merge (`merge_by_position`), zero-cost when unused | 4, 5, 11 (step 4) |
+| §4 Dtype preserved, never converted; sentinels untranslated | 3, 7, 9, 10 |
+| §5 Python `decode(fields=…)`, shared offsets, canonical `INFO/x` keys | 7, 8, 9 |
+| §6 No field arrays on the result structs; adding a field costs nothing | 5, 8 (per-field cost is one mmap + one `bytes_at` per record) |
+| §7 gvl-side dependents | out of scope by design; noted in the spec, not this plan |
+| Dense provenance is free (arithmetic) | 6 (`dense_abs_row`), 8 (`dense.src[j]` in `decode_hap_src`) |
+| Testing strategy (dtype coverage, subset/orig-sample, assert, merge tie-break, oracle parity, e2e, no-regression) | 3, 4, 5, 8, 9, 11 |
+| Docs (SKILL.md mandatory, CHANGELOG) | 10 |

--- a/docs/superpowers/specs/2026-07-12-svar2-fields-read-design.md
+++ b/docs/superpowers/specs/2026-07-12-svar2-fields-read-design.md
@@ -1,0 +1,318 @@
+# SVAR2 — reading INFO/FORMAT fields (spec #2 of 3)
+
+Status: **design, ready for spec review.** This is spec **#2** of a three-part
+effort:
+
+1. **Write INFO/FORMAT fields** into SVAR2 at conversion time — **landed**
+   (PR #100; [`2026-07-11-svar2-info-format-fields-write-design.md`](2026-07-11-svar2-info-format-fields-write-design.md),
+   plus [`2026-07-12-svar2-fields-followup-cleanup-optimization-design.md`](2026-07-12-svar2-fields-followup-cleanup-optimization-design.md)).
+2. **(this doc) Read/output** those fields on the SVAR2 query/decode path.
+3. **SVAR1 → SVAR2 conversion** —
+   ([`2026-07-11-svar1-to-svar2-conversion-design.md`](2026-07-11-svar1-to-svar2-conversion-design.md),
+   partial; explicitly blocked on #1 **and** #2). This spec unblocks it.
+
+Date: 2026-07-12
+
+## Problem / motivation
+
+Spec #1 gave SVAR2 the ability to *store* scalar-numeric INFO and FORMAT fields
+(`{contig}/fields/{cat}/{name}/{sub}/values.bin`), but nothing reads them back.
+There is currently **no field-read path at all** in `src/query/` or
+`src/py_query*.rs`.
+
+The driving consumer is GenVarLoader. Its SVAR2 path today has **no field
+plumbing whatsoever** — `_svar2_haps.py:174` hardcodes
+`available_var_fields = ["alt","ilen","start"]` and `:256` passes
+`dosages=None`. Meanwhile its SVAR1 path supplies dosages (and arbitrary
+`Number=G` custom fields) as a `Ragged` memmapped **on the genotype offsets**.
+Until SVAR2 can serve the same data, the SVAR1→SVAR2 migration (spec #3) would
+be a **data-loss migration** — which is why spec #3 is blocked on this one.
+
+## Scope
+
+**In:**
+- A public, mmap-backed **`FieldView`** read primitive over the on-disk
+  `values.bin` sidecars, mirroring the proven `mutcat` sidecar reader.
+- The **one missing piece of provenance** (`vk_src`) that lets a consumer map a
+  merged var_key record back to its absolute call index.
+- A Python **`decode(fields=…)`** surface returning a `Ragged` whose field
+  arrays share the genotype offsets (SVAR1 parity).
+
+**Out (deferred):**
+- Any dtype conversion or widening (see §4 — explicitly rejected).
+- Fields on the **merged Python `BatchResult`** dict contract
+  (`overlap_batch`/`read_ranges`/`gather_ranges`). No consumer needs them; gvl
+  uses the readbound/split path and its own merge, and Python users get
+  `decode()`. Revisit only on demand.
+- gvl-side consumer work (its own PR; see §7).
+
+## Background — the facts that shape this design
+
+### On-disk layout (from spec #1, confirmed in code)
+
+```
+{contig}/fields/{info|format}/{name}/{var_key_snp|var_key_indel|dense_snp|dense_indel}/values.bin
+```
+
+| sub-stream | INFO | FORMAT |
+| --- | --- | --- |
+| `var_key_snp`, `var_key_indel` | 1 value / **call** (duplicated per carrier) | 1 value / **call** (sample implicit in the CSR column) |
+| `dense_snp`, `dense_indel` | 1 value / **dense variant** | `n_dense_variants × n_samples`, variant-major: `idx = dense_row * n_samples + sample` |
+
+Two gotchas the reader **must** honour:
+
+- **Element width is not in the file.** Values are staged as 4-byte `i32`/`f32`
+  and rewritten in place to the resolved dtype by `field_finalize::rewrite_file`
+  (`src/field_finalize.rs:394-430`). Width comes **only** from `meta.json`'s
+  `fields[].dtype` (`src/meta.rs:21-39`).
+- **Dense FORMAT is indexed by the *original cohort* sample index**, not the
+  selected slot. A sample-subset query must use `HapRanges.orig_samples` /
+  `RangesBundle.sample_cols`.
+
+Missing values are `i*::MIN` / `u*::MAX` / `NaN` (`field_finalize.rs:437-495`),
+and a sentinel exists **only** when the field's `default` is `None`.
+
+### Precedent: the mutcat sidecar reader
+
+`MutcatView` (`src/mutcat/sidecar.rs:38-72`) is exactly the shape we need: an
+`Option<Mmap>` per sub-stream with `code_at(i)`, opened by `open_sidecar`.
+`mutcat::count::count_column_into` (`src/mutcat/count.rs:137-198`) already
+indexes it by the same two kinds of index this spec needs — the absolute var_key
+call index (`abs_i = o0 + i`) and the per-class dense variant row (`dcol`).
+`FieldView` mirrors it.
+
+### Where provenance survives — and where it doesn't
+
+| channel | provenance after gather | why |
+| --- | --- | --- |
+| `dense_snp` / `dense_indel` | **free** | Each per-region window is a *contiguous copy* of the on-disk slice, and `dense_*_range[q]` is retained. Absolute dense row = pure arithmetic. |
+| `vk` | **lost** | Per hap, var_key snp+indel are **merged by position** into one flat `vk` (`gather.rs:162`, and the hand-inlined twin at `gather.rs:586-597`). `KeyRef` is only `(position: u32, key: u32)` — 8 bytes, no record index. |
+
+Worse, the var_key runs are built by **filtering** (`if qs < v_end`), so the
+absolute index cannot be recovered from a record's position within the run
+afterwards — it must be captured **as records are kept**.
+
+This holds for **both** `BatchResult` (merged) and `BatchResultSplit`
+(readbound) — `BatchResultSplit.vk` is also a merged snp+indel channel
+(`gather.rs:103-105`). The dense side of the split path is the only free part.
+
+### What gvl actually needs
+
+gvl consumes genoray as a **Rust Cargo path-dep** and never asks for a
+materialized decode. It takes `BatchResultSplit` and runs its own streaming
+3-way merge over `(vk, dense_snp, dense_indel)`
+(`GenVarLoader/src/svar2/mod.rs:330-371`), decoding each key inline. **At the
+moment it emits a record it already holds the source channel and index**
+(`i_vk`, `i_sn`, `i_in`).
+
+That is the load-bearing observation: gvl does **not** want per-decoded-record
+field arrays. It wants to look a value up by the channel index it already has.
+So genoray does not need to gather, materialize, or even *know about* any
+particular field.
+
+## Design
+
+### 1. `FieldView` — the read primitive (public)
+
+New `src/query/field.rs`, mirroring `mutcat/sidecar.rs`:
+
+```rust
+pub struct FieldView {
+    values: Option<Mmap>,   // {contig}/fields/{cat}/{name}/{sub}/values.bin
+    dtype: StorageDtype,    // from meta.json — NOT from the file
+    n_samples: usize,       // cohort width, for dense FORMAT striding
+}
+
+impl FieldView {
+    /// var_key call `i`, or dense INFO variant row `i`.
+    pub fn value_at(&self, i: usize) -> FieldValue;
+    /// dense FORMAT: `dense_row * n_samples + orig_sample`.
+    /// `orig_sample` is the ORIGINAL cohort index, never the selected slot.
+    pub fn format_at(&self, dense_row: usize, orig_sample: usize) -> FieldValue;
+    /// Zero-copy typed slice for bulk consumers (bytemuck), dtype-checked.
+    pub fn as_slice<T: Pod>(&self) -> Option<&[T]>;
+    pub fn dtype(&self) -> StorageDtype;
+}
+```
+
+Opened on demand from a `ContigReader` (`open_field(cat, name, sub)`), so
+genoray never carries a field selection. `half = "2"` is already a dependency,
+so `f16` needs no new deps.
+
+**This type is public and crosses the genoray↔gvl seam deliberately.** Both
+packages are first-party; a lazy `FieldView` lookup beats materializing
+`n_selected_samples × dense_len` values per query, and it makes the cost of an
+additional field **zero** on the genoray side.
+
+### 2. `vk_src` — the single new piece of state
+
+`BatchResultSplit` (and `BatchResult`) gain one array parallel to `vk`:
+
+```rust
+/// Absolute var_key call index per `vk` record.
+/// bit 31 = sub-stream tag (0 = snp, 1 = indel); bits 0..=30 = call index.
+pub vk_src: Vec<u32>,
+```
+
+Captured with `.enumerate()` at the filtered push sites (`gather.rs:139-160`,
+`:546-561`, `reader.rs:143`) and merged in lockstep with the keys.
+
+**Packing + the assert.** Bit 31 caps var_key calls per contig at 2³¹ ≈ 2.1e9.
+Real stores are far below this, but a silent overflow would produce *silently
+wrong field values*, which is the worst possible failure mode. So the packing
+helper carries a hard assert:
+
+```rust
+#[inline]
+fn pack_vk_src(is_indel: bool, call_idx: usize) -> u32 {
+    assert!(call_idx < (1 << 31), "var_key call index {call_idx} exceeds the 2^31 vk_src ceiling");
+    (call_idx as u32) | ((is_indel as u32) << 31)
+}
+```
+
+The assert also fires at write/merge time (where the sub-stream call count is
+known) so an over-large store fails at conversion, not at query.
+
+### 3. One merge, not two
+
+`spine::merge_keys(runs: Vec<Vec<KeyRef>>)` (`spine.rs:67`) generalizes to a
+single implementation:
+
+```rust
+pub trait Positioned: Copy { fn position(&self) -> u32; }
+impl Positioned for KeyRef {}
+impl Positioned for (KeyRef, u32) {}   // key + vk_src
+
+pub fn merge_by_position<T: Positioned>(runs: Vec<Vec<T>>) -> Vec<T>;
+pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> { merge_by_position(runs) }
+```
+
+Monomorphization means the **no-fields path stays byte-identical and
+zero-cost** — load-bearing, because the hand-inlined twin at `gather.rs:586-597`
+carries a long comment justifying its tuning against the shared helper. Both
+merge sites must preserve the same stable tie-break (snp before indel on equal
+position); the existing "these two must stay identical" comments
+(`spine.rs:64-66`, `gather.rs:567-585`) get updated to cover the payload.
+
+This **shrinks** the divergence hazard (one generic merge) rather than doubling
+it.
+
+### 4. Dtype: preserved, never converted
+
+The stored dtype (`bool`, `i8`…`u32`, `f16`, `f32`) is carried through to the
+consumer unchanged. **No widening, no `as_f32`, no sentinel translation.**
+
+An earlier draft proposed widening to `f32` at the gvl seam to feed gvl's
+`dosage` slot. That was wrong: gvl's containers are **already generic over
+arbitrary named fields of arbitrary numpy scalar dtype**:
+
+- `RaggedVariants.__init__(alt, start, ref, ilen, dosage, **fields)`
+  (`_rag_variants.py:210-232`) — `dosage` is a dedicated *kwarg* but lands in the
+  same dict as `**fields`; the annotation is plain `Ragged`, with **no dtype
+  constraint**. `_share_offsets` branches only on string-vs-numeric and never
+  inspects `.data.dtype`.
+- `_FlatVariants.fields: dict[str, Any]` (`_flat_variants.py:341`) is generic.
+- SVAR1's `Number=G` custom fields already flow end-to-end **at their own on-disk
+  dtype** (`_haps.py:444-452`), never coerced.
+
+Widening would therefore be a lossy solution to a non-problem (and would lose
+precision for `i32` above 2²⁴). Missing values stay exactly as written —
+`i*::MIN` / `u*::MAX` / `NaN`, present only when `default` is `None` — and are
+documented, not translated.
+
+### 5. Python surface — `decode(fields=…)`
+
+SVAR1 parity (`SparseVar`'s `fields=` / `with_fields` / `available_fields`):
+
+```python
+sv = SparseVar2(path, fields=["DS"])       # or sv.with_fields(["DS"])
+sv.available_fields                        # {"DS": ("format", dtype("float32")), ...}
+rag = sv.decode("chr1", regions)
+# rag: pos, ilen, allele, DS — all sharing ONE offsets object, shape (R, S, P, None)
+```
+
+- **INFO is duplicated per carrier entry** — that is already how it is stored in
+  var_key, and it keeps the decoded `Ragged` uniform.
+- **Non-carrier FORMAT loss is invisible here.** `decode` only ever emits carrier
+  records, so spec #1's Option-A limitation cannot be observed on this surface.
+- **Name collisions**: INFO `DP` and FORMAT `DP` are already namespaced on disk.
+  The canonical key is the **bare name when unique across categories**, and
+  bcftools-style **`INFO/DP` / `FORMAT/DP`** when not. `available_fields` always
+  reports canonical keys.
+- Arrays come back in the **stored dtype**.
+
+### 6. What does *not* change
+
+- No new field arrays on `BatchResult`/`BatchResultSplit` (only `vk_src`).
+- No field selection state on `ContigReader`.
+- The `overlap_batch`/`read_ranges`/`gather_ranges` Python dict contract gains
+  `vk_src` and nothing else.
+- Adding a 2nd or 10th field costs genoray **nothing** at query time.
+
+### 7. Dependent (gvl-side, not this spec)
+
+Tracked here so spec #3 can sequence, but implemented in GenVarLoader's own PR:
+
+- `_svar2_haps.py:174` / `:256` — wire `available_var_fields` / `var_field_data`
+  for SVAR2, and push a value per decoded record inside
+  `decode_variants_from_split` (`GenVarLoader/src/svar2/mod.rs:282`, at the
+  `pos`/`ilen` push site `:367-368`).
+- **Perf note:** gvl's gather/compact kernels export only `i32`/`f32`
+  monomorphizations of already-generic Rust cores, with a **dtype-preserving
+  numpy-loop fallback**. SVAR2 auto-narrows integers to the smallest lossless
+  width, so `i8`/`i16` fields would land on the slow fallback path. Correct, but
+  quietly slow at exactly the widths SVAR2 prefers — worth exporting the extra
+  monomorphizations.
+- **Pre-existing bug (SVAR1-side):** `_impl.py:1443-1445` looks a non-builtin
+  field up in `variants.info`, but custom FORMAT fields are deliberately excluded
+  from `info` (`_haps.py:445`) → `KeyError` in memory estimation. Needs a
+  `var_field_data` branch.
+
+## Testing strategy
+
+- **Rust unit:** `FieldView` element access across every dtype (incl. `f16`,
+  `bool`) and both index kinds; dense FORMAT striding against a **subset**
+  query, asserting it uses the *original* cohort sample index (this is the
+  easiest thing in the design to get wrong).
+- **Rust unit:** `pack_vk_src` round-trip; the 2³¹ assert fires.
+- **Rust unit:** `merge_by_position` preserves the stable snp-before-indel
+  tie-break for both `KeyRef` and `(KeyRef, u32)`; `vk_src` stays aligned to `vk`
+  through a merge with **filtered** runs (the case that motivates `.enumerate()`).
+- **Golden/oracle:** existing readbound-vs-union oracle
+  (`oracle::gather_ranges_readbound`, `tests/test_readbound_gather.rs`) extends
+  to assert `vk_src` agreement between the two paths.
+- **e2e (Python):** convert a fixture with `from_vcf(info_fields=…,
+  format_fields=…)`, then `decode(fields=…)` and check values against the source
+  VCF at every carrier; missing → `default`/sentinel; INFO duplicated per
+  carrier; stored dtype preserved; `INFO/DP` vs `FORMAT/DP` disambiguation.
+- **Regression:** a no-fields `decode`/gather must be byte-identical to today's
+  output (guards the zero-cost claim).
+
+## Documentation / housekeeping
+
+- `skills/genoray-api/SKILL.md` — **mandatory** per `CLAUDE.md`'s public-API
+  rule: `SparseVar2(fields=…)`, `with_fields`, `available_fields`,
+  `decode(fields=…)`, the canonical field-key convention, dtype/missing
+  semantics.
+- `CHANGELOG.md` — entry under `## Unreleased` (`feat:`).
+- Reconcile the SVAR2 roadmap/data-model docs with the read path.
+- Unblock and finish [`2026-07-11-svar1-to-svar2-conversion-design.md`](2026-07-11-svar1-to-svar2-conversion-design.md).
+
+## Milestones
+
+1. **`FieldView` (public) + `vk_src` + `merge_by_position`.** Unblocks gvl to
+   read any field lazily, and unblocks spec #3.
+2. **Python `decode(fields=…)`** — `Ragged` on shared offsets, stored dtype,
+   canonical field keys.
+
+## Rejected alternatives
+
+- **Materialize per-channel field arrays on `BatchResultSplit`.** Costs
+  `n_selected_samples × dense_len` per query for dense FORMAT, scales with field
+  count, and buys nothing: gvl already holds the channel index at emit time.
+  Rejected in favour of lazy `FieldView` lookup.
+- **Widen everything to `f32` at the seam.** Rejected — see §4; gvl's containers
+  are already dtype-generic, and widening is lossy above 2²⁴.
+- **Grow `KeyRef` to carry provenance.** Would grow it 8→12 bytes in the hottest
+  structure in the query path and churn the frozen `vk_pos`/`vk_key` Python
+  contract. A parallel `vk_src` keeps `KeyRef` 8 bytes and `Copy`.

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -9,7 +9,12 @@ from natsort import natsorted
 import genoray._core as _core
 from genoray._svar2_batch import _BatchQueryMixin
 from genoray._svar2_decode import _DecodeMixin
-from genoray._svar2_fields import _resolve_fields
+from genoray._svar2_fields import (
+    StoredField,
+    _load_field_manifest,
+    _resolve_fields,
+    _resolve_read_fields,
+)
 from genoray._svar2_mutcat import _MutcatMixin
 
 if TYPE_CHECKING:
@@ -45,13 +50,21 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
     (raw two-channel result) and M6c (decoded ``seqpro.rag.Ragged``).
     """
 
-    def __init__(self, path: str | Path) -> None:
+    def __init__(
+        self, path: str | Path, *, fields: "Sequence[str] | None" = None
+    ) -> None:
         self.path = Path(path)
         meta = json.loads((self.path / "meta.json").read_text())
         self.format_version: int = meta["format_version"]
         self.available_samples: list[str] = list(meta["samples"])
         self.contigs: list[str] = list(meta["contigs"])
         self.ploidy: int = meta["ploidy"]
+        self.available_fields: dict[str, StoredField] = _load_field_manifest(meta)
+        #: The fields this reader decodes. Empty unless opted into via
+        #: ``fields=`` / :meth:`with_fields` — decoding a field costs extra I/O.
+        self._fields: list[StoredField] = _resolve_read_fields(
+            fields, self.available_fields
+        )
         self._readers: dict[str, _core.PyContigReader] = {
             contig: _core.PyContigReader(
                 str(self.path), contig, len(self.available_samples), self.ploidy
@@ -62,6 +75,15 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
     @property
     def n_samples(self) -> int:
         return len(self.available_samples)
+
+    def with_fields(self, fields: "Sequence[str]") -> "SparseVar2":
+        """A new reader over the same store that also decodes ``fields``.
+
+        Keys are those of :attr:`available_fields`: the bare field name when it
+        is unique across INFO/FORMAT, else bcftools-style ``INFO/DP`` /
+        ``FORMAT/DP``.
+        """
+        return SparseVar2(self.path, fields=fields)
 
     @classmethod
     def from_vcf(

--- a/python/genoray/_svar2_decode.py
+++ b/python/genoray/_svar2_decode.py
@@ -18,18 +18,39 @@ class _DecodeMixin:
     # and ploidy are @property on the host, so they can't be redeclared as plain
     # attributes here without a bad-override; they're accessed via an ignore below.)
     _readers: dict[str, Any]
+    _fields: list[Any]
+    path: Any
 
     def decode(self, contig: str, regions: Iterable[tuple[int, int]]) -> "Ragged":
         """Materialize overlapping variants for ``contig`` into a record ``Ragged``.
 
         Fields ``pos`` (i32), ``ilen`` (i32), ``allele`` (opaque-string ALT bytes),
-        one shared variant-axis offsets object, shape ``(R, S, P, None)`` — the same
-        layout as gvl's ``RaggedVariants``. Pure-deletion ALT is empty.
+        plus one entry per selected INFO/FORMAT field (see
+        :meth:`SparseVar2.with_fields`) — every one sharing a single variant-axis
+        offsets object, shape ``(R, S, P, None)``, the same layout as gvl's
+        ``RaggedVariants``. Pure-deletion ALT is empty.
+
+        Field values come back in the dtype they are STORED as (SVAR2
+        losslessly auto-narrows integers), and VCF-missing entries carry the
+        store's ``default`` or its reserved sentinel (``NaN`` for floats,
+        ``iinfo.min``/``iinfo.max`` for ints) — neither is translated.
         """
         from seqpro.rag import Ragged
 
+        from genoray._svar2_fields import _META_DTYPE
+
         reg = [(int(s), int(e)) for s, e in regions]
-        d = self._readers[contig].decode_batch(reg)
+        reader = self._readers[contig]
+        if not self._fields:
+            d = reader.decode_batch(reg)
+        else:
+            d = reader.decode_batch_fields(
+                reg,
+                [(f.category, f.name, _META_DTYPE[f.dtype]) for f in self._fields],
+                str(self.path),
+                contig,
+            )
+
         shape = (d["n_regions"], d["n_samples"], d["ploidy"], None)
         off = d["off"]
         pos = Ragged.from_offsets(d["pos"], shape, off)
@@ -39,7 +60,23 @@ class _DecodeMixin:
         )
         # If a consumer hits an error reading `.lengths` on a (2, N) offsets
         # layout, call `.to_packed()` first — a known seqpro slicing quirk.
-        return Ragged.from_fields({"pos": pos, "ilen": ilen, "allele": allele})
+        rec: dict[str, Ragged] = {"pos": pos, "ilen": ilen, "allele": allele}
+        for f in self._fields:
+            # Rust hands back raw little-endian bytes + an itemsize; the dtype is
+            # applied here (same trick as `allele`), so Rust does no dtype
+            # dispatch. `.view` is zero-copy.
+            raw: np.ndarray = d[f"field_{f.category}/{f.name}"]
+            itemsize = d[f"field_itemsize_{f.category}/{f.name}"]
+            if itemsize != f.dtype.itemsize:
+                # A width/dtype disagreement would silently reinterpret the
+                # bytes into wrong values — fail loudly instead.
+                raise ValueError(
+                    f"field {f.key!r}: store wrote {itemsize}-byte elements but "
+                    f"meta.json declares {f.dtype} ({f.dtype.itemsize} bytes)"
+                )
+            vals = raw.view(f.dtype)
+            rec[f.key] = Ragged.from_offsets(vals, shape, off)
+        return Ragged.from_fields(rec)
 
     def region_counts(
         self, contig: str, regions: Iterable[tuple[int, int]]

--- a/python/genoray/_svar2_fields.py
+++ b/python/genoray/_svar2_fields.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
 
+import numpy as np
 from cyvcf2 import VCF as _CyVCF
 
 FieldDtype = Literal["bool", "i8", "u8", "i16", "u16", "i32", "u32", "f16", "f32"]
@@ -106,3 +107,88 @@ def _resolve_fields(
         return out
     finally:
         vcf.close()
+
+
+#: Storage dtype (meta.json `fields[].dtype`) -> numpy dtype. The 9 dtypes the
+#: writer can resolve to; `bool` is stored as one byte per element.
+NP_DTYPE: dict[str, np.dtype] = {
+    "bool": np.dtype("bool"),
+    "i8": np.dtype("int8"),
+    "u8": np.dtype("uint8"),
+    "i16": np.dtype("int16"),
+    "u16": np.dtype("uint16"),
+    "i32": np.dtype("int32"),
+    "u32": np.dtype("uint32"),
+    "f16": np.dtype("float16"),
+    "f32": np.dtype("float32"),
+}
+
+
+@dataclass(frozen=True)
+class StoredField:
+    """A field present in a finished SVAR2 store, as declared by ``meta.json``.
+
+    ``key`` is the canonical name callers use: the bare ``name`` when it is
+    unique across categories, else bcftools-style ``INFO/<name>`` /
+    ``FORMAT/<name>``. ``default`` is the fill written for VCF-missing entries;
+    when it is ``None`` the store instead uses a reserved sentinel
+    (``iinfo.min`` / ``iinfo.max`` / ``NaN``), which is returned as-is.
+    """
+
+    name: str
+    category: Literal["info", "format"]
+    dtype: np.dtype
+    default: float | None
+    key: str
+
+
+def _load_field_manifest(meta: dict) -> dict[str, StoredField]:
+    """Parse ``meta.json``'s ``fields`` array into canonical-key -> StoredField.
+
+    A store written before fields existed simply has no ``fields`` key; that is
+    an empty manifest, not an error (same for an empty ``fields`` array).
+    """
+    entries = meta.get("fields") or []
+    counts: dict[str, int] = {}
+    for e in entries:
+        counts[e["name"]] = counts.get(e["name"], 0) + 1
+
+    out: dict[str, StoredField] = {}
+    for e in entries:
+        name = e["name"]
+        category = e["category"]
+        dtype_str = e["dtype"]
+        if dtype_str not in NP_DTYPE:
+            raise ValueError(
+                f"field {name!r} has unsupported stored dtype {dtype_str!r}; "
+                "the store may be corrupt or written by a newer genoray"
+            )
+        key = name if counts[name] == 1 else f"{category.upper()}/{name}"
+        out[key] = StoredField(
+            name=name,
+            category=category,
+            dtype=NP_DTYPE[dtype_str],
+            default=e.get("default"),
+            key=key,
+        )
+    return out
+
+
+def _resolve_read_fields(
+    requested: Sequence[str] | None, available: dict[str, StoredField]
+) -> list[StoredField]:
+    """Validate a field selection against the store's manifest.
+
+    ``None`` selects nothing (fields are opt-in — decoding them costs I/O).
+    """
+    if requested is None:
+        return []
+    out: list[StoredField] = []
+    for key in requested:
+        if key not in available:
+            raise ValueError(
+                f"field {key!r} is not in this store; available fields: "
+                f"{sorted(available)}"
+            )
+        out.append(available[key])
+    return out

--- a/python/genoray/_svar2_fields.py
+++ b/python/genoray/_svar2_fields.py
@@ -124,6 +124,10 @@ NP_DTYPE: dict[str, np.dtype] = {
 }
 
 
+#: numpy dtype -> the `meta.json` storage-dtype string the Rust side expects.
+_META_DTYPE: dict[np.dtype, str] = {v: k for k, v in NP_DTYPE.items()}
+
+
 @dataclass(frozen=True)
 class StoredField:
     """A field present in a finished SVAR2 store, as declared by ``meta.json``.

--- a/python/genoray/_svar2_fields.py
+++ b/python/genoray/_svar2_fields.py
@@ -153,6 +153,9 @@ def _load_field_manifest(meta: dict) -> dict[str, StoredField]:
     for e in entries:
         counts[e["name"]] = counts.get(e["name"], 0) + 1
 
+    # Invariant: a well-formed writer never emits duplicate (name, category)
+    # pairs, so `key` collisions here can't happen in practice. If they did,
+    # the later entry would silently overwrite the earlier one in `out`.
     out: dict[str, StoredField] = {}
     for e in entries:
         name = e["name"]

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -17,7 +17,7 @@ description: Use when writing or modifying Python code that imports `genoray` to
 - `genoray.VCF` — VCF/BCF reader
 - `genoray.Filter` — VCF filter value object bundling a cyvcf2 record predicate (`record`) with its matching `.gvi` polars expression (`expr`)
 - `genoray.SparseVar` — sparse `.svar` reader/writer
-- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`; scalar-numeric INFO/FORMAT field extraction during the write via `from_vcf(info_fields=, format_fields=)`)
+- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`; scalar-numeric INFO/FORMAT field extraction during the write via `from_vcf(info_fields=, format_fields=)`, read back opt-in via `fields=`/`with_fields`/`available_fields` and attached to `decode`'s result)
 - `genoray.InfoField` / `genoray.FormatField` — frozen dataclasses (`name`, `dtype=None`, `default=None`) configuring a single INFO/FORMAT field for `SparseVar2.from_vcf`; a bare `str` name uses inferred defaults instead
 - `genoray.exprs` — polars filter expressions for `.gvi` indexes
 - `genoray.cosmic_signatures` — fetch/cache COSMIC reference signatures
@@ -36,8 +36,8 @@ Prefer reading these over guessing:
 - `genoray/_vcf.py` — `VCF` class: constructor, `read`, `chunk`, mode constants near the top of the class; `get_record_info(contig=None, start=None, end=None, fields=None, info=None, lazy=False)` — non-FORMAT record-level fields (including INFO) for a range or the whole file, returns `pl.DataFrame` (or `pl.LazyFrame` when `lazy=True`)
 - `genoray/_pgen.py` — `PGEN` class: constructor, `read`, `chunk`, `read_ranges`, `chunk_ranges`, mode constants near the top of the class
 - `genoray/_svar.py` — `SparseVar`: `__init__`, `from_vcf`, `from_pgen`, `read_ranges`, `read_ranges_with_length(contig, starts=0, ends=POS_MAX, samples=None)` (length-guaranteed range read; returns the same type as `read_ranges` — a `Ragged` or fields-augmented record), `with_fields`, `annotate_mutations`, `mutation_matrix`, `assign_signatures`, `annotate_with_gtf(gtf, level_filter=1, write_back=True, *, strand_encoding=None, codon_null_token=None)` (GTF CDS annotation entry point, returns `pl.DataFrame` with `varID`/`gene_id`/`strand`/`codon_pos`), `cache_afs()` (computes and persists an `AF` column to the `.gvi` index; returns `None`)
-- `genoray/_svar2.py` — `SparseVar2`: `__init__`, `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write, `info_fields=`/`format_fields=` extract scalar-numeric fields during the write); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode`, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
-- `genoray/_svar2_fields.py` — `InfoField`/`FormatField` dataclasses + `FieldDtype` and the header/dtype validation used by `from_vcf(info_fields=, format_fields=)` (no public read-side API yet)
+- `genoray/_svar2.py` — `SparseVar2`: `__init__(path, *, fields=None)`, `with_fields(fields)` (new reader over the same store with those fields selected), `available_fields` (`dict[str, StoredField]`, set in `__init__`), `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write, `info_fields=`/`format_fields=` extract scalar-numeric fields during the write); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode` — attaches one `Ragged` per selected field, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
+- `genoray/_svar2_fields.py` — `InfoField`/`FormatField` dataclasses + `FieldDtype` and the header/dtype validation used by `from_vcf(info_fields=, format_fields=)`; `StoredField` (frozen dataclass: `name`, `category`, `dtype`, `default`, `key`) is the read-side manifest entry type returned by `SparseVar2.available_fields` — not exported at top-level `genoray`, only reached via that dict
 - `genoray/_cli/__main__.py` — the `genoray` CLI (`index`, `write` / `write svar1`, `view`)
 - `genoray/_signatures.py` — `cosmic_signatures`, `fit_signatures`
 - `genoray/_reference.py` — `Reference`: `from_path`, `fetch`, `contig_array`
@@ -311,10 +311,9 @@ Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_ou
     dense-routed variants. Non-carrier FORMAT values (e.g. an imputed
     dosage at a ref/ref genotype) are **dropped by design** in this version;
     an independent lossless FORMAT stream is deferred to a future spec.
-  - **No read path yet** — this only controls what gets written. Querying
-    stored field values back out (a decode/query API) is not implemented;
-    see `meta.json`'s `"fields"` array and `docs/roadmap/data-model.md` for
-    the on-disk layout if you need to inspect values directly.
+  - **Read path:** see "Reading INFO/FORMAT fields (SVAR2)" below —
+    `SparseVar2(path, fields=…)` / `.with_fields(…)` / `.available_fields`
+    opt into decoding these back out via `decode()`.
 
 ### Range queries
 
@@ -331,7 +330,9 @@ regions = [(0, 40), (1_000, 2_000)]   # 0-based half-open [start, end)
 
 # Analysis path — decode to a seqpro Ragged record (one call per contig)
 rag = sv.decode("chr1", regions)      # fields pos (i32), ilen (i32), allele (ALT bytes)
-                                      # shape (R, S, P, None); pure-DEL ALT is empty
+                                      # + one per selected field (see "Reading
+                                      # INFO/FORMAT fields" below); shape
+                                      # (R, S, P, None); pure-DEL ALT is empty
 
 # Decode-free per-(region, sample, ploid) variant count — replaces SVAR 1.0's var_ranges
 counts = sv.region_counts("chr1", regions)   # np.ndarray, shape (R, S, P)
@@ -362,6 +363,50 @@ scalars `n_regions`/`n_samples`/`ploidy`.
 the search/gather split used by a write-time overlap cache. They are **not**
 part of the public API, are not covered by semver, and may change or
 disappear without notice; don't call them from user code.
+
+### Reading INFO/FORMAT fields (SVAR2)
+
+Fields written by `from_vcf(info_fields=…, format_fields=…)` (above) are read
+back by opting in — they are **not** decoded by default (each one costs extra
+I/O).
+
+```python
+sv = SparseVar2("out.svar2")
+sv.available_fields                    # {"AF": StoredField(...), "DS": StoredField(...)}
+
+sv = sv.with_fields(["AF", "DS"])       # or SparseVar2("out.svar2", fields=["AF", "DS"])
+rag = sv.decode("chr1", [(0, 10_000)])
+rag["AF"]                              # Ragged, sharing offsets with pos/ilen/allele
+```
+
+- `SparseVar2(path, *, fields=None)` / `.with_fields(fields)` — `fields` is a
+  `Sequence[str]` of canonical keys (see `available_fields` below).
+  `with_fields` returns a **new** `SparseVar2` over the same store; it does
+  not mutate the original in place. `fields=None` (the constructor default)
+  selects nothing — fields are opt-in.
+- `available_fields -> dict[str, StoredField]` — every field declared in the
+  store's `meta.json`, keyed canonically: the bare field name when it is
+  unique across INFO and FORMAT, else bcftools-style `INFO/DP` / `FORMAT/DP`
+  when a name is used by both categories. `StoredField` (defined in
+  `genoray._svar2_fields`, not exported at top-level `genoray`) is a frozen
+  dataclass: `name`, `category` (`"info"`/`"format"`), `dtype` (`np.dtype`),
+  `default` (`float | None`), `key`.
+- `decode(contig, regions)` attaches one `Ragged` per selected field to the
+  returned record `Ragged`, alongside `pos`/`ilen`/`allele` — every one
+  sharing a single variant-axis offsets object, shape `(R, S, P, None)`.
+  Access a field's data via `rag["KEY"]` (`Ragged.__getitem__`), **not**
+  `rag.fields["KEY"]` — `Ragged.fields` is just the `list[str]` of field
+  names on the record.
+- **Dtype is preserved as stored.** SVAR2 losslessly auto-narrows integer
+  fields at write time, so e.g. an `AC` field may come back as `int8`;
+  nothing is widened on read.
+- **Missing values** are the field's `default` if one was set at write time,
+  else a reserved sentinel (`NaN` for floats, `iinfo.min`/`iinfo.max` for
+  ints) — returned as-is, never translated.
+- FORMAT fields are genotype-aligned (see `from_vcf`'s `format_fields=`
+  above) — `decode()` only ever emits carrier records, so the "non-carrier
+  values aren't stored" caveat from the write path is invisible on this
+  read surface.
 
 ### Mutational signatures (SBS96 / DBS78 / ID83)
 
@@ -755,6 +800,8 @@ plotting.
 | Calling `write_view` and expecting `mutcat` to be in the output | `write_view` **never** copies `mutcat` positionally (subsetting invalidates DBS adjacency codes). Pass `reference=` to `write_view` to recompute it on the subset, or call `annotate_mutations` on the output view yourself. Explicitly including `"mutcat"` in `fields=` without a `reference=` raises `ValueError`. |
 | Passing the source dataset directory as `output` to `write_view` (even with `overwrite=True`) | Raises `ValueError` — writing in place would delete the source before the view is written. Pass a different `output` path. |
 | Passing a FASTA path directly to `annotate_mutations` | Supported — it auto-wraps via `Reference.from_path` |
+| `rag.fields["AF"]` on a `SparseVar2.decode()` result | `Ragged.fields` is a `list[str]` of names, not a mapping; index the field itself with `rag["AF"]` |
+| Expecting `SparseVar2.decode()` to include INFO/FORMAT fields | Fields are opt-in — pass `fields=[...]` to `SparseVar2(...)` or call `.with_fields([...])` first |
 
 ## When this skill needs updating
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -59,6 +59,16 @@ impl StorageDtype {
         })
     }
 
+    /// Parse a finalized `meta.json` `fields[].dtype` string. Returns `None` for
+    /// `"auto"` — finalize always resolves `Auto` to a concrete dtype, so `auto`
+    /// on disk means the store is corrupt or was never finalized.
+    pub fn from_meta_str(s: &str) -> Option<Self> {
+        match Self::parse(s) {
+            Some(Self::Auto) | None => None,
+            Some(d) => Some(d),
+        }
+    }
+
     /// Lowercase on-disk/`meta.json` name. `Auto` never reaches here in
     /// practice (finalize always resolves it to a concrete dtype first), but
     /// maps to `"auto"` rather than panicking so this stays a total function.
@@ -183,5 +193,18 @@ mod tests {
     fn parse_manifest_rejects_bad_category() {
         let raw = vec![("X".into(), "bogus".into(), "int".into(), None, None)];
         assert!(parse_manifest(raw).is_err());
+    }
+
+    #[test]
+    fn test_from_meta_str_rejects_auto() {
+        assert_eq!(StorageDtype::from_meta_str("f16"), Some(StorageDtype::F16));
+        assert_eq!(StorageDtype::from_meta_str("i8"), Some(StorageDtype::I8));
+        assert_eq!(
+            StorageDtype::from_meta_str("bool"),
+            Some(StorageDtype::Bool)
+        );
+        // `auto` is never a finalized on-disk dtype.
+        assert_eq!(StorageDtype::from_meta_str("auto"), None);
+        assert_eq!(StorageDtype::from_meta_str("nonsense"), None);
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -28,6 +28,37 @@ impl MutcatSub {
     }
 }
 
+/// The four sub-streams a field sidecar mirrors. Same four directories as
+/// `MutcatSub`, but kept separate: field dirs live under `fields/{category}/`
+/// and gain no `has_ref` notion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldSub {
+    VkSnp,
+    VkIndel,
+    DenseSnp,
+    DenseIndel,
+}
+
+impl FieldSub {
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            FieldSub::VkSnp => "var_key_snp",
+            FieldSub::VkIndel => "var_key_indel",
+            FieldSub::DenseSnp => "dense_snp",
+            FieldSub::DenseIndel => "dense_indel",
+        }
+    }
+    /// Every sub-stream, in a fixed order (for iteration at open/finalize time).
+    pub fn all() -> [FieldSub; 4] {
+        [
+            FieldSub::VkSnp,
+            FieldSub::VkIndel,
+            FieldSub::DenseSnp,
+            FieldSub::DenseIndel,
+        ]
+    }
+}
+
 pub struct ContigPaths {
     base_out_dir: String,
     chrom: String,
@@ -94,6 +125,18 @@ impl ContigPaths {
     /// Directory created before writing a sidecar sub-stream.
     pub fn mutcat_sub_dir(&self, sub: MutcatSub) -> PathBuf {
         self.mutcat_dir(sub)
+    }
+
+    /// `{out}/{contig}/fields/{category}/{name}/{sub}/values.bin`.
+    /// `category` is `"info"` or `"format"` (see `FieldCategory::as_str`).
+    pub fn field_values(&self, category: &str, name: &str, sub: FieldSub) -> PathBuf {
+        Path::new(&self.base_out_dir)
+            .join(&self.chrom)
+            .join("fields")
+            .join(category)
+            .join(name)
+            .join(sub.dir_name())
+            .join("values.bin")
     }
 }
 
@@ -242,6 +285,19 @@ mod tests {
         assert_eq!(
             dense_max_del(contig),
             Path::new("/out/chr1/dense/max_del.npy")
+        );
+    }
+
+    #[test]
+    fn test_field_values_paths() {
+        let paths = ContigPaths::new("/out", "chr1");
+        assert_eq!(
+            paths.field_values("format", "DS", FieldSub::VkSnp),
+            Path::new("/out/chr1/fields/format/DS/var_key_snp/values.bin")
+        );
+        assert_eq!(
+            paths.field_values("info", "AF", FieldSub::DenseIndel),
+            Path::new("/out/chr1/fields/info/AF/dense_indel/values.bin")
         );
     }
 

--- a/src/py_query_decode.rs
+++ b/src/py_query_decode.rs
@@ -7,9 +7,193 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::bits;
+use crate::field::StorageDtype;
+use crate::layout::{ContigPaths, FieldSub};
 use crate::py_convert::{i32_to_pyarray, u8_to_pyarray};
 use crate::py_query::PyContigReader;
-use crate::query::overlap_batch;
+use crate::query::gather::overlap_batch_src;
+use crate::query::{BatchResult, ContigReader, FieldValue, FieldView, overlap_batch};
+
+/// The two legal field categories `decode_batch_fields` accepts. Parsing the
+/// caller-supplied `category: &str` into this enum up front means a typo (or
+/// any other garbage string) surfaces as a Python `ValueError` from
+/// `OpenField::open`, rather than silently opening four empty sub-streams
+/// (`FieldView::open`'s "missing file = legal empty sub-stream" contract) and
+/// panicking later in `bytes_at`/`value_at` — which would cross FFI as an
+/// opaque `PanicException`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldCategoryArg {
+    Info,
+    Format,
+}
+
+impl FieldCategoryArg {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "info" => Some(Self::Info),
+            "format" => Some(Self::Format),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Format => "format",
+        }
+    }
+}
+
+/// Why `OpenField::open` failed, kept distinct from a `PyErr` so the helper
+/// stays plain Rust (testable with no `Python<'py>`/GIL) and the pymethod
+/// wrapper decides the exact exception type.
+#[derive(Debug)]
+pub enum OpenFieldError {
+    /// Bad `category` string or unresolved/unknown `dtype` string — a
+    /// `ValueError` in Python: the caller passed a bad manifest entry.
+    BadInput(String),
+    /// The on-disk sidecar could not be mmap'd — an `OSError` in Python.
+    Io(std::io::Error),
+}
+
+impl OpenFieldError {
+    fn into_pyerr(self) -> PyErr {
+        match self {
+            Self::BadInput(msg) => pyo3::exceptions::PyValueError::new_err(msg),
+            Self::Io(e) => pyo3::exceptions::PyOSError::new_err(e.to_string()),
+        }
+    }
+}
+
+/// One requested field's four open sub-stream views (`FieldSub::all()` order:
+/// `VkSnp, VkIndel, DenseSnp, DenseIndel`), plus the metadata
+/// `gather_field_bytes` needs to select the right sub-stream and stride a
+/// dense-FORMAT column correctly.
+pub struct OpenField {
+    key: String,
+    is_format: bool,
+    width: usize,
+    views: [FieldView; 4],
+}
+
+impl OpenField {
+    /// Open all four sub-streams for one `(category, name)` field at
+    /// `base_dir`/`contig`. `dtype_str` is the finalized `meta.json` dtype
+    /// string. Fails on a bad category, an unresolved/unknown dtype, or an
+    /// I/O error opening a sidecar — never panics.
+    pub fn open(
+        paths: &ContigPaths,
+        category: &str,
+        name: &str,
+        dtype_str: &str,
+        n_samples_cohort: usize,
+    ) -> Result<Self, OpenFieldError> {
+        let cat = FieldCategoryArg::parse(category)
+            .ok_or_else(|| OpenFieldError::BadInput(format!("bad field category {category:?}")))?;
+        let dtype = StorageDtype::from_meta_str(dtype_str).ok_or_else(|| {
+            OpenFieldError::BadInput(format!(
+                "field {name:?} has unresolved/unknown dtype {dtype_str:?}"
+            ))
+        })?;
+        let width = dtype
+            .width_bytes()
+            .expect("from_meta_str rejects unresolved dtypes");
+        let mut views = Vec::with_capacity(4);
+        for sub in FieldSub::all() {
+            views.push(
+                FieldView::open(paths, cat.as_str(), name, sub, dtype, n_samples_cohort)
+                    .map_err(OpenFieldError::Io)?,
+            );
+        }
+        Ok(Self {
+            key: format!("{}/{name}", cat.as_str()),
+            is_format: cat == FieldCategoryArg::Format,
+            width,
+            views: views
+                .try_into()
+                .unwrap_or_else(|_| unreachable!("FieldSub::all() always yields exactly 4")),
+        })
+    }
+}
+
+/// Reduce a `FieldView` element to its raw little-endian bytes, left-aligned
+/// in a fixed 4-byte buffer (callers slice to `width`). Round-trips bit-exact
+/// for every `StorageDtype`: every variant was itself decoded via
+/// `from_le_bytes` in `FieldView::value_at`, so re-encoding via `to_le_bytes`
+/// reverses that exactly — no arithmetic, so NaN/sentinel bit patterns survive
+/// untouched.
+fn field_value_le_bytes(v: FieldValue) -> [u8; 4] {
+    match v {
+        FieldValue::Bool(b) => [b as u8, 0, 0, 0],
+        FieldValue::I8(x) => [x as u8, 0, 0, 0],
+        FieldValue::U8(x) => [x, 0, 0, 0],
+        FieldValue::I16(x) => {
+            let b = x.to_le_bytes();
+            [b[0], b[1], 0, 0]
+        }
+        FieldValue::U16(x) => {
+            let b = x.to_le_bytes();
+            [b[0], b[1], 0, 0]
+        }
+        FieldValue::I32(x) => x.to_le_bytes(),
+        FieldValue::U32(x) => x.to_le_bytes(),
+        FieldValue::F16(x) => {
+            let b = x.to_le_bytes();
+            [b[0], b[1], 0, 0]
+        }
+        FieldValue::F32(x) => x.to_le_bytes(),
+    }
+}
+
+/// Gather one raw-bytes buffer per requested field, aligned 1:1 with `br`'s
+/// decoded records in exactly `decode_hap_src`'s record order (region-major
+/// `h = (r*n_samples + s)*ploidy + p`, then per-hap merge order). Pure Rust —
+/// no `Python<'py>` in the signature — so this is directly unit-testable with
+/// no GIL. `br` MUST come from `overlap_batch_src` (asserted transitively by
+/// `decode_hap_src`).
+///
+/// For a dense FORMAT field, the element is read via `FieldView::format_at`
+/// (dense row, ORIGINAL cohort sample index) rather than hand-deriving the
+/// `row * n_samples + sample` stride here — that formula has exactly one
+/// copy, in `FieldView::format_at` itself. Every other case (var_key, dense
+/// INFO) reads via `FieldView::value_at`, which `format_at` itself calls.
+pub fn gather_field_bytes(
+    reader: &ContigReader,
+    br: &BatchResult,
+    fields: &[OpenField],
+) -> Vec<Vec<u8>> {
+    let mut fbytes: Vec<Vec<u8>> = vec![Vec::new(); fields.len()];
+    for r in 0..br.n_regions {
+        for s in 0..br.n_samples {
+            for p in 0..br.ploidy {
+                let (_, srcs) = br.decode_hap_src(reader, r, s, p);
+                for src in srcs {
+                    // FieldSub::all() order: VkSnp, VkIndel, DenseSnp, DenseIndel
+                    let sub_ix = match (src.is_dense, src.is_indel) {
+                        (false, false) => 0,
+                        (false, true) => 1,
+                        (true, false) => 2,
+                        (true, true) => 3,
+                    };
+                    for (fi, f) in fields.iter().enumerate() {
+                        let view = &f.views[sub_ix];
+                        // Dense FORMAT strides by the ORIGINAL cohort sample
+                        // index. `s` here is already the cohort index because
+                        // `overlap_batch_src` runs over the whole cohort.
+                        let value = if src.is_dense && f.is_format {
+                            view.format_at(src.idx, s)
+                        } else {
+                            view.value_at(src.idx)
+                        };
+                        let bytes = field_value_le_bytes(value);
+                        fbytes[fi].extend_from_slice(&bytes[..f.width]);
+                    }
+                }
+            }
+        }
+    }
+    fbytes
+}
 
 #[pymethods]
 impl PyContigReader {
@@ -60,6 +244,10 @@ impl PyContigReader {
     /// 1:1 with the decoded records. `fields` is `(category, name, dtype_str)`.
     /// Values are returned as little-endian bytes + an itemsize; Python applies
     /// the numpy dtype (same trick as `allele`), so Rust does no dtype dispatch.
+    ///
+    /// Thin marshalling wrapper: `OpenField::open` + `gather_field_bytes` do the
+    /// actual work and are plain Rust (no `Python<'py>`), so they are covered by
+    /// a Rust-only test in `tests/test_field_provenance.rs` with no GIL needed.
     #[pyo3(signature = (regions, fields, base_dir, contig))]
     pub fn decode_batch_fields<'py>(
         &self,
@@ -69,44 +257,16 @@ impl PyContigReader {
         base_dir: &str,
         contig: &str,
     ) -> PyResult<Bound<'py, PyDict>> {
-        use crate::field::StorageDtype;
-        use crate::layout::{ContigPaths, FieldSub};
-        use crate::query::{FieldView, gather::overlap_batch_src};
-
         let br = overlap_batch_src(&self.inner, &regions);
         let paths = ContigPaths::new(base_dir, contig);
         let n_samples_cohort = self.inner.n_samples();
 
-        // Open the four sub-stream views per field up front.
-        struct OpenField {
-            key: String,
-            is_format: bool,
-            width: usize,
-            views: [FieldView; 4], // indexed by FieldSub::all() order
-        }
         let mut open: Vec<OpenField> = Vec::with_capacity(fields.len());
         for (category, name, dtype_str) in &fields {
-            let dtype = StorageDtype::from_meta_str(dtype_str).ok_or_else(|| {
-                pyo3::exceptions::PyValueError::new_err(format!(
-                    "field {name:?} has unresolved/unknown dtype {dtype_str:?}"
-                ))
-            })?;
-            let width = dtype
-                .width_bytes()
-                .expect("from_meta_str rejects unresolved dtypes");
-            let mut views = Vec::with_capacity(4);
-            for sub in FieldSub::all() {
-                views.push(
-                    FieldView::open(&paths, category, name, sub, dtype, n_samples_cohort)
-                        .map_err(|e| pyo3::exceptions::PyOSError::new_err(e.to_string()))?,
-                );
-            }
-            open.push(OpenField {
-                key: format!("{category}/{name}"),
-                is_format: category == "format",
-                width,
-                views: views.try_into().map_err(|_| ()).expect("exactly 4 subs"),
-            });
+            open.push(
+                OpenField::open(&paths, category, name, dtype_str, n_samples_cohort)
+                    .map_err(OpenFieldError::into_pyerr)?,
+            );
         }
 
         let mut pos: Vec<i32> = Vec::new();
@@ -114,43 +274,23 @@ impl PyContigReader {
         let mut allele: Vec<u8> = Vec::new();
         let mut str_off: Vec<i64> = vec![0];
         let mut off: Vec<i64> = vec![0];
-        let mut fbytes: Vec<Vec<u8>> = vec![Vec::new(); open.len()];
 
         for r in 0..br.n_regions {
             for s in 0..br.n_samples {
                 for p in 0..br.ploidy {
-                    let (hc, srcs) = br.decode_hap_src(&self.inner, r, s, p);
-                    for (i, &src) in srcs.iter().enumerate() {
+                    let hc = br.decode_hap(&self.inner, r, s, p);
+                    for i in 0..hc.positions.len() {
                         pos.push(hc.positions[i] as i32);
                         ilen.push(hc.ilens[i]);
                         allele.extend_from_slice(&hc.alts[i]);
                         str_off.push(allele.len() as i64);
-
-                        // FieldSub::all() order: VkSnp, VkIndel, DenseSnp, DenseIndel
-                        let sub_ix = match (src.is_dense, src.is_indel) {
-                            (false, false) => 0,
-                            (false, true) => 1,
-                            (true, false) => 2,
-                            (true, true) => 3,
-                        };
-                        for (fi, f) in open.iter().enumerate() {
-                            let view = &f.views[sub_ix];
-                            // Dense FORMAT strides by the ORIGINAL cohort sample
-                            // index. `s` here is already the cohort index because
-                            // `overlap_batch_src` runs over the whole cohort.
-                            let elem = if src.is_dense && f.is_format {
-                                view.bytes_at(src.idx * n_samples_cohort + s)
-                            } else {
-                                view.bytes_at(src.idx)
-                            };
-                            debug_assert_eq!(elem.len(), f.width);
-                            fbytes[fi].extend_from_slice(elem);
-                        }
                     }
                     off.push(pos.len() as i64);
                 }
             }
         }
+
+        let fbytes = gather_field_bytes(&self.inner, &br, &open);
 
         let d = PyDict::new(py);
         d.set_item("pos", i32_to_pyarray(py, &pos))?;

--- a/src/py_query_decode.rs
+++ b/src/py_query_decode.rs
@@ -12,7 +12,7 @@ use crate::layout::{ContigPaths, FieldSub};
 use crate::py_convert::{i32_to_pyarray, u8_to_pyarray};
 use crate::py_query::PyContigReader;
 use crate::query::gather::overlap_batch_src;
-use crate::query::{BatchResult, ContigReader, FieldValue, FieldView, overlap_batch};
+use crate::query::{BatchResult, ContigReader, FieldView, overlap_batch};
 
 /// The two legal field categories `decode_batch_fields` accepts. Parsing the
 /// caller-supplied `category: &str` into this enum up front means a typo (or
@@ -67,13 +67,17 @@ impl OpenFieldError {
 
 /// One requested field's four open sub-stream views (`FieldSub::all()` order:
 /// `VkSnp, VkIndel, DenseSnp, DenseIndel`), plus the metadata
-/// `gather_field_bytes` needs to select the right sub-stream and stride a
+/// `gather_batch_fields` needs to select the right sub-stream and stride a
 /// dense-FORMAT column correctly.
 pub struct OpenField {
     key: String,
     is_format: bool,
     width: usize,
     views: [FieldView; 4],
+    /// Cohort sample count, needed to compute the dense-FORMAT byte index
+    /// (`dense_row * n_samples_cohort + orig_sample`) without decoding through
+    /// `FieldView::format_at` (which returns a `FieldValue`, not raw bytes).
+    n_samples_cohort: usize,
 }
 
 impl OpenField {
@@ -112,62 +116,65 @@ impl OpenField {
             views: views
                 .try_into()
                 .unwrap_or_else(|_| unreachable!("FieldSub::all() always yields exactly 4")),
+            n_samples_cohort,
         })
     }
 }
 
-/// Reduce a `FieldView` element to its raw little-endian bytes, left-aligned
-/// in a fixed 4-byte buffer (callers slice to `width`). Round-trips bit-exact
-/// for every `StorageDtype`: every variant was itself decoded via
-/// `from_le_bytes` in `FieldView::value_at`, so re-encoding via `to_le_bytes`
-/// reverses that exactly — no arithmetic, so NaN/sentinel bit patterns survive
-/// untouched.
-fn field_value_le_bytes(v: FieldValue) -> [u8; 4] {
-    match v {
-        FieldValue::Bool(b) => [b as u8, 0, 0, 0],
-        FieldValue::I8(x) => [x as u8, 0, 0, 0],
-        FieldValue::U8(x) => [x, 0, 0, 0],
-        FieldValue::I16(x) => {
-            let b = x.to_le_bytes();
-            [b[0], b[1], 0, 0]
-        }
-        FieldValue::U16(x) => {
-            let b = x.to_le_bytes();
-            [b[0], b[1], 0, 0]
-        }
-        FieldValue::I32(x) => x.to_le_bytes(),
-        FieldValue::U32(x) => x.to_le_bytes(),
-        FieldValue::F16(x) => {
-            let b = x.to_le_bytes();
-            [b[0], b[1], 0, 0]
-        }
-        FieldValue::F32(x) => x.to_le_bytes(),
-    }
+/// Everything `decode_batch_fields` needs to marshal into a `PyDict`: the same
+/// flat record arrays `decode_batch` produces (`pos`/`ilen`/`allele`/`str_off`/
+/// `off`), plus one raw-bytes buffer per requested field — all built from a
+/// SINGLE per-hap decode pass (see `gather_batch_fields`).
+#[derive(Default)]
+pub struct DecodedFields {
+    pub pos: Vec<i32>,
+    pub ilen: Vec<i32>,
+    pub allele: Vec<u8>,
+    pub str_off: Vec<i64>,
+    pub off: Vec<i64>,
+    /// One entry per requested field, in request order.
+    pub fbytes: Vec<Vec<u8>>,
 }
 
-/// Gather one raw-bytes buffer per requested field, aligned 1:1 with `br`'s
-/// decoded records in exactly `decode_hap_src`'s record order (region-major
+/// Decode every hap in `br` EXACTLY ONCE (via `decode_hap_src`) and, from that
+/// single pass, produce both the flat record arrays (`decode_batch`'s shape)
+/// and one raw-bytes buffer per requested field, aligned 1:1 with the decoded
+/// records in exactly `decode_hap_src`'s order (region-major
 /// `h = (r*n_samples + s)*ploidy + p`, then per-hap merge order). Pure Rust —
 /// no `Python<'py>` in the signature — so this is directly unit-testable with
 /// no GIL. `br` MUST come from `overlap_batch_src` (asserted transitively by
 /// `decode_hap_src`).
 ///
-/// For a dense FORMAT field, the element is read via `FieldView::format_at`
-/// (dense row, ORIGINAL cohort sample index) rather than hand-deriving the
-/// `row * n_samples + sample` stride here — that formula has exactly one
-/// copy, in `FieldView::format_at` itself. Every other case (var_key, dense
-/// INFO) reads via `FieldView::value_at`, which `format_at` itself calls.
-pub fn gather_field_bytes(
+/// Each field element's bytes are copied VERBATIM via `FieldView::bytes_at`
+/// (never decoded to a `FieldValue` and re-encoded), so this is bit-exact for
+/// every `StorageDtype` including `Bool` (a decode/re-encode round trip would
+/// collapse any stored byte > 1 to `1`). For a dense FORMAT field, the index
+/// is `dense_row * n_samples_cohort + orig_sample` — the ONE place that
+/// formula appears in this file; it mirrors `FieldView::format_at`, which
+/// can't be reused directly here since it returns a decoded `FieldValue`
+/// rather than a byte slice.
+pub fn gather_batch_fields(
     reader: &ContigReader,
     br: &BatchResult,
     fields: &[OpenField],
-) -> Vec<Vec<u8>> {
-    let mut fbytes: Vec<Vec<u8>> = vec![Vec::new(); fields.len()];
+) -> DecodedFields {
+    let mut out = DecodedFields {
+        str_off: vec![0],
+        off: vec![0],
+        fbytes: vec![Vec::new(); fields.len()],
+        ..Default::default()
+    };
+
     for r in 0..br.n_regions {
         for s in 0..br.n_samples {
             for p in 0..br.ploidy {
-                let (_, srcs) = br.decode_hap_src(reader, r, s, p);
-                for src in srcs {
+                let (hc, srcs) = br.decode_hap_src(reader, r, s, p);
+                for (i, &src) in srcs.iter().enumerate() {
+                    out.pos.push(hc.positions[i] as i32);
+                    out.ilen.push(hc.ilens[i]);
+                    out.allele.extend_from_slice(&hc.alts[i]);
+                    out.str_off.push(out.allele.len() as i64);
+
                     // FieldSub::all() order: VkSnp, VkIndel, DenseSnp, DenseIndel
                     let sub_ix = match (src.is_dense, src.is_indel) {
                         (false, false) => 0,
@@ -180,19 +187,19 @@ pub fn gather_field_bytes(
                         // Dense FORMAT strides by the ORIGINAL cohort sample
                         // index. `s` here is already the cohort index because
                         // `overlap_batch_src` runs over the whole cohort.
-                        let value = if src.is_dense && f.is_format {
-                            view.format_at(src.idx, s)
+                        let idx = if src.is_dense && f.is_format {
+                            src.idx * f.n_samples_cohort + s
                         } else {
-                            view.value_at(src.idx)
+                            src.idx
                         };
-                        let bytes = field_value_le_bytes(value);
-                        fbytes[fi].extend_from_slice(&bytes[..f.width]);
+                        out.fbytes[fi].extend_from_slice(view.bytes_at(idx));
                     }
                 }
+                out.off.push(out.pos.len() as i64);
             }
         }
     }
-    fbytes
+    out
 }
 
 #[pymethods]
@@ -245,9 +252,10 @@ impl PyContigReader {
     /// Values are returned as little-endian bytes + an itemsize; Python applies
     /// the numpy dtype (same trick as `allele`), so Rust does no dtype dispatch.
     ///
-    /// Thin marshalling wrapper: `OpenField::open` + `gather_field_bytes` do the
-    /// actual work and are plain Rust (no `Python<'py>`), so they are covered by
-    /// a Rust-only test in `tests/test_field_provenance.rs` with no GIL needed.
+    /// Thin marshalling wrapper: `OpenField::open` + `gather_batch_fields` do the
+    /// actual work — a single per-hap decode pass via `decode_hap_src` — and are
+    /// plain Rust (no `Python<'py>`), so they are covered by a Rust-only test in
+    /// `tests/test_field_provenance.rs` with no GIL needed.
     #[pyo3(signature = (regions, fields, base_dir, contig))]
     pub fn decode_batch_fields<'py>(
         &self,
@@ -269,40 +277,25 @@ impl PyContigReader {
             );
         }
 
-        let mut pos: Vec<i32> = Vec::new();
-        let mut ilen: Vec<i32> = Vec::new();
-        let mut allele: Vec<u8> = Vec::new();
-        let mut str_off: Vec<i64> = vec![0];
-        let mut off: Vec<i64> = vec![0];
-
-        for r in 0..br.n_regions {
-            for s in 0..br.n_samples {
-                for p in 0..br.ploidy {
-                    let hc = br.decode_hap(&self.inner, r, s, p);
-                    for i in 0..hc.positions.len() {
-                        pos.push(hc.positions[i] as i32);
-                        ilen.push(hc.ilens[i]);
-                        allele.extend_from_slice(&hc.alts[i]);
-                        str_off.push(allele.len() as i64);
-                    }
-                    off.push(pos.len() as i64);
-                }
-            }
-        }
-
-        let fbytes = gather_field_bytes(&self.inner, &br, &open);
+        // Single pass: every hap is decoded exactly once via `decode_hap_src`,
+        // producing both the record arrays and the per-field bytes together
+        // (see `gather_batch_fields` — Task 8 fix pass, Finding A).
+        let decoded = gather_batch_fields(&self.inner, &br, &open);
 
         let d = PyDict::new(py);
-        d.set_item("pos", i32_to_pyarray(py, &pos))?;
-        d.set_item("ilen", i32_to_pyarray(py, &ilen))?;
-        d.set_item("allele", u8_to_pyarray(py, &allele))?;
-        d.set_item("str_off", PyArray1::from_slice(py, &str_off))?;
-        d.set_item("off", PyArray1::from_slice(py, &off))?;
+        d.set_item("pos", i32_to_pyarray(py, &decoded.pos))?;
+        d.set_item("ilen", i32_to_pyarray(py, &decoded.ilen))?;
+        d.set_item("allele", u8_to_pyarray(py, &decoded.allele))?;
+        d.set_item("str_off", PyArray1::from_slice(py, &decoded.str_off))?;
+        d.set_item("off", PyArray1::from_slice(py, &decoded.off))?;
         d.set_item("n_regions", br.n_regions)?;
         d.set_item("n_samples", br.n_samples)?;
         d.set_item("ploidy", br.ploidy)?;
         for (fi, f) in open.iter().enumerate() {
-            d.set_item(format!("field_{}", f.key), u8_to_pyarray(py, &fbytes[fi]))?;
+            d.set_item(
+                format!("field_{}", f.key),
+                u8_to_pyarray(py, &decoded.fbytes[fi]),
+            )?;
             d.set_item(format!("field_itemsize_{}", f.key), f.width)?;
         }
         Ok(d)

--- a/src/py_query_decode.rs
+++ b/src/py_query_decode.rs
@@ -56,6 +56,118 @@ impl PyContigReader {
         Ok(d)
     }
 
+    /// As `decode_batch`, plus one raw-bytes buffer per requested field, aligned
+    /// 1:1 with the decoded records. `fields` is `(category, name, dtype_str)`.
+    /// Values are returned as little-endian bytes + an itemsize; Python applies
+    /// the numpy dtype (same trick as `allele`), so Rust does no dtype dispatch.
+    #[pyo3(signature = (regions, fields, base_dir, contig))]
+    pub fn decode_batch_fields<'py>(
+        &self,
+        py: Python<'py>,
+        regions: Vec<(u32, u32)>,
+        fields: Vec<(String, String, String)>,
+        base_dir: &str,
+        contig: &str,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        use crate::field::StorageDtype;
+        use crate::layout::{ContigPaths, FieldSub};
+        use crate::query::{FieldView, gather::overlap_batch_src};
+
+        let br = overlap_batch_src(&self.inner, &regions);
+        let paths = ContigPaths::new(base_dir, contig);
+        let n_samples_cohort = self.inner.n_samples();
+
+        // Open the four sub-stream views per field up front.
+        struct OpenField {
+            key: String,
+            is_format: bool,
+            width: usize,
+            views: [FieldView; 4], // indexed by FieldSub::all() order
+        }
+        let mut open: Vec<OpenField> = Vec::with_capacity(fields.len());
+        for (category, name, dtype_str) in &fields {
+            let dtype = StorageDtype::from_meta_str(dtype_str).ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "field {name:?} has unresolved/unknown dtype {dtype_str:?}"
+                ))
+            })?;
+            let width = dtype
+                .width_bytes()
+                .expect("from_meta_str rejects unresolved dtypes");
+            let mut views = Vec::with_capacity(4);
+            for sub in FieldSub::all() {
+                views.push(
+                    FieldView::open(&paths, category, name, sub, dtype, n_samples_cohort)
+                        .map_err(|e| pyo3::exceptions::PyOSError::new_err(e.to_string()))?,
+                );
+            }
+            open.push(OpenField {
+                key: format!("{category}/{name}"),
+                is_format: category == "format",
+                width,
+                views: views.try_into().map_err(|_| ()).expect("exactly 4 subs"),
+            });
+        }
+
+        let mut pos: Vec<i32> = Vec::new();
+        let mut ilen: Vec<i32> = Vec::new();
+        let mut allele: Vec<u8> = Vec::new();
+        let mut str_off: Vec<i64> = vec![0];
+        let mut off: Vec<i64> = vec![0];
+        let mut fbytes: Vec<Vec<u8>> = vec![Vec::new(); open.len()];
+
+        for r in 0..br.n_regions {
+            for s in 0..br.n_samples {
+                for p in 0..br.ploidy {
+                    let (hc, srcs) = br.decode_hap_src(&self.inner, r, s, p);
+                    for (i, &src) in srcs.iter().enumerate() {
+                        pos.push(hc.positions[i] as i32);
+                        ilen.push(hc.ilens[i]);
+                        allele.extend_from_slice(&hc.alts[i]);
+                        str_off.push(allele.len() as i64);
+
+                        // FieldSub::all() order: VkSnp, VkIndel, DenseSnp, DenseIndel
+                        let sub_ix = match (src.is_dense, src.is_indel) {
+                            (false, false) => 0,
+                            (false, true) => 1,
+                            (true, false) => 2,
+                            (true, true) => 3,
+                        };
+                        for (fi, f) in open.iter().enumerate() {
+                            let view = &f.views[sub_ix];
+                            // Dense FORMAT strides by the ORIGINAL cohort sample
+                            // index. `s` here is already the cohort index because
+                            // `overlap_batch_src` runs over the whole cohort.
+                            let elem = if src.is_dense && f.is_format {
+                                view.bytes_at(src.idx * n_samples_cohort + s)
+                            } else {
+                                view.bytes_at(src.idx)
+                            };
+                            debug_assert_eq!(elem.len(), f.width);
+                            fbytes[fi].extend_from_slice(elem);
+                        }
+                    }
+                    off.push(pos.len() as i64);
+                }
+            }
+        }
+
+        let d = PyDict::new(py);
+        d.set_item("pos", i32_to_pyarray(py, &pos))?;
+        d.set_item("ilen", i32_to_pyarray(py, &ilen))?;
+        d.set_item("allele", u8_to_pyarray(py, &allele))?;
+        d.set_item("str_off", PyArray1::from_slice(py, &str_off))?;
+        d.set_item("off", PyArray1::from_slice(py, &off))?;
+        d.set_item("n_regions", br.n_regions)?;
+        d.set_item("n_samples", br.n_samples)?;
+        d.set_item("ploidy", br.ploidy)?;
+        for (fi, f) in open.iter().enumerate() {
+            d.set_item(format!("field_{}", f.key), u8_to_pyarray(py, &fbytes[fi]))?;
+            d.set_item(format!("field_itemsize_{}", f.key), f.width)?;
+        }
+        Ok(d)
+    }
+
     /// Per-hap variant count over `regions` WITHOUT decoding: var_key slice length
     /// (`vk_off` diff) + dense-present popcount. Flat length `H`, region-major hap
     /// order; the caller reshapes to `(n_regions, n_samples, ploidy)`. The simplified

--- a/src/query/field.rs
+++ b/src/query/field.rs
@@ -1,0 +1,257 @@
+//! Read the per-contig INFO/FORMAT field sidecars written by the conversion
+//! pipeline. Mirrors `crate::mutcat::sidecar`: an mmap per (field, sub-stream)
+//! plus indexed accessors.
+//!
+//! Two things this reader must get right, both of which the file itself cannot
+//! tell you:
+//!  * The element width comes ONLY from `meta.json`'s `fields[].dtype` — values
+//!    are staged as 4-byte i32/f32 and rewritten in place at finalize.
+//!  * Dense FORMAT is indexed by the ORIGINAL cohort sample index, never a
+//!    selected subset slot.
+
+use half::f16;
+use memmap2::Mmap;
+
+use crate::field::StorageDtype;
+use crate::layout::{ContigPaths, FieldSub};
+use crate::query::sidecar::mmap_file;
+
+/// One field element, in the dtype it is stored as. Never widened or converted.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum FieldValue {
+    Bool(bool),
+    I8(i8),
+    U8(u8),
+    I16(i16),
+    U16(u16),
+    I32(i32),
+    U32(u32),
+    F16(f16),
+    F32(f32),
+}
+
+/// An mmap'd `values.bin` for one (field, sub-stream), plus the dtype needed to
+/// interpret it. A missing/empty file is a legal empty sub-stream.
+pub struct FieldView {
+    values: Option<Mmap>,
+    dtype: StorageDtype,
+    /// Cohort sample count — the stride for dense FORMAT columns.
+    n_samples: usize,
+    /// Element count (bytes / width).
+    n: usize,
+}
+
+impl FieldView {
+    pub fn open(
+        paths: &ContigPaths,
+        category: &str,
+        name: &str,
+        sub: FieldSub,
+        dtype: StorageDtype,
+        n_samples: usize,
+    ) -> std::io::Result<Self> {
+        let values = mmap_file(&paths.field_values(category, name, sub))?;
+        let width = dtype.width_bytes().ok_or_else(|| {
+            std::io::Error::other(format!(
+                "field {name:?} has unresolved dtype {:?}; the store was never finalized",
+                dtype.as_str()
+            ))
+        })?;
+        let n = values.as_ref().map(|m| m.len() / width).unwrap_or(0);
+        Ok(Self {
+            values,
+            dtype,
+            n_samples,
+            n,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> StorageDtype {
+        self.dtype
+    }
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.n
+    }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.n == 0
+    }
+
+    /// Zero-copy typed slice. `None` if the stored dtype's width does not match
+    /// `T`, the sub-stream is empty, or the mapped length is not an exact
+    /// multiple of `T`'s width (a truncated/corrupt store) — `bytemuck::cast_slice`
+    /// panics on a remainder, so we validate first rather than let a bad file on
+    /// disk crash the reader.
+    pub fn as_slice<T: bytemuck::Pod>(&self) -> Option<&[T]> {
+        let m = self.values.as_ref()?;
+        if self.dtype.width_bytes()? != std::mem::size_of::<T>() {
+            return None;
+        }
+        if m.len() % std::mem::size_of::<T>() != 0 {
+            return None;
+        }
+        Some(bytemuck::cast_slice(&m[..]))
+    }
+
+    /// Element `i`: a var_key **call** index, or a dense INFO **variant row**.
+    /// Panics if `i >= len()` (an out-of-range index means the caller's
+    /// provenance disagrees with the store — a bug, not bad input).
+    #[inline]
+    pub fn value_at(&self, i: usize) -> FieldValue {
+        let m = self
+            .values
+            .as_ref()
+            .expect("value_at on an empty field sub-stream");
+        let w = self
+            .dtype
+            .width_bytes()
+            .expect("open() rejected unresolved dtypes");
+        let b = &m[i * w..(i + 1) * w];
+        match self.dtype {
+            StorageDtype::Bool => FieldValue::Bool(b[0] != 0),
+            StorageDtype::I8 => FieldValue::I8(b[0] as i8),
+            StorageDtype::U8 => FieldValue::U8(b[0]),
+            StorageDtype::I16 => FieldValue::I16(i16::from_le_bytes([b[0], b[1]])),
+            StorageDtype::U16 => FieldValue::U16(u16::from_le_bytes([b[0], b[1]])),
+            StorageDtype::I32 => FieldValue::I32(i32::from_le_bytes([b[0], b[1], b[2], b[3]])),
+            StorageDtype::U32 => FieldValue::U32(u32::from_le_bytes([b[0], b[1], b[2], b[3]])),
+            StorageDtype::F16 => FieldValue::F16(f16::from_le_bytes([b[0], b[1]])),
+            StorageDtype::F32 => FieldValue::F32(f32::from_le_bytes([b[0], b[1], b[2], b[3]])),
+            StorageDtype::Auto => unreachable!("open() rejects Auto"),
+        }
+    }
+
+    /// Dense FORMAT element for `(dense_row, orig_sample)`.
+    /// `orig_sample` MUST be the original cohort sample index.
+    #[inline]
+    pub fn format_at(&self, dense_row: usize, orig_sample: usize) -> FieldValue {
+        debug_assert!(
+            orig_sample < self.n_samples,
+            "orig_sample {orig_sample} >= cohort n_samples {}",
+            self.n_samples
+        );
+        self.value_at(dense_row * self.n_samples + orig_sample)
+    }
+
+    /// Raw little-endian bytes for element `i` (width = `dtype().width_bytes()`).
+    /// Used by the Python decode path, which applies the dtype numpy-side.
+    #[inline]
+    pub fn bytes_at(&self, i: usize) -> &[u8] {
+        let m = self
+            .values
+            .as_ref()
+            .expect("bytes_at on an empty field sub-stream");
+        let w = self
+            .dtype
+            .width_bytes()
+            .expect("open() rejected unresolved dtypes");
+        &m[i * w..(i + 1) * w]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::StorageDtype;
+    use crate::layout::{ContigPaths, FieldSub};
+    use std::fs;
+
+    fn write_field(paths: &ContigPaths, cat: &str, name: &str, sub: FieldSub, bytes: &[u8]) {
+        let p = paths.field_values(cat, name, sub);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, bytes).unwrap();
+    }
+
+    #[test]
+    fn value_at_reads_each_dtype() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+
+        let vals: [i16; 3] = [-5, 0, 300];
+        write_field(
+            &paths,
+            "info",
+            "AC",
+            FieldSub::VkSnp,
+            bytemuck::cast_slice(&vals),
+        );
+        let v =
+            FieldView::open(&paths, "info", "AC", FieldSub::VkSnp, StorageDtype::I16, 2).unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.value_at(0), FieldValue::I16(-5));
+        assert_eq!(v.value_at(2), FieldValue::I16(300));
+
+        let f: [f32; 2] = [0.5, 1.25];
+        write_field(
+            &paths,
+            "info",
+            "AF",
+            FieldSub::DenseSnp,
+            bytemuck::cast_slice(&f),
+        );
+        let v = FieldView::open(
+            &paths,
+            "info",
+            "AF",
+            FieldSub::DenseSnp,
+            StorageDtype::F32,
+            2,
+        )
+        .unwrap();
+        assert_eq!(v.value_at(1), FieldValue::F32(1.25));
+    }
+
+    #[test]
+    fn format_at_strides_by_original_cohort_sample() {
+        // 3 dense variants x 4 cohort samples, variant-major.
+        // value = row*10 + sample
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let n_samples = 4usize;
+        let mut vals: Vec<i32> = Vec::new();
+        for row in 0..3i32 {
+            for s in 0..4i32 {
+                vals.push(row * 10 + s);
+            }
+        }
+        write_field(
+            &paths,
+            "format",
+            "DP",
+            FieldSub::DenseSnp,
+            bytemuck::cast_slice(&vals),
+        );
+        let v = FieldView::open(
+            &paths,
+            "format",
+            "DP",
+            FieldSub::DenseSnp,
+            StorageDtype::I32,
+            n_samples,
+        )
+        .unwrap();
+        // Must use the ORIGINAL cohort sample index, not a selected slot.
+        assert_eq!(v.format_at(0, 0), FieldValue::I32(0));
+        assert_eq!(v.format_at(2, 3), FieldValue::I32(23));
+        assert_eq!(v.format_at(1, 2), FieldValue::I32(12));
+    }
+
+    #[test]
+    fn missing_file_opens_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let v = FieldView::open(
+            &paths,
+            "info",
+            "NOPE",
+            FieldSub::VkIndel,
+            StorageDtype::F32,
+            2,
+        )
+        .unwrap();
+        assert!(v.is_empty());
+        assert_eq!(v.len(), 0);
+    }
+}

--- a/src/query/field.rs
+++ b/src/query/field.rs
@@ -53,7 +53,7 @@ impl FieldView {
         let values = mmap_file(&paths.field_values(category, name, sub))?;
         let width = dtype.width_bytes().ok_or_else(|| {
             std::io::Error::other(format!(
-                "field {name:?} has unresolved dtype {:?}; the store was never finalized",
+                "field {name:?} has unresolved dtype {}; the store was never finalized",
                 dtype.as_str()
             ))
         })?;
@@ -100,15 +100,7 @@ impl FieldView {
     /// provenance disagrees with the store — a bug, not bad input).
     #[inline]
     pub fn value_at(&self, i: usize) -> FieldValue {
-        let m = self
-            .values
-            .as_ref()
-            .expect("value_at on an empty field sub-stream");
-        let w = self
-            .dtype
-            .width_bytes()
-            .expect("open() rejected unresolved dtypes");
-        let b = &m[i * w..(i + 1) * w];
+        let b = self.bytes_at(i);
         match self.dtype {
             StorageDtype::Bool => FieldValue::Bool(b[0] != 0),
             StorageDtype::I8 => FieldValue::I8(b[0] as i8),
@@ -127,7 +119,7 @@ impl FieldView {
     /// `orig_sample` MUST be the original cohort sample index.
     #[inline]
     pub fn format_at(&self, dense_row: usize, orig_sample: usize) -> FieldValue {
-        debug_assert!(
+        assert!(
             orig_sample < self.n_samples,
             "orig_sample {orig_sample} >= cohort n_samples {}",
             self.n_samples
@@ -164,43 +156,257 @@ mod tests {
         fs::write(&p, bytes).unwrap();
     }
 
+    /// Covers all 9 storage dtypes. Each case includes a value that would
+    /// catch a width or signedness bug: a negative value for signed types
+    /// (would misread as huge-positive under an unsigned/wrong-width
+    /// interpretation), a value above the signed max for unsigned types
+    /// (would misread as negative under a signed interpretation), and a
+    /// value needing the full element width for 2- and 4-byte types (would
+    /// truncate/misalign under a narrower width). Missing-value sentinels
+    /// (`i*::MIN`, `u*::MAX`, `f32::NAN`) are included and must round-trip
+    /// untranslated.
     #[test]
     fn value_at_reads_each_dtype() {
         let tmp = tempfile::tempdir().unwrap();
         let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
 
-        let vals: [i16; 3] = [-5, 0, 300];
+        // Bool: 1 byte, non-zero/zero.
+        {
+            let bytes = [1u8, 0u8];
+            write_field(&paths, "info", "BOOL", FieldSub::VkSnp, &bytes);
+            let v = FieldView::open(
+                &paths,
+                "info",
+                "BOOL",
+                FieldSub::VkSnp,
+                StorageDtype::Bool,
+                2,
+            )
+            .unwrap();
+            assert_eq!(v.len(), 2);
+            assert_eq!(v.value_at(0), FieldValue::Bool(true));
+            assert_eq!(v.value_at(1), FieldValue::Bool(false));
+        }
+
+        // I8: negative sentinel i8::MIN, plus a positive value.
+        {
+            let vals: [i8; 3] = [i8::MIN, 0, 100];
+            let bytes: Vec<u8> = vals.iter().map(|x| *x as u8).collect();
+            write_field(&paths, "info", "I8F", FieldSub::VkSnp, &bytes);
+            let v = FieldView::open(&paths, "info", "I8F", FieldSub::VkSnp, StorageDtype::I8, 2)
+                .unwrap();
+            assert_eq!(v.value_at(0), FieldValue::I8(i8::MIN));
+            assert_eq!(v.value_at(2), FieldValue::I8(100));
+        }
+
+        // U8: unsigned max sentinel (would read as -1 under a signed cast).
+        {
+            let vals: [u8; 3] = [u8::MAX, 0, 200];
+            write_field(&paths, "info", "U8F", FieldSub::VkSnp, &vals);
+            let v = FieldView::open(&paths, "info", "U8F", FieldSub::VkSnp, StorageDtype::U8, 2)
+                .unwrap();
+            assert_eq!(v.value_at(0), FieldValue::U8(u8::MAX));
+            assert_eq!(v.value_at(2), FieldValue::U8(200));
+        }
+
+        // I16: negative, a value needing 2 bytes, and i16::MIN sentinel.
+        {
+            let vals: [i16; 4] = [-5, 0, 300, i16::MIN];
+            write_field(
+                &paths,
+                "info",
+                "AC",
+                FieldSub::VkSnp,
+                bytemuck::cast_slice(&vals),
+            );
+            let v = FieldView::open(&paths, "info", "AC", FieldSub::VkSnp, StorageDtype::I16, 2)
+                .unwrap();
+            assert_eq!(v.len(), 4);
+            assert_eq!(v.value_at(0), FieldValue::I16(-5));
+            assert_eq!(v.value_at(2), FieldValue::I16(300));
+            assert_eq!(v.value_at(3), FieldValue::I16(i16::MIN));
+        }
+
+        // U16: value above i16::MAX (would read negative under a signed
+        // interpretation), plus u16::MAX sentinel.
+        {
+            let vals: [u16; 3] = [40_000, 0, u16::MAX];
+            write_field(
+                &paths,
+                "info",
+                "U16F",
+                FieldSub::VkSnp,
+                bytemuck::cast_slice(&vals),
+            );
+            let v = FieldView::open(
+                &paths,
+                "info",
+                "U16F",
+                FieldSub::VkSnp,
+                StorageDtype::U16,
+                2,
+            )
+            .unwrap();
+            assert_eq!(v.value_at(0), FieldValue::U16(40_000));
+            assert_eq!(v.value_at(2), FieldValue::U16(u16::MAX));
+        }
+
+        // I32: negative sentinel i32::MIN, plus a value needing >2 bytes.
+        {
+            let vals: [i32; 3] = [i32::MIN, 0, 100_000];
+            write_field(
+                &paths,
+                "info",
+                "I32F",
+                FieldSub::VkSnp,
+                bytemuck::cast_slice(&vals),
+            );
+            let v = FieldView::open(
+                &paths,
+                "info",
+                "I32F",
+                FieldSub::VkSnp,
+                StorageDtype::I32,
+                2,
+            )
+            .unwrap();
+            assert_eq!(v.value_at(0), FieldValue::I32(i32::MIN));
+            assert_eq!(v.value_at(2), FieldValue::I32(100_000));
+        }
+
+        // U32: unsigned max sentinel, plus a value needing >2 bytes.
+        {
+            let vals: [u32; 3] = [u32::MAX, 0, 100_000];
+            write_field(
+                &paths,
+                "info",
+                "U32F",
+                FieldSub::VkSnp,
+                bytemuck::cast_slice(&vals),
+            );
+            let v = FieldView::open(
+                &paths,
+                "info",
+                "U32F",
+                FieldSub::VkSnp,
+                StorageDtype::U32,
+                2,
+            )
+            .unwrap();
+            assert_eq!(v.value_at(0), FieldValue::U32(u32::MAX));
+            assert_eq!(v.value_at(2), FieldValue::U32(100_000));
+        }
+
+        // F16: negative and positive fractional values. Built via
+        // `to_le_bytes` (not `bytemuck::cast_slice`) since this repo does not
+        // enable `half`'s `bytemuck` feature.
+        {
+            let vals = [f16::from_f32(-3.5), f16::from_f32(1.5)];
+            let bytes: Vec<u8> = vals.iter().flat_map(|v| v.to_le_bytes()).collect();
+            write_field(&paths, "info", "F16F", FieldSub::VkSnp, &bytes);
+            let v = FieldView::open(
+                &paths,
+                "info",
+                "F16F",
+                FieldSub::VkSnp,
+                StorageDtype::F16,
+                2,
+            )
+            .unwrap();
+            assert_eq!(v.value_at(0), FieldValue::F16(f16::from_f32(-3.5)));
+            assert_eq!(v.value_at(1), FieldValue::F16(f16::from_f32(1.5)));
+        }
+
+        // F32: negative value and the NaN sentinel. `f32::NAN != f32::NAN`,
+        // so assert bit-identity via `is_nan()` rather than equality.
+        {
+            let vals: [f32; 3] = [0.5, -3.5, f32::NAN];
+            write_field(
+                &paths,
+                "info",
+                "AF",
+                FieldSub::DenseSnp,
+                bytemuck::cast_slice(&vals),
+            );
+            let v = FieldView::open(
+                &paths,
+                "info",
+                "AF",
+                FieldSub::DenseSnp,
+                StorageDtype::F32,
+                2,
+            )
+            .unwrap();
+            assert_eq!(v.value_at(0), FieldValue::F32(0.5));
+            assert_eq!(v.value_at(1), FieldValue::F32(-3.5));
+            match v.value_at(2) {
+                FieldValue::F32(x) => assert!(x.is_nan()),
+                other => panic!("expected FieldValue::F32(NaN), got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn open_rejects_auto_dtype() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let err = match FieldView::open(
+            &paths,
+            "info",
+            "UNRESOLVED",
+            FieldSub::VkSnp,
+            StorageDtype::Auto,
+            2,
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("expected Err for StorageDtype::Auto"),
+        };
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        // The (fixed) error message should render the dtype name plainly,
+        // not doubly-quoted via `{:?}` on an already-`&str` value.
+        assert!(err.to_string().contains("unresolved dtype auto"));
+        assert!(!err.to_string().contains("\"auto\""));
+    }
+
+    #[test]
+    fn as_slice_checks_dtype_width_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let vals: [i32; 3] = [1, -2, 3];
         write_field(
             &paths,
             "info",
-            "AC",
+            "SL",
             FieldSub::VkSnp,
             bytemuck::cast_slice(&vals),
         );
         let v =
-            FieldView::open(&paths, "info", "AC", FieldSub::VkSnp, StorageDtype::I16, 2).unwrap();
-        assert_eq!(v.len(), 3);
-        assert_eq!(v.value_at(0), FieldValue::I16(-5));
-        assert_eq!(v.value_at(2), FieldValue::I16(300));
+            FieldView::open(&paths, "info", "SL", FieldSub::VkSnp, StorageDtype::I32, 2).unwrap();
 
-        let f: [f32; 2] = [0.5, 1.25];
+        // Matching width/type: zero-copy slice round-trips the values.
+        assert_eq!(v.as_slice::<i32>(), Some(&vals[..]));
+
+        // Mismatched width (i32 stored as 4 bytes; i16 is 2 bytes): None,
+        // not a reinterpreted/garbage slice.
+        assert_eq!(v.as_slice::<i16>(), None);
+    }
+
+    #[test]
+    fn bytes_at_returns_raw_little_endian_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let vals: [i32; 2] = [1, -2];
         write_field(
             &paths,
             "info",
-            "AF",
-            FieldSub::DenseSnp,
-            bytemuck::cast_slice(&f),
+            "RB",
+            FieldSub::VkSnp,
+            bytemuck::cast_slice(&vals),
         );
-        let v = FieldView::open(
-            &paths,
-            "info",
-            "AF",
-            FieldSub::DenseSnp,
-            StorageDtype::F32,
-            2,
-        )
-        .unwrap();
-        assert_eq!(v.value_at(1), FieldValue::F32(1.25));
+        let v =
+            FieldView::open(&paths, "info", "RB", FieldSub::VkSnp, StorageDtype::I32, 2).unwrap();
+        assert_eq!(v.bytes_at(0), &1i32.to_le_bytes());
+        assert_eq!(v.bytes_at(1), &(-2i32).to_le_bytes());
     }
 
     #[test]

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -93,6 +93,12 @@ pub struct BatchResult {
     /// concatenated; `dense_present_off` (len H+1) holds BIT offsets.
     pub dense_present: Vec<u8>,
     pub dense_present_off: Vec<usize>,
+    /// Per-entry dense provenance, parallel to `dense`: `(is_indel, per-class
+    /// dense row)`. **Empty** unless produced by `overlap_batch_src` — the
+    /// plain path does not pay for it. Lets `decode_hap_src` resolve dense
+    /// provenance via an O(1) index into this vec instead of rebuilding the
+    /// whole-contig dense union.
+    pub dense_src: Vec<(bool, u32)>,
 }
 
 /// Read-bound analog of `BatchResult`: the var_key channel merged per hap (as
@@ -190,11 +196,34 @@ pub fn overlap_batch_src(reader: &ContigReader, regions: &[(u32, u32)]) -> Batch
     overlap_batch_impl::<SrcKeyRef>(reader, regions)
 }
 
+/// Local extension of `spine::VkElem` (kept in `gather.rs` rather than
+/// `spine.rs` since this is purely a gather-level concern): whether `T` is the
+/// provenance-carrying element type. Gates `BatchResult::dense_src`
+/// population the same way `T::split` gates `vk_src` — `KeyRef`'s impl is
+/// `false` so the plain `overlap_batch`/`gather_ranges` path never builds it,
+/// `SrcKeyRef`'s is `true` so `overlap_batch_src` does. Implementing a local
+/// trait for `spine`'s types is fine under the orphan rule (same crate).
+trait DenseSrcElem: VkElem {
+    const CARRIES_SRC: bool;
+}
+
+impl DenseSrcElem for KeyRef {
+    const CARRIES_SRC: bool = false;
+}
+
+impl DenseSrcElem for SrcKeyRef {
+    const CARRIES_SRC: bool = true;
+}
+
 /// Shared body of `overlap_batch`/`overlap_batch_src`, generic over `T: VkElem`
 /// the same way `gather_haps_readbound_impl` is (see that function's doc
 /// comment). The only difference from the original monomorphic
-/// `overlap_batch` is `reader.vk_slice::<T>(...)` and the final `T::split(vk)`.
-fn overlap_batch_impl<T: VkElem>(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
+/// `overlap_batch` is `reader.vk_slice::<T>(...)`, the final `T::split(vk)`,
+/// and (for `dense_src`) `T::CARRIES_SRC`.
+fn overlap_batch_impl<T: DenseSrcElem>(
+    reader: &ContigReader,
+    regions: &[(u32, u32)],
+) -> BatchResult {
     let ploidy = reader.ploidy;
     let n_samples = reader.n_samples;
     let n_regions = regions.len();
@@ -241,6 +270,21 @@ fn overlap_batch_impl<T: VkElem>(reader: &ContigReader, regions: &[(u32, u32)]) 
     // — see `gather_haps_readbound_impl`'s identical final step.
     let (vk, vk_src) = T::split(vk);
 
+    // Capture dense provenance ONCE, here, where `dense` (the whole-contig
+    // union) is already built exactly once per query — this is what lets
+    // `decode_hap_src` avoid ever calling `dense_union()` itself. Only paid
+    // for on the provenance-carrying path (`T::CARRIES_SRC`); the plain path
+    // stays a `Vec::new()`.
+    let dense_src: Vec<(bool, u32)> = if T::CARRIES_SRC {
+        dense
+            .src
+            .iter()
+            .map(|&(class, col)| (matches!(class, crate::dense::DenseClass::Indel), col as u32))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     BatchResult {
         n_regions,
         n_samples,
@@ -252,6 +296,7 @@ fn overlap_batch_impl<T: VkElem>(reader: &ContigReader, regions: &[(u32, u32)]) 
         dense_range: ranges,
         dense_present,
         dense_present_off,
+        dense_src,
     }
 }
 
@@ -415,6 +460,7 @@ pub fn gather_ranges(reader: &ContigReader, rb: &RangesBundle) -> BatchResult {
         dense_range: rb.dense_range.clone(),
         dense_present,
         dense_present_off,
+        dense_src: Vec::new(),
     }
 }
 
@@ -813,6 +859,11 @@ impl BatchResult {
             self.vk.len(),
             "decode_hap_src requires a BatchResult from overlap_batch_src"
         );
+        assert_eq!(
+            self.dense_src.len(),
+            self.dense.len(),
+            "decode_hap_src requires a BatchResult from overlap_batch_src"
+        );
         let h = (r * self.n_samples + s) * self.ploidy + p;
 
         // var_key run for this hap, carrying provenance.
@@ -831,25 +882,22 @@ impl BatchResult {
             })
             .collect();
 
-        // Dense run: present entries of this region's window. `dense.src[j]`
-        // holds `(class, per-class row)` — the index a dense field's
-        // `values.bin` is aligned to (see `FieldView::value_at`/`format_at`).
-        // Rebuilding the union here mirrors `overlap_batch_src`'s inputs
-        // exactly (same reader, same deterministic sort), so `dense.refs[j]`
-        // is guaranteed identical to `self.dense[j]`.
-        let dense = reader.dense_union();
+        // Dense run: present entries of this region's window. `self.dense_src[j]`
+        // already holds `(is_indel, per-class row)` — captured ONCE by
+        // `overlap_batch_src` — so this is a plain index, no `dense_union()`
+        // rebuild (that would be an O(contig) sort per call).
         let (ds, de) = (self.dense_range[r].start, self.dense_range[r].end);
         let bit0 = self.dense_present_off[h];
         let mut dn_run: Vec<(KeyRef, RecordSrc)> = Vec::new();
         for (k, j) in (ds..de).enumerate() {
             if bits::get_bit(&self.dense_present, bit0 + k) {
-                let (class, dcol) = dense.src[j];
+                let (is_indel, dcol) = self.dense_src[j];
                 dn_run.push((
                     self.dense[j],
                     RecordSrc {
                         is_dense: true,
-                        is_indel: matches!(class, crate::dense::DenseClass::Indel),
-                        idx: dcol,
+                        is_indel,
+                        idx: dcol as usize,
                     },
                 ));
             }
@@ -915,6 +963,7 @@ mod tests {
             dense_range: vec![0..0],
             dense_present: vec![],
             dense_present_off: vec![0, 0, 0, 0, 0],
+            dense_src: vec![],
         };
         let h = br.n_regions * br.n_samples * br.ploidy;
         assert_eq!(br.vk_off.len(), h + 1);

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -698,6 +698,20 @@ pub fn gather_haps_readbound_src(reader: &ContigReader, rb: &HapRanges<'_>) -> B
     gather_haps_readbound_impl::<SrcKeyRef>(reader, rb)
 }
 
+/// Absolute dense **variant row** for entry `i` of a `BatchResultSplit` dense
+/// window — the index a `dense_snp`/`dense_indel` field `values.bin` is aligned
+/// to (INFO: `value_at(row)`; FORMAT: `format_at(row, orig_sample)`).
+///
+/// Dense provenance needs no extra state: each per-region window is a contiguous
+/// copy of the on-disk slice, so the absolute row is pure arithmetic.
+/// `on_disk` is `HapRanges::dense_*_range[q]`; `out` is
+/// `BatchResultSplit::dense_*_range[q]`; `i` indexes into `out`.
+#[inline]
+pub fn dense_abs_row(on_disk: &Range<usize>, out: &Range<usize>, i: usize) -> usize {
+    debug_assert!(out.contains(&i), "i must index into the output window");
+    on_disk.start + (i - out.start)
+}
+
 /// Fused search+gather: `find_ranges` then `gather_ranges` in one call. The
 /// public/live-query analog of the split; byte-identical to `overlap_batch`
 /// when `samples = None`, and the parity oracle for sample subsetting.

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -80,6 +80,11 @@ pub struct BatchResult {
     /// Flat var_key channel; `vk_off` (len H+1, CSR) slices it per hap.
     pub vk: Vec<KeyRef>,
     pub vk_off: Vec<usize>,
+    /// Absolute var_key provenance per `vk` record, packed by
+    /// `spine::pack_vk_src` (bit 31 = sub-stream, bits 0..=30 = call index).
+    /// **Empty** unless produced by `overlap_batch_src` — the plain gather
+    /// does not pay for it.
+    pub vk_src: Vec<u32>,
     /// Shared dense union (uniform keys, position-sorted); decode-once.
     pub dense: Vec<KeyRef>,
     /// `[s, e)` into `dense` per region (len n_regions).
@@ -169,7 +174,27 @@ pub(crate) fn gather_vk<T: VkElem>(
 /// Batched multi-region × whole-cohort query. `regions` is a list of half-open
 /// `[q_start, q_end)`. Single-threaded; `rayon` over the H hap-slices and dense-
 /// window subsetting are M6b concerns (see the design spec's open questions).
+///
+/// The no-provenance, zero-cost path (`T = KeyRef`; byte-identical to before
+/// `overlap_batch_impl` was introduced — `vk_src` stays empty and `KeyRef::make`
+/// discards the provenance args, so `spine::pack_vk_src` never runs).
 pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
+    overlap_batch_impl::<KeyRef>(reader, regions)
+}
+
+/// As `overlap_batch`, but additionally populates `vk_src` so a consumer can
+/// map each merged var_key record back to its `(sub-stream, absolute call
+/// index)` and index a `FieldView`. This is the entry point
+/// `decode_batch_fields` uses to read fields over the whole-cohort batch path.
+pub fn overlap_batch_src(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
+    overlap_batch_impl::<SrcKeyRef>(reader, regions)
+}
+
+/// Shared body of `overlap_batch`/`overlap_batch_src`, generic over `T: VkElem`
+/// the same way `gather_haps_readbound_impl` is (see that function's doc
+/// comment). The only difference from the original monomorphic
+/// `overlap_batch` is `reader.vk_slice::<T>(...)` and the final `T::split(vk)`.
+fn overlap_batch_impl<T: VkElem>(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
     let ploidy = reader.ploidy;
     let n_samples = reader.n_samples;
     let n_regions = regions.len();
@@ -181,7 +206,7 @@ pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResu
         .map(|&(qs, qe)| dense.overlap(qs, qe))
         .collect();
 
-    let mut vk: Vec<KeyRef> = Vec::new();
+    let mut vk: Vec<T> = Vec::new();
     let mut vk_off: Vec<usize> = vec![0];
     let mut presence = PresenceBitWriter::new();
 
@@ -192,7 +217,7 @@ pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResu
                 let col = s * ploidy + p;
 
                 // var_key channel slice for (region r, sample s, ploid p).
-                let slice = reader.vk_slice(col, s, p, qs, qe);
+                let slice: Vec<T> = reader.vk_slice(col, s, p, qs, qe);
                 vk.extend_from_slice(&slice);
                 vk_off.push(vk.len());
 
@@ -212,6 +237,9 @@ pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResu
     }
 
     let (dense_present, dense_present_off) = presence.into_parts();
+    // Project the generic element back into the frozen (vk, vk_src) contract
+    // — see `gather_haps_readbound_impl`'s identical final step.
+    let (vk, vk_src) = T::split(vk);
 
     BatchResult {
         n_regions,
@@ -219,6 +247,7 @@ pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResu
         ploidy,
         vk,
         vk_off,
+        vk_src,
         dense: dense.refs,
         dense_range: ranges,
         dense_present,
@@ -381,6 +410,7 @@ pub fn gather_ranges(reader: &ContigReader, rb: &RangesBundle) -> BatchResult {
         ploidy,
         vk,
         vk_off,
+        vk_src: Vec::new(),
         dense: dense.refs,
         dense_range: rb.dense_range.clone(),
         dense_present,
@@ -755,6 +785,109 @@ impl BatchResult {
     }
 }
 
+/// Where one decoded record came from, so a consumer can index a `FieldView`.
+/// var_key: `idx` is the absolute call index in `var_key/{snp,indel}`.
+/// dense: `idx` is the absolute dense variant row in `dense/{snp,indel}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecordSrc {
+    pub is_dense: bool,
+    pub is_indel: bool,
+    pub idx: usize,
+}
+
+impl BatchResult {
+    /// As `decode_hap`, but also returns one `RecordSrc` per decoded record, in
+    /// the same order. Requires a `BatchResult` built by `overlap_batch_src`
+    /// (i.e. with `vk_src` populated); panics otherwise, since silently
+    /// returning wrong provenance would attach field values to the wrong
+    /// variants.
+    pub fn decode_hap_src(
+        &self,
+        reader: &ContigReader,
+        r: usize,
+        s: usize,
+        p: usize,
+    ) -> (HapCalls, Vec<RecordSrc>) {
+        assert_eq!(
+            self.vk_src.len(),
+            self.vk.len(),
+            "decode_hap_src requires a BatchResult from overlap_batch_src"
+        );
+        let h = (r * self.n_samples + s) * self.ploidy + p;
+
+        // var_key run for this hap, carrying provenance.
+        let (lo, hi) = (self.vk_off[h], self.vk_off[h + 1]);
+        let vk_run: Vec<(KeyRef, RecordSrc)> = (lo..hi)
+            .map(|i| {
+                let (is_indel, idx) = spine::unpack_vk_src(self.vk_src[i]);
+                (
+                    self.vk[i],
+                    RecordSrc {
+                        is_dense: false,
+                        is_indel,
+                        idx,
+                    },
+                )
+            })
+            .collect();
+
+        // Dense run: present entries of this region's window. `dense.src[j]`
+        // holds `(class, per-class row)` — the index a dense field's
+        // `values.bin` is aligned to (see `FieldView::value_at`/`format_at`).
+        // Rebuilding the union here mirrors `overlap_batch_src`'s inputs
+        // exactly (same reader, same deterministic sort), so `dense.refs[j]`
+        // is guaranteed identical to `self.dense[j]`.
+        let dense = reader.dense_union();
+        let (ds, de) = (self.dense_range[r].start, self.dense_range[r].end);
+        let bit0 = self.dense_present_off[h];
+        let mut dn_run: Vec<(KeyRef, RecordSrc)> = Vec::new();
+        for (k, j) in (ds..de).enumerate() {
+            if bits::get_bit(&self.dense_present, bit0 + k) {
+                let (class, dcol) = dense.src[j];
+                dn_run.push((
+                    self.dense[j],
+                    RecordSrc {
+                        is_dense: true,
+                        is_indel: matches!(class, crate::dense::DenseClass::Indel),
+                        idx: dcol,
+                    },
+                ));
+            }
+        }
+
+        // Merge by position with the SAME stable tie-break as `decode_hap`
+        // (`spine::merge_keys(vec![vk_slice, dn])`: earlier run — var_key —
+        // wins ties). This two-pointer merge reproduces that exactly (mirrors
+        // `merge_by_position`'s tie-break, as `gather_haps_readbound_impl`'s
+        // hand-inlined merge already does for the read-bound path).
+        let mut merged: Vec<(KeyRef, RecordSrc)> = Vec::with_capacity(vk_run.len() + dn_run.len());
+        let (mut a, mut b) = (0usize, 0usize);
+        while a < vk_run.len() && b < dn_run.len() {
+            if vk_run[a].0.position <= dn_run[b].0.position {
+                merged.push(vk_run[a]);
+                a += 1;
+            } else {
+                merged.push(dn_run[b]);
+                b += 1;
+            }
+        }
+        merged.extend_from_slice(&vk_run[a..]);
+        merged.extend_from_slice(&dn_run[b..]);
+
+        let lut = reader.lut.as_ref();
+        let mut hc = HapCalls::default();
+        let mut srcs = Vec::with_capacity(merged.len());
+        for (kr, src) in merged {
+            let c = decode_keyref(kr, lut);
+            hc.positions.push(c.position);
+            hc.ilens.push(c.ilen);
+            hc.alts.push(c.alt);
+            srcs.push(src);
+        }
+        (hc, srcs)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::sidecar::mmap_file;
@@ -777,6 +910,7 @@ mod tests {
                 key: 1 << PAYLOAD_TOP_SHIFT,
             }],
             vk_off: vec![0, 1, 1, 1, 1],
+            vk_src: vec![],
             dense: vec![],
             dense_range: vec![0..0],
             dense_present: vec![],

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -708,7 +708,7 @@ pub fn gather_haps_readbound_src(reader: &ContigReader, rb: &HapRanges<'_>) -> B
 /// `BatchResultSplit::dense_*_range[q]`; `i` indexes into `out`.
 #[inline]
 pub fn dense_abs_row(on_disk: &Range<usize>, out: &Range<usize>, i: usize) -> usize {
-    debug_assert!(out.contains(&i), "i must index into the output window");
+    assert!(out.contains(&i), "i must index into the output window");
     on_disk.start + (i - out.start)
 }
 

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 
 use crate::bits;
 use crate::rvk;
-use crate::spine::{self, KeyRef};
+use crate::spine::{self, KeyRef, SrcKeyRef, VkElem};
 
 use super::decode::{HapCalls, decode_keyref};
 use super::reader::ContigReader;
@@ -103,6 +103,11 @@ pub struct BatchResultSplit {
     /// Flat merged var_key channel (snp+indel per hap); `vk_off` (len H+1) slices it.
     pub vk: Vec<KeyRef>,
     pub vk_off: Vec<usize>,
+    /// Absolute var_key provenance per `vk` record, packed by
+    /// `spine::pack_vk_src` (bit 31 = sub-stream, bits 0..=30 = call index).
+    /// **Empty** unless produced by `gather_haps_readbound_src` — the plain
+    /// gather does not pay for it.
+    pub vk_src: Vec<u32>,
     /// Per-region `dense/snp` windows (uniform keys), concatenated.
     pub dense_snp: Vec<KeyRef>,
     /// `[s, e)` into `dense_snp` per region (len n_regions).
@@ -123,43 +128,42 @@ pub struct BatchResultSplit {
 /// This is the shared body the batch/ranges/read-bound gathers previously
 /// hand-inlined. `vk_slice` already performs the union+merge for a column; this
 /// wrapper is the seam the read-bound path replays from precomputed ranges.
-pub(crate) fn gather_vk(
+pub(crate) fn gather_vk<T: VkElem>(
     reader: &ContigReader,
     vk_snp_range: Range<usize>,
     vk_indel_range: Range<usize>,
     q_start: u32,
-) -> Vec<KeyRef> {
+) -> Vec<T> {
     let snp_positions = reader.vk_snp.positions();
     let snp_keys = as_bytes(&reader.vk_snp.keys);
     let indel_positions = reader.vk_indel.positions();
     let indel_keys = as_u32(&reader.vk_indel.keys);
 
     let (ss, se) = (vk_snp_range.start, vk_snp_range.end);
-    let mut snp_run: Vec<KeyRef> = Vec::new();
+    let mut snp_run: Vec<T> = Vec::new();
     for (j, &pos) in snp_positions.iter().enumerate().take(se).skip(ss) {
         if q_start < pos + 1 {
             // snp v_end = pos + 1
-            snp_run.push(KeyRef {
-                position: pos,
-                key: rvk::snp_code_to_key(rvk::unpack_snp_key_at(snp_keys, j)),
-            });
+            snp_run.push(T::make(
+                pos,
+                rvk::snp_code_to_key(rvk::unpack_snp_key_at(snp_keys, j)),
+                false,
+                j,
+            ));
         }
     }
 
     let (is_, ie_) = (vk_indel_range.start, vk_indel_range.end);
-    let mut indel_run: Vec<KeyRef> = Vec::new();
+    let mut indel_run: Vec<T> = Vec::new();
     for j in is_..ie_ {
         let pos = indel_positions[j];
         let v_end = pos + 1 + rvk::deletion_len(indel_keys[j]);
         if q_start < v_end {
-            indel_run.push(KeyRef {
-                position: pos,
-                key: indel_keys[j],
-            });
+            indel_run.push(T::make(pos, indel_keys[j], true, j));
         }
     }
 
-    spine::merge_keys(vec![snp_run, indel_run])
+    spine::merge_by_position(vec![snp_run, indel_run])
 }
 
 /// Batched multi-region × whole-cohort query. `regions` is a list of half-open
@@ -451,8 +455,16 @@ impl<'a> HapRanges<'a> {
 /// length n_q) or per-(query,ploid) (`vk_*_range`, length n_q*ploidy, row =
 /// q*ploidy + p). Builds zero SearchTrees and never calls `dense_union()`.
 /// Returns a `BatchResultSplit` with `n_samples = 1`, hap index `q*ploidy + p`.
+///
+/// Generic over `T: VkElem`: `gather_haps_readbound` (`T = KeyRef`) is the
+/// no-provenance, zero-cost path (byte-identical to before this generic was
+/// introduced); `gather_haps_readbound_src` (`T = SrcKeyRef`) additionally
+/// populates `vk_src`.
 #[allow(clippy::needless_range_loop)]
-pub fn gather_haps_readbound(reader: &ContigReader, rb: &HapRanges<'_>) -> BatchResultSplit {
+fn gather_haps_readbound_impl<T: VkElem>(
+    reader: &ContigReader,
+    rb: &HapRanges<'_>,
+) -> BatchResultSplit {
     let region_starts = rb.region_starts;
     let orig_samples = rb.orig_samples;
     let vk_snp_range = rb.vk_snp_range;
@@ -508,7 +520,7 @@ pub fn gather_haps_readbound(reader: &ContigReader, rb: &HapRanges<'_>) -> Batch
         dense_indel_range_out.push(base..dense_indel.len());
     }
 
-    let mut vk: Vec<KeyRef> = Vec::new();
+    let mut vk: Vec<T> = Vec::new();
     let mut vk_off: Vec<usize> = vec![0];
     let mut snp_presence = PresenceBitWriter::new();
     let mut indel_presence = PresenceBitWriter::new();
@@ -542,50 +554,61 @@ pub fn gather_haps_readbound(reader: &ContigReader, rb: &HapRanges<'_>) -> Batch
             // recovers the absolute call index `unpack_snp_key_at` needs
             // against the (unsliced, 2-bit-packed) `snp_keys` buffer.
             // Capacity is pre-sized so the filter below never reallocs.
-            let mut snp_run: Vec<KeyRef> = Vec::with_capacity(ve.saturating_sub(vs));
+            let mut snp_run: Vec<T> = Vec::with_capacity(ve.saturating_sub(vs));
             for (k, &pos) in snp_positions[vs..ve].iter().enumerate() {
                 let j = vs + k;
                 if qs < pos + 1 {
-                    snp_run.push(KeyRef {
-                        position: pos,
-                        key: rvk::snp_code_to_key(rvk::unpack_snp_key_at(snp_keys, j)),
-                    });
+                    snp_run.push(T::make(
+                        pos,
+                        rvk::snp_code_to_key(rvk::unpack_snp_key_at(snp_keys, j)),
+                        false,
+                        j,
+                    ));
                 }
             }
             let (vis, vie) = (vk_indel_range[row].start, vk_indel_range[row].end);
             // Same slicing treatment: `indel_positions`/`indel_keys` are
             // both plain `&[u32]` in the same absolute index space, so a
             // paired slice iterator drops the per-element bounds checks
-            // that `indel_positions[j]`/`indel_keys[j]` incurred.
-            let mut indel_run: Vec<KeyRef> = Vec::with_capacity(vie.saturating_sub(vis));
-            for (&pos, &key) in indel_positions[vis..vie].iter().zip(&indel_keys[vis..vie]) {
+            // that `indel_positions[j]`/`indel_keys[j]` incurred. RE-ADD the
+            // absolute index the plain zip previously dropped: `T::make`
+            // needs the true absolute call index `vis + k` for provenance.
+            let mut indel_run: Vec<T> = Vec::with_capacity(vie.saturating_sub(vis));
+            for (k, (&pos, &key)) in indel_positions[vis..vie]
+                .iter()
+                .zip(&indel_keys[vis..vie])
+                .enumerate()
+            {
+                let j = vis + k;
                 let v_end = pos + 1 + rvk::deletion_len(key);
                 if qs < v_end {
-                    indel_run.push(KeyRef { position: pos, key });
+                    indel_run.push(T::make(pos, key, true, j));
                 }
             }
             // Specialized 2-way merge, provably byte-identical to
-            // `spine::merge_keys(vec![snp_run, indel_run])`: that generic
-            // k-way merge picks `best = Some(0)` (snp_run) on the first
-            // scan and only switches to run 1 (indel_run) when
-            // `!(snp_run[h0].position <= indel_run[h1].position)`, i.e.
+            // `spine::merge_by_position(vec![snp_run, indel_run])`: that
+            // generic k-way merge picks `best = Some(0)` (snp_run) on the
+            // first scan and only switches to run 1 (indel_run) when
+            // `!(snp_run[h0].position() <= indel_run[h1].position())`, i.e.
             // exactly the `<=` two-pointer comparison below (ties still
-            // favor snp_run).
+            // favor snp_run). The `VkElem` payload rides along unchanged, so
+            // this stays a mirror of the generic merge for `SrcKeyRef` as
+            // well as `KeyRef`.
             //
             // Task 3 (gather_vk extraction) benched routing this hap-major
             // loop through the shared `gather_vk` helper (which rebuilds
-            // `snp_run`/`indel_run` via `merge_keys` per call, like
+            // `snp_run`/`indel_run` via `merge_by_position` per call, like
             // `gather_ranges`/`gather_ranges_readbound` do). The readbound
             // test fixtures are too small (single-digit variant counts) for
             // a stable wall-clock signal, so the decision was made on
             // algorithmic grounds instead: unifying would reintroduce the
             // slicing/allocation costs this block was written to remove
             // (re-walking `snp_positions[0..vs]` per hap via `skip`, plus
-            // three extra allocations per hap from `merge_keys`'s
+            // three extra allocations per hap from `merge_by_position`'s
             // `vec![...]`/`heads`/`out`). This tuned merge is retained.
             let (mut si, mut ii) = (0usize, 0usize);
             while si < snp_run.len() && ii < indel_run.len() {
-                if snp_run[si].position <= indel_run[ii].position {
+                if snp_run[si].position() <= indel_run[ii].position() {
                     vk.push(snp_run[si]);
                     si += 1;
                 } else {
@@ -636,12 +659,18 @@ pub fn gather_haps_readbound(reader: &ContigReader, rb: &HapRanges<'_>) -> Batch
     let (dense_snp_present, dense_snp_present_off) = snp_presence.into_parts();
     let (dense_indel_present, dense_indel_present_off) = indel_presence.into_parts();
 
+    // Project the generic element back into the frozen (vk, vk_src) contract.
+    // For T = KeyRef this is a no-op move plus an empty `vk_src` alloc (which
+    // optimizes away); for T = SrcKeyRef it splits the payload apart.
+    let (vk, vk_src) = T::split(vk);
+
     BatchResultSplit {
         n_regions: n_q,
         n_samples: 1,
         ploidy,
         vk,
         vk_off,
+        vk_src,
         dense_snp,
         dense_snp_range: dense_snp_range_out,
         dense_snp_present,
@@ -651,6 +680,22 @@ pub fn gather_haps_readbound(reader: &ContigReader, rb: &HapRanges<'_>) -> Batch
         dense_indel_present,
         dense_indel_present_off,
     }
+}
+
+/// Flat per-query read-bound gather (see `gather_haps_readbound_impl`). Does
+/// NOT populate `vk_src` — the no-provenance path, byte-identical to
+/// pre-field behaviour and zero-cost (`KeyRef::make` discards the provenance
+/// args, so the packing in `spine::pack_vk_src` never runs).
+pub fn gather_haps_readbound(reader: &ContigReader, rb: &HapRanges<'_>) -> BatchResultSplit {
+    gather_haps_readbound_impl::<KeyRef>(reader, rb)
+}
+
+/// As `gather_haps_readbound`, but also populates `vk_src` so a consumer can
+/// map each merged var_key record back to its `(sub-stream, absolute call
+/// index)` and index a `FieldView`. This is the entry point gvl uses to read
+/// fields.
+pub fn gather_haps_readbound_src(reader: &ContigReader, rb: &HapRanges<'_>) -> BatchResultSplit {
+    gather_haps_readbound_impl::<SrcKeyRef>(reader, rb)
 }
 
 /// Fused search+gather: `find_ranges` then `gather_ranges` in one call. The

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -32,11 +32,11 @@ pub mod reader;
 pub mod sidecar;
 pub mod union;
 
-pub use crate::spine::KeyRef;
+pub use crate::spine::{KeyRef, SrcKeyRef, VK_SRC_INDEL_BIT, VkElem, pack_vk_src, unpack_vk_src};
 pub use decode::{HapCalls, QueryResult};
 pub use field::{FieldValue, FieldView};
 pub use gather::{
-    BatchResult, BatchResultSplit, HapRanges, RangesBundle, find_ranges, gather_haps_readbound,
-    gather_ranges, overlap_batch, read_ranges,
+    BatchResult, BatchResultSplit, HapRanges, RangesBundle, dense_abs_row, find_ranges,
+    gather_haps_readbound, gather_haps_readbound_src, gather_ranges, overlap_batch, read_ranges,
 };
 pub use reader::ContigReader;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -25,6 +25,7 @@
 //! [`oracle::gather_ranges_readbound`].
 
 pub mod decode;
+pub mod field;
 pub mod gather;
 pub mod oracle;
 pub mod reader;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -34,6 +34,7 @@ pub mod union;
 
 pub use crate::spine::KeyRef;
 pub use decode::{HapCalls, QueryResult};
+pub use field::{FieldValue, FieldView};
 pub use gather::{
     BatchResult, BatchResultSplit, HapRanges, RangesBundle, find_ranges, gather_haps_readbound,
     gather_ranges, overlap_batch, read_ranges,

--- a/src/query/oracle.rs
+++ b/src/query/oracle.rs
@@ -191,6 +191,7 @@ pub fn gather_ranges_readbound(reader: &ContigReader, rb: &RangesBundle) -> Batc
         ploidy,
         vk,
         vk_off,
+        vk_src: Vec::new(),
         dense_snp,
         dense_snp_range,
         dense_snp_present,

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -141,6 +141,8 @@ impl ContigReader {
                 |_| 0,
                 |_| true,
                 |i| rvk::snp_code_to_key(rvk::unpack_snp_key_at(keys, o0 + i)),
+                false,
+                o0,
                 &mut run,
             );
             runs.push(run);
@@ -162,6 +164,8 @@ impl ContigReader {
                 |i| rvk::deletion_len(keys[i]),
                 |_| true,
                 |i| keys[i],
+                true,
+                o0,
                 &mut run,
             );
             runs.push(run);

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -92,6 +92,35 @@ impl ContigReader {
 }
 
 impl ContigReader {
+    /// Cohort size this reader was opened with. Part of the public read
+    /// surface a field-sidecar consumer needs alongside `vk_snp_positions` /
+    /// `vk_indel_positions` to resolve `vk_src` provenance back to a record.
+    pub fn n_samples(&self) -> usize {
+        self.n_samples
+    }
+
+    /// Ploidy this reader was opened with.
+    pub fn ploidy(&self) -> usize {
+        self.ploidy
+    }
+
+    /// All `var_key/snp` absolute positions, in on-disk (packed, column-CSR)
+    /// order. Index with the absolute call index unpacked from a `vk_src`
+    /// entry (`spine::unpack_vk_src`, `is_indel == false`) to recover the
+    /// record a merged `vk` entry came from.
+    pub fn vk_snp_positions(&self) -> &[u32] {
+        self.vk_snp.positions()
+    }
+
+    /// All `var_key/indel` absolute positions, in on-disk (packed,
+    /// column-CSR) order. Index with the absolute call index unpacked from a
+    /// `vk_src` entry (`spine::unpack_vk_src`, `is_indel == true`).
+    pub fn vk_indel_positions(&self) -> &[u32] {
+        self.vk_indel.positions()
+    }
+}
+
+impl ContigReader {
     /// Raw long-allele LUT for the M6b contract: all bytes + CSR row offsets.
     /// A contig with no LUT returns empty bytes and a single `[0]` offset (an
     /// empty CSR), so the numpy side never special-cases a missing file.
@@ -116,15 +145,18 @@ impl ContigReader {
 impl ContigReader {
     /// `var_key` channel for one flat hap-column over one region: `snp`+`indel`
     /// unioned, uniform keys (SNP re-expanded via `snp_code_to_key`), sorted.
-    pub(crate) fn vk_slice(
+    /// Generic over `T: VkElem` so the no-provenance (`KeyRef`) and
+    /// provenance-carrying (`SrcKeyRef`) callers share one body; `T = KeyRef`
+    /// is zero-cost (`KeyRef::make` discards the provenance args).
+    pub(crate) fn vk_slice<T: spine::VkElem>(
         &self,
         col: usize,
         sample: usize,
         p: usize,
         q_start: u32,
         q_end: u32,
-    ) -> Vec<KeyRef> {
-        let mut runs: Vec<Vec<KeyRef>> = Vec::with_capacity(2);
+    ) -> Vec<T> {
+        let mut runs: Vec<Vec<T>> = Vec::with_capacity(2);
 
         // var_key/snp: 2-bit codes, absolute index o0 + i into the packed buffer.
         {
@@ -132,7 +164,7 @@ impl ContigReader {
             let (o0, o1) = (vk_range.start, vk_range.end);
             let positions = &self.vk_snp.positions()[o0..o1];
             let keys = as_bytes(&self.vk_snp.keys);
-            let mut run = Vec::new();
+            let mut run: Vec<T> = Vec::new();
             spine::gather_keys(
                 positions,
                 0,
@@ -155,7 +187,7 @@ impl ContigReader {
             let positions = &self.vk_indel.positions()[o0..o1];
             let keys = &as_u32(&self.vk_indel.keys)[o0..o1];
             let max_del = self.vk_indel_max_del[[sample, p]];
-            let mut run = Vec::new();
+            let mut run: Vec<T> = Vec::new();
             spine::gather_keys(
                 positions,
                 max_del,
@@ -171,7 +203,7 @@ impl ContigReader {
             runs.push(run);
         }
 
-        spine::merge_keys(runs)
+        spine::merge_by_position(runs)
     }
 
     /// The dense variants in `union[s..e]` that `hap` carries and that TRULY

--- a/src/spine.rs
+++ b/src/spine.rs
@@ -19,6 +19,76 @@ pub struct KeyRef {
     pub key: u32,
 }
 
+/// Bit 31 of a packed `vk_src`: 0 = `var_key/snp`, 1 = `var_key/indel`.
+pub const VK_SRC_INDEL_BIT: u32 = 1 << 31;
+
+/// Pack a var_key record's provenance: sub-stream tag in bit 31, absolute call
+/// index in bits 0..=30.
+///
+/// The assert is deliberate and load-bearing: a silent overflow here would
+/// return values from the WRONG record, which is far worse than a panic. It is
+/// unreachable on any real store (2^31 calls in a single contig sub-stream), and
+/// it never runs on the no-provenance path (`KeyRef::make` ignores its args).
+#[inline]
+pub fn pack_vk_src(is_indel: bool, call_idx: usize) -> u32 {
+    assert!(
+        call_idx < (1usize << 31),
+        "var_key call index {call_idx} exceeds the 2^31 vk_src ceiling"
+    );
+    (call_idx as u32) | if is_indel { VK_SRC_INDEL_BIT } else { 0 }
+}
+
+/// Inverse of [`pack_vk_src`]: `(is_indel, call_idx)`.
+#[inline]
+pub fn unpack_vk_src(src: u32) -> (bool, usize) {
+    (
+        src & VK_SRC_INDEL_BIT != 0,
+        (src & !VK_SRC_INDEL_BIT) as usize,
+    )
+}
+
+/// A `KeyRef` plus the provenance needed to index a field sidecar: which
+/// var_key sub-stream it came from and its absolute call index there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SrcKeyRef {
+    pub key: KeyRef,
+    /// Packed via [`pack_vk_src`].
+    pub src: u32,
+}
+
+/// The element type a var_key gather emits. Monomorphizing over this is what
+/// keeps the no-fields path zero-cost: `KeyRef::make` discards the provenance
+/// args, so the packing (and its assert) is dead code and compiles away.
+pub trait VkElem: Copy {
+    fn make(position: u32, key: u32, is_indel: bool, call_idx: usize) -> Self;
+    fn position(&self) -> u32;
+}
+
+impl VkElem for KeyRef {
+    #[inline]
+    fn make(position: u32, key: u32, _is_indel: bool, _call_idx: usize) -> Self {
+        KeyRef { position, key }
+    }
+    #[inline]
+    fn position(&self) -> u32 {
+        self.position
+    }
+}
+
+impl VkElem for SrcKeyRef {
+    #[inline]
+    fn make(position: u32, key: u32, is_indel: bool, call_idx: usize) -> Self {
+        SrcKeyRef {
+            key: KeyRef { position, key },
+            src: pack_vk_src(is_indel, call_idx),
+        }
+    }
+    #[inline]
+    fn position(&self) -> u32 {
+        self.key.position
+    }
+}
+
 /// Gathers `(position, key)` pairs from `positions` that TRULY overlap
 /// `[q_start, q_end)` (exact overlap: `pos < q_end && q_start < v_end`), among
 /// those `carried`. `overlap_range` only guarantees the right half (`pos <
@@ -27,7 +97,7 @@ pub struct KeyRef {
 /// later elements whose `v_end <= q_start` (they end before the query
 /// starts), so this checks the left half (`q_start < v_end`) per element.
 #[allow(clippy::too_many_arguments)]
-pub fn gather_keys(
+pub fn gather_keys<T: VkElem>(
     positions: &[u32],
     max_region_length: u32,
     q_start: u32,
@@ -35,7 +105,12 @@ pub fn gather_keys(
     del_len: impl Fn(usize) -> u32,
     carried: impl Fn(usize) -> bool,
     to_key: impl Fn(usize) -> u32,
-    out: &mut Vec<KeyRef>,
+    // Sub-stream tag for provenance (`false` = snp, `true` = indel).
+    is_indel: bool,
+    // Absolute index of `positions[0]` in the sub-stream's packed buffer, so
+    // the absolute call index of element `i` is `abs_base + i`.
+    abs_base: usize,
+    out: &mut Vec<T>,
 ) {
     if positions.is_empty() {
         return;
@@ -49,10 +124,7 @@ pub fn gather_keys(
     let (s_idx, e_idx) = overlap_range(&tree, &v_ends, max_region_length, q_start, q_end);
     for (i, &position) in positions.iter().enumerate().take(e_idx).skip(s_idx) {
         if carried(i) && q_start < v_ends[i] {
-            out.push(KeyRef {
-                position,
-                key: to_key(i),
-            });
+            out.push(T::make(position, to_key(i), is_indel, abs_base + i));
         }
     }
 }
@@ -63,8 +135,9 @@ pub fn gather_keys(
 ///
 /// `query::gather_haps_readbound` hand-inlines a 2-run (snp_run, indel_run)
 /// equivalent of this merge for allocation reasons — any change to this
-/// function's ordering or tie-break MUST be mirrored there.
-pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
+/// function's ordering or tie-break MUST be mirrored there. That twin now
+/// carries the same `VkElem` payload, so the mirroring covers `src` too.
+pub fn merge_by_position<T: VkElem>(runs: Vec<Vec<T>>) -> Vec<T> {
     let total: usize = runs.iter().map(|r| r.len()).sum();
     let mut heads = vec![0usize; runs.len()];
     let mut out = Vec::with_capacity(total);
@@ -76,7 +149,7 @@ pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
             }
             match best {
                 // Keep `best` on ties so the earlier run emits first (stable).
-                Some(b) if runs[b][heads[b]].position <= runs[r][heads[r]].position => {}
+                Some(b) if runs[b][heads[b]].position() <= runs[r][heads[r]].position() => {}
                 _ => best = Some(r),
             }
         }
@@ -85,6 +158,12 @@ pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
         heads[b] += 1;
     }
     out
+}
+
+/// Bare-`KeyRef` merge — the pre-existing signature, now a thin alias so every
+/// existing caller is untouched and provably unchanged.
+pub fn merge_keys(runs: Vec<Vec<KeyRef>>) -> Vec<KeyRef> {
+    merge_by_position(runs)
 }
 
 #[cfg(test)]
@@ -100,7 +179,7 @@ mod tests {
         // positions [10, 20, 30], v_end = pos + 1, max_del 0; query [15, 25):
         // only index 1 (pos 20) overlaps. to_key(i) = i as a marker key.
         let positions = [10u32, 20, 30];
-        let mut out = Vec::new();
+        let mut out: Vec<KeyRef> = Vec::new();
         gather_keys(
             &positions,
             0,
@@ -109,6 +188,8 @@ mod tests {
             |_| 0,
             |_| true,
             |i| i as u32,
+            false,
+            0,
             &mut out,
         );
         assert_eq!(out, vec![kr(20, 1)]);
@@ -120,7 +201,7 @@ mod tests {
         // only v0 (2..9) spans it. max_region_length 6 covers the deletion.
         let positions = [2u32, 10];
         let dels = [6u32, 0];
-        let mut out = Vec::new();
+        let mut out: Vec<KeyRef> = Vec::new();
         gather_keys(
             &positions,
             6,
@@ -129,6 +210,8 @@ mod tests {
             |i| dels[i],
             |_| true,
             |i| 100 + i as u32,
+            false,
+            0,
             &mut out,
         );
         assert_eq!(out, vec![kr(2, 100)]);
@@ -138,7 +221,7 @@ mod tests {
     fn test_gather_keys_carried_filter() {
         // Only even indices carried; query covers all.
         let positions = [10u32, 20, 30, 40];
-        let mut out = Vec::new();
+        let mut out: Vec<KeyRef> = Vec::new();
         gather_keys(
             &positions,
             0,
@@ -147,6 +230,8 @@ mod tests {
             |_| 0,
             |i| i % 2 == 0,
             |i| i as u32,
+            false,
+            0,
             &mut out,
         );
         assert_eq!(out, vec![kr(10, 0), kr(30, 2)]);
@@ -162,7 +247,7 @@ mod tests {
         // All carried; max_region_length 20 covers the deletion.
         let positions = [100u32, 105, 112];
         let del_len = [20u32, 0, 0];
-        let mut out = Vec::new();
+        let mut out: Vec<KeyRef> = Vec::new();
         gather_keys(
             &positions,
             20,
@@ -171,6 +256,8 @@ mod tests {
             |i| del_len[i],
             |_| true,
             |i| i as u32,
+            false,
+            0,
             &mut out,
         );
         assert_eq!(out, vec![kr(100, 0), kr(112, 2)]);
@@ -178,8 +265,8 @@ mod tests {
 
     #[test]
     fn test_gather_keys_empty_positions() {
-        let mut out = Vec::new();
-        gather_keys(&[], 0, 0, 100, |_| 0, |_| true, |_| 0, &mut out);
+        let mut out: Vec<KeyRef> = Vec::new();
+        gather_keys(&[], 0, 0, 100, |_| 0, |_| true, |_| 0, false, 0, &mut out);
         assert!(out.is_empty());
     }
 
@@ -200,5 +287,123 @@ mod tests {
     fn test_merge_keys_ties_keep_earlier_run_first() {
         let runs = vec![vec![kr(50, 111)], vec![kr(50, 222)]];
         assert_eq!(merge_keys(runs), vec![kr(50, 111), kr(50, 222)]);
+    }
+
+    #[test]
+    fn pack_unpack_vk_src_round_trips() {
+        assert_eq!(unpack_vk_src(pack_vk_src(false, 0)), (false, 0));
+        assert_eq!(unpack_vk_src(pack_vk_src(true, 0)), (true, 0));
+        assert_eq!(unpack_vk_src(pack_vk_src(false, 12345)), (false, 12345));
+        assert_eq!(
+            unpack_vk_src(pack_vk_src(true, (1 << 31) - 1)),
+            (true, (1 << 31) - 1)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds the 2^31 vk_src ceiling")]
+    fn pack_vk_src_asserts_on_overflow() {
+        pack_vk_src(false, 1 << 31);
+    }
+
+    #[test]
+    fn merge_by_position_carries_src_and_keeps_snp_tie_break() {
+        // snp run at positions 10, 20 (calls 0, 1); indel run at 10, 15 (calls 7, 8).
+        // Ties at position 10 must keep the SNP first (run 0 wins).
+        let snp: Vec<SrcKeyRef> = vec![
+            SrcKeyRef {
+                key: KeyRef {
+                    position: 10,
+                    key: 100,
+                },
+                src: pack_vk_src(false, 0),
+            },
+            SrcKeyRef {
+                key: KeyRef {
+                    position: 20,
+                    key: 200,
+                },
+                src: pack_vk_src(false, 1),
+            },
+        ];
+        let indel: Vec<SrcKeyRef> = vec![
+            SrcKeyRef {
+                key: KeyRef {
+                    position: 10,
+                    key: 300,
+                },
+                src: pack_vk_src(true, 7),
+            },
+            SrcKeyRef {
+                key: KeyRef {
+                    position: 15,
+                    key: 400,
+                },
+                src: pack_vk_src(true, 8),
+            },
+        ];
+        let out = merge_by_position(vec![snp, indel]);
+        let got: Vec<(u32, bool, usize)> = out
+            .iter()
+            .map(|e| {
+                let (is_indel, idx) = unpack_vk_src(e.src);
+                (e.key.position, is_indel, idx)
+            })
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                (10, false, 0), // snp wins the tie
+                (10, true, 7),
+                (15, true, 8),
+                (20, false, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_keys_is_unchanged_for_bare_keyrefs() {
+        let a = vec![
+            KeyRef {
+                position: 1,
+                key: 10,
+            },
+            KeyRef {
+                position: 5,
+                key: 50,
+            },
+        ];
+        let b = vec![
+            KeyRef {
+                position: 1,
+                key: 99,
+            },
+            KeyRef {
+                position: 3,
+                key: 30,
+            },
+        ];
+        let out = merge_keys(vec![a, b]);
+        assert_eq!(
+            out,
+            vec![
+                KeyRef {
+                    position: 1,
+                    key: 10
+                }, // stable: earlier run first
+                KeyRef {
+                    position: 1,
+                    key: 99
+                },
+                KeyRef {
+                    position: 3,
+                    key: 30
+                },
+                KeyRef {
+                    position: 5,
+                    key: 50
+                },
+            ]
+        );
     }
 }

--- a/src/spine.rs
+++ b/src/spine.rs
@@ -62,6 +62,10 @@ pub struct SrcKeyRef {
 pub trait VkElem: Copy {
     fn make(position: u32, key: u32, is_indel: bool, call_idx: usize) -> Self;
     fn position(&self) -> u32;
+
+    /// Split a merged run into the frozen `(keys, src)` contract. `KeyRef`
+    /// yields an empty `src`; `SrcKeyRef` yields one entry per key.
+    fn split(v: Vec<Self>) -> (Vec<KeyRef>, Vec<u32>);
 }
 
 impl VkElem for KeyRef {
@@ -72,6 +76,10 @@ impl VkElem for KeyRef {
     #[inline]
     fn position(&self) -> u32 {
         self.position
+    }
+    #[inline]
+    fn split(v: Vec<Self>) -> (Vec<KeyRef>, Vec<u32>) {
+        (v, Vec::new())
     }
 }
 
@@ -86,6 +94,16 @@ impl VkElem for SrcKeyRef {
     #[inline]
     fn position(&self) -> u32 {
         self.key.position
+    }
+    #[inline]
+    fn split(v: Vec<Self>) -> (Vec<KeyRef>, Vec<u32>) {
+        let mut keys = Vec::with_capacity(v.len());
+        let mut src = Vec::with_capacity(v.len());
+        for e in v {
+            keys.push(e.key);
+            src.push(e.src);
+        }
+        (keys, src)
     }
 }
 

--- a/tests/test_field_provenance.rs
+++ b/tests/test_field_provenance.rs
@@ -254,6 +254,20 @@ fn field_provenance_reader(out: &std::path::Path) -> ContigReader {
             alts: vec![&b"C"[..]],
             gt: vec![1, 1, 1, 1],
         },
+        // var_key/snp tie-break probe: AC=1, at the SAME position (150) as the
+        // dense/snp record above, carried by the SAME hap (S0,p0 — the dense
+        // record's gt is all-1s, so it always carries too). A flipped
+        // `decode_hap_src` tie-break (`<=` -> `<` at the var_key/dense merge)
+        // would swap this pair's order — undetectable by
+        // `decode_hap_src_matches_decode_hap_order` without this collision,
+        // since every other position in this fixture is unique. Different ALT
+        // (T vs C) makes the two records distinguishable in `hc.alts`.
+        SynthRecord {
+            pos: 150,
+            ref_allele: b"A",
+            alts: vec![&b"T"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
         // dense/snp: AC=2, partial carriage -> exercises a mixed presence row.
         // Different ALT than the pos-150 record so a wrong-allele bug would
         // be caught by a decode-level comparison.
@@ -382,4 +396,200 @@ fn decode_hap_src_matches_decode_hap_order() {
             assert_eq!(srcs.len(), b.positions.len());
         }
     }
+}
+
+/// Explicit pin for the var_key/dense position tie at hap (S0, p0): the
+/// var_key/snp AC=1 record (ALT `T`) and the dense/snp AC=4 record (ALT `C`)
+/// both sit at position 150 and are both carried by this hap (AC=4's gt is
+/// all-1s). Per the merge's documented contract (`decode_hap`'s
+/// `spine::merge_keys`, mirrored by `decode_hap_src`'s two-pointer merge),
+/// var_key must win the tie and come first.
+///
+/// `decode_hap_src_matches_decode_hap_order` above already catches a flipped
+/// tie-break generically (its `assert_eq!(a.alts, b.alts)` would fail, since
+/// `decode_hap` — untouched — still orders var_key first), but this test
+/// pins the expected order directly and verifies the fixture actually routed
+/// each AC to the class this test assumes, rather than assuming it.
+#[test]
+fn decode_hap_src_pins_var_key_dense_position_tie() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = field_provenance_reader(&out);
+    let regions = [(0u32, 1_000_000u32)];
+    let br = overlap_batch_src(&reader, &regions);
+
+    // Class-routing guard: verify, don't assume.
+    assert!(
+        reader.vk_snp_positions().contains(&150),
+        "the AC=1 record at 150 must have routed to var_key/snp"
+    );
+
+    let (hc, srcs) = br.decode_hap_src(&reader, 0, 0, 0);
+    let at_150: Vec<usize> = hc
+        .positions
+        .iter()
+        .enumerate()
+        .filter(|&(_, &p)| p == 150)
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(
+        at_150.len(),
+        2,
+        "both records at position 150 must be carried by hap (S0,p0)"
+    );
+    let (i0, i1) = (at_150[0], at_150[1]);
+
+    assert!(!srcs[i0].is_dense, "var_key must win the position tie");
+    assert_eq!(hc.alts[i0], b"T", "var_key entry's ALT");
+    assert!(srcs[i1].is_dense, "dense must come second on the tie");
+    assert_eq!(hc.alts[i1], b"C", "dense entry's ALT");
+}
+
+// --- Task 8 fix pass (Finding 3): pin `decode_batch_fields`'s emitted BYTES,
+// not just that it builds. `gather_field_bytes`/`OpenField` are plain Rust
+// (no `Python<'py>`), so this needs no GIL. -----------------------------
+
+use genoray_core::layout::{ContigPaths, FieldSub};
+use genoray_core::py_query_decode::{OpenField, gather_field_bytes};
+
+fn write_field_i32(paths: &ContigPaths, category: &str, name: &str, sub: FieldSub, vals: &[i32]) {
+    let p = paths.field_values(category, name, sub);
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    let bytes: Vec<u8> = vals.iter().flat_map(|v| v.to_le_bytes()).collect();
+    std::fs::write(&p, bytes).unwrap();
+}
+
+/// `decode_batch_fields`'s Rust core (`OpenField::open` + `gather_field_bytes`)
+/// must gather the right byte for the right record — through all four
+/// provenance classes (var_key snp/indel, dense snp/indel) and through the
+/// dense-FORMAT `(row, orig_sample)` stride, which is the one bug class a
+/// build-only smoke test cannot catch. Every written value is distinct (per
+/// field, class-offset + index) so a wrong index reads a wrong-but-plausible
+/// value instead of accidentally still matching.
+#[test]
+fn gather_field_bytes_pins_bytes_per_class_and_dense_format_stride() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = field_provenance_reader(&out);
+    let n_samples = reader.n_samples();
+    assert_eq!(n_samples, 2, "fixture is a fixed 2-sample cohort");
+
+    // Per-class call/row counts — verified via the reader's own accessors for
+    // var_key, and via the already-pinned dense row layout
+    // (`decode_hap_src_is_aligned_with_decoded_records`'s
+    // `dense_snp_expected`/`dense_indel_expected`, unaffected by the Finding-2
+    // var_key addition above) for dense.
+    let n_vk_snp = reader.vk_snp_positions().len();
+    let n_vk_indel = reader.vk_indel_positions().len();
+    assert_eq!(n_vk_snp, 2, "var_key/snp: pos-100 and pos-150 AC=1 records");
+    assert_eq!(n_vk_indel, 1, "var_key/indel: the pos-130 AC=1 record");
+    let n_dense_snp = 2usize; // rows: pos150 (AC=4), pos175 (AC=2)
+    let n_dense_indel = 2usize; // rows: pos200 (AC=3 ins), pos300 (AC=3 del)
+
+    // --- INFO field "IV" (i32): one value per (class, call/row), disjoint
+    // ranges per class so a cross-class index bug reads an out-of-range value.
+    let vk_snp_iv: Vec<i32> = (0..n_vk_snp as i32).map(|i| 100 + i).collect();
+    let vk_indel_iv: Vec<i32> = (0..n_vk_indel as i32).map(|i| 200 + i).collect();
+    let dense_snp_iv: Vec<i32> = (0..n_dense_snp as i32).map(|i| 300 + i).collect();
+    let dense_indel_iv: Vec<i32> = (0..n_dense_indel as i32).map(|i| 400 + i).collect();
+
+    let paths = ContigPaths::new(out.to_str().unwrap(), "chr1");
+    write_field_i32(&paths, "info", "IV", FieldSub::VkSnp, &vk_snp_iv);
+    write_field_i32(&paths, "info", "IV", FieldSub::VkIndel, &vk_indel_iv);
+    write_field_i32(&paths, "info", "IV", FieldSub::DenseSnp, &dense_snp_iv);
+    write_field_i32(&paths, "info", "IV", FieldSub::DenseIndel, &dense_indel_iv);
+
+    // --- FORMAT field "DP" (i32): var_key is per-call (no sample stride, per
+    // the cost model: FORMAT is paid per carrier call in var_key); dense is
+    // per (row, orig_sample) — `value = 5000 + row*10 + sample`, so samples
+    // DIFFER at the same row. This is the assertion that catches a missing or
+    // wrong dense-FORMAT stride.
+    let vk_snp_dp: Vec<i32> = (0..n_vk_snp as i32).map(|i| 600 + i).collect();
+    let vk_indel_dp: Vec<i32> = (0..n_vk_indel as i32).map(|i| 700 + i).collect();
+    let mut dense_snp_dp: Vec<i32> = Vec::with_capacity(n_dense_snp * n_samples);
+    for row in 0..n_dense_snp {
+        for s in 0..n_samples {
+            dense_snp_dp.push((5000 + row * 10 + s) as i32);
+        }
+    }
+    let mut dense_indel_dp: Vec<i32> = Vec::with_capacity(n_dense_indel * n_samples);
+    for row in 0..n_dense_indel {
+        for s in 0..n_samples {
+            dense_indel_dp.push((8000 + row * 10 + s) as i32);
+        }
+    }
+    write_field_i32(&paths, "format", "DP", FieldSub::VkSnp, &vk_snp_dp);
+    write_field_i32(&paths, "format", "DP", FieldSub::VkIndel, &vk_indel_dp);
+    write_field_i32(&paths, "format", "DP", FieldSub::DenseSnp, &dense_snp_dp);
+    write_field_i32(
+        &paths,
+        "format",
+        "DP",
+        FieldSub::DenseIndel,
+        &dense_indel_dp,
+    );
+
+    let regions = [(0u32, 1_000_000u32)];
+    let br = overlap_batch_src(&reader, &regions);
+
+    let iv = OpenField::open(&paths, "info", "IV", "i32", n_samples).unwrap();
+    let dp = OpenField::open(&paths, "format", "DP", "i32", n_samples).unwrap();
+    let fields = vec![iv, dp];
+    let fbytes = gather_field_bytes(&reader, &br, &fields);
+    assert_eq!(fbytes.len(), 2);
+
+    // Independently replicate the expected bytes via the SAME provenance
+    // (`decode_hap_src`) `gather_field_bytes` itself uses, but computing the
+    // expected value here rather than calling into the code under test.
+    let mut expect_iv: Vec<u8> = Vec::new();
+    let mut expect_dp: Vec<u8> = Vec::new();
+    let mut n_records = 0usize;
+    for r in 0..br.n_regions {
+        for s in 0..br.n_samples {
+            for p in 0..br.ploidy {
+                let (_, srcs) = br.decode_hap_src(&reader, r, s, p);
+                for src in &srcs {
+                    n_records += 1;
+                    let iv_val = match (src.is_dense, src.is_indel) {
+                        (false, false) => vk_snp_iv[src.idx],
+                        (false, true) => vk_indel_iv[src.idx],
+                        (true, false) => dense_snp_iv[src.idx],
+                        (true, true) => dense_indel_iv[src.idx],
+                    };
+                    expect_iv.extend_from_slice(&iv_val.to_le_bytes());
+
+                    let dp_val = match (src.is_dense, src.is_indel) {
+                        (false, false) => vk_snp_dp[src.idx],
+                        (false, true) => vk_indel_dp[src.idx],
+                        // Dense: format_at(row, orig_sample) == row*n_samples + orig_sample.
+                        (true, false) => dense_snp_dp[src.idx * n_samples + s],
+                        (true, true) => dense_indel_dp[src.idx * n_samples + s],
+                    };
+                    expect_dp.extend_from_slice(&dp_val.to_le_bytes());
+                }
+            }
+        }
+    }
+
+    assert_eq!(fbytes[0], expect_iv, "INFO field bytes mismatch");
+    assert_eq!(fbytes[1], expect_dp, "FORMAT field bytes mismatch");
+    assert_eq!(
+        fbytes[0].len(),
+        n_records * 4,
+        "field_bytes.len() must equal n_records * itemsize"
+    );
+    assert_eq!(fbytes[1].len(), n_records * 4);
+
+    // Sanity: this fixture must actually exercise a dense record carried by
+    // BOTH samples with DIFFERING per-sample DP values (else the dense-FORMAT
+    // stride assertion above would pass vacuously). The AC=4 dense/snp record
+    // at row 0 (pos 150) is carried by every hap, so both s=0 and s=1 read it.
+    let row0 = 0usize;
+    assert_ne!(
+        dense_snp_dp[row0 * n_samples],
+        dense_snp_dp[row0 * n_samples + 1],
+        "row-0 DP must differ across samples for the stride test to be meaningful"
+    );
 }

--- a/tests/test_field_provenance.rs
+++ b/tests/test_field_provenance.rs
@@ -215,3 +215,171 @@ fn vk_src_is_aligned_with_vk_and_survives_the_merge() {
     assert_eq!(reader.n_samples(), n_samples);
     assert_eq!(reader.ploidy(), ploidy);
 }
+
+// --- Task 8: `decode_hap_src` record-order + per-record provenance --------
+
+use genoray_core::query::gather::overlap_batch_src;
+use genoray_core::query::overlap_batch;
+
+/// A store with all four provenance classes present: a var_key SNP, a var_key
+/// indel, a dense SNP table (one fully-carried + one partially-carried
+/// record), and a dense indel table (two records). Modeled on `synth_reader`
+/// in `tests/test_readbound_gather.rs`, which already routes an AC=4 and an
+/// AC=2 SNP to Dense and two AC=3 indels to Dense; this fixture additionally
+/// adds an AC=1 indel so `var_key/indel` is exercised too — `synth_reader` has
+/// none. Per `cost_model::choose_representation` at n_samples=2/ploidy=2
+/// (np=4): AC=1 always stays `VarKey` for both classes; AC>=2 routes SNPs to
+/// `Dense` and AC>=2 routes indels to `Dense` too.
+fn field_provenance_reader(out: &std::path::Path) -> ContigReader {
+    let samples = ["S0", "S1"];
+    let records = vec![
+        // var_key/snp: AC=1 (S0,p0).
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+        // var_key/indel: AC=1 (S1,p0). Insertion (ref "A" -> alt "AC"), ilen +1.
+        SynthRecord {
+            pos: 130,
+            ref_allele: b"A",
+            alts: vec![&b"AC"[..]],
+            gt: vec![0, 0, 1, 0],
+        },
+        // dense/snp: AC=4, all haps carry -> exercises an all-true presence row.
+        SynthRecord {
+            pos: 150,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 1, 1, 1],
+        },
+        // dense/snp: AC=2, partial carriage -> exercises a mixed presence row.
+        // Different ALT than the pos-150 record so a wrong-allele bug would
+        // be caught by a decode-level comparison.
+        SynthRecord {
+            pos: 175,
+            ref_allele: b"A",
+            alts: vec![&b"G"[..]],
+            gt: vec![1, 1, 0, 0],
+        },
+        // dense/indel: AC=3, insertion.
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: vec![0, 1, 1, 1],
+        },
+        // dense/indel: AC=3, deletion.
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"AT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 0, 1],
+        },
+    ];
+    build_contig(out, "chr1", &samples, 2, &records);
+    ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
+}
+
+/// `decode_hap_src` must emit exactly one provenance entry per decoded
+/// record, in the same order as `decode_hap`, and each entry must resolve
+/// back to the record that actually produced it — for var_key entries via the
+/// public `vk_snp_positions`/`vk_indel_positions` accessors, and for dense
+/// entries via this fixture's known (and asserted-monotonic-by-construction)
+/// per-class row order. A coverage guard fails loudly if any of the four
+/// provenance classes (var_key snp/indel, dense snp/indel) stops appearing.
+#[test]
+fn decode_hap_src_is_aligned_with_decoded_records() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = field_provenance_reader(&out);
+    let n_samples = 2usize;
+    let ploidy = 2usize;
+    let regions = [(0u32, 1_000_000u32)];
+    let br = overlap_batch_src(&reader, &regions);
+
+    let snp_pos = reader.vk_snp_positions();
+    let indel_pos = reader.vk_indel_positions();
+
+    // Known dense per-class row -> position mapping for THIS fixture: both
+    // dense tables are built from records already given in increasing
+    // position order, and `SearchTree`/`overlap_range` require monotonic
+    // per-class positions, so row i is exactly the i-th dense record of that
+    // class in insertion order.
+    let dense_snp_expected = [150u32, 175u32];
+    let dense_indel_expected = [200u32, 300u32];
+
+    let (mut n_vk_snp, mut n_vk_indel, mut n_dense_snp, mut n_dense_indel) =
+        (0u32, 0u32, 0u32, 0u32);
+
+    for s in 0..n_samples {
+        for p in 0..ploidy {
+            let (hc, srcs) = br.decode_hap_src(&reader, 0, s, p);
+            assert_eq!(hc.positions.len(), srcs.len(), "one src per decoded record");
+            for (i, src) in srcs.iter().enumerate() {
+                let want_pos = hc.positions[i];
+                if !src.is_dense {
+                    let pos = if src.is_indel {
+                        n_vk_indel += 1;
+                        indel_pos[src.idx]
+                    } else {
+                        n_vk_snp += 1;
+                        snp_pos[src.idx]
+                    };
+                    assert_eq!(
+                        pos, want_pos,
+                        "var_key src[{i}] resolves to the wrong position"
+                    );
+                } else if src.is_indel {
+                    n_dense_indel += 1;
+                    assert_eq!(
+                        dense_indel_expected[src.idx], want_pos,
+                        "dense/indel src[{i}] resolves to the wrong row"
+                    );
+                } else {
+                    n_dense_snp += 1;
+                    assert_eq!(
+                        dense_snp_expected[src.idx], want_pos,
+                        "dense/snp src[{i}] resolves to the wrong row"
+                    );
+                }
+            }
+        }
+    }
+
+    assert!(n_vk_snp > 0, "fixture must exercise a var_key/snp record");
+    assert!(
+        n_vk_indel > 0,
+        "fixture must exercise a var_key/indel record"
+    );
+    assert!(n_dense_snp > 0, "fixture must exercise a dense/snp record");
+    assert!(
+        n_dense_indel > 0,
+        "fixture must exercise a dense/indel record"
+    );
+}
+
+/// `decode_hap_src` must return records in EXACTLY the order `decode_hap`
+/// does — otherwise field values would be attached to the wrong variants.
+#[test]
+fn decode_hap_src_matches_decode_hap_order() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = field_provenance_reader(&out);
+    let regions = [(0u32, 1_000_000u32)];
+    let plain = overlap_batch(&reader, &regions);
+    let with_src = overlap_batch_src(&reader, &regions);
+    for s in 0..2 {
+        for p in 0..2 {
+            let a = plain.decode_hap(&reader, 0, s, p);
+            let (b, srcs) = with_src.decode_hap_src(&reader, 0, s, p);
+            assert_eq!(a.positions, b.positions);
+            assert_eq!(a.ilens, b.ilens);
+            assert_eq!(a.alts, b.alts);
+            assert_eq!(srcs.len(), b.positions.len());
+        }
+    }
+}

--- a/tests/test_field_provenance.rs
+++ b/tests/test_field_provenance.rs
@@ -446,12 +446,18 @@ fn decode_hap_src_pins_var_key_dense_position_tie() {
     assert_eq!(hc.alts[i1], b"C", "dense entry's ALT");
 }
 
-// --- Task 8 fix pass (Finding 3): pin `decode_batch_fields`'s emitted BYTES,
-// not just that it builds. `gather_field_bytes`/`OpenField` are plain Rust
-// (no `Python<'py>`), so this needs no GIL. -----------------------------
+// --- Task 8 fix pass (Finding 3, re-verified in fix pass 2 after Finding A/B):
+// pin `decode_batch_fields`'s emitted BYTES, not just that it builds.
+// `gather_batch_fields`/`OpenField` are plain Rust (no `Python<'py>`), so this
+// needs no GIL. `gather_batch_fields` now does the record decode AND the
+// per-field byte gather in a single `decode_hap_src` pass (fix pass 2,
+// Finding A), so this test also implicitly proves that single pass produces
+// bit-exact bytes (fix pass 2, Finding B) — the assertions below are
+// unchanged from before that restructuring, only the call site (`.fbytes`)
+// differs. ---------------------------------------------------------------
 
 use genoray_core::layout::{ContigPaths, FieldSub};
-use genoray_core::py_query_decode::{OpenField, gather_field_bytes};
+use genoray_core::py_query_decode::{OpenField, gather_batch_fields};
 
 fn write_field_i32(paths: &ContigPaths, category: &str, name: &str, sub: FieldSub, vals: &[i32]) {
     let p = paths.field_values(category, name, sub);
@@ -460,7 +466,7 @@ fn write_field_i32(paths: &ContigPaths, category: &str, name: &str, sub: FieldSu
     std::fs::write(&p, bytes).unwrap();
 }
 
-/// `decode_batch_fields`'s Rust core (`OpenField::open` + `gather_field_bytes`)
+/// `decode_batch_fields`'s Rust core (`OpenField::open` + `gather_batch_fields`)
 /// must gather the right byte for the right record — through all four
 /// provenance classes (var_key snp/indel, dense snp/indel) and through the
 /// dense-FORMAT `(row, orig_sample)` stride, which is the one bug class a
@@ -468,7 +474,7 @@ fn write_field_i32(paths: &ContigPaths, category: &str, name: &str, sub: FieldSu
 /// field, class-offset + index) so a wrong index reads a wrong-but-plausible
 /// value instead of accidentally still matching.
 #[test]
-fn gather_field_bytes_pins_bytes_per_class_and_dense_format_stride() {
+fn gather_batch_fields_pins_bytes_per_class_and_dense_format_stride() {
     let tmp = tempdir().unwrap();
     let out = tmp.path().join("out");
     std::fs::create_dir_all(&out).unwrap();
@@ -537,11 +543,12 @@ fn gather_field_bytes_pins_bytes_per_class_and_dense_format_stride() {
     let iv = OpenField::open(&paths, "info", "IV", "i32", n_samples).unwrap();
     let dp = OpenField::open(&paths, "format", "DP", "i32", n_samples).unwrap();
     let fields = vec![iv, dp];
-    let fbytes = gather_field_bytes(&reader, &br, &fields);
+    let decoded = gather_batch_fields(&reader, &br, &fields);
+    let fbytes = &decoded.fbytes;
     assert_eq!(fbytes.len(), 2);
 
     // Independently replicate the expected bytes via the SAME provenance
-    // (`decode_hap_src`) `gather_field_bytes` itself uses, but computing the
+    // (`decode_hap_src`) `gather_batch_fields` itself uses, but computing the
     // expected value here rather than calling into the code under test.
     let mut expect_iv: Vec<u8> = Vec::new();
     let mut expect_dp: Vec<u8> = Vec::new();

--- a/tests/test_field_provenance.rs
+++ b/tests/test_field_provenance.rs
@@ -1,0 +1,217 @@
+//! Task 5: `vk_src` provenance must be aligned 1:1 with the merged `vk`
+//! channel, and every entry must resolve back to the record that actually
+//! produced it — through the snp/indel position-merge, through multiple
+//! var_key columns with different absolute-index bases, and through the
+//! per-element overlap filter that drops candidates a narrower query excludes.
+mod common;
+
+use common::{SynthRecord, build_contig};
+use genoray_core::query::gather::gather_haps_readbound_src;
+use genoray_core::query::{
+    BatchResultSplit, ContigReader, HapRanges, find_ranges, gather_haps_readbound,
+};
+use genoray_core::spine;
+use tempfile::tempdir;
+
+/// A store with BOTH var_key/snp and var_key/indel records, spread across all
+/// four (sample, ploid) columns of a 2-sample/ploidy-2 cohort, plus a
+/// same-position SNP+indel tie on column (S0, p0) — modeled on
+/// `tie_break_reader` in `tests/test_readbound_gather.rs`. Every record here
+/// is AC=1, so `cost_model::choose_representation` always keeps it in
+/// `var_key` (never `dense`) — see that reader's doc comment.
+fn provenance_reader(out: &std::path::Path) -> ContigReader {
+    let samples = ["S0", "S1"];
+    let records = vec![
+        // col0 (S0,p0): SNP only.
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+        // col2 (S1,p0): indel only.
+        SynthRecord {
+            pos: 150,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: vec![0, 0, 1, 0],
+        },
+        // col1 (S0,p1): SNP only. This is the record that pins absolute (not
+        // column-local) indexing: col0 already contributed 2 snp entries
+        // ahead of it in the packed buffer, so its absolute index is 2 even
+        // though it is the FIRST snp entry in its own column.
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"A",
+            alts: vec![&b"G"[..]],
+            gt: vec![0, 1, 0, 0],
+        },
+        // col3 (S1,p1): indel only.
+        SynthRecord {
+            pos: 250,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: vec![0, 0, 0, 1],
+        },
+        // col0 (S0,p0) again: SNP+indel at the SAME position 400, same hap as
+        // the pos-100 SNP above -> exercises the position-merge tie-break
+        // (snp must win) on a column whose absolute base is already nonzero.
+        SynthRecord {
+            pos: 400,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+        SynthRecord {
+            pos: 400,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+    ];
+    build_contig(out, "chr1", &samples, 2, &records);
+    ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
+}
+
+/// `vk_src` must be aligned 1:1 with `vk`, and each entry must point at the
+/// record that actually produced it — including through the position-merge
+/// of snp+indel and through the overlap FILTER that drops records (the
+/// filter is why the index can't be recovered from run position afterwards).
+#[test]
+fn vk_src_is_aligned_with_vk_and_survives_the_merge() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = provenance_reader(&out);
+    let n_samples = 2usize;
+    let ploidy = 2usize;
+
+    // Region 0: full coverage, sees every record. Region 1: q_start = 300
+    // drops the pos-100/150/200/250 records via the left-overlap re-check
+    // (`q_start < v_end`) while keeping the pos-400 tie (v_end 401/402 > 300)
+    // — this is the "overlap filter drops records" case the provenance must
+    // survive: the surviving vk_src entries must still resolve to their true
+    // absolute indices, not renumbered ones.
+    let regions = [(0u32, 1_000_000u32), (300u32, 1_000_000u32)];
+
+    let rb = find_ranges(&reader, &regions, None);
+
+    // Flatten into HapRanges in the same region-major, sample-major order
+    // `find_ranges`/`gather_ranges_readbound` use (see
+    // `test_flat_gather_matches_cartesian_full_cohort` in
+    // tests/test_readbound_gather.rs, which this mirrors for the full cohort).
+    let s_n = rb.n_samples;
+    assert_eq!(s_n, n_samples);
+    let mut region_starts = Vec::new();
+    let mut orig_samples = Vec::new();
+    let mut vk_snp_range = Vec::new();
+    let mut vk_indel_range = Vec::new();
+    let mut dsr = Vec::new();
+    let mut dir_ = Vec::new();
+    for r in 0..regions.len() {
+        for s in 0..s_n {
+            region_starts.push(rb.region_starts[r]);
+            orig_samples.push(rb.sample_cols[s]);
+            dsr.push(rb.dense_snp_range[r].clone());
+            dir_.push(rb.dense_indel_range[r].clone());
+            for p in 0..ploidy {
+                let row = r * (s_n * ploidy) + s * ploidy + p;
+                vk_snp_range.push(rb.vk_snp_range[row].clone());
+                vk_indel_range.push(rb.vk_indel_range[row].clone());
+            }
+        }
+    }
+    let hr = HapRanges::new(
+        &region_starts,
+        &orig_samples,
+        &vk_snp_range,
+        &vk_indel_range,
+        &dsr,
+        &dir_,
+        ploidy,
+    );
+
+    let plain: BatchResultSplit = gather_haps_readbound(&reader, &hr);
+    let with_src: BatchResultSplit = gather_haps_readbound_src(&reader, &hr);
+
+    // The no-provenance path is unchanged, and provenance is purely additive.
+    assert!(
+        plain.vk_src.is_empty(),
+        "plain path must not populate vk_src"
+    );
+    assert_eq!(
+        plain.vk, with_src.vk,
+        "adding provenance must not change vk"
+    );
+    assert_eq!(plain.vk_off, with_src.vk_off);
+    assert_eq!(with_src.vk_src.len(), with_src.vk.len());
+
+    // Coverage guard: fail loudly if the fixture stopped exercising both
+    // sub-streams (rather than passing vacuously on an all-snp or all-indel
+    // vk).
+    let (mut any_snp, mut any_indel) = (false, false);
+
+    // Every vk_src must resolve to the record that produced its key,
+    // regardless of which hap/region it came from or whether the query
+    // narrowed the candidate window.
+    let snp_pos = reader.vk_snp_positions();
+    let indel_pos = reader.vk_indel_positions();
+    for (i, kr) in with_src.vk.iter().enumerate() {
+        let (is_indel, idx) = spine::unpack_vk_src(with_src.vk_src[i]);
+        any_snp |= !is_indel;
+        any_indel |= is_indel;
+        let pos = if is_indel {
+            indel_pos[idx]
+        } else {
+            snp_pos[idx]
+        };
+        assert_eq!(
+            pos, kr.position,
+            "vk_src[{i}] points at position {pos} but vk[{i}] is at {}",
+            kr.position
+        );
+    }
+    assert!(any_snp, "fixture must exercise a var_key/snp vk_src entry");
+    assert!(
+        any_indel,
+        "fixture must exercise a var_key/indel vk_src entry"
+    );
+
+    // Pin the tie-break explicitly: hap (region 0, sample S0, ploid 0) must
+    // merge to [snp@100, snp@400, indel@400] — snp wins the position-400 tie.
+    let s0_slot = rb
+        .sample_cols
+        .iter()
+        .position(|&orig| orig == 0)
+        .expect("S0 must be present");
+    let row0 = s0_slot * ploidy; // region 0, S0, p0
+    let (vs, ve) = (with_src.vk_off[row0], with_src.vk_off[row0 + 1]);
+    let got: Vec<(u32, bool)> = with_src.vk[vs..ve]
+        .iter()
+        .zip(&with_src.vk_src[vs..ve])
+        .map(|(kr, &src)| (kr.position, spine::unpack_vk_src(src).0))
+        .collect();
+    assert_eq!(
+        got,
+        vec![(100, false), (400, false), (400, true)],
+        "hap (region0, S0, p0) must merge to [snp@100, snp@400, indel@400] with snp winning the tie"
+    );
+
+    // Also pin the absolute-index recovery is correct on this same hap: the
+    // pos-400 snp entry's absolute index must land in vk_snp_positions/keys
+    // at exactly `pos == 400`, distinguishing it from the pos-100 entry.
+    let (is_indel0, idx0) = spine::unpack_vk_src(with_src.vk_src[vs]);
+    assert!(!is_indel0);
+    assert_eq!(snp_pos[idx0], 100);
+    let (is_indel1, idx1) = spine::unpack_vk_src(with_src.vk_src[vs + 1]);
+    assert!(!is_indel1);
+    assert_eq!(snp_pos[idx1], 400);
+    let (is_indel2, idx2) = spine::unpack_vk_src(with_src.vk_src[vs + 2]);
+    assert!(is_indel2);
+    assert_eq!(indel_pos[idx2], 400);
+
+    // n_samples()/ploidy() accessors (needed by gvl regardless of fields):
+    // confirm they report what the reader was opened with.
+    assert_eq!(reader.n_samples(), n_samples);
+    assert_eq!(reader.ploidy(), ploidy);
+}

--- a/tests/test_field_read.rs
+++ b/tests/test_field_read.rs
@@ -1,0 +1,55 @@
+//! Proves the field-read API is reachable from OUTSIDE the crate — the same way
+//! GenVarLoader consumes it (Cargo path-dep, `default-features = false`). This
+//! is the Milestone-1 acceptance test: everything gvl needs (`FieldView`,
+//! `FieldValue`, `vk_src` pack/unpack, `gather_haps_readbound_src`, and
+//! `dense_abs_row`) must be reachable via a short, stable `genoray_core::...`
+//! path without reaching into private modules.
+
+use genoray_core::field::StorageDtype;
+use genoray_core::layout::{ContigPaths, FieldSub};
+use genoray_core::query::gather::dense_abs_row;
+use genoray_core::query::{FieldValue, FieldView, pack_vk_src, unpack_vk_src};
+
+#[test]
+fn field_view_is_publicly_constructible() {
+    let tmp = tempfile::tempdir().unwrap();
+    let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+    let p = paths.field_values("format", "DS", FieldSub::VkSnp);
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    let vals: [f32; 3] = [0.0, 1.5, 2.0];
+    std::fs::write(&p, bytemuck::cast_slice(&vals)).unwrap();
+
+    let v = FieldView::open(
+        &paths,
+        "format",
+        "DS",
+        FieldSub::VkSnp,
+        StorageDtype::F32,
+        1,
+    )
+    .unwrap();
+    assert_eq!(v.len(), 3);
+    assert_eq!(v.value_at(1), FieldValue::F32(1.5));
+    assert_eq!(v.as_slice::<f32>().unwrap(), &vals[..]);
+}
+
+#[test]
+fn vk_src_helpers_are_public() {
+    let s = pack_vk_src(true, 42);
+    assert_eq!(unpack_vk_src(s), (true, 42));
+}
+
+#[test]
+fn dense_abs_row_is_public_and_correct() {
+    // on-disk window [10, 16), output window [0, 6) — pure translation.
+    let on_disk = 10usize..16usize;
+    let out = 0usize..6usize;
+    assert_eq!(dense_abs_row(&on_disk, &out, 0), 10);
+    assert_eq!(dense_abs_row(&on_disk, &out, 5), 15);
+
+    // Out window need not start at 0 (e.g. a second query's slice appended
+    // after a first): the offset within `out` is what matters.
+    let out2 = 6usize..12usize;
+    assert_eq!(dense_abs_row(&on_disk, &out2, 6), 10);
+    assert_eq!(dense_abs_row(&on_disk, &out2, 11), 15);
+}

--- a/tests/test_field_read.rs
+++ b/tests/test_field_read.rs
@@ -1,14 +1,17 @@
 //! Proves the field-read API is reachable from OUTSIDE the crate — the same way
 //! GenVarLoader consumes it (Cargo path-dep, `default-features = false`). This
 //! is the Milestone-1 acceptance test: everything gvl needs (`FieldView`,
-//! `FieldValue`, `vk_src` pack/unpack, `gather_haps_readbound_src`, and
-//! `dense_abs_row`) must be reachable via a short, stable `genoray_core::...`
-//! path without reaching into private modules.
+//! `FieldValue`, `vk_src` pack/unpack, `SrcKeyRef`/`VkElem`, `VK_SRC_INDEL_BIT`,
+//! `gather_haps_readbound_src`, and `dense_abs_row`) must be reachable via a
+//! short, stable `genoray_core::...` path without reaching into private
+//! modules.
 
 use genoray_core::field::StorageDtype;
 use genoray_core::layout::{ContigPaths, FieldSub};
 use genoray_core::query::gather::dense_abs_row;
-use genoray_core::query::{FieldValue, FieldView, pack_vk_src, unpack_vk_src};
+use genoray_core::query::{
+    FieldValue, FieldView, SrcKeyRef, VK_SRC_INDEL_BIT, VkElem, pack_vk_src, unpack_vk_src,
+};
 
 #[test]
 fn field_view_is_publicly_constructible() {
@@ -37,6 +40,29 @@ fn field_view_is_publicly_constructible() {
 fn vk_src_helpers_are_public() {
     let s = pack_vk_src(true, 42);
     assert_eq!(unpack_vk_src(s), (true, 42));
+}
+
+#[test]
+fn vk_src_tag_bit_value_is_pinned() {
+    // Pins the tag bit's actual VALUE — not just that pack/unpack agree with
+    // each other, which would still hold if both used a different bit.
+    assert_eq!(pack_vk_src(true, 3), VK_SRC_INDEL_BIT | 3);
+    assert_eq!(pack_vk_src(false, 3) & VK_SRC_INDEL_BIT, 0);
+}
+
+#[test]
+fn src_key_ref_and_vk_elem_are_publicly_usable() {
+    // `VkElem` must be in scope to call the trait method `make` on `SrcKeyRef`.
+    let indel_elem = SrcKeyRef::make(100, 0xAB, true, 3);
+    assert_eq!(indel_elem.key.position, 100);
+    assert_eq!(indel_elem.key.key, 0xAB);
+    assert_eq!(indel_elem.src, VK_SRC_INDEL_BIT | 3);
+    assert_eq!(indel_elem.position(), 100);
+    assert_eq!(unpack_vk_src(indel_elem.src), (true, 3));
+
+    let snp_elem = SrcKeyRef::make(200, 0xCD, false, 7);
+    assert_eq!(snp_elem.src & VK_SRC_INDEL_BIT, 0);
+    assert_eq!(unpack_vk_src(snp_elem.src), (false, 7));
 }
 
 #[test]

--- a/tests/test_svar2_fields_read.py
+++ b/tests/test_svar2_fields_read.py
@@ -54,3 +54,21 @@ def test_resolve_rejects_unknown_field():
 def test_no_fields_in_meta_is_empty_not_an_error():
     assert _load_field_manifest({}) == {}
     assert _load_field_manifest({"fields": []}) == {}
+
+
+def test_rejects_auto_dtype_in_meta():
+    meta = {
+        "fields": [{"name": "AF", "category": "info", "dtype": "auto", "default": None}]
+    }
+    with pytest.raises(ValueError, match="AF"):
+        _load_field_manifest(meta)
+
+
+def test_rejects_unknown_dtype_in_meta():
+    meta = {
+        "fields": [
+            {"name": "DP", "category": "format", "dtype": "bogus", "default": None}
+        ]
+    }
+    with pytest.raises(ValueError, match="DP"):
+        _load_field_manifest(meta)

--- a/tests/test_svar2_fields_read.py
+++ b/tests/test_svar2_fields_read.py
@@ -161,6 +161,15 @@ def test_decode_with_fields_shares_offsets_and_preserves_dtype(store_with_fields
     np.testing.assert_array_equal(af.offsets, pos.offsets)
     np.testing.assert_array_equal(ds.offsets, pos.offsets)
 
+    # `Ragged.offsets` is a property that returns the underlying offsets
+    # array by reference (no copy), so object identity here is meaningful:
+    # it pins the "one shared offsets object across pos/ilen/allele and
+    # every decoded field" contract that GenVarLoader relies on. A
+    # regression that defensively copies offsets per field would still pass
+    # the `assert_array_equal` checks above but MUST fail these.
+    assert af.offsets is pos.offsets
+    assert ds.offsets is pos.offsets
+
 
 def test_decode_rejects_unknown_field(store_with_fields):
     with pytest.raises(ValueError, match="NOPE"):

--- a/tests/test_svar2_fields_read.py
+++ b/tests/test_svar2_fields_read.py
@@ -171,6 +171,51 @@ def test_decode_with_fields_shares_offsets_and_preserves_dtype(store_with_fields
     assert ds.offsets is pos.offsets
 
 
+def test_decode_field_values_match_fixture(store_with_fields):
+    """Pin decoded field VALUES against what the fixture wrote.
+
+    The sibling test above (`..._shares_offsets_and_preserves_dtype`) checks
+    dtype/shape/offset-identity but never a concrete value, so it can't catch
+    a bug isolated to the Rust->Python FFI boundary (raw bytes ->
+    `u8_to_pyarray` -> `.view(dtype)` -> `Ragged`) — e.g. an endianness slip,
+    a wrong `.view(dtype)`, or a byte-length/offset misalignment. This test
+    independently pins expected values straight from the fixture's
+    `record(...)` call (not recomputed from the decode output).
+
+    Fixture ground truth (see `store_with_fields` above):
+      - genotypes: s1 = 0|1 (hap0 REF, hap1 ALT), s2 = 1|1 (hap0 ALT, hap1 ALT)
+      - INFO AF = 0.25 for the single variant -> every emitted record carries it
+      - FORMAT DS is per-sample: s1 wrote 0.4, s2 wrote 1.9
+
+    `decode()`'s carrier-only semantics (only ALT-carrying haplotypes emit a
+    record — see `_svar2_decode.py` sharing one offsets object across all
+    fields) mean s1-hap0 contributes ZERO records, while s1-hap1, s2-hap0,
+    s2-hap1 each contribute one. `Ragged.lengths` reshapes to `(R, S, P)` in
+    C order (`seqpro/rag/_core.py`), so the flat cell order is
+    (s1,h0), (s1,h1), (s2,h0), (s2,h1) — this is the same layout
+    `test_svar2_decode.py::test_decode_record_shape_and_counts` documents.
+    """
+    sv = store_with_fields.with_fields(["AF", "DS"])
+    rag = sv.decode("chr1", [(0, 1_000_000)])
+
+    # Per-(sample, ploid) record counts, flat row-major (R,S,P): only
+    # ALT-carrying haplotypes emit a record.
+    lengths = rag["pos"].lengths.reshape(-1)
+    assert lengths.tolist() == [0, 1, 1, 1]  # s1h0, s1h1, s2h0, s2h1
+
+    # INFO AF is per-variant: every one of the 3 emitted records carries the
+    # single value the fixture declared for this variant's only ALT allele.
+    af = np.asarray(rag["AF"].data)
+    np.testing.assert_array_equal(af, np.full(3, 0.25, dtype=np.float32))
+
+    # FORMAT DS is sample-aligned: s1's lone record (hap1) must carry s1's
+    # value (0.4); s2's two records (hap0, hap1) must both carry s2's value
+    # (1.9). A dropped sample-stride or byte-misalignment at the FFI
+    # boundary would surface here as a wrong/shifted value.
+    ds = np.asarray(rag["DS"].data)
+    np.testing.assert_array_equal(ds, np.array([0.4, 1.9, 1.9], dtype=np.float32))
+
+
 def test_decode_rejects_unknown_field(store_with_fields):
     with pytest.raises(ValueError, match="NOPE"):
         store_with_fields.with_fields(["NOPE"])

--- a/tests/test_svar2_fields_read.py
+++ b/tests/test_svar2_fields_read.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+
+from genoray._svar2_fields import (
+    StoredField,
+    _load_field_manifest,
+    _resolve_read_fields,
+)
+
+
+def test_canonical_keys_are_bare_when_unique():
+    meta = {
+        "fields": [
+            {"name": "AF", "category": "info", "dtype": "f32", "default": None},
+            {"name": "DS", "category": "format", "dtype": "f16", "default": 0.0},
+        ]
+    }
+    avail = _load_field_manifest(meta)
+    assert set(avail) == {"AF", "DS"}
+    assert isinstance(avail["AF"], StoredField)
+    assert avail["AF"].dtype == np.dtype("float32")
+    assert avail["DS"].dtype == np.dtype("float16")
+    assert avail["DS"].default == 0.0
+    assert avail["AF"].default is None
+
+
+def test_colliding_names_are_qualified_bcftools_style():
+    meta = {
+        "fields": [
+            {"name": "DP", "category": "info", "dtype": "i32", "default": None},
+            {"name": "DP", "category": "format", "dtype": "i16", "default": None},
+        ]
+    }
+    avail = _load_field_manifest(meta)
+    assert set(avail) == {"INFO/DP", "FORMAT/DP"}
+    assert avail["INFO/DP"].dtype == np.dtype("int32")
+    assert avail["FORMAT/DP"].dtype == np.dtype("int16")
+
+
+def test_resolve_rejects_unknown_field():
+    avail = _load_field_manifest(
+        {
+            "fields": [
+                {"name": "AF", "category": "info", "dtype": "f32", "default": None}
+            ]
+        }
+    )
+    assert _resolve_read_fields(None, avail) == []
+    assert _resolve_read_fields(["AF"], avail) == [avail["AF"]]
+    with pytest.raises(ValueError, match="NOPE"):
+        _resolve_read_fields(["NOPE"], avail)
+
+
+def test_no_fields_in_meta_is_empty_not_an_error():
+    assert _load_field_manifest({}) == {}
+    assert _load_field_manifest({"fields": []}) == {}

--- a/tests/test_svar2_fields_read.py
+++ b/tests/test_svar2_fields_read.py
@@ -1,7 +1,13 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
+from vcfixture import Number, Seq, Type, VcfBuilder
 
+from genoray import SparseVar2
 from genoray._svar2_fields import (
+    FormatField,
+    InfoField,
     StoredField,
     _load_field_manifest,
     _resolve_read_fields,
@@ -72,3 +78,90 @@ def test_rejects_unknown_dtype_in_meta():
     }
     with pytest.raises(ValueError, match="DP"):
         _load_field_manifest(meta)
+
+
+# --- e2e: SparseVar2(fields=...) / with_fields / decode() (Task 9) ---------
+#
+# DEVIATION FROM THE BRIEF: the brief's Step-1 fixture converts
+# `tests/data/biallelic.vcf.gz`. That file is a GENERATED artifact (built by
+# `tests/data/gen_from_vcf.sh` / `gen_svar.py`, not committed) and, as of this
+# worktree, declares FORMAT DS but NO info fields at all — converting it with
+# `info_fields=[InfoField("AF", ...)]` raises "field not found in the VCF
+# header". Rather than hand-edit the generated corpus (out of scope for this
+# task and reverted on the next `pixi run gen`), we build a small
+# self-contained VCF inline with `vcfixture.VcfBuilder`, exactly like
+# `tests/test_svar2_fields.py` already does for the write-path tests. This
+# keeps every assertion from the brief intact (see below) while giving a
+# fixture that actually has an INFO field, a FORMAT field, >=2 samples, and
+# real genotypes.
+
+
+@pytest.fixture
+def store_with_fields(tmp_path: Path) -> SparseVar2:
+    """Convert a small inline VCF carrying one INFO and one FORMAT field."""
+    doc = (
+        VcfBuilder(samples=["s1", "s2"], contigs=[("chr1", None)])
+        .fmt("GT")
+        .info("AF", Number.A, Type.FLOAT)
+        .fmt("DS", Number.A, Type.FLOAT)
+        .record(
+            "chr1",
+            1000,
+            ref="A",
+            alt=[Seq("T")],
+            gt=["0|1", "1|1"],
+            info={"AF": [0.25]},
+            DS=[[0.4], [1.9]],
+        )
+    )
+    vcf = doc.write(tmp_path / "src.vcf.gz", bgzip=True, index=True)
+
+    out = tmp_path / "fields.svar2"
+    SparseVar2.from_vcf(
+        out,
+        vcf,
+        no_reference=True,
+        info_fields=[InfoField("AF", dtype="f32")],
+        format_fields=[FormatField("DS", dtype="f32", default=0.0)],
+    )
+    return SparseVar2(out)
+
+
+def test_available_fields_reports_canonical_keys(store_with_fields):
+    avail = store_with_fields.available_fields
+    assert set(avail) == {"AF", "DS"}
+    assert avail["AF"].category == "info"
+    assert avail["DS"].category == "format"
+
+
+def test_decode_without_fields_is_unchanged(store_with_fields):
+    rag = store_with_fields.decode("chr1", [(0, 1_000_000)])
+    assert set(rag.fields) == {"pos", "ilen", "allele"}
+
+
+def test_decode_with_fields_shares_offsets_and_preserves_dtype(store_with_fields):
+    sv = store_with_fields.with_fields(["AF", "DS"])
+    rag = sv.decode("chr1", [(0, 1_000_000)])
+    assert set(rag.fields) == {"pos", "ilen", "allele", "AF", "DS"}
+
+    # `rag.fields` is the list of field NAMES on a record Ragged; per-field
+    # data/offsets access goes through `rag["name"]` (`__getitem__`), not
+    # `rag.fields["name"]`.
+    pos = rag["pos"]
+    af = rag["AF"]
+    ds = rag["DS"]
+
+    # Stored dtype is preserved end to end — no widening.
+    assert af.data.dtype == np.dtype("float32")
+    assert ds.data.dtype == np.dtype("float32")
+
+    # One field value per decoded record, on the SAME offsets object.
+    assert af.data.shape == pos.data.shape
+    assert ds.data.shape == pos.data.shape
+    np.testing.assert_array_equal(af.offsets, pos.offsets)
+    np.testing.assert_array_equal(ds.offsets, pos.offsets)
+
+
+def test_decode_rejects_unknown_field(store_with_fields):
+    with pytest.raises(ValueError, match="NOPE"):
+        store_with_fields.with_fields(["NOPE"])


### PR DESCRIPTION
## Summary

Adds **reading** of INFO/FORMAT field values from the SVAR2 sparse-variant format, in two layers:

- **Milestone 1 — public Rust read API (unblocks GenVarLoader):**
  - `query::FieldView` — mmap over a field's `values.bin`; element width comes only from `meta.json`'s dtype, never from file length.
  - `vk_src` provenance — a packed `(sub-stream, absolute-call-index)` per merged var_key record, threaded through all three var_key gathers via a monomorphized `VkElem` generic so the no-fields path stays byte-identical and pays nothing.
  - `query::gather_haps_readbound_src` / `overlap_batch_src`, and `query::dense_abs_row` (dense-provenance arithmetic).
- **Milestone 2 — Python surface:**
  - `SparseVar2(fields=…)` / `with_fields` / `available_fields`.
  - `SparseVar2.decode(contig, regions)` returns each selected field as a `seqpro.rag.Ragged` sharing **one** variant-axis offsets object with `pos`/`ilen`/`allele`.
  - Fields are opt-in (decoding costs extra I/O); dtype is preserved exactly as stored (SVAR2 losslessly auto-narrows ints); missing values carry the field's `default` or its reserved sentinel, untranslated.

## Design guarantees held

- **Zero-cost:** the no-fields path is byte-identical to before — `tests/test_readbound_gather.rs` and `tests/test_svar2_decode.py` pass **unmodified** vs `main`.
- **Dtype fidelity** across the FFI boundary is guarded on both sides (Rust `width_bytes` vs Python `dtype.itemsize`), and the decoded values are pinned against fixture ground truth, including a sample-aware FORMAT check.
- **Record-order parity:** the fields decode path returns records in exactly the no-fields order (var_key wins position ties).
- **Backward compatible:** a store written before fields existed (no `fields` key in `meta.json`) reads as an empty manifest.

## Testing

- Rust: 271 passed, 0 failed (`pixi run test-rust`).
- Python: 586 passed, 0 failed (`pixi run test`).
- clippy `--tests -D warnings`, `cargo fmt --check`, `ruff check`, `ruff format --check`: all clean.

## Process

Executed task-by-task via subagent-driven development (11 tasks): fresh implementer per task, spec+quality review after each, and a whole-branch review at the end. Public API documented in `skills/genoray-api/SKILL.md` and `CHANGELOG.md` per repo policy.

Plan: `docs/superpowers/plans/2026-07-12-svar2-fields-read.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
