### PR TITLE
feat(svar2): SparseVar2.from_pgen (PGEN → SVAR2 conversion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+- `SparseVar2.from_pgen` converts a PLINK2 PGEN (`.pgen`/`.pvar`/`.psam`) to an
+  SVAR2 store through the same normalization, atom, and merge spine as
+  `from_vcf`. Diploid-only (no `ploidy=` kwarg); dosages, INFO/FORMAT fields,
+  and sample subsetting are out of scope for this entry point.
 - `SparseVar2.annotate_mutations`, `mutation_matrix`, and `assign_signatures`
   for COSMIC mutational-signature workflows (SBS96/ID83/DBS78), implemented in
   Rust with a per-record sidecar and streaming count matrix. `from_vcf` gains a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@
 - **vcf**: apply configured `filter` on `VCF.read(..., mode=Genos*Dosages)` when no
   `.gvi` index is loaded, matching the genotype-only and dosage-only modes
   (previously the filter was silently ignored on this path).
+- **svar2**: `SparseVar2.from_pgen` no longer silently corrupts every variant
+  after the first monomorphic site (`.pvar` ALT `.`, which plink2 routinely
+  emits for real cohorts). A null ALT was propagating as NaN into a `uintp`
+  cumulative-sum array, corrupting `allele_idx_offsets` file-wide; the Rust
+  `.pvar` reader also no longer treats a bare `.` ALT as a literal one-character
+  allele.
 
 ## 2.15.0 (2026-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,15 @@
   `uint32` variant-index array) as its third tuple element instead of an
   `n_extension_vars` count, matching `PGEN._chunk_ranges_with_length`.
 
+### Perf
+
+- Conversion reader staging memory no longer scales with `chunk_size`:
+  presence bits are packed in word-aligned windows and each atom's per-column
+  genotype vector is dropped as soon as its bits are set, bounding reader
+  memory at `window * n_samples * ploidy * 4` bytes instead of
+  `chunk_size * n_samples * ploidy * 4`. Output is bit-identical. Benefits
+  both `from_vcf` and `from_pgen`.
+
 ### Fix
 
 - **vcf**: apply configured `filter` on `VCF.read(..., mode=Genos*Dosages)` when no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@
 - `SparseVar2.from_pgen` converts a PLINK2 PGEN (`.pgen`/`.pvar`/`.psam`) to an
   SVAR2 store through the same normalization, atom, and merge spine as
   `from_vcf`. Diploid-only (no `ploidy=` kwarg); dosages, INFO/FORMAT fields,
-  and sample subsetting are out of scope for this entry point.
+  and sample subsetting are out of scope for this entry point. Verified
+  byte-for-byte equivalent to `from_vcf` on a 3202-sample/1,001,385-variant
+  germline cohort (chr21, symbolics filtered so both backends see the same
+  variant set); on that cohort `from_pgen` converts in **152.7s** vs
+  `from_vcf`'s **547.0s** (**3.6× faster**, confirming the reader-not-the-
+  bottleneck hypothesis), at the cost of **~2.1× peak RSS** (1065 MiB vs
+  497 MiB) — see the benchmark notes in
+  `docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md` for the full
+  methodology, the `.pvar`-skip and OpenMP-oversubscription findings, and
+  follow-ups.
 - `SparseVar2.annotate_mutations`, `mutation_matrix`, and `assign_signatures`
   for COSMIC mutational-signature workflows (SBS96/ID83/DBS78), implemented in
   Rust with a per-record sidecar and streaming count matrix. `from_vcf` gains a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "svar2-codec",
  "tempfile",
  "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]
@@ -1614,4 +1615,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ rust-htslib = { version = "1.0", default-features = false, optional = true }
 serde_json = "1"
 svar2-codec = { path = "svar2-codec" }
 thiserror = "2"
+# .pvar.zst decompression for the PGEN record source. BSD-3/MIT; no plink-ng code.
+zstd = { version = "0.13", optional = true }
 
 [dev-dependencies]
 proptest = "1.11.0"
@@ -41,7 +43,7 @@ pyo3 = { version = "0.29", features = ["auto-initialize"] }
 # `conversion` pulls in rust-htslib and gates the VCF→svar2 write/convert
 # pipeline. Off => query-only core (what gvl links as a path-dep).
 default = ["conversion", "extension-module"]
-conversion = ["dep:rust-htslib"]
+conversion = ["dep:rust-htslib", "dep:zstd"]
 extension-module = ["pyo3/extension-module"]
 # abi3 (stable ABI) is opt-in ONLY at wheel-build time (`maturin build --features
 # abi3`) so lint hooks (default features) and `cargo test --no-default-features`

--- a/docs/superpowers/plans/2026-07-12-pgen-to-svar2.md
+++ b/docs/superpowers/plans/2026-07-12-pgen-to-svar2.md
@@ -1,0 +1,2141 @@
+# PGEN → SVAR2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `SparseVar2.from_pgen`, converting a PLINK2 PGEN to an SVAR2 store by reusing the existing VCF conversion pipeline's normalization/atom/merge spine behind a new record source.
+
+**Architecture:** Split `VcfChunkReader` into a source-agnostic `ChunkAssembler` (reorder heap, atom decomposition, presence packing, field staging) plus a `RecordSource` trait with two implementations: `VcfRecordSource` (htslib) and `PgenRecordSource`. `PgenRecordSource` gets per-haplotype allele codes from the **already-depended-on** `pgenlib` Python wheel via `read_alleles_range` (which releases the GIL), and variant metadata from a new Rust `.pvar` streamer. Along the way, presence packing becomes windowed so staging memory stops scaling with `chunk_size × n_samples`.
+
+**Tech Stack:** Rust (pyo3 0.29, numpy, rayon, crossbeam, new: `zstd`), Python 3.10+ (polars, pgenlib), pixi, pytest, proptest.
+
+## Global Constraints
+
+- **Licensing (non-negotiable).** genoray is MIT. **Do not copy any code or comments from plink-ng into this repo.** Do not link, vendor, or build plink-ng C++. The only permitted use of plink code is calling the **already-installed** `pgenlib` PyPI wheel (LGPL-3.0) through its **public Python API**, exactly as `genoray/_pgen.py` and `genoray/_svar/_convert.py` already do. `plink2` the binary may be invoked as a subprocess in tests only (already in `pixi.toml`).
+- **Coordinates:** all ranges 0-based, half-open `[start, end)`. `.pvar` POS is 1-based on disk and must be converted to 0-based.
+- **Missing sentinels:** pgenlib allele codes use `-9` for missing; the pipeline's `PendingAtom.gt` convention is `-1`. Map `-9 → -1`.
+- **Ploidy:** PGEN is diploid-only. `ploidy = 2` everywhere on the PGEN path; do not add a `ploidy` parameter to `from_pgen`.
+- **Public API rule (CLAUDE.md):** any change to a name reachable from `import genoray` without an underscore MUST update `skills/genoray-api/SKILL.md` in the same PR.
+- **Commits:** Conventional Commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `perf:`). Do **not** bump the version or regenerate `CHANGELOG.md`'s versioned sections by hand — add entries under `## Unreleased` only.
+- **Rust tests must be run as** `pixi run bash -lc 'cargo test --no-default-features <args>'`. With default features the pyo3 test binary fails to link (`undefined symbol: _Py_Dealloc`).
+- **Never background a long `cargo`/`maturin` build.** Run them in the foreground and wait.
+- Working tree: worktree `.claude/worktrees/pgen-to-svar2`, branch `worktree-pgen-to-svar2`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/vcf_reader.rs` (modify) | **Shrinks.** Keeps only htslib-specific work: open/fetch, GT decode, INFO/FORMAT raw decode. Becomes `VcfRecordSource`. |
+| `src/record_source.rs` (create) | `RawRecord` (owned) + `RecordSource` trait. The seam. |
+| `src/chunk_assembler.rs` (create) | Source-agnostic: `PendingAtom`, `AtomMeta`, presence packing, reorder heap, REF validation, left-alignment, atomization, field resolution, `DenseChunk` assembly. |
+| `src/pvar.rs` (create) | Streaming `.pvar` / `.pvar.zst` reader → `PvarRecord { pos, reference, alts }`. |
+| `src/pgen_reader.rs` (create) | `PgenRecordSource`: pgenlib handle + batched `(B, 2S)` int32 buffer + `PvarReader`. |
+| `src/orchestrator.rs` (modify) | `process_chromosome` takes a `SourceSpec` and builds the right `RecordSource`. |
+| `src/lib.rs` (modify) | Adds the `run_pgen_conversion_pipeline` pyfunction. |
+| `src/types.rs` (unchanged) | `DenseChunk`, `BitGrid3` (already has `truncate_v`). |
+| `python/genoray/_svar2.py` (modify) | `SparseVar2.from_pgen`. |
+| `python/genoray/_cli/__main__.py` (modify) | `genoray write` dispatches on the `.pgen` suffix. |
+| `skills/genoray-api/SKILL.md` (modify) | Document `from_pgen`. |
+| `CHANGELOG.md` (modify) | `## Unreleased` entry. |
+| `tests/test_svar2_from_pgen.py` (create) | Cross-backend equivalence + error cases. |
+| `tests/test_pvar.rs` (create) | Rust `.pvar` parser tests. |
+
+---
+
+## Task 1: Windowed presence packing (VCF path, memory fix)
+
+Today `read_next_chunk` buffers `chunk_size` `PendingAtom`s, each holding an `S × P` i32 `gt` vector — 32× the packed bit-grid it produces (~2 GB at `chunk_size=25_000`, 10k samples; not representable at biobank scale). Pack in windows and drop `gt` as soon as its bits are set.
+
+**Files:**
+- Modify: `src/vcf_reader.rs` (the `read_next_chunk` function around line 592, plus new helpers)
+- Test: `src/vcf_reader.rs` `mod tests` (existing proptest module at the bottom)
+
+**Interfaces:**
+- Consumes: existing `PendingAtom`, `pack_presence_seq`, `pack_presence_par`, `gcd`, `BitGrid3::{zeros, truncate_v}`.
+- Produces: `struct AtomMeta`, `fn flush_window(...)`, `const PACK_WINDOW: usize`. Task 2 moves all of these verbatim into `chunk_assembler.rs`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `mod tests` in `src/vcf_reader.rs` (it already has a `test_pool()` helper and an `atom(gt, src)` builder):
+
+```rust
+    // Windowed packing must be bit-identical to packing the whole chunk at once.
+    // `flush_window` is only ever called at word-aligned variant offsets except
+    // for the final (partial) window, which nothing follows — mirror that here.
+    proptest! {
+        #[test]
+        fn windowed_pack_matches_full_pack(
+            n_samples in 1usize..9,
+            ploidy in 1usize..3,
+            srcs in prop::collection::vec(0u16..3u16, 1..200),
+        ) {
+            let columns = n_samples * ploidy;
+            let v = srcs.len();
+
+            // Deterministic gt: column c of variant i carries allele (i + c) % 3.
+            let atoms: Vec<PendingAtom> = srcs
+                .iter()
+                .enumerate()
+                .map(|(i, &src)| {
+                    let gt: Vec<i32> = (0..columns).map(|c| ((i + c) % 3) as i32).collect();
+                    atom_at(gt, src, i as u32)
+                })
+                .collect();
+
+            // Reference: one full-grid sequential pack.
+            let mut expect = BitGrid3::zeros(v, n_samples, ploidy);
+            pack_presence_seq(&mut expect.words, &atoms, columns);
+
+            // Windowed: flush every `window` atoms, where `window` is a multiple of
+            // the word-aligned block size `g`.
+            let g = 64 / gcd(columns, 64);
+            let window = 4 * g;
+            let mut got = BitGrid3::zeros(v, n_samples, ploidy);
+            let mut metas: Vec<AtomMeta> = Vec::new();
+            let mut buf: Vec<PendingAtom> = Vec::new();
+            let mut v0 = 0usize;
+            for a in atoms {
+                buf.push(a);
+                if buf.len() == window {
+                    let n = buf.len();
+                    flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
+                    v0 += n;
+                }
+            }
+            if !buf.is_empty() {
+                flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
+            }
+
+            prop_assert_eq!(got.words, expect.words);
+            prop_assert_eq!(metas.len(), v);
+        }
+    }
+```
+
+The existing `atom(gt, src)` helper hardcodes `pos: 0`. Add a sibling that also sets `pos`/`seq` so `metas` ordering is checkable:
+
+```rust
+    fn atom_at(gt: Vec<i32>, src: u16, pos: u32) -> PendingAtom {
+        PendingAtom {
+            pos,
+            ilen: 0,
+            alt: Vec::new(),
+            source_alt_index: src,
+            gt: std::sync::Arc::new(gt),
+            seq: pos as u64,
+            info_vals: Vec::new(),
+            format_vals: Vec::new(),
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features windowed_pack_matches_full_pack'`
+Expected: FAIL to compile — `cannot find function 'flush_window'`, `cannot find type 'AtomMeta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/vcf_reader.rs`, above `pub struct VcfChunkReader`, add:
+
+```rust
+// An atom whose presence bits are already packed into the chunk's BitGrid. `gt`
+// and `source_alt_index` are dropped at that point, so per-chunk staging memory
+// no longer scales with `chunk_size * num_samples * ploidy`.
+struct AtomMeta {
+    pos: u32,
+    ilen: i32,
+    alt: Vec<u8>,
+    info_vals: Vec<f64>,
+    format_vals: Vec<f64>,
+}
+
+// Atoms buffered before their presence bits are flushed into the chunk's BitGrid.
+// Rounded UP to a multiple of the word-aligned block size `g = 64/gcd(columns,64)`
+// at call time, so every flush offset lands on a u64 boundary and
+// `pack_presence_par` keeps its word-disjoint invariant. 1024 keeps the window
+// above `PARALLEL_MIN_VARIANTS` (512) so parallel packing still engages.
+const PACK_WINDOW: usize = 1024;
+
+// Pack `buf`'s presence bits into `genos` starting at variant offset `v0`, then
+// move each atom's metadata into `metas`, dropping `gt`.
+//
+// `v0` MUST be a multiple of the word-aligned block size, so `v0 * columns` is a
+// multiple of 64 and the window owns a whole-word-aligned sub-slice of
+// `genos.words`. Only the FINAL window may have a length that is not a multiple of
+// that block size (its trailing partial word is not shared, because nothing is
+// packed after it).
+fn flush_window(
+    genos: &mut BitGrid3,
+    metas: &mut Vec<AtomMeta>,
+    buf: &mut Vec<PendingAtom>,
+    v0: usize,
+    columns: usize,
+    pool: Option<&rayon::ThreadPool>,
+) {
+    if buf.is_empty() {
+        return;
+    }
+    debug_assert_eq!((v0 * columns) % 64, 0, "flush offset must be word-aligned");
+    let word_base = (v0 * columns) / 64;
+    let n_words = (buf.len() * columns).div_ceil(64);
+    let words = &mut genos.words[word_base..word_base + n_words];
+
+    let parallel = matches!(pool, Some(p) if p.current_num_threads() >= 2)
+        && buf.len() >= PARALLEL_MIN_VARIANTS;
+    if parallel {
+        pack_presence_par(words, buf, columns, pool.unwrap());
+    } else {
+        pack_presence_seq(words, buf, columns);
+    }
+
+    metas.reserve(buf.len());
+    for a in buf.drain(..) {
+        metas.push(AtomMeta {
+            pos: a.pos,
+            ilen: a.ilen,
+            alt: a.alt,
+            info_vals: a.info_vals,
+            format_vals: a.format_vals,
+        });
+    }
+}
+```
+
+Then replace the body of `read_next_chunk` (currently lines ~592-670) with:
+
+```rust
+    // Pull up to `chunk_size` atoms (already globally position-sorted) and pack them
+    // into a variant-major DenseChunk. Presence bits are packed in windows of
+    // `PACK_WINDOW` atoms so the reader never holds more than one window's worth of
+    // per-column genotype vectors. `pool`, when present and the window is large
+    // enough, hosts parallel packing; otherwise packing is sequential. Output is
+    // bit-identical either way. Returns None once no atoms remain.
+    pub fn read_next_chunk(
+        &mut self,
+        chunk_size: usize,
+        chunk_id: usize,
+        pool: Option<&rayon::ThreadPool>,
+    ) -> Result<Option<DenseChunk>, ConversionError> {
+        let columns = self.num_samples * self.ploidy;
+        // Word-aligned block size: `g` variants span exactly `columns/gcd` u64 words.
+        let g = 64 / gcd(columns, 64);
+        let window = PACK_WINDOW.div_ceil(g) * g;
+
+        // Allocate for the full chunk up front (packed size: chunk_size*columns bits),
+        // then shrink to the true variant count after EOF.
+        let mut genos = BitGrid3::zeros(chunk_size, self.num_samples, self.ploidy);
+        let mut metas: Vec<AtomMeta> = Vec::with_capacity(chunk_size);
+        let mut buf: Vec<PendingAtom> = Vec::with_capacity(window);
+        let mut v = 0usize;
+
+        while v + buf.len() < chunk_size {
+            match self.next_atom()? {
+                Some(a) => {
+                    buf.push(a);
+                    if buf.len() == window {
+                        flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
+                        v += window;
+                    }
+                }
+                None => break,
+            }
+        }
+        if !buf.is_empty() {
+            let n = buf.len();
+            flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
+            v += n;
+        }
+
+        if v == 0 {
+            return Ok(None);
+        }
+        genos.truncate_v(v);
+
+        let num_samples = self.num_samples;
+        let mut pos = Vec::with_capacity(v);
+        let mut ilens = Vec::with_capacity(v);
+        let mut alt = Vec::with_capacity(v * 2);
+        let mut alt_offsets = Vec::with_capacity(v + 1);
+        alt_offsets.push(0u32);
+        let mut info_staged: Vec<StagedColumn> = self
+            .info_fields
+            .iter()
+            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v))
+            .collect();
+        let mut format_staged: Vec<StagedColumn> = self
+            .format_fields
+            .iter()
+            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v * num_samples))
+            .collect();
+
+        // Sequential metadata pass (cheap, ordering-preserving).
+        let mut off = 0u32;
+        for a in metas.iter() {
+            pos.push(a.pos);
+            ilens.push(a.ilen);
+            alt.extend_from_slice(&a.alt);
+            off += a.alt.len() as u32;
+            alt_offsets.push(off);
+
+            for (i, col) in info_staged.iter_mut().enumerate() {
+                col.push_f64(a.info_vals[i]);
+            }
+            for (j, col) in format_staged.iter_mut().enumerate() {
+                for s in 0..num_samples {
+                    col.push_f64(a.format_vals[j * num_samples + s]);
+                }
+            }
+        }
+
+        Ok(Some(DenseChunk {
+            chunk_id,
+            pos,
+            ilens,
+            alt,
+            alt_offsets,
+            genos,
+            info_staged,
+            format_staged,
+        }))
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: PASS, including `windowed_pack_matches_full_pack` and the pre-existing `pack_presence_par`-vs-`seq` proptests.
+
+Run: `pixi run pytest tests/test_svar2_from_vcf.py tests/test_svar2.py tests/test_svar2_fields.py -q`
+Expected: PASS. **This is the byte-identical-output guard** — the VCF path's stored output must not change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vcf_reader.rs
+git commit -m "perf(svar2): pack presence bits in windows, drop gt eagerly
+
+The reader buffered chunk_size PendingAtoms, each holding an S*P i32 genotype
+vector -- 32x the packed bit-grid they produce. Pack in PACK_WINDOW-sized,
+word-aligned windows and drop gt as soon as its bits are set, so reader staging
+memory is bounded by window*S*P*4 instead of chunk_size*S*P*4. Output is
+bit-identical."
+```
+
+---
+
+## Task 2: Extract `RecordSource` + `ChunkAssembler`
+
+Pure refactor. `VcfChunkReader` currently fuses htslib iteration, atom decomposition, the reorder heap, chunk packing, and field staging. Only the first is VCF-specific.
+
+**Files:**
+- Create: `src/record_source.rs`
+- Create: `src/chunk_assembler.rs`
+- Modify: `src/vcf_reader.rs` (becomes `VcfRecordSource`; loses everything moved out)
+- Modify: `src/lib.rs` (declare the two new modules)
+- Modify: `src/orchestrator.rs` (construct `ChunkAssembler::new(Box::new(VcfRecordSource::new(...)), ...)`)
+
+**Interfaces:**
+- Produces (consumed by Tasks 4 and 5):
+  - `record_source::RawRecord { pos: u32, reference: Vec<u8>, alts: Vec<Vec<u8>>, gt: Vec<i32>, info_raw: Vec<Option<Vec<f64>>>, format_raw: Vec<Option<Vec<Vec<f64>>>> }`
+  - `record_source::RecordSource` trait with `fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError>`
+  - `chunk_assembler::ChunkAssembler::new(source: Box<dyn RecordSource + Send>, num_samples: usize, ploidy: usize, fasta_path: Option<&str>, chrom: &str, skip_out_of_scope: bool, fields: &[FieldSpec]) -> Result<Self, ConversionError>`
+  - `ChunkAssembler::read_next_chunk(&mut self, chunk_size: usize, chunk_id: usize, pool: Option<&rayon::ThreadPool>) -> Result<Option<DenseChunk>, ConversionError>`
+  - `ChunkAssembler::dropped_out_of_scope(&self) -> u64`
+  - `vcf_reader::VcfRecordSource::new(vcf_path: &str, chrom: &str, samples: &[&str], htslib_threads: usize, ploidy: usize, fields: &[FieldSpec]) -> Result<Self, ConversionError>`
+  - `vcf_reader::load_contig_seq` stays where it is (the orchestrator's `signatures` pass already calls it).
+
+**Design note — `RawRecord` is OWNED, not borrowed.** A borrowed `RawRecord<'a>` would fight the borrow checker inside `ChunkAssembler::next_atom` (source borrowed while the heap is mutated). Owning costs nothing: the VCF path *already* allocates `ref_allele.to_vec()`, `alts_owned`, and a fresh `gt` vec per record, and the assembler needs `gt` in an `Arc<Vec<i32>>` regardless.
+
+**Design note — `format_raw` sample indexing.** Today `decode_format_raw` returns buffers indexed by *header* sample index, and `decompose_current_record` remaps via `self.sample_indices`. The assembler cannot know about `sample_indices` (PGEN has no such mapping). So `VcfRecordSource` does the remap when it builds `RawRecord`: `format_raw[j][selected_sample_index]`. `PgenRecordSource` always emits an empty `format_raw`.
+
+- [ ] **Step 1: Create `src/record_source.rs`**
+
+```rust
+//! The seam between "where variant records come from" (VCF via htslib, PGEN via
+//! pgenlib) and the source-agnostic conversion spine (`chunk_assembler`).
+//!
+//! `RawRecord` is deliberately OWNED rather than borrowed: the assembler mutates
+//! its heap while consuming a record, and the VCF path already allocates every one
+//! of these fields per record anyway, so owning costs nothing.
+
+use crate::error::ConversionError;
+
+/// One variant record, decoded to the minimum the conversion spine needs.
+pub struct RawRecord {
+    /// 0-based start position (VCF/pvar POS minus 1).
+    pub pos: u32,
+    /// REF allele bases, uppercase ASCII.
+    pub reference: Vec<u8>,
+    /// ALT alleles in file order. ALT1 is `alts[0]`; note `PendingAtom::
+    /// source_alt_index` is 1-based (ALT1 => 1), matching BCF GT allele codes.
+    pub alts: Vec<Vec<u8>>,
+    /// Allele index per haplotype column, length `num_samples * ploidy`,
+    /// sample-major then ploidy-minor. `0` = REF, `k` = ALT k, `-1` = missing.
+    pub gt: Vec<i32>,
+    /// Raw INFO buffers, widened to f64, one entry per requested INFO `FieldSpec`
+    /// in spec order. `None` = the field is absent from this record. Empty when no
+    /// INFO fields were requested.
+    pub info_raw: Vec<Option<Vec<f64>>>,
+    /// Raw FORMAT buffers, widened to f64: outer index = requested FORMAT
+    /// `FieldSpec` in spec order, inner index = **selected** sample
+    /// (`0..num_samples`, already remapped from the source's own sample order).
+    /// Outer `None` = the field is absent from this record for all samples. Empty
+    /// when no FORMAT fields were requested.
+    pub format_raw: Vec<Option<Vec<Vec<f64>>>>,
+}
+
+/// A cursor over one contig's variant records, in file order.
+pub trait RecordSource {
+    /// Next record, or `None` at end of contig.
+    fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError>;
+}
+```
+
+- [ ] **Step 2: Create `src/chunk_assembler.rs`**
+
+Move, verbatim from `src/vcf_reader.rs`: `PendingAtom` (+ its `PartialEq`/`Eq`/`PartialOrd`/`Ord` impls), `pack_row`, `pack_presence_seq`, `PARALLEL_MIN_VARIANTS`, `gcd`, `pack_presence_par`, `sentinel_default`, `is_htslib_missing`, `resolve_scalar`, `AtomMeta`, `PACK_WINDOW`, `flush_window`, and the whole `mod tests` block. Then add the assembler:
+
+```rust
+pub struct ChunkAssembler {
+    source: Box<dyn RecordSource + Send>,
+    num_samples: usize,
+    ploidy: usize,
+    /// Full 0-based contig sequence, uppercased; empty when no reference was given.
+    ref_seq: Vec<u8>,
+    has_reference: bool,
+    skip_out_of_scope: bool,
+    dropped_out_of_scope: u64,
+    info_fields: Vec<FieldSpec>,
+    format_fields: Vec<FieldSpec>,
+    heap: BinaryHeap<Reverse<PendingAtom>>,
+    frontier: u32,
+    eof: bool,
+    next_seq: u64,
+}
+
+impl ChunkAssembler {
+    pub fn new(
+        source: Box<dyn RecordSource + Send>,
+        num_samples: usize,
+        ploidy: usize,
+        fasta_path: Option<&str>,
+        chrom: &str,
+        skip_out_of_scope: bool,
+        fields: &[FieldSpec],
+    ) -> Result<Self, ConversionError> {
+        let (ref_seq, has_reference) = match fasta_path {
+            Some(path) => (crate::vcf_reader::load_contig_seq(path, chrom)?, true),
+            None => (Vec::new(), false),
+        };
+        Ok(Self {
+            source,
+            num_samples,
+            ploidy,
+            ref_seq,
+            has_reference,
+            skip_out_of_scope,
+            dropped_out_of_scope: 0,
+            info_fields: fields
+                .iter()
+                .filter(|f| f.category == FieldCategory::Info)
+                .cloned()
+                .collect(),
+            format_fields: fields
+                .iter()
+                .filter(|f| f.category == FieldCategory::Format)
+                .cloned()
+                .collect(),
+            heap: BinaryHeap::new(),
+            frontier: 0,
+            eof: false,
+            next_seq: 0,
+        })
+    }
+
+    /// Total out-of-scope (symbolic/breakend) ALTs dropped so far. Valid after the
+    /// read loop drains.
+    pub fn dropped_out_of_scope(&self) -> u64 {
+        self.dropped_out_of_scope
+    }
+
+    // Decompose one record into atoms and push them onto the reorder heap, sharing
+    // one decoded genotype vector across all atoms of the record.
+    fn decompose_record(&mut self, rec: RawRecord) -> Result<(), ConversionError> {
+        let pos = rec.pos;
+        let gt = Arc::new(rec.gt);
+
+        // Fail fast only when a reference is available; without one we trust the
+        // input is already normalized/left-aligned.
+        if self.has_reference {
+            crate::normalize::validate_ref(pos, &rec.reference, &self.ref_seq)?;
+        }
+
+        let alt_refs: Vec<&[u8]> = rec.alts.iter().map(|a| a.as_slice()).collect();
+        let mut atoms = Vec::new();
+        let dropped = atomize_record(
+            pos,
+            &rec.reference,
+            &alt_refs,
+            &mut atoms,
+            self.skip_out_of_scope,
+        )?;
+        self.dropped_out_of_scope += dropped as u64;
+
+        for atom in atoms {
+            let atom = if self.has_reference {
+                crate::normalize::left_align(atom, &self.ref_seq, crate::normalize::L_MAX)
+            } else {
+                atom
+            };
+
+            let info_vals: Vec<f64> = self
+                .info_fields
+                .iter()
+                .zip(rec.info_raw.iter())
+                .map(|(spec, raw)| resolve_scalar(raw.as_deref(), atom.source_alt_index, spec))
+                .collect();
+
+            let mut format_vals = Vec::with_capacity(self.format_fields.len() * self.num_samples);
+            for (spec, raw) in self.format_fields.iter().zip(rec.format_raw.iter()) {
+                for s in 0..self.num_samples {
+                    let sample_vals = raw.as_ref().map(|v| v[s].as_slice());
+                    format_vals.push(resolve_scalar(sample_vals, atom.source_alt_index, spec));
+                }
+            }
+
+            let seq = self.next_seq;
+            self.next_seq += 1;
+            self.heap.push(Reverse(PendingAtom {
+                pos: atom.pos,
+                ilen: atom.ilen,
+                alt: atom.alt,
+                source_alt_index: atom.source_alt_index,
+                gt: Arc::clone(&gt),
+                seq,
+                info_vals,
+                format_vals,
+            }));
+        }
+        Ok(())
+    }
+
+    // Yield the next atom in global position order. Left-alignment can move an atom
+    // up to `L_MAX` bases below its record's start, so an atom is safe to emit only
+    // once its position is strictly below `frontier - L_MAX` (saturating), or the
+    // input is exhausted. This preserves the position-sorted invariant the Phase-2
+    // merge relies on. (Unchanged from the pre-refactor VcfChunkReader.)
+    fn next_atom(&mut self) -> Result<Option<PendingAtom>, ConversionError> {
+        loop {
+            if let Some(Reverse(top)) = self.heap.peek() {
+                if self.eof || top.pos < self.frontier.saturating_sub(crate::normalize::L_MAX) {
+                    return Ok(Some(self.heap.pop().unwrap().0));
+                }
+            } else if self.eof {
+                return Ok(None);
+            }
+
+            match self.source.next_record()? {
+                Some(rec) => {
+                    self.frontier = rec.pos;
+                    self.decompose_record(rec)?;
+                }
+                None => self.eof = true,
+            }
+        }
+    }
+
+    // Body is EXACTLY the `read_next_chunk` written in Task 1, with `self.num_samples`
+    // / `self.ploidy` / `self.info_fields` / `self.format_fields` reading from the
+    // assembler instead of the old VcfChunkReader.
+    pub fn read_next_chunk(
+        &mut self,
+        chunk_size: usize,
+        chunk_id: usize,
+        pool: Option<&rayon::ThreadPool>,
+    ) -> Result<Option<DenseChunk>, ConversionError> {
+        // ... paste Task 1's read_next_chunk body verbatim ...
+    }
+}
+```
+
+with these imports at the top of the file:
+
+```rust
+use crate::error::ConversionError;
+use crate::field::{FieldCategory, FieldSpec};
+use crate::normalize::atomize_record;
+use crate::record_source::{RawRecord, RecordSource};
+use crate::types::{BitGrid3, DenseChunk, StagedColumn};
+use rayon::prelude::*;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::sync::Arc;
+```
+
+- [ ] **Step 3: Reduce `src/vcf_reader.rs` to `VcfRecordSource`**
+
+Delete everything moved to `chunk_assembler.rs`. Keep `load_contig_seq` (make it `pub(crate)`, unchanged), `HtslibType`-driven `decode_info_raw` / `decode_format_raw` (unchanged), and rewrite the struct:
+
+```rust
+pub struct VcfRecordSource {
+    inner_reader: IndexedReader,
+    num_samples: usize,
+    ploidy: usize,
+    sample_indices: Vec<usize>,
+    info_fields: Vec<FieldSpec>,
+    format_fields: Vec<FieldSpec>,
+    record: Record,
+    eof: bool,
+}
+
+impl VcfRecordSource {
+    pub fn new(
+        vcf_path: &str,
+        chrom: &str,
+        samples: &[&str],
+        htslib_threads: usize,
+        ploidy: usize,
+        fields: &[FieldSpec],
+    ) -> Result<Self, ConversionError> {
+        // Body is the old VcfChunkReader::new MINUS the fasta/ref_seq handling
+        // (that moved to ChunkAssembler::new) and MINUS the heap/frontier/next_seq
+        // fields. Keep the MissingFile check, IndexedReader::from_path, set_threads,
+        // name2rid, fetch(rid, 0, None), and the sample_indices lookup verbatim.
+        // ...
+    }
+}
+
+impl RecordSource for VcfRecordSource {
+    fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError> {
+        if self.eof {
+            return Ok(None);
+        }
+        match self.inner_reader.read(&mut self.record) {
+            None => {
+                self.eof = true;
+                return Ok(None);
+            }
+            Some(Err(e)) => {
+                return Err(ConversionError::Io {
+                    context: "reading next VCF record".to_string(),
+                    source: std::io::Error::other(e.to_string()),
+                });
+            }
+            Some(Ok(())) => {}
+        }
+
+        let pos = self.record.pos() as u32;
+
+        let reference: Vec<u8>;
+        let alts: Vec<Vec<u8>>;
+        {
+            let alleles = self.record.alleles();
+            reference = alleles[0].to_vec();
+            alts = alleles[1..].iter().map(|a| a.to_vec()).collect();
+        }
+
+        // Decode GT straight from the raw BCF integer buffer instead of
+        // `record.genotypes().get(i)`, which allocates a per-sample
+        // `Genotype(Vec<GenotypeAllele>)` for every sample of every record -- the
+        // dominant reader-side allocation churn. BCF GT encoding: an allele is
+        // `(idx + 1) << 1 | phased`, so `e >= 2` decodes to `(e >> 1) - 1`; `e` of
+        // 0/1 is missing and `i32::MIN` is vector-end padding -- both `< 2`, so a
+        // single `e >= 2` test reproduces `GenotypeAllele::index()` exactly.
+        let columns = self.num_samples * self.ploidy;
+        let mut gt = vec![-1i32; columns];
+        {
+            let gts = self.record.format(b"GT").integer().map_err(|e| {
+                ConversionError::Input(format!("Failed to read GT format at pos {pos}: {e}"))
+            })?;
+            let ploidy = self.ploidy;
+            for (s_idx, &vcf_idx) in self.sample_indices.iter().enumerate() {
+                let raw = gts[vcf_idx];
+                let base = s_idx * ploidy;
+                for p in 0..ploidy {
+                    gt[base + p] = match raw.get(p) {
+                        Some(&e) if e >= 2 => (e >> 1) - 1,
+                        _ => -1,
+                    };
+                }
+            }
+        }
+
+        let info_raw: Vec<Option<Vec<f64>>> = self
+            .info_fields
+            .iter()
+            .map(|spec| decode_info_raw(&self.record, spec))
+            .collect::<Result<_, _>>()?;
+
+        // Remap htslib's header-sample-indexed FORMAT buffers into SELECTED-sample
+        // order, so the assembler never needs to know about `sample_indices`.
+        let format_raw: Vec<Option<Vec<Vec<f64>>>> = self
+            .format_fields
+            .iter()
+            .map(|spec| {
+                decode_format_raw(&self.record, spec).map(|opt| {
+                    opt.map(|per_header_sample| {
+                        self.sample_indices
+                            .iter()
+                            .map(|&vcf_idx| per_header_sample[vcf_idx].clone())
+                            .collect()
+                    })
+                })
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(Some(RawRecord {
+            pos,
+            reference,
+            alts,
+            gt,
+            info_raw,
+            format_raw,
+        }))
+    }
+}
+```
+
+- [ ] **Step 4: Wire up `src/lib.rs` and `src/orchestrator.rs`**
+
+In `src/lib.rs`, next to the existing `mod` declarations, add (keeping the `conversion` feature gating that `vcf_reader` already has):
+
+```rust
+#[cfg(feature = "conversion")]
+mod chunk_assembler;
+#[cfg(feature = "conversion")]
+mod record_source;
+```
+
+In `src/orchestrator.rs`, replace the reader construction inside the reader thread closure:
+
+```rust
+                let s_refs: Vec<&str> = s_owned.iter().map(|s| s.as_str()).collect();
+                let source = crate::vcf_reader::VcfRecordSource::new(
+                    &vcf,
+                    &chr,
+                    &s_refs,
+                    htslib_threads,
+                    ploidy,
+                    &fields_owned,
+                )?;
+                let mut reader = crate::chunk_assembler::ChunkAssembler::new(
+                    Box::new(source),
+                    s_refs.len(),
+                    ploidy,
+                    fasta.as_deref(),
+                    &chr,
+                    skip_out_of_scope,
+                    &fields_owned,
+                )?;
+                let mut chunk_id = 0;
+                while let Some(dense_chunk) =
+                    reader.read_next_chunk(chunk_size, chunk_id, Some(&pool))?
+                {
+                    tx_dense.send(dense_chunk).unwrap();
+                    chunk_id += 1;
+                }
+                Ok(reader.dropped_out_of_scope())
+```
+
+- [ ] **Step 5: Run the full suite — this is the regression gate**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features'`
+Expected: PASS (all moved proptests still pass under their new module).
+
+Run: `pixi run test`
+Expected: PASS. The VCF path must be **byte-identical**; any diff in `tests/test_svar2*.py` output means the refactor changed behavior.
+
+Run: `pixi run bash -lc 'cargo clippy --all-targets -- -D warnings && cargo fmt --check'`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/record_source.rs src/chunk_assembler.rs src/vcf_reader.rs src/lib.rs src/orchestrator.rs
+git commit -m "refactor(svar2): split VcfChunkReader into RecordSource + ChunkAssembler
+
+VcfChunkReader fused htslib iteration, atom decomposition, the reorder heap,
+presence packing, and field staging; only the first is VCF-specific. Extract the
+source-agnostic spine into ChunkAssembler behind a RecordSource trait yielding an
+owned RawRecord, leaving VcfRecordSource as the htslib adapter. No behavior
+change -- SVAR2 output is byte-identical."
+```
+
+---
+
+## Task 3: Streaming `.pvar` reader
+
+**Files:**
+- Create: `src/pvar.rs`
+- Modify: `Cargo.toml` (add `zstd`)
+- Modify: `src/lib.rs` (declare `mod pvar`)
+- Test: `src/pvar.rs` `mod tests`
+
+**Interfaces:**
+- Produces (consumed by Task 4):
+  - `pvar::PvarRecord { pub pos: u32, pub reference: Vec<u8>, pub alts: Vec<Vec<u8>> }`
+  - `pvar::PvarReader::open(path: &str, var_start: usize) -> Result<PvarReader, ConversionError>`
+  - `PvarReader::next_variant(&mut self) -> Result<Option<PvarRecord>, ConversionError>`
+
+- [ ] **Step 1: Add the `zstd` dependency**
+
+In `Cargo.toml`, under `[dependencies]` (alphabetical, after `thiserror`):
+
+```toml
+# .pvar.zst decompression for the PGEN record source. BSD-3/MIT; no plink-ng code.
+zstd = { version = "0.13", optional = true }
+```
+
+and extend the `conversion` feature:
+
+```toml
+conversion = ["dep:rust-htslib", "dep:zstd"]
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src/pvar.rs` with only the test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, body: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join(name)).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        dir
+    }
+
+    const BODY: &str = "\
+##fileformat=PVARv1.0
+#CHROM\tPOS\tID\tREF\tALT
+chr1\t3\t.\tA\tG
+chr1\t7\t.\tC\tCAT
+chr1\t12\t.\tGTA\tG,GT
+";
+
+    #[test]
+    fn reads_pos_ref_alts_zero_based() {
+        let dir = write_tmp("x.pvar", BODY);
+        let p = dir.path().join("x.pvar");
+        let mut r = PvarReader::open(p.to_str().unwrap(), 0).unwrap();
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 2); // 1-based 3 -> 0-based 2
+        assert_eq!(v.reference, b"A");
+        assert_eq!(v.alts, vec![b"G".to_vec()]);
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 6);
+        assert_eq!(v.alts, vec![b"CAT".to_vec()]);
+
+        // Multiallelic ALT is comma-separated.
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 11);
+        assert_eq!(v.reference, b"GTA");
+        assert_eq!(v.alts, vec![b"G".to_vec(), b"GT".to_vec()]);
+
+        assert!(r.next_variant().unwrap().is_none());
+    }
+
+    #[test]
+    fn var_start_skips_leading_variants() {
+        let dir = write_tmp("x.pvar", BODY);
+        let p = dir.path().join("x.pvar");
+        let mut r = PvarReader::open(p.to_str().unwrap(), 2).unwrap();
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 11);
+        assert!(r.next_variant().unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_header_line_is_an_error() {
+        let dir = write_tmp("x.pvar", "chr1\t3\t.\tA\tG\n");
+        let p = dir.path().join("x.pvar");
+        let err = PvarReader::open(p.to_str().unwrap(), 0).unwrap_err();
+        assert!(format!("{err}").contains("#CHROM"));
+    }
+
+    #[test]
+    fn reads_zstd_compressed_pvar() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("x.pvar.zst");
+        let f = std::fs::File::create(&p).unwrap();
+        let mut enc = zstd::stream::write::Encoder::new(f, 3).unwrap();
+        enc.write_all(BODY.as_bytes()).unwrap();
+        enc.finish().unwrap();
+
+        let mut r = PvarReader::open(p.to_str().unwrap(), 0).unwrap();
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 2);
+        assert_eq!(v.reference, b"A");
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features pvar'`
+Expected: FAIL to compile — `cannot find type 'PvarReader'`.
+
+- [ ] **Step 4: Implement the reader**
+
+Prepend to `src/pvar.rs`:
+
+```rust
+//! Streaming `.pvar` / `.pvar.zst` variant-metadata reader for the PGEN record
+//! source. PGEN stores genotypes only; POS/REF/ALT live in the sibling `.pvar`.
+//!
+//! Written against the PLINK2 `.pvar` text format (a VCF-like TSV). Contains no
+//! plink-ng code.
+//!
+//! `.bim` is intentionally unsupported: it only accompanies a PLINK1 `.bed`,
+//! which SVAR2 does not read.
+
+use crate::error::ConversionError;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+/// One `.pvar` row, reduced to what the conversion spine needs.
+pub struct PvarRecord {
+    /// 0-based start position (`.pvar` POS is 1-based on disk).
+    pub pos: u32,
+    pub reference: Vec<u8>,
+    /// ALT alleles, comma-split. ALT1 is `alts[0]`.
+    pub alts: Vec<Vec<u8>>,
+}
+
+pub struct PvarReader {
+    lines: Box<dyn BufRead + Send>,
+    path: String,
+    pos_col: usize,
+    ref_col: usize,
+    alt_col: usize,
+    /// Global variant index of the next row to be returned. Only used for error
+    /// messages; the caller tracks its own range.
+    vidx: usize,
+    buf: String,
+}
+
+impl PvarReader {
+    /// Open `path` (`.pvar` or `.pvar.zst`), consume the header, and skip forward
+    /// to variant index `var_start` (0-based, counting data rows only).
+    pub fn open(path: &str, var_start: usize) -> Result<Self, ConversionError> {
+        if !std::path::Path::new(path).exists() {
+            return Err(ConversionError::MissingFile {
+                path: path.to_string(),
+            });
+        }
+        let file = File::open(path).map_err(|e| ConversionError::Io {
+            context: format!("opening pvar {path}"),
+            source: e,
+        })?;
+        let lines: Box<dyn BufRead + Send> = if path.ends_with(".zst") {
+            let dec = zstd::stream::read::Decoder::new(file).map_err(|e| ConversionError::Io {
+                context: format!("opening zstd stream for {path}"),
+                source: e,
+            })?;
+            Box::new(BufReader::new(dec))
+        } else {
+            Box::new(BufReader::new(file))
+        };
+
+        let mut me = Self {
+            lines,
+            path: path.to_string(),
+            pos_col: 0,
+            ref_col: 0,
+            alt_col: 0,
+            vidx: 0,
+            buf: String::new(),
+        };
+
+        // Header: skip `##` meta lines, then require the `#CHROM ...` column line.
+        // plink2 --make-pgen always writes one; a headerless .pvar is rejected
+        // rather than guessed at.
+        loop {
+            me.buf.clear();
+            let n = me.read_line()?;
+            if n == 0 {
+                return Err(ConversionError::Input(format!(
+                    "{path}: reached EOF without a '#CHROM' header line"
+                )));
+            }
+            if me.buf.starts_with("##") {
+                continue;
+            }
+            if !me.buf.starts_with("#CHROM") {
+                return Err(ConversionError::Input(format!(
+                    "{path}: expected a '#CHROM' header line, found '{}'. \
+                     Headerless .pvar files are not supported.",
+                    me.buf.trim_end()
+                )));
+            }
+            let cols: Vec<&str> = me.buf.trim_end().split('\t').collect();
+            let find = |name: &str| -> Result<usize, ConversionError> {
+                cols.iter().position(|c| *c == name).ok_or_else(|| {
+                    ConversionError::Input(format!("{path}: header is missing a '{name}' column"))
+                })
+            };
+            me.pos_col = find("POS")?;
+            me.ref_col = find("REF")?;
+            me.alt_col = find("ALT")?;
+            break;
+        }
+
+        for _ in 0..var_start {
+            me.buf.clear();
+            if me.read_line()? == 0 {
+                return Err(ConversionError::Input(format!(
+                    "{path}: ran out of variants while skipping to index {var_start}"
+                )));
+            }
+            me.vidx += 1;
+        }
+        Ok(me)
+    }
+
+    fn read_line(&mut self) -> Result<usize, ConversionError> {
+        self.lines
+            .read_line(&mut self.buf)
+            .map_err(|e| ConversionError::Io {
+                context: format!("reading pvar {}", self.path),
+                source: e,
+            })
+    }
+
+    /// Next variant, or `None` at EOF.
+    pub fn next_variant(&mut self) -> Result<Option<PvarRecord>, ConversionError> {
+        self.buf.clear();
+        if self.read_line()? == 0 {
+            return Ok(None);
+        }
+        let line = self.buf.trim_end_matches(['\n', '\r']);
+        let cols: Vec<&str> = line.split('\t').collect();
+        let want = self.pos_col.max(self.ref_col).max(self.alt_col);
+        if cols.len() <= want {
+            return Err(ConversionError::Input(format!(
+                "{}: variant {} has {} columns, need at least {}",
+                self.path,
+                self.vidx,
+                cols.len(),
+                want + 1
+            )));
+        }
+
+        let pos_1based: u32 = cols[self.pos_col].parse().map_err(|_| {
+            ConversionError::Input(format!(
+                "{}: variant {} has a non-integer POS '{}'",
+                self.path, self.vidx, cols[self.pos_col]
+            ))
+        })?;
+        if pos_1based == 0 {
+            return Err(ConversionError::Input(format!(
+                "{}: variant {} has POS 0; .pvar POS is 1-based",
+                self.path, self.vidx
+            )));
+        }
+
+        let mut reference = cols[self.ref_col].as_bytes().to_vec();
+        reference.make_ascii_uppercase();
+        let alts: Vec<Vec<u8>> = cols[self.alt_col]
+            .split(',')
+            .map(|a| {
+                let mut v = a.as_bytes().to_vec();
+                v.make_ascii_uppercase();
+                v
+            })
+            .collect();
+
+        self.vidx += 1;
+        Ok(Some(PvarRecord {
+            pos: pos_1based - 1,
+            reference,
+            alts,
+        }))
+    }
+}
+```
+
+Declare it in `src/lib.rs` alongside the other conversion-gated modules:
+
+```rust
+#[cfg(feature = "conversion")]
+mod pvar;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'cargo test --no-default-features pvar'`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/pvar.rs src/lib.rs
+git commit -m "feat(svar2): streaming .pvar/.pvar.zst variant-metadata reader
+
+PGEN stores genotypes only; POS/REF/ALT come from the sibling .pvar. Streams
+rather than materializing, so per-contig metadata memory stays O(1) in variants.
+Written against the PLINK2 text format; contains no plink-ng code."
+```
+
+---
+
+## Task 4: `PgenRecordSource`
+
+**Files:**
+- Create: `src/pgen_reader.rs`
+- Modify: `src/lib.rs` (declare `mod pgen_reader`)
+
+**Interfaces:**
+- Consumes: `record_source::{RawRecord, RecordSource}` (Task 2), `pvar::{PvarReader, PvarRecord}` (Task 3).
+- Produces (consumed by Task 5):
+  - `pgen_reader::PGEN_BATCH_BYTES: usize`
+  - `pgen_reader::PgenRecordSource::new(pgen_reader: Py<PyAny>, pvar_path: &str, var_start: usize, var_end: usize, num_samples: usize, chunk_size: usize) -> Result<PgenRecordSource, ConversionError>`
+  - `impl RecordSource for PgenRecordSource`
+
+**Design notes:**
+- `pgen_reader` is a **`pgenlib.PgenReader` constructed in Python** and handed down as `Py<PyAny>` (`Py<T>` is `Send`, so it can cross into the `py.detach` worker threads). One reader per contig — each contig's reader seeks independently, so they must not be shared.
+- `read_alleles_range(lo, hi, out, hap_maj=False)` fills `out[(hi-lo), 2*S]` int32 with per-haplotype allele codes (phase-aware, multiallelic-aware, missing `-9`) and runs its decode under `prange(..., nogil=True)` — the GIL is released for the actual work, so `Python::attach` here costs only call dispatch.
+- Batch size is a **byte budget**, not a variant count: at 200 samples this is thousands of variants per Python call; at 500k samples it is a handful. That single knob keeps the FFI boundary cheap and memory bounded across the whole cohort-size range.
+- `.pvar` and `.pgen` advance in lockstep — one `next_variant()` per served row.
+
+- [ ] **Step 1: Write the implementation**
+
+There is no pure-Rust unit test for this type (it needs a live `pgenlib.PgenReader`); it is covered end-to-end by Task 7's Python tests. Create `src/pgen_reader.rs`:
+
+```rust
+//! PGEN record source.
+//!
+//! Genotypes come from the `pgenlib` PyPI wheel (LGPL-3.0) via its **public Python
+//! API** -- the same way `genoray/_pgen.py` already uses it. genoray links no
+//! plink-ng code and vendors none; `_core` stays MIT. Do not change this without
+//! reading `docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md`.
+//!
+//! `PgenReader.read_alleles_range` releases the GIL for its decode loop, so the
+//! `Python::attach` below only costs call dispatch, not the decode.
+
+use crate::error::ConversionError;
+use crate::pvar::PvarReader;
+use crate::record_source::{RawRecord, RecordSource};
+use numpy::{PyArray2, PyArrayMethods};
+use pyo3::prelude::*;
+
+/// Byte budget for the `(batch, 2 * n_samples)` int32 allele-code buffer. Sized so
+/// small cohorts get thousands of variants per Python call (amortizing dispatch)
+/// while biobank cohorts stay memory-bounded.
+pub const PGEN_BATCH_BYTES: usize = 32 * 1024 * 1024;
+
+pub struct PgenRecordSource {
+    /// A `pgenlib.PgenReader`, constructed in Python and owned here.
+    reader: Py<PyAny>,
+    /// `(batch, 2 * num_samples)` int32 allele-code scratch buffer, reused per refill.
+    buf: Py<PyArray2<i32>>,
+    batch: usize,
+    num_samples: usize,
+    /// Next global variant index to fetch from the .pgen.
+    var_next: usize,
+    /// Exclusive end of this contig's variant index range.
+    var_end: usize,
+    /// Rows currently valid in `buf`, and the next one to serve.
+    filled: usize,
+    row: usize,
+    pvar: PvarReader,
+}
+
+impl PgenRecordSource {
+    pub fn new(
+        reader: Py<PyAny>,
+        pvar_path: &str,
+        var_start: usize,
+        var_end: usize,
+        num_samples: usize,
+        chunk_size: usize,
+    ) -> Result<Self, ConversionError> {
+        let batch = (PGEN_BATCH_BYTES / (2 * num_samples * 4)).clamp(1, chunk_size.max(1));
+        let pvar = PvarReader::open(pvar_path, var_start)?;
+        let buf = Python::attach(|py| {
+            PyArray2::<i32>::zeros(py, [batch, 2 * num_samples], false).unbind()
+        });
+        Ok(Self {
+            reader,
+            buf,
+            batch,
+            num_samples,
+            var_next: var_start,
+            var_end,
+            filled: 0,
+            row: 0,
+            pvar,
+        })
+    }
+
+    /// Refill `buf` with the next `min(batch, var_end - var_next)` variants.
+    /// Returns the number of rows filled (0 => this contig is exhausted).
+    fn refill(&mut self) -> Result<usize, ConversionError> {
+        let lo = self.var_next;
+        if lo >= self.var_end {
+            return Ok(0);
+        }
+        let hi = (lo + self.batch).min(self.var_end);
+        Python::attach(|py| -> Result<(), ConversionError> {
+            self.reader
+                .bind(py)
+                .call_method1(
+                    "read_alleles_range",
+                    (lo as u32, hi as u32, self.buf.bind(py), false),
+                )
+                .map_err(|e| {
+                    ConversionError::Input(format!(
+                        "pgenlib read_alleles_range({lo}, {hi}) failed: {e}"
+                    ))
+                })?;
+            Ok(())
+        })?;
+        self.var_next = hi;
+        self.filled = hi - lo;
+        self.row = 0;
+        Ok(self.filled)
+    }
+}
+
+impl RecordSource for PgenRecordSource {
+    fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError> {
+        if self.row == self.filled && self.refill()? == 0 {
+            return Ok(None);
+        }
+
+        // .pvar and .pgen advance in lockstep -- one metadata row per genotype row.
+        let Some(meta) = self.pvar.next_variant()? else {
+            return Err(ConversionError::Input(
+                "pvar ran out of variants before the .pgen did; \
+                 the .pvar and .pgen disagree on variant count"
+                    .to_string(),
+            ));
+        };
+
+        let columns = 2 * self.num_samples;
+        let mut gt = vec![-1i32; columns];
+        Python::attach(|py| {
+            let arr = self.buf.bind(py).readonly();
+            let flat = arr.as_slice().expect("pgen buffer is C-contiguous");
+            let base = self.row * columns;
+            for (c, out) in gt.iter_mut().enumerate() {
+                // pgenlib encodes missing as -9; the conversion spine uses -1.
+                let code = flat[base + c];
+                *out = if code < 0 { -1 } else { code };
+            }
+        });
+        self.row += 1;
+
+        Ok(Some(RawRecord {
+            pos: meta.pos,
+            reference: meta.reference,
+            alts: meta.alts,
+            gt,
+            // PGEN has no FORMAT, and .pvar INFO extraction is out of scope for v1.
+            info_raw: Vec::new(),
+            format_raw: Vec::new(),
+        }))
+    }
+}
+```
+
+Declare it in `src/lib.rs`:
+
+```rust
+#[cfg(feature = "conversion")]
+mod pgen_reader;
+```
+
+- [ ] **Step 2: Verify it compiles and lints**
+
+Run: `pixi run bash -lc 'cargo check && cargo clippy --all-targets -- -D warnings && cargo fmt --check'`
+Expected: clean. (No new tests here — Task 7's end-to-end tests are what exercise this.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pgen_reader.rs src/lib.rs
+git commit -m "feat(svar2): PgenRecordSource backed by pgenlib read_alleles_range
+
+Gets per-haplotype allele codes (phase- and multiallelic-aware) from the already-
+depended-on pgenlib wheel through its public Python API, in byte-budgeted batches
+so the FFI boundary stays cheap at 200 samples and memory-bounded at 500k. No
+plink-ng code is linked or vendored."
+```
+
+---
+
+## Task 5: Orchestrator `SourceSpec` + `run_pgen_conversion_pipeline`
+
+**Files:**
+- Modify: `src/orchestrator.rs` (`process_chromosome` takes a `SourceSpec`)
+- Modify: `src/lib.rs` (add the `run_pgen_conversion_pipeline` pyfunction; register it)
+
+**Interfaces:**
+- Consumes: `PgenRecordSource::new` (Task 4), `VcfRecordSource::new` + `ChunkAssembler::new` (Task 2).
+- Produces (consumed by Task 6):
+  - `_core.run_pgen_conversion_pipeline(pgen_path: str, pvar_path: str, reference_path: str | None, chroms: list[str], contig_ranges: list[tuple[int, int]], output_dir: str, samples: list[str], chunk_size: int, max_threads: int | None, long_allele_capacity: int, skip_out_of_scope: bool, signatures: bool, pgen_readers: list[Any]) -> int`
+  - `contig_ranges[i]` is the half-open `[var_start, var_end)` variant index range of `chroms[i]` in the `.pvar`. `pgen_readers[i]` is a distinct `pgenlib.PgenReader` for `chroms[i]`.
+
+- [ ] **Step 1: Add `SourceSpec` and make `process_chromosome` generic over it**
+
+In `src/orchestrator.rs`, above `process_chromosome`:
+
+```rust
+/// Which backend a contig's records come from. Everything downstream of
+/// `ChunkAssembler` is identical for both.
+pub enum SourceSpec {
+    Vcf {
+        vcf_path: String,
+        htslib_threads: usize,
+    },
+    Pgen {
+        pgen_path: String,
+        pvar_path: String,
+        var_start: usize,
+        var_end: usize,
+        /// A `pgenlib.PgenReader` for THIS contig. Readers seek independently, so
+        /// each concurrent contig needs its own -- never share one.
+        reader: pyo3::Py<pyo3::PyAny>,
+    },
+}
+```
+
+Change `process_chromosome`'s signature: drop `vcf_path: &str` and `htslib_threads: usize`, add `source: SourceSpec`. Inside the reader thread closure, replace the `VcfChunkReader::new` call with:
+
+```rust
+                let s_refs: Vec<&str> = s_owned.iter().map(|s| s.as_str()).collect();
+                let src: Box<dyn crate::record_source::RecordSource + Send> = match source {
+                    SourceSpec::Vcf {
+                        vcf_path,
+                        htslib_threads,
+                    } => Box::new(crate::vcf_reader::VcfRecordSource::new(
+                        &vcf_path,
+                        &chr,
+                        &s_refs,
+                        htslib_threads,
+                        ploidy,
+                        &fields_owned,
+                    )?),
+                    SourceSpec::Pgen {
+                        pgen_path: _,
+                        pvar_path,
+                        var_start,
+                        var_end,
+                        reader,
+                    } => Box::new(crate::pgen_reader::PgenRecordSource::new(
+                        reader,
+                        &pvar_path,
+                        var_start,
+                        var_end,
+                        s_refs.len(),
+                        chunk_size,
+                    )?),
+                };
+                let mut reader = crate::chunk_assembler::ChunkAssembler::new(
+                    src,
+                    s_refs.len(),
+                    ploidy,
+                    fasta.as_deref(),
+                    &chr,
+                    skip_out_of_scope,
+                    &fields_owned,
+                )?;
+```
+
+`source` must be `move`d into the closure (it already captures by `move`). `SourceSpec::Pgen.pgen_path` is unused by the reader (pgenlib already holds the open file) but is kept for error messages and symmetry — silence the unused binding with `pgen_path: _` as above.
+
+**Note on the thread budget:** the PGEN path needs no htslib decompression threads. Task 6 calls `plan_thread_budget` exactly as the VCF path does and simply ignores `htslib_threads`; those cores go idle rather than being reallocated. That is deliberate — reallocating is a separate, measurable optimization, not a guess.
+
+- [ ] **Step 2: Add the pyfunction in `src/lib.rs`**
+
+Model it directly on the existing `run_conversion_pipeline` (same budgeting, same rayon fan-out, same error aggregation). The only differences are the `SourceSpec` it builds and the absent `fields`.
+
+```rust
+/// Convert a PLINK2 PGEN to an SVAR2 store.
+///
+/// `contig_ranges[i]` is the half-open `[var_start, var_end)` variant index range
+/// of `chroms[i]` within the `.pvar`. `pgen_readers[i]` is a distinct
+/// `pgenlib.PgenReader` for `chroms[i]` -- readers seek independently, so contigs
+/// must not share one.
+#[pyfunction]
+#[allow(clippy::too_many_arguments)]
+fn run_pgen_conversion_pipeline(
+    py: Python,
+    pgen_path: String,
+    pvar_path: String,
+    reference_path: Option<String>,
+    chroms: Vec<String>,
+    contig_ranges: Vec<(usize, usize)>,
+    output_dir: String,
+    samples: Vec<String>,
+    chunk_size: usize,
+    max_threads: Option<usize>,
+    long_allele_capacity: usize,
+    skip_out_of_scope: bool,
+    signatures: bool,
+    pgen_readers: Vec<Py<PyAny>>,
+) -> PyResult<usize> {
+    if chroms.len() != contig_ranges.len() || chroms.len() != pgen_readers.len() {
+        return Err(PyValueError::new_err(
+            "chroms, contig_ranges, and pgen_readers must be the same length",
+        ));
+    }
+    let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
+    // PGEN is diploid-only.
+    let ploidy = 2usize;
+    // PGEN carries no FORMAT, and .pvar INFO extraction is out of scope.
+    let fields: Vec<crate::field::FieldSpec> = Vec::new();
+
+    // Pair each contig with its own reader BEFORE detaching, so the Py handles move
+    // into the worker threads (Py<PyAny> is Send; PyAny is not).
+    let jobs: Vec<(String, (usize, usize), Py<PyAny>)> = chroms
+        .iter()
+        .cloned()
+        .zip(contig_ranges.iter().copied())
+        .zip(pgen_readers)
+        .map(|((c, r), rd)| (c, r, rd))
+        .collect();
+
+    let results: Vec<Result<u64, crate::error::ConversionError>> = py.detach(|| {
+        let available_cores = match max_threads {
+            Some(t) if t > 0 => t,
+            _ => std::thread::available_parallelism().unwrap().get(),
+        };
+        let plan = crate::budget::plan_thread_budget(available_cores, jobs.len());
+        let concurrent_chroms = plan.concurrent_chroms;
+        let processing_threads = plan.processing_threads;
+        println!(
+            "Pipeline Config (PGEN): {} concurrent chromosomes | {} processing threads each.",
+            concurrent_chroms, processing_threads
+        );
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(concurrent_chroms)
+            .thread_name(|i| format!("chrom-{}", i))
+            .build()
+            .expect("build chrom pool");
+
+        pool.install(|| {
+            use rayon::prelude::*;
+            jobs.into_par_iter()
+                .map(|(chrom, (lo, hi), reader)| {
+                    crate::orchestrator::process_chromosome(
+                        crate::orchestrator::SourceSpec::Pgen {
+                            pgen_path: pgen_path.clone(),
+                            pvar_path: pvar_path.clone(),
+                            var_start: lo,
+                            var_end: hi,
+                            reader,
+                        },
+                        reference_path.as_deref(),
+                        &chrom,
+                        &output_dir,
+                        &sample_refs,
+                        chunk_size,
+                        ploidy,
+                        long_allele_capacity,
+                        skip_out_of_scope,
+                        processing_threads,
+                        signatures,
+                        &fields,
+                    )
+                })
+                .collect()
+        })
+    });
+
+    let mut dropped = 0u64;
+    for r in results {
+        dropped += r.map_err(crate::error::to_pyerr)?;
+    }
+    Ok(dropped as usize)
+}
+```
+
+Adjust the argument order of the `process_chromosome` call to match whatever the refactored signature actually is, and reuse the **existing** error-conversion helper that `run_conversion_pipeline` uses (read it; do not invent `to_pyerr` if the codebase names it differently). Register the function next to the others:
+
+```rust
+    #[cfg(feature = "conversion")]
+    m.add_function(wrap_pyfunction!(run_pgen_conversion_pipeline, m)?)?;
+```
+
+- [ ] **Step 3: Build and verify the VCF path still works**
+
+Run: `pixi run bash -lc 'cargo clippy --all-targets -- -D warnings && cargo fmt --check'`
+Expected: clean.
+
+Run: `pixi run bash -lc 'maturin develop'` (foreground — this takes minutes; do NOT background it)
+Expected: builds.
+
+Run: `pixi run pytest tests/test_svar2_from_vcf.py -q`
+Expected: PASS — the VCF path is unaffected by the `SourceSpec` plumbing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/orchestrator.rs src/lib.rs
+git commit -m "feat(svar2): SourceSpec + run_pgen_conversion_pipeline
+
+process_chromosome now selects its RecordSource from a SourceSpec, so the PGEN
+backend reuses the whole executor/merge/finalize spine. One pgenlib.PgenReader per
+contig -- readers seek independently and must not be shared."
+```
+
+---
+
+## Task 6: `SparseVar2.from_pgen`
+
+**Files:**
+- Modify: `python/genoray/_svar2.py`
+- Test: `tests/test_svar2_from_pgen.py` (created here, extended in Task 7)
+
+**Interfaces:**
+- Consumes: `_core.run_pgen_conversion_pipeline` (Task 5), and from `genoray._pgen`: `_read_psam`, `_scan_pvar`.
+- Produces: `SparseVar2.from_pgen(...) -> int` (see the signature below).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_svar2_from_pgen.py`:
+
+```python
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from genoray import SparseVar2
+
+# 40 bp reference. 1-based POS 3 = 'A', 7 = 'C', 12..14 = 'GTA'.
+_REF = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"
+
+# Phased, no half-calls, no symbolics: plink2's VCF import is lossless here, so
+# from_pgen and from_vcf must agree exactly. (A half-call like './1' would NOT
+# round-trip: gen_from_vcf.sh passes --vcf-half-call r, which rewrites it.)
+_VCF_BODY = (
+    "##fileformat=VCFv4.2\n"
+    "##contig=<ID=chr1,length=40>\n"
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+    "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+    "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
+    "chr1\t12\t.\tGTA\tG,GT\t.\t.\t.\tGT\t1|2\t0|1\n"
+    "chr1\t20\t.\tT\tA\t.\t.\t.\tGT\t.|.\t1|0\n"
+)
+
+
+@pytest.fixture(scope="module")
+def sources(tmp_path_factory) -> tuple[Path, Path, Path]:
+    """(reference fasta, bgzipped+indexed vcf, pgen) for the same variants."""
+    d = tmp_path_factory.mktemp("frompgen")
+
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    plain = d / "in.vcf"
+    plain.write_text(_VCF_BODY)
+    gz = d / "in.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+
+    subprocess.run(
+        ["plink2", "--make-pgen", "--vcf", str(gz), "--out", str(d / "in")],
+        check=True,
+    )
+    return ref, gz, d / "in.pgen"
+
+
+def test_from_pgen_matches_from_vcf(sources, tmp_path):
+    ref, vcf, pgen = sources
+    from_vcf = tmp_path / "vcf.svar2"
+    from_pgen = tmp_path / "pgen.svar2"
+
+    SparseVar2.from_vcf(from_vcf, vcf, ref)
+    SparseVar2.from_pgen(from_pgen, pgen, ref)
+
+    a = SparseVar2(from_vcf)
+    b = SparseVar2(from_pgen)
+    assert a.n_samples == b.n_samples == 2
+
+    regions = [(0, len(_REF))]
+    ragged_vcf = a.decode("chr1", regions)
+    ragged_pgen = b.decode("chr1", regions)
+    assert ragged_pgen.offsets.tolist() == ragged_vcf.offsets.tolist()
+    assert ragged_pgen.data.tolist() == ragged_vcf.data.tolist()
+
+
+def test_from_pgen_requires_exactly_one_of_reference_or_no_reference(sources, tmp_path):
+    _, _, pgen = sources
+    with pytest.raises(ValueError, match="exactly one"):
+        SparseVar2.from_pgen(tmp_path / "a.svar2", pgen)
+    with pytest.raises(ValueError, match="exactly one"):
+        SparseVar2.from_pgen(
+            tmp_path / "b.svar2", pgen, "ref.fa", no_reference=True
+        )
+
+
+def test_from_pgen_refuses_to_overwrite(sources, tmp_path):
+    ref, _, pgen = sources
+    out = tmp_path / "exists.svar2"
+    SparseVar2.from_pgen(out, pgen, ref)
+    with pytest.raises(FileExistsError):
+        SparseVar2.from_pgen(out, pgen, ref)
+    SparseVar2.from_pgen(out, pgen, ref, overwrite=True)  # no raise
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar2_from_pgen.py -q`
+Expected: FAIL with `AttributeError: type object 'SparseVar2' has no attribute 'from_pgen'`.
+
+- [ ] **Step 3: Implement `from_pgen`**
+
+In `python/genoray/_svar2.py`, add a classmethod after `from_vcf`:
+
+```python
+    @classmethod
+    def from_pgen(
+        cls,
+        out: str | Path,
+        source: str | Path,
+        reference: str | Path | None = None,
+        *,
+        no_reference: bool = False,
+        skip_out_of_scope: bool = False,
+        chunk_size: int | None = None,
+        threads: int | None = None,
+        overwrite: bool = False,
+        long_allele_capacity: int = 8 * 1024 * 1024,
+        signatures: bool = False,
+    ) -> int:
+        """Convert a PLINK2 PGEN to an SVAR2 store.
+
+        Genotypes are read through the ``pgenlib`` package; variant metadata comes
+        from the sibling ``.pvar``/``.pvar.zst`` and sample names from the ``.psam``.
+
+        Exactly one of `reference` or `no_reference=True` is required, with the same
+        meaning as :meth:`from_vcf`: with a reference, indels are validated against
+        and left-aligned to the FASTA; with `no_reference`, both are skipped and the
+        input is trusted to be already normalized. Returns the number of
+        out-of-scope (symbolic/breakend) ALTs dropped (0 unless `skip_out_of_scope`).
+
+        PGEN is diploid, so there is no `ploidy` parameter.
+
+        chunk_size: variants per conversion chunk. Defaults to a value derived from
+        a memory budget, since a packed dense chunk costs
+        ``chunk_size * n_samples * 2 / 8`` bytes.
+
+        Not supported (and silently ignored rather than errored, where noted):
+
+        - **Dosages.** SVAR2 stores no dosages; a ``.pgen`` dosage track is ignored
+          and hardcalls are read as usual.
+        - **INFO/FORMAT fields.** PGEN has no FORMAT; ``.pvar`` INFO extraction is
+          not implemented.
+        - **Sample subsetting.** All samples in the ``.psam`` are converted, matching
+          :meth:`from_vcf`.
+
+        Haplotype resolution for *unphased* heterozygotes follows the allele-code
+        order ``pgenlib`` returns — the same caveat :meth:`from_vcf` carries for
+        unphased ``GT``.
+        """
+        from genoray._pgen import _read_psam, _scan_pvar
+
+        out = Path(out)
+        source = Path(source)
+
+        if (reference is None) == (not no_reference):
+            raise ValueError(
+                "provide exactly one of `reference` (a FASTA path) or "
+                "`no_reference=True`"
+            )
+        if signatures and no_reference:
+            raise ValueError("signatures=True requires a reference (not no_reference).")
+        if out.exists() and not overwrite:
+            raise FileExistsError(
+                f"Output path {out} already exists. Use overwrite=True to overwrite."
+            )
+        if source.suffix != ".pgen":
+            raise ValueError(f"Expected a .pgen file, got {source}")
+        if not source.exists():
+            raise FileNotFoundError(source)
+
+        pvar = _find_pvar(source)
+        psam = source.with_suffix(".psam")
+        if not psam.exists():
+            raise FileNotFoundError(psam)
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+        samples = cast("list[str]", _read_psam(psam).tolist())
+        n_samples = len(samples)
+        if n_samples == 0:
+            raise ValueError(f"No samples found in {psam}.")
+
+        contigs, ranges = _pvar_contig_ranges(pvar)
+        if not contigs:
+            raise ValueError(f"No variants found in {pvar}.")
+
+        if chunk_size is None:
+            chunk_size = _auto_chunk_size(n_samples)
+
+        import pgenlib
+
+        # One reader per contig: readers seek independently, so concurrent contigs
+        # must not share one.
+        readers = [
+            pgenlib.PgenReader(bytes(source), n_samples) for _ in contigs
+        ]
+
+        return _core.run_pgen_conversion_pipeline(
+            str(source),
+            str(pvar),
+            None if no_reference else str(reference),
+            contigs,
+            ranges,
+            str(out),
+            samples,
+            chunk_size,
+            threads,
+            long_allele_capacity,
+            skip_out_of_scope,
+            signatures,
+            readers,
+        )
+```
+
+and these module-level helpers in the same file:
+
+```python
+def _find_pvar(pgen: Path) -> Path:
+    """Locate the `.pvar` / `.pvar.zst` sibling of `pgen`."""
+    for suffix in (".pvar", ".pvar.zst"):
+        cand = pgen.with_suffix(suffix)
+        if cand.exists():
+            return cand
+    raise FileNotFoundError(
+        f"No .pvar or .pvar.zst found next to {pgen}. "
+        f"Looked for {pgen.with_suffix('.pvar')} and {pgen.with_suffix('.pvar.zst')}."
+    )
+
+
+def _pvar_contig_ranges(pvar: Path) -> tuple[list[str], list[tuple[int, int]]]:
+    """Contigs in `.pvar` file order, with each one's half-open `[lo, hi)` variant
+    index range.
+
+    Raises if a contig's variants are not contiguous — SVAR2 converts one contig at
+    a time from a variant index range, which requires the `.pvar` to be grouped by
+    contig (as plink2 always writes it).
+    """
+    import polars as pl
+
+    from genoray._pgen import _scan_pvar
+
+    df = (
+        _scan_pvar(pvar)
+        .select("#CHROM")
+        .with_row_index("vidx")
+        .group_by("#CHROM", maintain_order=True)
+        .agg(
+            pl.col("vidx").min().alias("lo"),
+            pl.col("vidx").max().alias("hi"),
+            pl.len().alias("n"),
+        )
+        .collect()
+    )
+    contigs: list[str] = []
+    ranges: list[tuple[int, int]] = []
+    for chrom, lo, hi, n in df.iter_rows():
+        if hi - lo + 1 != n:
+            raise ValueError(
+                f"Contig {chrom!r} is not contiguous in {pvar} "
+                f"(spans indices {lo}..{hi} but has {n} variants). "
+                "SVAR2 requires a .pvar grouped by contig."
+            )
+        contigs.append(str(chrom))
+        ranges.append((int(lo), int(hi) + 1))
+    return contigs, ranges
+
+
+# Target byte size of one packed dense chunk (chunk_size * n_samples * ploidy / 8).
+_DENSE_CHUNK_TARGET_BYTES = 256 * 1024 * 1024
+
+
+def _auto_chunk_size(n_samples: int, ploidy: int = 2) -> int:
+    """Variants per chunk, derived from a memory budget rather than a fixed count.
+
+    A packed dense chunk costs `chunk_size * n_samples * ploidy / 8` bytes, so a
+    fixed 25k chunk that is fine at 200 samples is not at 500k.
+    """
+    bits_per_variant = n_samples * ploidy
+    by_budget = (_DENSE_CHUNK_TARGET_BYTES * 8) // max(bits_per_variant, 1)
+    return max(1024, min(25_000, int(by_budget)))
+```
+
+Ensure `cast` is imported from `typing` at the top of the module if it is not already.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run bash -lc 'maturin develop'` (foreground)
+Run: `pixi run pytest tests/test_svar2_from_pgen.py -q`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_svar2.py tests/test_svar2_from_pgen.py
+git commit -m "feat(svar2): SparseVar2.from_pgen
+
+Converts a PLINK2 PGEN to an SVAR2 store through the same normalization, atom,
+and merge spine as from_vcf. Diploid-only (no ploidy kwarg); dosages, INFO/FORMAT
+fields, and sample subsetting are out of scope and documented as such."
+```
+
+---
+
+## Task 7: Coverage tests — multiallelic, missing, indels, `.pvar.zst`, no-reference
+
+**Files:**
+- Modify: `tests/test_svar2_from_pgen.py`
+
+**Interfaces:**
+- Consumes: `SparseVar2.from_pgen` (Task 6), the `sources` fixture from Task 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_svar2_from_pgen.py`:
+
+```python
+def test_from_pgen_no_reference_matches_from_vcf(sources, tmp_path):
+    """The no_reference path (no REF validation, no left-alignment) must also agree."""
+    _, vcf, pgen = sources
+    from_vcf = tmp_path / "vcf.svar2"
+    from_pgen = tmp_path / "pgen.svar2"
+
+    SparseVar2.from_vcf(from_vcf, vcf, no_reference=True)
+    SparseVar2.from_pgen(from_pgen, pgen, no_reference=True)
+
+    a = SparseVar2(from_vcf)
+    b = SparseVar2(from_pgen)
+    regions = [(0, len(_REF))]
+    assert b.decode("chr1", regions).data.tolist() == a.decode("chr1", regions).data.tolist()
+
+
+def test_from_pgen_reads_zstd_pvar(sources, tmp_path):
+    """plink2 `vzs` writes a .pvar.zst; the Rust streamer must handle it."""
+    ref, vcf, _ = sources
+    d = tmp_path / "zst"
+    d.mkdir()
+    subprocess.run(
+        ["plink2", "--make-pgen", "vzs", "--vcf", str(vcf), "--out", str(d / "in")],
+        check=True,
+    )
+    assert (d / "in.pvar.zst").exists()
+
+    out_zst = tmp_path / "zst.svar2"
+    out_ref = tmp_path / "plain.svar2"
+    SparseVar2.from_pgen(out_zst, d / "in.pgen", ref)
+    SparseVar2.from_vcf(out_ref, vcf, ref)
+
+    regions = [(0, len(_REF))]
+    a = SparseVar2(out_ref).decode("chr1", regions)
+    b = SparseVar2(out_zst).decode("chr1", regions)
+    assert b.data.tolist() == a.data.tolist()
+
+
+def test_from_pgen_multi_contig(tmp_path):
+    """Contigs are converted from disjoint .pvar index ranges; a two-contig file
+    exercises the range computation and the per-contig PgenReader."""
+    d = tmp_path / "multi"
+    d.mkdir()
+
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n>chr2\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=chr1,length=40>\n"
+        "##contig=<ID=chr2,length=40>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+        "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr2\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
+    )
+    plain = d / "in.vcf"
+    plain.write_text(body)
+    gz = d / "in.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+    subprocess.run(
+        ["plink2", "--make-pgen", "--vcf", str(gz), "--out", str(d / "in")], check=True
+    )
+
+    from_vcf = tmp_path / "mv.svar2"
+    from_pgen = tmp_path / "mp.svar2"
+    SparseVar2.from_vcf(from_vcf, gz, ref)
+    SparseVar2.from_pgen(from_pgen, d / "in.pgen", ref)
+
+    a, b = SparseVar2(from_vcf), SparseVar2(from_pgen)
+    regions = [(0, len(_REF))]
+    for contig in ("chr1", "chr2"):
+        assert (
+            b.decode(contig, regions).data.tolist()
+            == a.decode(contig, regions).data.tolist()
+        )
+
+
+def test_from_pgen_missing_pvar_is_a_clear_error(sources, tmp_path):
+    _, _, pgen = sources
+    lonely = tmp_path / "lonely.pgen"
+    lonely.write_bytes(pgen.read_bytes())
+    with pytest.raises(FileNotFoundError, match="No .pvar or .pvar.zst"):
+        SparseVar2.from_pgen(tmp_path / "x.svar2", lonely, no_reference=True)
+```
+
+The multiallelic (`1|2`), missing (`.|.`), and indel (`C -> CAT`, `GTA -> G`) cases are already in `_VCF_BODY` from Task 6, so `test_from_pgen_matches_from_vcf` covers them; these tests add the no-reference path, zstd, multi-contig, and the sibling-file error.
+
+- [ ] **Step 2: Run tests**
+
+Run: `pixi run pytest tests/test_svar2_from_pgen.py -q`
+Expected: PASS (7 tests).
+
+If `test_from_pgen_matches_from_vcf` fails on the multiallelic or missing row, **do not "fix" the test** — that is a real bug in `PgenRecordSource`'s allele-code mapping. Debug with `pgenlib.PgenReader.read_alleles_range` directly in a scratch script and compare its codes against the VCF GTs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_svar2_from_pgen.py
+git commit -m "test(svar2): from_pgen coverage for zstd pvar, multi-contig, no-reference"
+```
+
+---
+
+## Task 8: CLI, skill doc, changelog
+
+**Files:**
+- Modify: `python/genoray/_cli/__main__.py`
+- Modify: `skills/genoray-api/SKILL.md`
+- Modify: `CHANGELOG.md`
+- Test: `tests/cli/` (follow the existing CLI test layout)
+
+**Interfaces:**
+- Consumes: `SparseVar2.from_pgen` (Task 6).
+
+- [ ] **Step 1: Write the failing CLI test**
+
+Add to the existing CLI test module (`tests/cli/`, matching its current style — read it first):
+
+```python
+def test_write_dispatches_pgen(tmp_path, capsys):
+    """`genoray write` already advertises VCF/PGEN in its help; make it true."""
+    # Build ref + vcf + pgen exactly as tests/test_svar2_from_pgen.py's `sources`
+    # fixture does, then:
+    from genoray._cli.__main__ import app
+
+    out = tmp_path / "cli.svar2"
+    app(["write", str(pgen), str(out), "--reference", str(ref)])
+    assert (out / "chr1").is_dir()
+```
+
+- [ ] **Step 2: Implement the dispatch**
+
+In `python/genoray/_cli/__main__.py`, inside `write_svar2`, replace the direct `SparseVar2.from_vcf(...)` call with a suffix dispatch. Note `ploidy`, `chunk_size`, and `long_allele_capacity` are already CLI parameters; PGEN accepts `chunk_size` but not `ploidy`.
+
+```python
+    from genoray import SparseVar2
+
+    skip_out_of_scope = skip_symbolics_and_breakends
+    if source.suffix == ".pgen":
+        if ploidy != 2:
+            raise ValueError(
+                "PGEN is diploid; --ploidy is only meaningful for VCF/BCF sources."
+            )
+        dropped = SparseVar2.from_pgen(
+            out,
+            source,
+            reference,
+            no_reference=no_reference,
+            skip_out_of_scope=skip_out_of_scope,
+            chunk_size=chunk_size,
+            threads=threads,
+            overwrite=overwrite,
+            long_allele_capacity=long_allele_capacity,
+        )
+    else:
+        dropped = SparseVar2.from_vcf(
+            out,
+            source,
+            reference,
+            no_reference=no_reference,
+            skip_out_of_scope=skip_out_of_scope,
+            ploidy=ploidy,
+            chunk_size=chunk_size,
+            threads=threads,
+            overwrite=overwrite,
+            long_allele_capacity=long_allele_capacity,
+        )
+```
+
+The CLI's `chunk_size` currently defaults to `25_000`. Change its default to `None` and update the docstring, so PGEN gets the memory-derived default and VCF keeps 25k:
+
+```python
+    chunk_size: int | None = None,
+```
+
+and in the VCF branch pass `chunk_size=chunk_size if chunk_size is not None else 25_000`.
+
+Update the `source` and `chunk_size` docstring entries:
+
+```
+    source
+        Path to a bgzipped VCF (``.vcf.gz``), BCF (``.bcf``), or PLINK2 PGEN
+        (``.pgen``, with its ``.pvar``/``.pvar.zst`` and ``.psam`` siblings).
+        VCF/BCF inputs are auto-indexed (``.csi``) if no index is present.
+    chunk_size
+        Variants per conversion chunk. Defaults to 25000 for VCF/BCF, and to a
+        memory-derived value for PGEN.
+    ploidy
+        Ploidy of the samples. Default 2. VCF/BCF only — PGEN is diploid.
+```
+
+- [ ] **Step 3: Update `skills/genoray-api/SKILL.md`**
+
+Read the existing `SparseVar2.from_vcf` section and add a sibling `from_pgen` section in the same style, documenting: the signature, that exactly one of `reference`/`no_reference` is required, the absence of `ploidy`, the return value (dropped out-of-scope ALT count), and the four unsupported things (dosages, INFO/FORMAT fields, sample subsetting, PLINK1 `.bed`). Also update the CLI section to note that `genoray write` accepts `.pgen`.
+
+- [ ] **Step 4: Add the CHANGELOG entry**
+
+Under `## Unreleased` → `### Added` in `CHANGELOG.md`:
+
+```markdown
+- `SparseVar2.from_pgen` converts a PLINK2 PGEN to an SVAR2 store, reusing the
+  VCF pipeline's normalization, atomization, and merge spine behind a new
+  `RecordSource` seam. Genotypes come from the existing `pgenlib` dependency via
+  its public Python API (no plink-ng code is linked or vendored; genoray stays
+  MIT); variant metadata is streamed from the `.pvar`/`.pvar.zst`. `genoray write`
+  dispatches on the `.pgen` suffix. Diploid-only; dosages, INFO/FORMAT field
+  extraction, and sample subsetting are not supported.
+```
+
+and under `### Fix` (or a new `### Perf` heading, matching whatever the file already uses):
+
+```markdown
+- Conversion reader staging memory no longer scales with `chunk_size`: presence
+  bits are packed in word-aligned windows and each atom's per-column genotype
+  vector is dropped as soon as its bits are set, bounding reader memory at
+  `window * n_samples * ploidy * 4` bytes instead of
+  `chunk_size * n_samples * ploidy * 4`. Output is bit-identical. Benefits both
+  `from_vcf` and `from_pgen`.
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `pixi run test`
+Expected: PASS.
+
+Run: `pixi run bash -lc 'cargo test --no-default-features && cargo clippy --all-targets -- -D warnings && cargo fmt --check'`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genoray/_cli/__main__.py skills/genoray-api/SKILL.md CHANGELOG.md tests/cli
+git commit -m "feat(cli): genoray write accepts .pgen; document from_pgen
+
+The write command's help already claimed VCF/PGEN; make it true. Updates the
+installable API skill and the changelog per CLAUDE.md's public-name rule."
+```
+
+---
+
+## Task 9: Benchmark PGEN vs VCF conversion
+
+The spec's performance claim — "the reader stops being the bottleneck" — is a hypothesis. Measure it; do not assert it.
+
+**Files:**
+- Create: `benches/` entry or a `scripts/` benchmark, following whatever the repo already does for the conversion profiling harness (there is prior art: see the `[profile.profiling]` section in `Cargo.toml` and the SVAR1-vs-SVAR2 timing design doc at `docs/superpowers/specs/2026-07-07-svar1-vs-svar2-timing-and-profiling-design.md` — read it first and match its methodology).
+- Modify: `CHANGELOG.md` (fill in the measured numbers)
+
+- [ ] **Step 1: Build a cohort-scale fixture**
+
+Take an existing multi-sample VCF (or subset a public one), convert it with
+`plink2 --make-pgen`, and confirm both conversions produce equivalent stores
+before timing anything. A benchmark of a wrong conversion is worthless.
+
+- [ ] **Step 2: Time both paths**
+
+```bash
+pixi run bash -lc '
+  /usr/bin/time -v python -c "
+from genoray import SparseVar2
+SparseVar2.from_vcf(\"/tmp/out_vcf.svar2\", \"<cohort>.vcf.gz\", \"<ref>.fa\", overwrite=True)
+" 2>&1 | grep -E "Elapsed|Maximum resident"
+  /usr/bin/time -v python -c "
+from genoray import SparseVar2
+SparseVar2.from_pgen(\"/tmp/out_pgen.svar2\", \"<cohort>.pgen\", \"<ref>.fa\", overwrite=True)
+" 2>&1 | grep -E "Elapsed|Maximum resident"
+'
+```
+
+Record wall time and peak RSS for both.
+
+- [ ] **Step 3: Check the two open performance questions from the spec**
+
+1. **Is the `.pvar` skip cost material?** Each contig's reader skips through the
+   `.pvar` from the top, so total `.pvar` I/O is `n_contigs × pvar_size`. Time a
+   multi-contig conversion; if the skip is a visible fraction of wall time, the
+   mitigation is a one-time contig byte-offset sidecar — note it as a follow-up,
+   do not build it speculatively.
+2. **Do concurrent contig readers serialize on the GIL, or does pgenlib's OpenMP
+   `prange` oversubscribe?** Watch thread counts (`top -H`, `pidstat -t`) during a
+   multi-contig run. If readers serialize, the batch byte budget
+   (`PGEN_BATCH_BYTES`) is the first knob to turn.
+
+- [ ] **Step 4: Record the results honestly**
+
+Update the CHANGELOG entry from Task 8 with the measured numbers. **If PGEN
+conversion is not faster than VCF, say so** — the point of the benchmark is to
+find out, not to confirm. File the findings as a follow-up note in the design doc.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md
+git commit -m "perf(svar2): benchmark PGEN vs VCF conversion, record results"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+| --- | --- |
+| Licensing position (no linking, pgenlib via Python API only) | Global Constraints; Task 4 module doc |
+| `RecordSource` refactor, `RawRecord`, `ChunkAssembler` | Task 2 |
+| `PgenRecordSource`, byte-budgeted batch, `-9 → -1` | Task 4 |
+| `.pvar` / `.pvar.zst` streaming, Python-computed contig ranges | Tasks 3, 6 |
+| Bounded-window packing | Task 1 |
+| Auto `chunk_size` for `from_pgen` | Task 6 (`_auto_chunk_size`) |
+| Public API `from_pgen`, no `ploidy` | Task 6 |
+| CLI dispatch, SKILL.md, CHANGELOG | Task 8 |
+| Out-of-scope items documented in the docstring | Task 6 |
+| Unphased-het / missing semantics documented | Task 6 |
+| Tests: cross-backend equivalence, `.pvar` unit tests, refactor guard | Tasks 2, 3, 6, 7 |
+| Benchmark + the two open perf questions | Task 9 |
+
+**Deviation from the spec, called out deliberately:** the spec named "pgenlib itself" as the *primary* test oracle. In the plan, the primary oracle is **cross-backend equivalence** (`from_pgen ≡ from_vcf`), because SVAR2's public read surface returns decoded sequences rather than allele codes, so a direct allele-code comparison would require a test-only API. This is not a weakening: the VCF path is already oracle-tested against `vcfixture`'s decoded `GroundTruth`, so cross-backend equality transitively grounds `from_pgen` in the same ground truth — and it additionally catches errors a raw allele-code check would miss (normalization, left-alignment, atomization). Fixtures are chosen to avoid the places plink2's VCF import is genuinely lossy (half-calls under `--vcf-half-call r`, symbolic ALTs).
+
+**Type consistency:** `RawRecord` fields (`pos`, `reference`, `alts`, `gt`, `info_raw`, `format_raw`) are used identically in Tasks 2 and 4. `ChunkAssembler::new`'s argument list matches its call sites in Tasks 2 and 5. `PvarReader::open(path, var_start)` / `next_variant()` match Task 4's usage. `run_pgen_conversion_pipeline`'s parameter order matches the Python call in Task 6.

--- a/docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md
+++ b/docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md
@@ -263,3 +263,159 @@ and is exactly what `SparseVar.from_pgen` (SVAR1) already does. Missing calls ar
   oversubscribe alongside `concurrent_chroms`. Check thread counts in the
   benchmark; cap via `OMP_NUM_THREADS` if needed. Note that the PGEN path needs
   no htslib decompression threads, so those cores are available to give back.
+
+---
+
+# Results (2026-07-12) — Task 9 benchmark
+
+Methodology follows
+`docs/superpowers/specs/2026-07-07-svar1-vs-svar2-timing-and-profiling-design.md`
+(same fixture family, same `/usr/bin/time -v` protocol, same honesty bar). Ran
+on a `carter-compute` allocation (`carter-cn-04`, 32 cores, 64 GB, via
+`sbatch`) — **not a dedicated node**: several unrelated `nf-PHASI*` jobs from
+the same user were concurrently scheduled on the same physical node the whole
+time, so absolute wall-clock numbers below likely carry some contention
+inflation relative to a quiet node (the from_vcf baseline here, 547s, is
+notably slower than the 36.5s figure the 2026-07-07 doc measured for the same
+germline chr21 file on a dedicated node — same code path, so the delta is
+node contention, not a regression). The **relative** from_vcf-vs-from_pgen
+comparison is still valid since both ran back-to-back on the same
+contended node under the same conditions.
+
+## Fixture
+
+`/carter/users/dlaub/repos/for_loukik/chr21.bcf` (germline, 3202 samples,
+phased) contains `<DEL>`/`<DEL:ME>` symbolic ALTs that plink2 cannot import.
+Built one filtered BCF and used it for **both** backends, per the task brief:
+
+```bash
+bcftools view -e 'ALT~"<"' chr21.bcf -Ob -o chr21.nosym.bcf   # 1,001,385 / 1,002,753 kept (1,368 symbolic dropped)
+bcftools index chr21.nosym.bcf
+plink2 --bcf chr21.nosym.bcf --make-pgen --output-chr chrM --out chr21.nosym   # preserves "chr21" (not "21")
+```
+
+Reference: `/carter/shared/data/gdc/resources/GRCh38.d1.vd1.fa` (chr21 length
+46,709,983, matches the `.pvar`).
+
+## Equivalence check (before any timing)
+
+Two tiers, both against the identical filtered input:
+
+1. **Decode-free `region_counts`** over the whole chromosome `(0,
+   46_709_983)`: identical `(region, sample, ploidy)` count arrays for both
+   stores, 285,721,479 total carried variants either way.
+2. **Full decoded-record comparison** (`pos`/`ilen`/`allele`, the
+   `_assert_ragged_equal` fields) on 5 spot-check windows spanning the
+   chromosome (0–2 Mb, 10–12 Mb, 20–22 Mb, 30–32 Mb, 44–46.7 Mb): offsets and
+   all three fields matched exactly on every window (0 to 21.5M records per
+   window).
+
+**PASS.** `from_pgen ≡ from_vcf` on this cohort — the timing numbers below are
+measuring two paths to the same data, not two different datasets.
+
+## Timing (Step 2 of the brief)
+
+`/usr/bin/time -v python -c "SparseVar2.from_{vcf,pgen}(...)"`, filtered chr21
+in, fresh output each run:
+
+| Path | Wall time | Peak RSS |
+| --- | --- | --- |
+| `from_vcf` | 547.0s (9:06.98) | 497 MiB (496,508 KiB) |
+| `from_pgen` | **152.7s** (2:32.67) | 1040 MiB (1,065,212 KiB) |
+
+**`from_pgen` is 3.6× faster wall-clock**, confirming the design's central
+hypothesis — the reader does stop being the bottleneck once htslib decode is
+out of the picture. It is **not a free win**: peak RSS is ~2.1× higher than
+`from_vcf`'s on the same cohort. This wasn't budgeted for in the design and is
+worth a follow-up look (candidates: the byte-budgeted `read_alleles_range`
+buffer, or pgenlib's own internal decode buffers held concurrently with the
+Rust-side staging window) — out of scope to fix here since Task 9 is
+measurement-only, but real enough to flag rather than bury.
+
+An independent re-run during equivalence verification (same code paths, same
+node, run immediately before the numbers above) gave from_vcf=538.8s /
+from_pgen=138.9s (3.9×) — consistent with the timed numbers within the noise
+expected from a shared node.
+
+## Open question 1 — is the `.pvar` skip cost material?
+
+Built a **same-total-data, different-`n_contigs`** fixture to isolate this:
+sliced the identical filtered chr21.nosym.bcf (1,001,385 variants, all 3202
+samples — nothing shrunk) into genomic windows via `bcftools view -r` +
+`bcftools annotate --rename-chrs` + `bcftools concat` (index-seek slicing,
+no genotype-text materialization), tagged each window with a synthetic
+contig name (`synth_0`..`synth_15`), and built one reference FASTA holding 16
+copies of the full chr21 sequence under those names (so absolute chr21
+coordinates resolve identically regardless of which synthetic contig a
+variant landed on). This keeps total variant count, total genotype payload,
+and total `.pvar` bytes ~constant; only `n_contigs` (and therefore the number
+of independent top-of-`.pvar` skips) changes.
+
+- `N=1` (single contig, whole cohort): **151.1s**, 1074 MiB peak RSS.
+- `N=16` split (`synth_0` window landed on chr21's acrocentric p-arm gap and
+  got 0 variants, so effectively 15 populated contigs; still 1,001,385
+  variants total): **~104.7s** wall (measured from the thread-sampling
+  window's first/last timestamps around the run).
+
+The 15-contig split was **faster**, not slower, than the single-contig
+baseline (~1.44×) — the `plan_thread_budget`-driven concurrency
+(`concurrent_chroms=5` on 32 cores) more than pays for the extra redundant
+`.pvar` scanning. At this file's `.pvar` size (~36 MB total across the
+cohort), the top-of-file skip cost is **not material** — it's noise next to
+the genotype-decode work, even multiplied by 15 concurrent skips.
+
+**Caveat:** this only rules it out at this scale (≤16 contigs, 36 MB `.pvar`).
+A whole-genome cohort with real chromosome-scale `.pvar` files (hundreds of MB
+to GB) and `n_contigs` in the dozens (autosomes + alts/decoys) could still
+show it — reasoning from the `n_contigs × pvar_size` model, the risk grows
+with both factors simultaneously, which this fixture didn't stress. **Not
+building the byte-offset sidecar mitigation** — no evidence it's needed yet;
+flagged as a follow-up to revisit if a whole-genome benchmark ever shows
+`.pvar` scanning show up in a profile.
+
+## Open question 2 — GIL serialization vs OpenMP oversubscription
+
+Sampled `ps -T -p <pid> -o pid,tid,pcpu,comm` every 0.5s for the whole `N=16`
+run (46 samples, ~23s window) to look at both questions at once.
+
+- **Readers do not serialize on the GIL.** `Pipeline Config (PGEN): 5
+  concurrent chromosomes` actually ran concurrently — `chrom-0`..`chrom-4`
+  rayon workers plus each contig's own `read-synth_*`/`exec-synth_*`/
+  `cw-synth_*`/`lw-synth_*`/`samp-synth_*` OS threads all showed up live and
+  overlapping across samples, and the wall-clock result above (5-way split
+  faster than 1-way) is itself evidence of real parallelism, not GIL-bound
+  serialization.
+- **pgenlib's OpenMP `prange` does oversubscribe, confirmed.** The dominant
+  thread `comm` in every sample was the generic, un-renamed `python` (2804 of
+  the ~7000 total thread-sample rows, i.e. an average of ~61 threads/sample
+  reporting as `python` — Rust's own threads are all explicitly named via
+  `thread_name`, so any unnamed OS thread showing as `python` is coming from
+  a C-extension's own thread spawns, consistent with an OpenMP worker team
+  pgenlib spins up per `read_alleles_range` call). **Max concurrent OS thread
+  count observed: 172**, against a 32-core allocation — a ~5.4× oversubscription
+  ratio. (Smaller contributions from `async-executor-`/`tokio-runtime-w`
+  threads and `jemalloc_bg_thd` background threads were also visible but much
+  less numerous; not investigated further as they're not contig-count-scaled.)
+- **Net effect:** the oversubscription is real but did not net-negative this
+  run's throughput — `N=16` was still faster than `N=1`, not slower. It's
+  still resource-impolite on a shared, multi-tenant node (172 threads
+  competing for 32 cgroup-scoped cores affects everyone else on the node, even
+  if this job's own wall time survives it).
+
+**Conclusion:** the design doc's own suggested mitigation for *this* symptom
+(OpenMP fan-out, not GIL serialization) is the right one —
+**`OMP_NUM_THREADS`**, not `PGEN_BATCH_BYTES` (that knob addresses a GIL-
+serialization symptom we did not observe). Recommended **follow-up**: set
+`OMP_NUM_THREADS=1` (or a small cap) around the `pgenlib.PgenReader` calls
+when `concurrent_chroms > 1`, purely for cluster citizenship — not filed as a
+correctness or throughput bug, since throughput was fine here.
+
+## Summary
+
+| Question | Answer |
+| --- | --- |
+| Is PGEN faster than VCF on the same cohort? | **Yes, 3.6×** (152.7s vs 547.0s), confirming the design hypothesis. |
+| Is it free? | **No** — ~2.1× peak RSS (1040 MiB vs 497 MiB). Follow-up, not fixed here. |
+| Is `.pvar` top-of-file skip cost material? | **Not at this scale** (≤16 contigs, 36 MB `.pvar`); flagged as a watch-item for whole-genome-scale cohorts, sidecar mitigation not built. |
+| Do concurrent contig readers serialize on the GIL? | **No** — 5-way contig concurrency measurably sped things up. |
+| Does pgenlib's OpenMP oversubscribe? | **Yes, confirmed** (≤172 threads on 32 cores); did not hurt this run's throughput, but `OMP_NUM_THREADS` capping is a recommended follow-up for shared-node citizenship. |

--- a/docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md
+++ b/docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md
@@ -1,0 +1,265 @@
+# PGEN → SVAR2 conversion
+
+Date: 2026-07-12
+Status: approved (design), ready for implementation planning
+
+## Problem
+
+`SparseVar2` can only be built from a VCF/BCF (`SparseVar2.from_vcf`). PLINK2
+PGEN is the format cohort- and biobank-scale genotype data actually ships in, so
+SVAR2 needs a `from_pgen` path. Two things make this non-trivial:
+
+1. **Licensing.** The PGEN decoder that matters (plink-ng / plink 2.0) is
+   copyleft. genoray is MIT. We must not create an obligation we cannot meet.
+2. **Performance and memory.** PGEN's reason for existing is large `n_samples`.
+   The current conversion pipeline has a staging buffer whose size scales as
+   `chunk_size × n_samples × ploidy × 4 bytes`, which is not representable at
+   biobank scale.
+
+## Licensing position
+
+| Component | License | How genoray uses it |
+| --- | --- | --- |
+| genoray | MIT | — |
+| `pgenlib` (PyPI) | LGPL-3.0 | **Already** a hard runtime dependency; unmodified, separately-installed wheel, used through its public Python API |
+| plink-ng `2.0/include/pgenlib_*.cc` | LGPL-3.0 | not linked, not vendored |
+| plink2 application | GPL-3.0 | invoked as a separate program at *test* time only (already in `pixi.toml`) |
+
+This design **does not change how genoray consumes plink code**. It keeps using
+the `pgenlib` Python wheel through its public API, which imposes no copyleft
+obligation on genoray's own source or on the compiled `_core` extension. The
+`_core` extension continues to contain zero plink-ng code and stays MIT.
+
+Rejected on licensing grounds:
+
+- **Statically linking plink-ng's C++ `pgenlib` into `_core`.** This creates a
+  combined work and triggers LGPLv3 §4: prominent notice, license texts, and
+  *either* dynamic linking *or* shipping relinkable object code with every
+  wheel. That is an ongoing compliance burden on our release CI (which builds
+  four portable wheel platforms) for a decoder we already ship via pip.
+
+Rule for implementers: **do not copy code or comments from plink-ng into
+genoray.** If a native decoder is ever written, it must be written from
+`pgen_spec.pdf`, and that provenance must be documented.
+
+## Rejected alternative: a native Rust PGEN decoder
+
+`genoio` (github.com/mancusolab/genoio, MIT) has a from-spec Rust PGEN decoder.
+Its Rust sources contain no reference to plink-ng, pgenlib, Purcell, or Chang,
+and read as independent work — the MIT label appears accurate. It is still not
+usable here:
+
+- **Multiallelic decode is not implemented** and is an explicit hard error
+  (`pgen/header.rs`: "unsupported pgen multiallelic hard-call patch set"); its
+  `.pvar` parser silently keeps only the first ALT.
+- **No allele-code API.** Everything funnels into an f32 dense matrix. There is
+  no equivalent of `read_alleles_range`, and haplotype reads *error* on an
+  unphased het rather than reporting a phasepresent mask.
+- Storage modes 0x01 and 0x11 are rejected.
+- Not published to crates.io (path-only inter-crate deps, no `description`), and
+  `genoio-io` pulls in noodles + bundled SQLite with no cargo features to slim
+  it.
+
+Writing our own equivalent means ~3k lines of difflist / LD-compression / aux-track
+bit-twiddling with real correctness risk, to replace a decoder that is already a
+dependency and is faster (genoio self-reports pgenlib at 1.4–1.8× its speed).
+Not worth it. Revisit only if the GIL boundary below is measured to be a
+bottleneck.
+
+## Why pgenlib is the right decoder
+
+`pgenlib.PgenReader.read_alleles_range(start, end, out, hap_maj=0)`:
+
+- fills an `(n_variants, 2 · n_samples)` **int32** buffer with **per-haplotype
+  allele codes**, phase-aware, multiallelic-aware, missing = `-9`;
+- runs its decode loop under `prange(..., nogil=True)` — **the GIL is released**
+  for the actual work, so a Rust reader thread holds it only for call dispatch.
+
+The pipeline's `PendingAtom.gt` is a `Vec<i32>` of length
+`n_samples × ploidy` holding allele index per haplotype column (`-1` = missing).
+That is the same layout `read_alleles_range` produces. PGEN therefore needs only
+a new *record source*; normalization, left-alignment, atom decomposition, the
+executor, merge, and finalize are all reused unchanged.
+
+## Architecture
+
+### 1. `RecordSource` refactor (prerequisite, VCF-neutral)
+
+`VcfChunkReader` currently fuses five responsibilities: htslib record iteration,
+record → atom decomposition (REF validation, left-alignment, multiallelic split,
+out-of-scope skipping), the `L_MAX` reorder heap, chunk assembly and presence
+bit-packing, and INFO/FORMAT field staging. Only the first is VCF-specific.
+
+Introduce:
+
+```rust
+pub struct RawRecord<'a> {
+    pos: u32,               // 0-based
+    reference: &'a [u8],
+    alts: &'a [&'a [u8]],
+    gt: &'a [i32],          // len = n_samples * ploidy; -1 = missing
+    info_vals: &'a [f64],   // empty for PGEN
+    format_vals: &'a [f64], // empty for PGEN
+}
+
+pub trait RecordSource {
+    fn next_record(&mut self) -> Result<Option<RawRecord<'_>>, ConversionError>;
+}
+```
+
+Everything downstream of `next_record` moves into a source-agnostic
+`ChunkAssembler` that owns the heap, the decomposition, and chunk packing.
+`VcfRecordSource` wraps htslib; `PgenRecordSource` is new.
+`process_chromosome` becomes generic over the source (or takes a
+`Box<dyn RecordSource>`).
+
+Consequence: **PGEN inherits REF validation, indel left-alignment, and symbolic /
+breakend skipping for free, with semantics identical to the VCF path.**
+
+This lands as its own commit, with the existing test suite green and
+**byte-identical** SVAR2 output on a VCF fixture, before any PGEN code is added.
+
+### 2. `PgenRecordSource`
+
+Owns:
+
+- a `Py<PyAny>` handle to a `pgenlib.PgenReader` (constructed in Python, passed
+  down), and a reusable `(B, 2·S)` int32 numpy buffer;
+- a streaming `.pvar` reader for variant metadata.
+
+`next_record()` serves from the buffer; on exhaustion it refills via
+`Python::attach(|py| reader.call_method1("read_alleles_range", (lo, hi, buf, false)))`.
+The GIL is held only for call dispatch — pgenlib's decode is `nogil`. Allele
+codes are mapped `-9 → -1` to match the `PendingAtom.gt` convention.
+
+**Batch size is derived from a byte budget, not a variant count:**
+
+```
+B = clamp(PGEN_BATCH_BYTES / (2 * S * 4), 1, chunk_size)   # PGEN_BATCH_BYTES = 32 MiB
+```
+
+At 200 samples this is thousands of variants per Python call (overhead
+amortized); at 500k samples it is ~8 (memory bounded). This is the single knob
+that keeps the Rust↔Python boundary cheap across the whole cohort-size range.
+
+**Variant metadata.** Rust streams `.pvar` / `.pvar.zst` with a small TSV parser
+(adds the `zstd` crate — BSD/MIT). `.bim` is not supported, since it only
+accompanies a PLINK1 `.bed`, which is out of scope. Python computes the
+per-contig `[var_start, var_end)` variant index ranges up front using the
+**existing** `_scan_pvar` polars scan (which already handles header sniffing and
+`.zst`) and passes only those ranges to Rust; the Rust streamer skips to
+`var_start` by line count.
+
+Known cost: with `concurrent_chroms > 1`, each contig's reader skips through the
+`.pvar` from the top, so total `.pvar` I/O is `n_contigs × pvar_size`. This is
+sequential scan I/O, parallel across contigs, and is expected to be negligible
+next to the genotype decode. **Measure it in the benchmark.** If it shows up,
+the mitigation is a one-time contig byte-offset sidecar — do not build that
+speculatively.
+
+Sample names come from the existing `_read_psam`.
+
+### 3. Bounded-window packing (shared with the VCF path, in this PR)
+
+`read_next_chunk` today collects `chunk_size` `PendingAtom`s into a `Vec` and
+packs them all at the end. Each atom holds an `S × P` i32 `gt` vector — **32×
+the size of the packed bit-grid it ultimately produces**. At
+`chunk_size = 25_000` and 10k samples that staging buffer is ~2 GB; at biobank
+scale it is not representable.
+
+Fix: **pack in sub-blocks.** Buffer `W` atoms (`W ≈ 1024`), pack them in parallel
+into the growing `BitGrid3` at their variant offset, drop their `gt`, and
+continue. Staging memory becomes `W · S · P · 4` instead of
+`chunk_size · S · P · 4`, and parallel packing (previously measured worth −6.7%)
+is retained. The `L_MAX = 1000` reorder heap already bounds the sort window, so
+atom ordering is unaffected and output is byte-identical.
+
+This is a shared improvement: it benefits `from_vcf` identically and is what
+makes large-`n_samples` conversion feasible on either backend.
+
+Additionally, `from_pgen` auto-derives `chunk_size` from a memory budget when the
+caller does not supply one, since the packed dense chunk is itself
+`chunk_size · S · P / 8` bytes. `from_vcf`'s default (`25_000`) is unchanged.
+
+## Public API
+
+```python
+SparseVar2.from_pgen(
+    out: str | Path,
+    source: str | Path,
+    reference: str | Path | None = None,
+    *,
+    no_reference: bool = False,
+    skip_out_of_scope: bool = False,
+    chunk_size: int | None = None,   # None => auto from a memory budget
+    threads: int | None = None,
+    overwrite: bool = False,
+    long_allele_capacity: int = 8 * 1024 * 1024,
+    signatures: bool = False,
+) -> int   # number of out-of-scope ALTs dropped
+```
+
+- `source` is a `.pgen` path; `.pvar[.zst]` and `.psam` siblings are resolved by
+  stem.
+- **No `ploidy` parameter.** PGEN is diploid; exposing the knob would only create
+  an invalid state to reject.
+- `reference` / `no_reference` are mutually exclusive and behave exactly as in
+  `from_vcf`. `signatures=True` requires a reference, as in `from_vcf`.
+- CLI: `genoray write` dispatches on the `.pgen` suffix (its help text already
+  claims VCF/PGEN).
+- `skills/genoray-api/SKILL.md` is updated in the same PR (CLAUDE.md requires it
+  for any public-name change).
+- `CHANGELOG.md` gains an entry under `## Unreleased`.
+
+### Out of scope for v1 (documented in the docstring)
+
+- **Dosages.** SVAR2 has no dosage store. A `.pgen` dosage track is ignored;
+  hardcalls are still read correctly.
+- **`info_fields` / `format_fields`.** PGEN has no FORMAT; `.pvar` INFO
+  extraction is deferred.
+- **Sample subsetting / reordering.** Matches `from_vcf`, which also converts all
+  samples.
+- **PLINK1 `.bed`.**
+
+### Semantics to document
+
+Haplotype resolution for **unphased** heterozygotes follows the allele-code order
+pgenlib returns. This is the same caveat the VCF path carries for unphased `GT`,
+and is exactly what `SparseVar.from_pgen` (SVAR1) already does. Missing calls are
+`-9` in pgenlib and are mapped to `-1`.
+
+## Testing
+
+1. **Primary oracle — pgenlib itself.** Write an SVAR2 store from a PGEN, decode
+   it back to `(samples, ploidy, variants)` allele indices via the existing query
+   API, and compare against `pgenlib.PgenReader.read_alleles_list` on the same
+   variant indices. Exact, and independent of the VCF path.
+2. **Cross-backend equivalence.** Generate PGEN twins of the existing VCF
+   fixtures with `plink2 --vcf ... --make-pgen` (plink2 is already in
+   `pixi.toml`) and assert `from_pgen ≡ from_vcf` on curated fixtures covering
+   phased, multiallelic, and indel records. Where plink2's VCF import legitimately
+   differs (symbolic ALTs, unphased-het haplotype order), compare genotype
+   presence rather than raw store bytes.
+3. **Rust unit tests** for the `.pvar` streamer: header sniffing, `.zst`,
+   multiallelic ALT splitting, missing codes, `[var_start, var_end)` skipping.
+4. **Refactor guard:** the `RecordSource` commit must produce byte-identical
+   SVAR2 output for an existing VCF fixture.
+5. **Bounded-window packing guard:** byte-identical output before/after, plus a
+   peak-RSS assertion (or measurement) showing staging memory no longer scales
+   with `chunk_size`.
+6. **Benchmark** PGEN vs VCF conversion on the same cohort. Expectation: the
+   reader stops being the bottleneck (VCF conversion is currently
+   htslib-input-bound). Record the numbers in the CHANGELOG entry.
+
+## Risks
+
+- **Refactor regresses the VCF path.** Mitigated by landing it as an isolated
+  commit gated on byte-identical output.
+- **GIL contention across concurrent contigs.** Each contig's reader briefly
+  attaches to call `read_alleles_range`. The decode is `nogil`, so contention is
+  on call dispatch only. If the benchmark shows readers serializing, the batch
+  byte budget is the first knob; a native decoder is the last resort.
+- **pgenlib's `prange` uses OpenMP if its wheel was built with it**, which could
+  oversubscribe alongside `concurrent_chroms`. Check thread counts in the
+  benchmark; cap via `OMP_NUM_THREADS` if needed. Note that the PGEN path needs
+  no htslib decompression threads, so those cores are available to give back.

--- a/python/genoray/_cli/__main__.py
+++ b/python/genoray/_cli/__main__.py
@@ -59,7 +59,7 @@ def write_svar2(
         bool, Parameter(name="--no-reference", negative="")
     ] = False,
     ploidy: int = 2,
-    chunk_size: int = 25_000,
+    chunk_size: int | None = None,
     threads: Annotated[int | None, Parameter(name=["--threads", "-@"])] = None,
     long_allele_capacity: int = 8 * 1024 * 1024,
     overwrite: bool = False,
@@ -68,13 +68,14 @@ def write_svar2(
     ] = False,
 ) -> None:
     """
-    Convert a bgzipped VCF or BCF to an SVAR2 store (the default, better-across-the-board format).
+    Convert a bgzipped VCF, BCF, or PLINK2 PGEN to an SVAR2 store (the default, better-across-the-board format).
 
     Parameters
     ----------
     source
-        Path to a bgzipped VCF (``.vcf.gz``) or BCF (``.bcf``). Auto-indexed
-        (``.csi``) if no index is present.
+        Path to a bgzipped VCF (``.vcf.gz``), BCF (``.bcf``), or PLINK2 PGEN
+        (``.pgen``, with its ``.pvar``/``.pvar.zst`` and ``.psam`` siblings).
+        VCF/BCF inputs are auto-indexed (``.csi``) if no index is present.
     out
         Path to the output SVAR2 directory.
     reference
@@ -86,9 +87,10 @@ def write_svar2(
         already normalized. Use only for pre-normalized (e.g. ``bcftools norm``)
         inputs.
     ploidy
-        Ploidy of the samples. Default 2.
+        Ploidy of the samples. Default 2. VCF/BCF only — PGEN is diploid.
     chunk_size
-        Variants per conversion chunk. Default 25000.
+        Variants per conversion chunk. Defaults to 25000 for VCF/BCF, and to a
+        memory-derived value for PGEN.
     threads
         Number of threads. Defaults to all available cores.
     long_allele_capacity
@@ -105,18 +107,35 @@ def write_svar2(
     from genoray import SparseVar2
 
     skip_out_of_scope = skip_symbolics_and_breakends
-    dropped = SparseVar2.from_vcf(
-        out,
-        source,
-        reference,
-        no_reference=no_reference,
-        skip_out_of_scope=skip_out_of_scope,
-        ploidy=ploidy,
-        chunk_size=chunk_size,
-        threads=threads,
-        overwrite=overwrite,
-        long_allele_capacity=long_allele_capacity,
-    )
+    if source.suffix == ".pgen":
+        if ploidy != 2:
+            raise ValueError(
+                "PGEN is diploid; --ploidy is only meaningful for VCF/BCF sources."
+            )
+        dropped = SparseVar2.from_pgen(
+            out,
+            source,
+            reference,
+            no_reference=no_reference,
+            skip_out_of_scope=skip_out_of_scope,
+            chunk_size=chunk_size,
+            threads=threads,
+            overwrite=overwrite,
+            long_allele_capacity=long_allele_capacity,
+        )
+    else:
+        dropped = SparseVar2.from_vcf(
+            out,
+            source,
+            reference,
+            no_reference=no_reference,
+            skip_out_of_scope=skip_out_of_scope,
+            ploidy=ploidy,
+            chunk_size=chunk_size if chunk_size is not None else 25_000,
+            threads=threads,
+            overwrite=overwrite,
+            long_allele_capacity=long_allele_capacity,
+        )
     if skip_out_of_scope:
         print(f"Dropped {dropped} out-of-scope (symbolic/breakend) ALT alleles.")
 

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -288,9 +288,11 @@ def _pvar_contig_ranges(
 
     `allele_idx_offsets` has length `n_variants + 1`: `offsets[0] = 0` and
     `offsets[i+1] = offsets[i] + 1 + n_alts(i)`, where `n_alts(i)` is the number of
-    comma-separated ALT alleles of variant `i`. It is a single, file-wide array --
-    every per-contig reader is constructed with the same one, not a per-contig
-    slice.
+    comma-separated ALT tokens of variant `i` -- including a variant whose ALT is
+    the bare `.` sentinel (no ALT observed), which still counts as 1 token/2 total
+    alleles, matching `pgenlib`'s on-disk model (see the comment at its
+    computation below). It is a single, file-wide array -- every per-contig reader
+    is constructed with the same one, not a per-contig slice.
 
     Raises if a contig's variants are not contiguous -- SVAR2 converts one contig at
     a time from a variant index range, which requires the `.pvar` to be grouped by
@@ -302,7 +304,40 @@ def _pvar_contig_ranges(
 
     df = _scan_pvar(pvar).select("#CHROM", "ALT").with_row_index("vidx").collect()
 
-    n_alts = df["ALT"].str.split(",").list.len().to_numpy()
+    # `_scan_pvar` opens the .pvar with `null_values="."`, so a monomorphic
+    # variant's ALT ('.' -- no alternate allele observed) reads as a polars
+    # null, and `.list.len()` on a null is null. Left un-guarded, `.to_numpy()`
+    # would upcast to float64 (NaN for that slot) and
+    # `np.cumsum(..., out=<uintp>)` would silently reinterpret that NaN as a
+    # huge garbage integer -- for that variant *and every one after it*, since
+    # cumsum is prefix-summed.
+    #
+    # The count to fill in is 1, not 0: `pgenlib`'s on-disk `allele_idx_offsets`
+    # model reserves a minimum of 2 allele slots (REF + one ALT slot) per
+    # variant, even when plink2 has no observed ALT to report -- the ALT
+    # column's bare '.' is a *display* convention for "no ALT was observed",
+    # not "no ALT slot exists". Verified directly against `pgenlib`: building
+    # `allele_idx_offsets` with a 0-count (1 total allele) for a '.'-ALT
+    # variant makes `PgenReader.read_alleles_range` segfault on every
+    # multiallelic variant after it (offsets one short of what the file
+    # actually stores); a 1-count (2 total alleles, matching every other
+    # biallelic row) reads correctly and matches the VCF-derived genotypes.
+    # (Rust's `PvarReader` separately empties `alts` for a '.' ALT -- that's
+    # about which alleles the *conversion spine* atomizes, an independent
+    # question from what `pgenlib` needs to step through the file.)
+    n_alts_col = df["ALT"].str.split(",").list.len().fill_null(1)
+    if n_alts_col.null_count():  # pragma: no cover - defensive, should be unreachable
+        raise ValueError(
+            f"Could not determine the ALT-allele count for every variant in {pvar}; "
+            "expected only null ALTs (from the '.' monomorphic sentinel) to be null "
+            "here, but some remained null after filling."
+        )
+    n_alts = n_alts_col.to_numpy()
+    if n_alts.dtype.kind not in "iu" or (n_alts < 0).any():
+        raise ValueError(
+            f"Computed a negative or non-integer ALT-allele count while parsing {pvar} "
+            f"(dtype={n_alts.dtype}); this indicates a malformed ALT column."
+        )
     allele_idx_offsets = np.empty(len(n_alts) + 1, dtype=np.uintp)
     allele_idx_offsets[0] = 0
     np.cumsum(n_alts + 1, out=allele_idx_offsets[1:])

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+import numpy as np
 from natsort import natsorted
 
 import genoray._core as _core
@@ -14,6 +15,8 @@ from genoray._svar2_mutcat import _MutcatMixin
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+    from numpy.typing import NDArray
 
     from genoray._svar2_fields import FormatField, InfoField
 
@@ -149,3 +152,195 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             info,
             format_,
         )
+
+    @classmethod
+    def from_pgen(
+        cls,
+        out: str | Path,
+        source: str | Path,
+        reference: str | Path | None = None,
+        *,
+        no_reference: bool = False,
+        skip_out_of_scope: bool = False,
+        chunk_size: int | None = None,
+        threads: int | None = None,
+        overwrite: bool = False,
+        long_allele_capacity: int = 8 * 1024 * 1024,
+        signatures: bool = False,
+    ) -> int:
+        """Convert a PLINK2 PGEN to an SVAR2 store.
+
+        Genotypes are read through the ``pgenlib`` package; variant metadata comes
+        from the sibling ``.pvar``/``.pvar.zst`` and sample names from the ``.psam``.
+
+        Exactly one of `reference` or `no_reference=True` is required, with the same
+        meaning as :meth:`from_vcf`: with a reference, indels are validated against
+        and left-aligned to the FASTA; with `no_reference`, both are skipped and the
+        input is trusted to be already normalized. Returns the number of
+        out-of-scope (symbolic/breakend) ALTs dropped (0 unless `skip_out_of_scope`).
+
+        PGEN is diploid, so there is no `ploidy` parameter.
+
+        chunk_size: variants per conversion chunk. Defaults to a value derived from
+        a memory budget, since a packed dense chunk costs
+        ``chunk_size * n_samples * 2 / 8`` bytes.
+
+        Not supported (and silently ignored rather than errored, where noted):
+
+        - **Dosages.** SVAR2 stores no dosages; a ``.pgen`` dosage track is ignored
+          and hardcalls are read as usual.
+        - **INFO/FORMAT fields.** PGEN has no FORMAT; ``.pvar`` INFO extraction is
+          not implemented.
+        - **Sample subsetting.** All samples in the ``.psam`` are converted, matching
+          :meth:`from_vcf`.
+
+        Haplotype resolution for *unphased* heterozygotes follows the allele-code
+        order ``pgenlib`` returns — the same caveat :meth:`from_vcf` carries for
+        unphased ``GT``.
+        """
+        from genoray._pgen import _read_psam
+
+        out = Path(out)
+        source = Path(source)
+
+        if (reference is None) == (not no_reference):
+            raise ValueError(
+                "provide exactly one of `reference` (a FASTA path) or "
+                "`no_reference=True`"
+            )
+        if signatures and no_reference:
+            raise ValueError("signatures=True requires a reference (not no_reference).")
+        if out.exists() and not overwrite:
+            raise FileExistsError(
+                f"Output path {out} already exists. Use overwrite=True to overwrite."
+            )
+        if source.suffix != ".pgen":
+            raise ValueError(f"Expected a .pgen file, got {source}")
+        if not source.exists():
+            raise FileNotFoundError(source)
+
+        pvar = _find_pvar(source)
+        psam = source.with_suffix(".psam")
+        if not psam.exists():
+            raise FileNotFoundError(psam)
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+        samples = cast("list[str]", _read_psam(psam).tolist())
+        n_samples = len(samples)
+        if n_samples == 0:
+            raise ValueError(f"No samples found in {psam}.")
+
+        contigs, ranges, allele_idx_offsets = _pvar_contig_ranges(pvar)
+        if not contigs:
+            raise ValueError(f"No variants found in {pvar}.")
+
+        if chunk_size is None:
+            chunk_size = _auto_chunk_size(n_samples)
+
+        import pgenlib
+
+        # One reader per contig: readers seek independently, so concurrent contigs
+        # must not share one. `allele_idx_offsets` is required (not just used) once
+        # any variant in the file is multiallelic -- it is a file-wide array, so
+        # every contig's reader is constructed with the same one.
+        readers = [
+            pgenlib.PgenReader(
+                bytes(source), n_samples, allele_idx_offsets=allele_idx_offsets
+            )
+            for _ in contigs
+        ]
+
+        return _core.run_pgen_conversion_pipeline(
+            str(source),
+            str(pvar),
+            None if no_reference else str(reference),
+            contigs,
+            ranges,
+            str(out),
+            samples,
+            chunk_size,
+            threads,
+            long_allele_capacity,
+            skip_out_of_scope,
+            signatures,
+            readers,
+        )
+
+
+def _find_pvar(pgen: Path) -> Path:
+    """Locate the `.pvar` / `.pvar.zst` sibling of `pgen`."""
+    for suffix in (".pvar", ".pvar.zst"):
+        cand = pgen.with_suffix(suffix)
+        if cand.exists():
+            return cand
+    raise FileNotFoundError(
+        f"No .pvar or .pvar.zst found next to {pgen}. "
+        f"Looked for {pgen.with_suffix('.pvar')} and {pgen.with_suffix('.pvar.zst')}."
+    )
+
+
+def _pvar_contig_ranges(
+    pvar: Path,
+) -> tuple[list[str], list[tuple[int, int]], NDArray[np.uintp]]:
+    """Contigs in `.pvar` file order, each one's half-open `[lo, hi)` variant
+    index range, and the file-wide `allele_idx_offsets` array `pgenlib.PgenReader`
+    requires once any variant in the file is multiallelic.
+
+    `allele_idx_offsets` has length `n_variants + 1`: `offsets[0] = 0` and
+    `offsets[i+1] = offsets[i] + 1 + n_alts(i)`, where `n_alts(i)` is the number of
+    comma-separated ALT alleles of variant `i`. It is a single, file-wide array --
+    every per-contig reader is constructed with the same one, not a per-contig
+    slice.
+
+    Raises if a contig's variants are not contiguous -- SVAR2 converts one contig at
+    a time from a variant index range, which requires the `.pvar` to be grouped by
+    contig (as plink2 always writes it).
+    """
+    import polars as pl
+
+    from genoray._pgen import _scan_pvar
+
+    df = _scan_pvar(pvar).select("#CHROM", "ALT").with_row_index("vidx").collect()
+
+    n_alts = df["ALT"].str.split(",").list.len().to_numpy()
+    allele_idx_offsets = np.empty(len(n_alts) + 1, dtype=np.uintp)
+    allele_idx_offsets[0] = 0
+    np.cumsum(n_alts + 1, out=allele_idx_offsets[1:])
+
+    grouped = (
+        df.lazy()
+        .group_by("#CHROM", maintain_order=True)
+        .agg(
+            pl.col("vidx").min().alias("lo"),
+            pl.col("vidx").max().alias("hi"),
+            pl.len().alias("n"),
+        )
+        .collect()
+    )
+    contigs: list[str] = []
+    ranges: list[tuple[int, int]] = []
+    for chrom, lo, hi, n in grouped.iter_rows():
+        if hi - lo + 1 != n:
+            raise ValueError(
+                f"Contig {chrom!r} is not contiguous in {pvar} "
+                f"(spans indices {lo}..{hi} but has {n} variants). "
+                "SVAR2 requires a .pvar grouped by contig."
+            )
+        contigs.append(str(chrom))
+        ranges.append((int(lo), int(hi) + 1))
+    return contigs, ranges, allele_idx_offsets
+
+
+# Target byte size of one packed dense chunk (chunk_size * n_samples * ploidy / 8).
+_DENSE_CHUNK_TARGET_BYTES = 256 * 1024 * 1024
+
+
+def _auto_chunk_size(n_samples: int, ploidy: int = 2) -> int:
+    """Variants per chunk, derived from a memory budget rather than a fixed count.
+
+    A packed dense chunk costs `chunk_size * n_samples * ploidy / 8` bytes, so a
+    fixed 25k chunk that is fine at 200 samples is not at 500k.
+    """
+    bits_per_variant = n_samples * ploidy
+    by_budget = (_DENSE_CHUNK_TARGET_BYTES * 8) // max(bits_per_variant, 1)
+    return max(1024, min(25_000, int(by_budget)))

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -459,19 +459,23 @@ SVAR 1.0 behavior.
 genoray write file.vcf.gz out.svar2 --reference ref.fa
 genoray write file.vcf.gz out.svar2 --no-reference
 genoray write file.vcf.gz out.svar2 --reference ref.fa --skip-symbolics-and-breakends --threads 4
+genoray write file.pgen out.svar2 --reference ref.fa
 
 # SVAR 1.0 (previous default) — VCF or PGEN, dosages, --haploid, --max-mem
 genoray write svar1 file.vcf.gz out.svar --max-mem 4g --haploid
 ```
 
-- `genoray write` (SVAR2, thin wrapper over `SparseVar2.from_vcf`): `--reference`
-  XOR `--no-reference` (required), `--ploidy` (default 2), `--chunk-size`
-  (default 25000), `--threads`/`-@`, `--overwrite`, `--long-allele-capacity`
-  (advanced), and a single `--skip-symbolics-and-breakends` flag (maps to
+- `genoray write` (SVAR2, thin wrapper over `SparseVar2.from_vcf`/`from_pgen`):
+  dispatches on the `.pgen` suffix — a `.pgen` source calls `from_pgen`,
+  anything else calls `from_vcf`. `--reference` XOR `--no-reference`
+  (required), `--chunk-size` (default 25000 for VCF/BCF, memory-derived for
+  PGEN), `--threads`/`-@`, `--overwrite`, `--long-allele-capacity` (advanced),
+  and a single `--skip-symbolics-and-breakends` flag (maps to
   `skip_out_of_scope=`) — the SVAR2 core can't expand either symbolic ALTs
   (`<DEL>`, `<INS>`, …) or breakends into nucleotides, so they're dropped
   together; prints a `Dropped {n} out-of-scope (symbolic/breakend) ALT
-  alleles.` line when set. VCF/BCF source only.
+  alleles.` line when set. `--ploidy` (default 2) is VCF/BCF only — PGEN is
+  diploid, and passing a non-default `--ploidy` with a `.pgen` source raises.
 - `genoray write svar1`: unchanged SVAR 1.0 behavior — VCF or PGEN source,
   `--dosages`, `--max-mem`, `--haploid`, `--no-symbolic`/`--no-breakend`
   (independent flags here, unlike SVAR2).

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -17,7 +17,7 @@ description: Use when writing or modifying Python code that imports `genoray` to
 - `genoray.VCF` — VCF/BCF reader
 - `genoray.Filter` — VCF filter value object bundling a cyvcf2 record predicate (`record`) with its matching `.gvi` polars expression (`expr`)
 - `genoray.SparseVar` — sparse `.svar` reader/writer
-- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`; range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`; scalar-numeric INFO/FORMAT field extraction during the write via `from_vcf(info_fields=, format_fields=)`)
+- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf`, PLINK2 PGEN → SVAR2 conversion via `from_pgen`; range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`/`from_pgen(signatures=True)`; scalar-numeric INFO/FORMAT field extraction during the write via `from_vcf(info_fields=, format_fields=)` — VCF only, not supported by `from_pgen`)
 - `genoray.InfoField` / `genoray.FormatField` — frozen dataclasses (`name`, `dtype=None`, `default=None`) configuring a single INFO/FORMAT field for `SparseVar2.from_vcf`; a bare `str` name uses inferred defaults instead
 - `genoray.exprs` — polars filter expressions for `.gvi` indexes
 - `genoray.cosmic_signatures` — fetch/cache COSMIC reference signatures
@@ -36,7 +36,7 @@ Prefer reading these over guessing:
 - `genoray/_vcf.py` — `VCF` class: constructor, `read`, `chunk`, mode constants near the top of the class; `get_record_info(contig=None, start=None, end=None, fields=None, info=None, lazy=False)` — non-FORMAT record-level fields (including INFO) for a range or the whole file, returns `pl.DataFrame` (or `pl.LazyFrame` when `lazy=True`)
 - `genoray/_pgen.py` — `PGEN` class: constructor, `read`, `chunk`, `read_ranges`, `chunk_ranges`, mode constants near the top of the class
 - `genoray/_svar.py` — `SparseVar`: `__init__`, `from_vcf`, `from_pgen`, `read_ranges`, `read_ranges_with_length(contig, starts=0, ends=POS_MAX, samples=None)` (length-guaranteed range read; returns the same type as `read_ranges` — a `Ragged` or fields-augmented record), `with_fields`, `annotate_mutations`, `mutation_matrix`, `assign_signatures`, `annotate_with_gtf(gtf, level_filter=1, write_back=True, *, strand_encoding=None, codon_null_token=None)` (GTF CDS annotation entry point, returns `pl.DataFrame` with `varID`/`gene_id`/`strand`/`codon_pos`), `cache_afs()` (computes and persists an `AF` column to the `.gvi` index; returns `None`)
-- `genoray/_svar2.py` — `SparseVar2`: `__init__`, `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write, `info_fields=`/`format_fields=` extract scalar-numeric fields during the write); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode`, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
+- `genoray/_svar2.py` — `SparseVar2`: `__init__`, `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write, `info_fields=`/`format_fields=` extract scalar-numeric fields during the write), `from_pgen` (PLINK2 PGEN → SVAR2 conversion entry point; diploid-only, no `ploidy=`/`info_fields=`/`format_fields=`); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode`, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
 - `genoray/_svar2_fields.py` — `InfoField`/`FormatField` dataclasses + `FieldDtype` and the header/dtype validation used by `from_vcf(info_fields=, format_fields=)` (no public read-side API yet)
 - `genoray/_cli/__main__.py` — the `genoray` CLI (`index`, `write` / `write svar1`, `view`)
 - `genoray/_signatures.py` — `cosmic_signatures`, `fit_signatures`
@@ -248,8 +248,9 @@ dropped = SparseVar2.from_vcf("out.svar2", "file.vcf.gz", no_reference=True)
 
 Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None) -> int`
 
-- `source` — a bgzipped VCF (`.vcf.gz`) or BCF (`.bcf`). **VCF/BCF only** — no PGEN
-  source yet (roadmap M7). Auto-indexes (`.csi`) if no `.csi`/`.tbi` is found.
+- `source` — a bgzipped VCF (`.vcf.gz`) or BCF (`.bcf`). Auto-indexes (`.csi`) if
+  no `.csi`/`.tbi` is found. For a PLINK2 PGEN source, use `from_pgen` instead
+  (below).
 - Exactly one of `reference` (a FASTA path, used to validate REF and left-align
   indels) or `no_reference=True` (trusts pre-normalized input, skips
   validation/left-align) is required — passing both or neither raises
@@ -315,6 +316,37 @@ Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_ou
     stored field values back out (a decode/query API) is not implemented;
     see `meta.json`'s `"fields"` array and `docs/roadmap/data-model.md` for
     the on-disk layout if you need to inspect values directly.
+
+### Conversion from PGEN
+
+```python
+from genoray import SparseVar2
+
+dropped = SparseVar2.from_pgen(
+    "out.svar2", "file.pgen", "ref.fa",   # reference: validates REF + left-aligns indels
+    overwrite=True,
+)
+```
+
+Signature: `from_pgen(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, chunk_size=None, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False) -> int`
+
+- `source` — a `.pgen` file. Variant metadata is read from the sibling
+  `.pvar`/`.pvar.zst`, sample names from the sibling `.psam` (all samples are
+  converted — no subsetting). `reference`/`no_reference`, `skip_out_of_scope`,
+  `overwrite`, `long_allele_capacity`, and `signatures` all mean the same as
+  `from_vcf` (above), and return the same `int` (dropped out-of-scope ALTs).
+- **Diploid only** — no `ploidy=` kwarg (`from_vcf`'s default `ploidy=2` is
+  implicit and fixed here).
+- `chunk_size=None` — unlike `from_vcf`'s fixed `25_000` default, `None` here
+  derives a variant-count budget from sample count (a packed dense chunk costs
+  `chunk_size * n_samples * 2 / 8` bytes), so a fixed constant that's fine at
+  200 samples doesn't blow memory at 500k. Pass an explicit `int` to override.
+- **No `info_fields=`/`format_fields=`** — PGEN carries no FORMAT, and `.pvar`
+  INFO extraction is not implemented.
+- **No dosages** — a `.pgen` dosage track (if present) is ignored; only
+  hardcalls are read.
+- Unphased heterozygotes resolve haplotypes in the allele-code order
+  `pgenlib` returns — the same caveat `from_vcf` carries for unphased `GT`.
 
 ### Range queries
 

--- a/src/chunk_assembler.rs
+++ b/src/chunk_assembler.rs
@@ -1,0 +1,630 @@
+use crate::error::ConversionError;
+use crate::field::{FieldCategory, FieldSpec};
+use crate::normalize::atomize_record;
+use crate::record_source::{RawRecord, RecordSource};
+use crate::types::{BitGrid3, DenseChunk, StagedColumn};
+use rayon::prelude::*;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::sync::Arc;
+
+// A decomposed atom awaiting emission. Carries a shared handle to its source record's
+// per-column allele indices so genotype presence is computed at chunk-build time.
+struct PendingAtom {
+    pos: u32,
+    ilen: i32,
+    alt: Vec<u8>,
+    source_alt_index: u16,
+    gt: Arc<Vec<i32>>, // len = num_samples * ploidy; allele index per column (-1 = missing)
+    seq: u64,          // stable tiebreak for equal positions
+
+    // Resolved field values for THIS atom (already indexed by source_alt_index
+    // where the underlying VCF field is Number=A). Populated in
+    // `decompose_current_record`, gathered into `DenseChunk::{info,format}_staged`
+    // in `read_next_chunk`'s sequential metadata pass. Empty when no fields of
+    // that category were requested.
+    info_vals: Vec<f64>,   // len == VcfChunkReader::info_fields.len()
+    format_vals: Vec<f64>, // len == VcfChunkReader::format_fields.len() * num_samples, field-major then sample: field*num_samples + sample
+}
+
+impl PartialEq for PendingAtom {
+    fn eq(&self, other: &Self) -> bool {
+        self.pos == other.pos && self.seq == other.seq
+    }
+}
+impl Eq for PendingAtom {}
+impl PartialOrd for PendingAtom {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for PendingAtom {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.pos.cmp(&other.pos).then(self.seq.cmp(&other.seq))
+    }
+}
+
+// Pack variant row `vi`'s presence bits into `words`, where `words[0]` corresponds
+// to global word index `word_base`. Bit for (row vi, column col) lives at global
+// flat index `vi*columns + col`; the local word index subtracts `word_base`.
+// Presence is `gt[col] == source_alt_index`. Bits start zeroed and are only OR-set,
+// and each word is assembled in a register and written once (identical result to a
+// per-bit `or_bit` loop, far fewer stores).
+#[inline]
+fn pack_row(words: &mut [u64], word_base: usize, vi: usize, a: &PendingAtom, columns: usize) {
+    let src = a.source_alt_index as i32;
+    let gtc: &[i32] = &a.gt;
+    let base = vi * columns;
+    let mut col = 0usize;
+    while col < columns {
+        let flat = base + col;
+        let w = (flat >> 6) - word_base;
+        let b = flat & 63;
+        let n = (64 - b).min(columns - col);
+        let mut acc = 0u64;
+        for k in 0..n {
+            // SAFETY: col + k < columns == gtc.len().
+            acc |= ((unsafe { *gtc.get_unchecked(col + k) } == src) as u64) << (b + k);
+        }
+        // SAFETY: w indexes a word within this row's target slice.
+        unsafe {
+            *words.get_unchecked_mut(w) |= acc;
+        }
+        col += n;
+    }
+}
+
+// Sequential full-grid presence packing: one row at a time into the whole `words`
+// slice (global word index == local word index, so `word_base == 0`).
+fn pack_presence_seq(words: &mut [u64], atoms: &[PendingAtom], columns: usize) {
+    for (vi, a) in atoms.iter().enumerate() {
+        pack_row(words, 0, vi, a, columns);
+    }
+}
+
+// Below this many variants in a chunk, parallel packing's per-task overhead
+// outweighs the win — pack sequentially instead. Tunable; measure on gdc/germline.
+const PARALLEL_MIN_VARIANTS: usize = 512;
+
+#[inline]
+fn gcd(mut a: usize, mut b: usize) -> usize {
+    while b != 0 {
+        let t = a % b;
+        a = b;
+        b = t;
+    }
+    a
+}
+
+// Parallel presence packing. Variants are partitioned into word-aligned blocks:
+// row `vi` occupies bits `[vi*columns, (vi+1)*columns)`, so a block boundary at a
+// multiple of `g = 64/gcd(columns,64)` variants lands exactly on a u64 boundary.
+// `par_chunks_mut(words_per_block)` hands each rayon task a word-DISJOINT slice, so
+// there are no shared boundary words and no atomics — the result is bit-identical to
+// `pack_presence_seq`. Block `c` covers variants `[c*g, min((c+1)*g, v))` and words
+// `[c*words_per_block, ...)`, whose global base is `word_base = c*words_per_block`.
+fn pack_presence_par(
+    words: &mut [u64],
+    atoms: &[PendingAtom],
+    columns: usize,
+    pool: &rayon::ThreadPool,
+) {
+    let d = gcd(columns, 64);
+    let g = 64 / d; // variants per word-aligned block
+    let words_per_block = columns / d; // == g * columns / 64, always an integer
+    let v = atoms.len();
+
+    pool.install(|| {
+        words
+            .par_chunks_mut(words_per_block)
+            .enumerate()
+            .for_each(|(c, wchunk)| {
+                let vi_start = c * g;
+                let vi_end = ((c + 1) * g).min(v);
+                let word_base = c * words_per_block;
+                // `vi` is dual-purpose here: it's both the `atoms` index and the row
+                // index `pack_row` needs to compute the flat bit offset, so it can't
+                // be replaced by a plain iterator/enumerate.
+                #[allow(clippy::needless_range_loop)]
+                for vi in vi_start..vi_end {
+                    pack_row(wchunk, word_base, vi, &atoms[vi], columns);
+                }
+            });
+    });
+}
+
+// Delegates to `FieldSpec::missing_sentinel` — single source of truth shared
+// with `dense2sparse_vk`'s genotype-aligned non-carrier fill (src/rvk.rs).
+fn sentinel_default(spec: &FieldSpec) -> f64 {
+    spec.missing_sentinel()
+}
+
+// htslib missing-value detection on an already-widened f64: floats use NaN
+// (covers both htslib's MISSING and VECTOR_END float encodings, which are
+// distinct NaN bit patterns); ints use MISSING (i32::MIN) or VECTOR_END
+// (i32::MIN + 1) — the round-trip through f64 is exact for both since they're
+// in i32 range.
+fn is_htslib_missing(raw_val: f64, is_float: bool) -> bool {
+    if is_float {
+        raw_val.is_nan()
+    } else {
+        let iv = raw_val as i32;
+        iv == i32::MIN || iv == i32::MIN + 1
+    }
+}
+
+// Resolve one atom's value from a record-level raw buffer (already widened to
+// f64): `None` (field absent from the record/sample) or an out-of-range
+// Number=A index falls back to the spec's sentinel/default; a length-1 buffer
+// is a Number=1 scalar, otherwise indexed by `source_alt_index - 1` (Number=A):
+// `source_alt_index` is 1-based (ALT1 → 1, matching BCF GT allele codes; see
+// `normalize::atomize_record`), but htslib's Number=A buffer is 0-based
+// per-ALT (ALT1's value lives at `vals[0]`).
+fn resolve_scalar(vals: Option<&[f64]>, source_alt_index: u16, spec: &FieldSpec) -> f64 {
+    let default_val = sentinel_default(spec);
+    let Some(vals) = vals else {
+        return default_val;
+    };
+    if vals.is_empty() {
+        return default_val;
+    }
+    let raw_val = if vals.len() == 1 {
+        vals[0]
+    } else {
+        // source_alt_index is 1-based; htslib Number=A buffers are 0-based per-ALT.
+        match vals.get(source_alt_index.saturating_sub(1) as usize) {
+            Some(&v) => v,
+            None => return default_val,
+        }
+    };
+    if is_htslib_missing(raw_val, spec.stage_is_float()) {
+        default_val
+    } else {
+        raw_val
+    }
+}
+
+// An atom whose presence bits are already packed into the chunk's BitGrid. `gt`
+// and `source_alt_index` are dropped at that point, so per-chunk staging memory
+// no longer scales with `chunk_size * num_samples * ploidy`.
+struct AtomMeta {
+    pos: u32,
+    ilen: i32,
+    alt: Vec<u8>,
+    info_vals: Vec<f64>,
+    format_vals: Vec<f64>,
+}
+
+// Atoms buffered before their presence bits are flushed into the chunk's BitGrid.
+// Rounded UP to a multiple of the word-aligned block size `g = 64/gcd(columns,64)`
+// at call time, so every flush offset lands on a u64 boundary and
+// `pack_presence_par` keeps its word-disjoint invariant. 1024 keeps the window
+// above `PARALLEL_MIN_VARIANTS` (512) so parallel packing still engages.
+const PACK_WINDOW: usize = 1024;
+
+// Pack `buf`'s presence bits into `genos` starting at variant offset `v0`, then
+// move each atom's metadata into `metas`, dropping `gt`.
+//
+// `v0` MUST be a multiple of the word-aligned block size, so `v0 * columns` is a
+// multiple of 64 and the window owns a whole-word-aligned sub-slice of
+// `genos.words`. Only the FINAL window may have a length that is not a multiple of
+// that block size (its trailing partial word is not shared, because nothing is
+// packed after it).
+fn flush_window(
+    genos: &mut BitGrid3,
+    metas: &mut Vec<AtomMeta>,
+    buf: &mut Vec<PendingAtom>,
+    v0: usize,
+    columns: usize,
+    pool: Option<&rayon::ThreadPool>,
+) {
+    if buf.is_empty() {
+        return;
+    }
+    debug_assert_eq!((v0 * columns) % 64, 0, "flush offset must be word-aligned");
+    let word_base = (v0 * columns) / 64;
+    let n_words = (buf.len() * columns).div_ceil(64);
+    let words = &mut genos.words[word_base..word_base + n_words];
+
+    let parallel = matches!(pool, Some(p) if p.current_num_threads() >= 2)
+        && buf.len() >= PARALLEL_MIN_VARIANTS;
+    if parallel {
+        pack_presence_par(words, buf, columns, pool.unwrap());
+    } else {
+        pack_presence_seq(words, buf, columns);
+    }
+
+    metas.reserve(buf.len());
+    for a in buf.drain(..) {
+        metas.push(AtomMeta {
+            pos: a.pos,
+            ilen: a.ilen,
+            alt: a.alt,
+            info_vals: a.info_vals,
+            format_vals: a.format_vals,
+        });
+    }
+}
+
+pub struct ChunkAssembler {
+    source: Box<dyn RecordSource + Send>,
+    num_samples: usize,
+    ploidy: usize,
+    /// Full 0-based contig sequence, uppercased; empty when no reference was given.
+    ref_seq: Vec<u8>,
+    has_reference: bool,
+    skip_out_of_scope: bool,
+    dropped_out_of_scope: u64,
+    info_fields: Vec<FieldSpec>,
+    format_fields: Vec<FieldSpec>,
+    heap: BinaryHeap<Reverse<PendingAtom>>,
+    frontier: u32,
+    eof: bool,
+    next_seq: u64,
+}
+
+impl ChunkAssembler {
+    pub fn new(
+        source: Box<dyn RecordSource + Send>,
+        num_samples: usize,
+        ploidy: usize,
+        fasta_path: Option<&str>,
+        chrom: &str,
+        skip_out_of_scope: bool,
+        fields: &[FieldSpec],
+    ) -> Result<Self, ConversionError> {
+        let (ref_seq, has_reference) = match fasta_path {
+            Some(path) => (crate::vcf_reader::load_contig_seq(path, chrom)?, true),
+            None => (Vec::new(), false),
+        };
+        Ok(Self {
+            source,
+            num_samples,
+            ploidy,
+            ref_seq,
+            has_reference,
+            skip_out_of_scope,
+            dropped_out_of_scope: 0,
+            info_fields: fields
+                .iter()
+                .filter(|f| f.category == FieldCategory::Info)
+                .cloned()
+                .collect(),
+            format_fields: fields
+                .iter()
+                .filter(|f| f.category == FieldCategory::Format)
+                .cloned()
+                .collect(),
+            heap: BinaryHeap::new(),
+            frontier: 0,
+            eof: false,
+            next_seq: 0,
+        })
+    }
+
+    /// Total out-of-scope (symbolic/breakend) ALTs dropped so far. Valid after the
+    /// read loop drains.
+    pub fn dropped_out_of_scope(&self) -> u64 {
+        self.dropped_out_of_scope
+    }
+
+    // Decompose one record into atoms and push them onto the reorder heap, sharing
+    // one decoded genotype vector across all atoms of the record.
+    fn decompose_record(&mut self, rec: RawRecord) -> Result<(), ConversionError> {
+        let pos = rec.pos;
+        let gt = Arc::new(rec.gt);
+
+        // Fail fast only when a reference is available; without one we trust the
+        // input is already normalized/left-aligned.
+        if self.has_reference {
+            crate::normalize::validate_ref(pos, &rec.reference, &self.ref_seq)?;
+        }
+
+        let alt_refs: Vec<&[u8]> = rec.alts.iter().map(|a| a.as_slice()).collect();
+        let mut atoms = Vec::new();
+        let dropped = atomize_record(
+            pos,
+            &rec.reference,
+            &alt_refs,
+            &mut atoms,
+            self.skip_out_of_scope,
+        )?;
+        self.dropped_out_of_scope += dropped as u64;
+
+        for atom in atoms {
+            let atom = if self.has_reference {
+                crate::normalize::left_align(atom, &self.ref_seq, crate::normalize::L_MAX)
+            } else {
+                atom
+            };
+
+            let info_vals: Vec<f64> = self
+                .info_fields
+                .iter()
+                .zip(rec.info_raw.iter())
+                .map(|(spec, raw)| resolve_scalar(raw.as_deref(), atom.source_alt_index, spec))
+                .collect();
+
+            let mut format_vals = Vec::with_capacity(self.format_fields.len() * self.num_samples);
+            for (spec, raw) in self.format_fields.iter().zip(rec.format_raw.iter()) {
+                for s in 0..self.num_samples {
+                    let sample_vals = raw.as_ref().map(|v| v[s].as_slice());
+                    format_vals.push(resolve_scalar(sample_vals, atom.source_alt_index, spec));
+                }
+            }
+
+            let seq = self.next_seq;
+            self.next_seq += 1;
+            self.heap.push(Reverse(PendingAtom {
+                pos: atom.pos,
+                ilen: atom.ilen,
+                alt: atom.alt,
+                source_alt_index: atom.source_alt_index,
+                gt: Arc::clone(&gt),
+                seq,
+                info_vals,
+                format_vals,
+            }));
+        }
+        Ok(())
+    }
+
+    // Yield the next atom in global position order. Left-alignment can move an atom
+    // up to `L_MAX` bases below its record's start, so an atom is safe to emit only
+    // once its position is strictly below `frontier - L_MAX` (saturating), or the
+    // input is exhausted. This preserves the position-sorted invariant the Phase-2
+    // merge relies on. (Unchanged from the pre-refactor VcfChunkReader.)
+    fn next_atom(&mut self) -> Result<Option<PendingAtom>, ConversionError> {
+        loop {
+            if let Some(Reverse(top)) = self.heap.peek() {
+                if self.eof || top.pos < self.frontier.saturating_sub(crate::normalize::L_MAX) {
+                    return Ok(Some(self.heap.pop().unwrap().0));
+                }
+            } else if self.eof {
+                return Ok(None);
+            }
+
+            match self.source.next_record()? {
+                Some(rec) => {
+                    self.frontier = rec.pos;
+                    self.decompose_record(rec)?;
+                }
+                None => self.eof = true,
+            }
+        }
+    }
+
+    // Pull up to `chunk_size` atoms (already globally position-sorted) and pack them
+    // into a variant-major DenseChunk. Presence bits are packed in windows of
+    // `PACK_WINDOW` atoms so the reader never holds more than one window's worth of
+    // per-column genotype vectors. `pool`, when present and the window is large
+    // enough, hosts parallel packing; otherwise packing is sequential. Output is
+    // bit-identical either way. Returns None once no atoms remain.
+    pub fn read_next_chunk(
+        &mut self,
+        chunk_size: usize,
+        chunk_id: usize,
+        pool: Option<&rayon::ThreadPool>,
+    ) -> Result<Option<DenseChunk>, ConversionError> {
+        let columns = self.num_samples * self.ploidy;
+        // Word-aligned block size: `g` variants span exactly `columns/gcd` u64 words.
+        let g = 64 / gcd(columns, 64);
+        let window = PACK_WINDOW.div_ceil(g) * g;
+
+        // Allocate for the full chunk up front (packed size: chunk_size*columns bits),
+        // then shrink to the true variant count after EOF.
+        let mut genos = BitGrid3::zeros(chunk_size, self.num_samples, self.ploidy);
+        let mut metas: Vec<AtomMeta> = Vec::with_capacity(chunk_size);
+        let mut buf: Vec<PendingAtom> = Vec::with_capacity(window);
+        let mut v = 0usize;
+
+        while v + buf.len() < chunk_size {
+            match self.next_atom()? {
+                Some(a) => {
+                    buf.push(a);
+                    if buf.len() == window {
+                        flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
+                        v += window;
+                    }
+                }
+                None => break,
+            }
+        }
+        if !buf.is_empty() {
+            let n = buf.len();
+            flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
+            v += n;
+        }
+
+        if v == 0 {
+            return Ok(None);
+        }
+        genos.truncate_v(v);
+
+        let num_samples = self.num_samples;
+        let mut pos = Vec::with_capacity(v);
+        let mut ilens = Vec::with_capacity(v);
+        let mut alt = Vec::with_capacity(v * 2);
+        let mut alt_offsets = Vec::with_capacity(v + 1);
+        alt_offsets.push(0u32);
+        let mut info_staged: Vec<StagedColumn> = self
+            .info_fields
+            .iter()
+            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v))
+            .collect();
+        let mut format_staged: Vec<StagedColumn> = self
+            .format_fields
+            .iter()
+            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v * num_samples))
+            .collect();
+
+        // Sequential metadata pass (cheap, ordering-preserving).
+        let mut off = 0u32;
+        for a in metas.iter() {
+            pos.push(a.pos);
+            ilens.push(a.ilen);
+            alt.extend_from_slice(&a.alt);
+            off += a.alt.len() as u32;
+            alt_offsets.push(off);
+
+            for (i, col) in info_staged.iter_mut().enumerate() {
+                col.push_f64(a.info_vals[i]);
+            }
+            for (j, col) in format_staged.iter_mut().enumerate() {
+                for s in 0..num_samples {
+                    col.push_f64(a.format_vals[j * num_samples + s]);
+                }
+            }
+        }
+
+        Ok(Some(DenseChunk {
+            chunk_id,
+            pos,
+            ilens,
+            alt,
+            alt_offsets,
+            genos,
+            info_staged,
+            format_staged,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::sync::OnceLock;
+
+    // One shared 4-thread pool for all proptest cases (building a pool per case is slow).
+    fn test_pool() -> &'static rayon::ThreadPool {
+        static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+        POOL.get_or_init(|| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(4)
+                .build()
+                .unwrap()
+        })
+    }
+
+    // Minimal PendingAtom carrying only the fields the packers read.
+    fn atom(gt: Vec<i32>, src: u16) -> PendingAtom {
+        PendingAtom {
+            pos: 0,
+            ilen: 0,
+            alt: Vec::new(),
+            source_alt_index: src,
+            gt: std::sync::Arc::new(gt),
+            seq: 0,
+            info_vals: Vec::new(),
+            format_vals: Vec::new(),
+        }
+    }
+
+    fn atom_at(gt: Vec<i32>, src: u16, pos: u32) -> PendingAtom {
+        PendingAtom {
+            pos,
+            ilen: 0,
+            alt: Vec::new(),
+            source_alt_index: src,
+            gt: std::sync::Arc::new(gt),
+            seq: pos as u64,
+            info_vals: Vec::new(),
+            format_vals: Vec::new(),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(300))]
+
+        // Parallel packing reproduces sequential packing bit-for-bit, for arbitrary
+        // shapes (incl. v not a multiple of the word-aligned block size), allele
+        // indices (incl. missing -1 and out-of-range values), and source alts.
+        #[test]
+        fn test_par_packing_matches_seq(
+            num_samples in 1usize..40,
+            ploidy in 1usize..4,
+            v in 1usize..70,
+            seed in any::<u64>(),
+        ) {
+            let columns = num_samples * ploidy;
+            // xorshift64 for deterministic per-case gt/src patterns.
+            let mut state = seed | 1;
+            let mut next = || { state ^= state << 13; state ^= state >> 7; state ^= state << 17; state };
+
+            let mut atoms = Vec::with_capacity(v);
+            for _ in 0..v {
+                let src = (next() % 4) as u16; // small alt index space
+                let gt: Vec<i32> = (0..columns)
+                    .map(|_| match next() % 5 {
+                        0 => -1,            // missing
+                        1 => src as i32,    // present (matches src)
+                        2 => 7,             // out-of-range allele
+                        _ => (next() % 4) as i32,
+                    })
+                    .collect();
+                atoms.push(atom(gt, src));
+            }
+
+            let mut seq = BitGrid3::zeros(v, num_samples, ploidy);
+            pack_presence_seq(&mut seq.words, &atoms, columns);
+
+            let mut par = BitGrid3::zeros(v, num_samples, ploidy);
+            pack_presence_par(&mut par.words, &atoms, columns, test_pool());
+
+            prop_assert_eq!(seq.words, par.words, "columns={}, v={}", columns, v);
+        }
+    }
+
+    // Windowed packing must be bit-identical to packing the whole chunk at once.
+    // `flush_window` is only ever called at word-aligned variant offsets except
+    // for the final (partial) window, which nothing follows — mirror that here.
+    proptest! {
+        #[test]
+        fn windowed_pack_matches_full_pack(
+            n_samples in 1usize..9,
+            ploidy in 1usize..3,
+            srcs in prop::collection::vec(0u16..3u16, 1..200),
+        ) {
+            let columns = n_samples * ploidy;
+            let v = srcs.len();
+
+            // Deterministic gt: column c of variant i carries allele (i + c) % 3.
+            let atoms: Vec<PendingAtom> = srcs
+                .iter()
+                .enumerate()
+                .map(|(i, &src)| {
+                    let gt: Vec<i32> = (0..columns).map(|c| ((i + c) % 3) as i32).collect();
+                    atom_at(gt, src, i as u32)
+                })
+                .collect();
+
+            // Reference: one full-grid sequential pack.
+            let mut expect = BitGrid3::zeros(v, n_samples, ploidy);
+            pack_presence_seq(&mut expect.words, &atoms, columns);
+
+            // Windowed: flush every `window` atoms, where `window` is a multiple of
+            // the word-aligned block size `g`.
+            let g = 64 / gcd(columns, 64);
+            let window = 4 * g;
+            let mut got = BitGrid3::zeros(v, n_samples, ploidy);
+            let mut metas: Vec<AtomMeta> = Vec::new();
+            let mut buf: Vec<PendingAtom> = Vec::new();
+            let mut v0 = 0usize;
+            for a in atoms {
+                buf.push(a);
+                if buf.len() == window {
+                    let n = buf.len();
+                    flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
+                    v0 += n;
+                }
+            }
+            if !buf.is_empty() {
+                flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
+            }
+
+            prop_assert_eq!(got.words, expect.words);
+            prop_assert_eq!(metas.len(), v);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,28 @@ fn run_pgen_conversion_pipeline(
     for r in results {
         dropped += r?;
     }
+
+    // All contigs staged — resolve each field's global on-disk dtype (no-op:
+    // PGEN carries no fields) and rewrite its staged values.bin files to that
+    // width, then write the top-level meta.json describing the cohort. Mirrors
+    // the tail of `run_conversion_pipeline` -- without this, `SparseVar2(out)`
+    // has no `meta.json` to load.
+    let resolved_fields = crate::field_finalize::finalize_fields(
+        std::path::Path::new(&output_dir),
+        &chroms,
+        &fields,
+    )?;
+
+    crate::meta::write_meta(
+        std::path::Path::new(&output_dir),
+        crate::meta::FORMAT_VERSION,
+        &samples,
+        &chroms,
+        ploidy,
+        &resolved_fields,
+    )
+    .map_err(|e| pyo3::exceptions::PyOSError::new_err(format!("failed to write meta.json: {e}")))?;
+
     Ok(dropped as usize)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub fn bits_get_bit(bytes: &[u8], i: usize) -> bool {
 }
 #[cfg(feature = "conversion")]
 pub mod budget;
+#[cfg(feature = "conversion")]
+pub mod chunk_assembler;
 pub mod cost_model;
 pub mod dense;
 #[cfg(feature = "conversion")]
@@ -55,6 +57,8 @@ pub mod py_query_batch;
 pub mod py_query_decode;
 pub mod py_query_ranges;
 pub mod query;
+#[cfg(feature = "conversion")]
+pub mod record_source;
 pub mod rvk;
 pub mod search;
 pub mod spine;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub mod nrvk;
 #[cfg(feature = "conversion")]
 pub mod orchestrator;
 #[cfg(feature = "conversion")]
+pub mod pgen_reader;
+#[cfg(feature = "conversion")]
 pub mod pvar;
 // NOTE: `py_convert` is *not* conversion-only despite being in the original gate
 // list: query-core `py_query_batch.rs`/`py_query_decode.rs`/`py_query_ranges.rs`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ pub mod normalize;
 pub mod nrvk;
 #[cfg(feature = "conversion")]
 pub mod orchestrator;
+#[cfg(feature = "conversion")]
+pub mod pvar;
 // NOTE: `py_convert` is *not* conversion-only despite being in the original gate
 // list: query-core `py_query_batch.rs`/`py_query_decode.rs`/`py_query_ranges.rs`
 // import its numpy-array conversion helpers unconditionally, and py_convert.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,14 +183,16 @@ fn run_conversion_pipeline(
                 .map(|chrom| {
                     println!("==> Processing {}", chrom);
                     orchestrator::process_chromosome(
-                        &vcf_path,
+                        orchestrator::SourceSpec::Vcf {
+                            vcf_path: vcf_path.clone(),
+                            htslib_threads,
+                        },
                         fasta_ref,
                         chrom,
                         &output_dir,
                         &sample_refs,
                         chunk_size,
                         ploidy,
-                        htslib_threads,
                         long_allele_capacity,
                         skip_out_of_scope,
                         processing_threads,
@@ -232,10 +234,113 @@ fn run_conversion_pipeline(
     Ok(total_dropped as usize)
 }
 
+/// Convert a PLINK2 PGEN to an SVAR2 store.
+///
+/// `contig_ranges[i]` is the half-open `[var_start, var_end)` variant index range
+/// of `chroms[i]` within the `.pvar`. `pgen_readers[i]` is a distinct
+/// `pgenlib.PgenReader` for `chroms[i]` -- readers seek independently, so contigs
+/// must not share one.
+#[cfg(feature = "conversion")]
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(signature = (pgen_path, pvar_path, reference_path, chroms, contig_ranges, output_dir, samples, chunk_size, max_threads, long_allele_capacity, skip_out_of_scope, signatures, pgen_readers))]
+fn run_pgen_conversion_pipeline(
+    py: Python,
+    pgen_path: String,
+    pvar_path: String,
+    reference_path: Option<String>,
+    chroms: Vec<String>,
+    contig_ranges: Vec<(usize, usize)>,
+    output_dir: String,
+    samples: Vec<String>,
+    chunk_size: usize,
+    max_threads: Option<usize>,
+    long_allele_capacity: usize,
+    skip_out_of_scope: bool,
+    signatures: bool,
+    pgen_readers: Vec<Py<PyAny>>,
+) -> PyResult<usize> {
+    if chroms.len() != contig_ranges.len() || chroms.len() != pgen_readers.len() {
+        return Err(PyValueError::new_err(
+            "chroms, contig_ranges, and pgen_readers must be the same length",
+        ));
+    }
+    let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
+    // PGEN is diploid-only.
+    let ploidy = 2usize;
+    // PGEN carries no FORMAT, and .pvar INFO extraction is out of scope.
+    let fields: Vec<crate::field::FieldSpec> = Vec::new();
+
+    // Pair each contig with its own reader BEFORE detaching, so the Py handles move
+    // into the worker threads (Py<PyAny> is Send; PyAny is not).
+    let jobs: Vec<(String, (usize, usize), Py<PyAny>)> = chroms
+        .iter()
+        .cloned()
+        .zip(contig_ranges.iter().copied())
+        .zip(pgen_readers)
+        .map(|((c, r), rd)| (c, r, rd))
+        .collect();
+
+    let results: Vec<Result<u64, crate::error::ConversionError>> = py.detach(|| {
+        let available_cores = match max_threads {
+            Some(t) if t > 0 => t,
+            _ => std::thread::available_parallelism().unwrap().get(),
+        };
+        let plan = crate::budget::plan_thread_budget(available_cores, jobs.len());
+        let concurrent_chroms = plan.concurrent_chroms;
+        let processing_threads = plan.processing_threads;
+        println!(
+            "Pipeline Config (PGEN): {} concurrent chromosomes | {} processing threads each.",
+            concurrent_chroms, processing_threads
+        );
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(concurrent_chroms)
+            .thread_name(|i| format!("chrom-{}", i))
+            .build()
+            .expect("build chrom pool");
+
+        pool.install(|| {
+            jobs.into_par_iter()
+                .map(|(chrom, (lo, hi), reader)| {
+                    orchestrator::process_chromosome(
+                        orchestrator::SourceSpec::Pgen {
+                            pgen_path: pgen_path.clone(),
+                            pvar_path: pvar_path.clone(),
+                            var_start: lo,
+                            var_end: hi,
+                            reader,
+                        },
+                        reference_path.as_deref(),
+                        &chrom,
+                        &output_dir,
+                        &sample_refs,
+                        chunk_size,
+                        ploidy,
+                        long_allele_capacity,
+                        skip_out_of_scope,
+                        processing_threads,
+                        signatures,
+                        &fields,
+                    )
+                })
+                .collect()
+        })
+    });
+
+    let mut dropped = 0u64;
+    for r in results {
+        dropped += r?;
+    }
+    Ok(dropped as usize)
+}
+
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     #[cfg(feature = "conversion")]
     m.add_function(wrap_pyfunction!(run_conversion_pipeline, m)?)?;
+    #[cfg(feature = "conversion")]
+    m.add_function(wrap_pyfunction!(run_pgen_conversion_pipeline, m)?)?;
     #[cfg(feature = "conversion")]
     m.add_function(wrap_pyfunction!(index_vcf, m)?)?;
     m.add_class::<crate::py_query::PyContigReader>()?;

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -9,7 +9,6 @@ use crate::enum_map::EnumKey;
 use crate::error::ConversionError;
 use crate::nrvk::LongAlleleTableWriter;
 use crate::streams::{REGISTRY, StreamMap, StreamTag};
-use crate::vcf_reader::VcfChunkReader;
 use crate::{executor, merge, monitor, writer};
 
 /*
@@ -151,13 +150,20 @@ pub fn process_chromosome(
             move || -> Result<u64, ConversionError> {
                 // passing the thread budget down to HTSLib
                 let s_refs: Vec<&str> = s_owned.iter().map(|s| s.as_str()).collect();
-                let mut reader = VcfChunkReader::new(
+                let source = crate::vcf_reader::VcfRecordSource::new(
                     &vcf,
-                    fasta.as_deref(),
                     &chr,
                     &s_refs,
                     htslib_threads,
                     ploidy,
+                    &fields_owned,
+                )?;
+                let mut reader = crate::chunk_assembler::ChunkAssembler::new(
+                    Box::new(source),
+                    s_refs.len(),
+                    ploidy,
+                    fasta.as_deref(),
+                    &chr,
                     skip_out_of_scope,
                     &fields_owned,
                 )?;

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -39,17 +39,34 @@ parallel memory architecture.
 
 */
 
+/// Which backend a contig's records come from. Everything downstream of
+/// `ChunkAssembler` is identical for both.
+pub enum SourceSpec {
+    Vcf {
+        vcf_path: String,
+        htslib_threads: usize,
+    },
+    Pgen {
+        pgen_path: String,
+        pvar_path: String,
+        var_start: usize,
+        var_end: usize,
+        /// A `pgenlib.PgenReader` for THIS contig. Readers seek independently, so
+        /// each concurrent contig needs its own -- never share one.
+        reader: pyo3::Py<pyo3::PyAny>,
+    },
+}
+
 //The rust pipeline (Per chromosome conversion from Dense to Sparse)
 #[allow(clippy::too_many_arguments)]
 pub fn process_chromosome(
-    vcf_path: &str,
+    source: SourceSpec,
     fasta_path: Option<&str>,
     chrom: &str,
     base_out_dir: &str,
     samples: &[&str],
     chunk_size: usize,
     ploidy: usize,
-    htslib_threads: usize,
     long_allele_capacity: usize,
     skip_out_of_scope: bool,
     processing_threads: usize,
@@ -139,7 +156,6 @@ pub fn process_chromosome(
     let reader_thread = thread::Builder::new()
         .name(format!("read-{}", chrom))
         .spawn({
-            let vcf = vcf_path.to_string();
             let fasta = fasta_path.map(|s| s.to_string());
             let chr = chrom.to_string();
             // Convert references into owned Strings that can safely live forever in the thread
@@ -150,16 +166,35 @@ pub fn process_chromosome(
             move || -> Result<u64, ConversionError> {
                 // passing the thread budget down to HTSLib
                 let s_refs: Vec<&str> = s_owned.iter().map(|s| s.as_str()).collect();
-                let source = crate::vcf_reader::VcfRecordSource::new(
-                    &vcf,
-                    &chr,
-                    &s_refs,
-                    htslib_threads,
-                    ploidy,
-                    &fields_owned,
-                )?;
+                let src: Box<dyn crate::record_source::RecordSource + Send> = match source {
+                    SourceSpec::Vcf {
+                        vcf_path,
+                        htslib_threads,
+                    } => Box::new(crate::vcf_reader::VcfRecordSource::new(
+                        &vcf_path,
+                        &chr,
+                        &s_refs,
+                        htslib_threads,
+                        ploidy,
+                        &fields_owned,
+                    )?),
+                    SourceSpec::Pgen {
+                        pgen_path: _,
+                        pvar_path,
+                        var_start,
+                        var_end,
+                        reader,
+                    } => Box::new(crate::pgen_reader::PgenRecordSource::new(
+                        reader,
+                        &pvar_path,
+                        var_start,
+                        var_end,
+                        s_refs.len(),
+                        chunk_size,
+                    )?),
+                };
                 let mut reader = crate::chunk_assembler::ChunkAssembler::new(
-                    Box::new(source),
+                    src,
                     s_refs.len(),
                     ploidy,
                     fasta.as_deref(),

--- a/src/pgen_reader.rs
+++ b/src/pgen_reader.rs
@@ -1,0 +1,134 @@
+//! PGEN record source.
+//!
+//! Genotypes come from the `pgenlib` PyPI wheel (LGPL-3.0) via its **public Python
+//! API** -- the same way `genoray/_pgen.py` already uses it. genoray links no
+//! plink-ng code and vendors none; `_core` stays MIT. Do not change this without
+//! reading `docs/superpowers/specs/2026-07-12-pgen-to-svar2-design.md`.
+//!
+//! `PgenReader.read_alleles_range` releases the GIL for its decode loop, so the
+//! `Python::attach` below only costs call dispatch, not the decode.
+
+use crate::error::ConversionError;
+use crate::pvar::PvarReader;
+use crate::record_source::{RawRecord, RecordSource};
+use numpy::{PyArray2, PyArrayMethods};
+use pyo3::prelude::*;
+
+/// Byte budget for the `(batch, 2 * n_samples)` int32 allele-code buffer. Sized so
+/// small cohorts get thousands of variants per Python call (amortizing dispatch)
+/// while biobank cohorts stay memory-bounded.
+pub const PGEN_BATCH_BYTES: usize = 32 * 1024 * 1024;
+
+pub struct PgenRecordSource {
+    /// A `pgenlib.PgenReader`, constructed in Python and owned here.
+    reader: Py<PyAny>,
+    /// `(batch, 2 * num_samples)` int32 allele-code scratch buffer, reused per refill.
+    buf: Py<PyArray2<i32>>,
+    batch: usize,
+    num_samples: usize,
+    /// Next global variant index to fetch from the .pgen.
+    var_next: usize,
+    /// Exclusive end of this contig's variant index range.
+    var_end: usize,
+    /// Rows currently valid in `buf`, and the next one to serve.
+    filled: usize,
+    row: usize,
+    pvar: PvarReader,
+}
+
+impl PgenRecordSource {
+    pub fn new(
+        reader: Py<PyAny>,
+        pvar_path: &str,
+        var_start: usize,
+        var_end: usize,
+        num_samples: usize,
+        chunk_size: usize,
+    ) -> Result<Self, ConversionError> {
+        let batch = (PGEN_BATCH_BYTES / (2 * num_samples * 4)).clamp(1, chunk_size.max(1));
+        let pvar = PvarReader::open(pvar_path, var_start)?;
+        let buf = Python::attach(|py| {
+            PyArray2::<i32>::zeros(py, [batch, 2 * num_samples], false).unbind()
+        });
+        Ok(Self {
+            reader,
+            buf,
+            batch,
+            num_samples,
+            var_next: var_start,
+            var_end,
+            filled: 0,
+            row: 0,
+            pvar,
+        })
+    }
+
+    /// Refill `buf` with the next `min(batch, var_end - var_next)` variants.
+    /// Returns the number of rows filled (0 => this contig is exhausted).
+    fn refill(&mut self) -> Result<usize, ConversionError> {
+        let lo = self.var_next;
+        if lo >= self.var_end {
+            return Ok(0);
+        }
+        let hi = (lo + self.batch).min(self.var_end);
+        Python::attach(|py| -> Result<(), ConversionError> {
+            self.reader
+                .bind(py)
+                .call_method1(
+                    "read_alleles_range",
+                    (lo as u32, hi as u32, self.buf.bind(py)),
+                )
+                .map_err(|e| {
+                    ConversionError::Input(format!(
+                        "pgenlib read_alleles_range({lo}, {hi}) failed: {e}"
+                    ))
+                })?;
+            Ok(())
+        })?;
+        self.var_next = hi;
+        self.filled = hi - lo;
+        self.row = 0;
+        Ok(self.filled)
+    }
+}
+
+impl RecordSource for PgenRecordSource {
+    fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError> {
+        if self.row == self.filled && self.refill()? == 0 {
+            return Ok(None);
+        }
+
+        // .pvar and .pgen advance in lockstep -- one metadata row per genotype row.
+        let Some(meta) = self.pvar.next_variant()? else {
+            return Err(ConversionError::Input(
+                "pvar ran out of variants before the .pgen did; \
+                 the .pvar and .pgen disagree on variant count"
+                    .to_string(),
+            ));
+        };
+
+        let columns = 2 * self.num_samples;
+        let mut gt = vec![-1i32; columns];
+        Python::attach(|py| {
+            let arr = self.buf.bind(py).readonly();
+            let flat = arr.as_slice().expect("pgen buffer is C-contiguous");
+            let base = self.row * columns;
+            for (c, out) in gt.iter_mut().enumerate() {
+                // pgenlib encodes missing as -9; the conversion spine uses -1.
+                let code = flat[base + c];
+                *out = if code < 0 { -1 } else { code };
+            }
+        });
+        self.row += 1;
+
+        Ok(Some(RawRecord {
+            pos: meta.pos,
+            reference: meta.reference,
+            alts: meta.alts,
+            gt,
+            // PGEN has no FORMAT, and .pvar INFO extraction is out of scope for v1.
+            info_raw: Vec::new(),
+            format_raw: Vec::new(),
+        }))
+    }
+}

--- a/src/pvar.rs
+++ b/src/pvar.rs
@@ -1,0 +1,265 @@
+//! Streaming `.pvar` / `.pvar.zst` variant-metadata reader for the PGEN record
+//! source. PGEN stores genotypes only; POS/REF/ALT live in the sibling `.pvar`.
+//!
+//! Written against the PLINK2 `.pvar` text format (a VCF-like TSV). Contains no
+//! plink-ng code.
+//!
+//! `.bim` is intentionally unsupported: it only accompanies a PLINK1 `.bed`,
+//! which SVAR2 does not read.
+
+use crate::error::ConversionError;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+/// One `.pvar` row, reduced to what the conversion spine needs.
+pub struct PvarRecord {
+    /// 0-based start position (`.pvar` POS is 1-based on disk).
+    pub pos: u32,
+    pub reference: Vec<u8>,
+    /// ALT alleles, comma-split. ALT1 is `alts[0]`.
+    pub alts: Vec<Vec<u8>>,
+}
+
+pub struct PvarReader {
+    lines: Box<dyn BufRead + Send>,
+    path: String,
+    pos_col: usize,
+    ref_col: usize,
+    alt_col: usize,
+    /// Global variant index of the next row to be returned. Only used for error
+    /// messages; the caller tracks its own range.
+    vidx: usize,
+    buf: String,
+}
+
+// Manual impl: `lines` is `Box<dyn BufRead + Send>`, which has no `Debug` impl,
+// so `#[derive(Debug)]` isn't available. `Result::unwrap_err` (used in tests)
+// requires the `Ok` type to be `Debug`.
+impl std::fmt::Debug for PvarReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PvarReader")
+            .field("path", &self.path)
+            .field("pos_col", &self.pos_col)
+            .field("ref_col", &self.ref_col)
+            .field("alt_col", &self.alt_col)
+            .field("vidx", &self.vidx)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PvarReader {
+    /// Open `path` (`.pvar` or `.pvar.zst`), consume the header, and skip forward
+    /// to variant index `var_start` (0-based, counting data rows only).
+    pub fn open(path: &str, var_start: usize) -> Result<Self, ConversionError> {
+        if !std::path::Path::new(path).exists() {
+            return Err(ConversionError::MissingFile {
+                path: path.to_string(),
+            });
+        }
+        let file = File::open(path).map_err(|e| ConversionError::Io {
+            context: format!("opening pvar {path}"),
+            source: e,
+        })?;
+        let lines: Box<dyn BufRead + Send> = if path.ends_with(".zst") {
+            let dec = zstd::stream::read::Decoder::new(file).map_err(|e| ConversionError::Io {
+                context: format!("opening zstd stream for {path}"),
+                source: e,
+            })?;
+            Box::new(BufReader::new(dec))
+        } else {
+            Box::new(BufReader::new(file))
+        };
+
+        let mut me = Self {
+            lines,
+            path: path.to_string(),
+            pos_col: 0,
+            ref_col: 0,
+            alt_col: 0,
+            vidx: 0,
+            buf: String::new(),
+        };
+
+        // Header: skip `##` meta lines, then require the `#CHROM ...` column line.
+        // plink2 --make-pgen always writes one; a headerless .pvar is rejected
+        // rather than guessed at.
+        loop {
+            me.buf.clear();
+            let n = me.read_line()?;
+            if n == 0 {
+                return Err(ConversionError::Input(format!(
+                    "{path}: reached EOF without a '#CHROM' header line"
+                )));
+            }
+            if me.buf.starts_with("##") {
+                continue;
+            }
+            if !me.buf.starts_with("#CHROM") {
+                return Err(ConversionError::Input(format!(
+                    "{path}: expected a '#CHROM' header line, found '{}'. \
+                     Headerless .pvar files are not supported.",
+                    me.buf.trim_end()
+                )));
+            }
+            let cols: Vec<&str> = me.buf.trim_end().split('\t').collect();
+            let find = |name: &str| -> Result<usize, ConversionError> {
+                cols.iter().position(|c| *c == name).ok_or_else(|| {
+                    ConversionError::Input(format!("{path}: header is missing a '{name}' column"))
+                })
+            };
+            me.pos_col = find("POS")?;
+            me.ref_col = find("REF")?;
+            me.alt_col = find("ALT")?;
+            break;
+        }
+
+        for _ in 0..var_start {
+            me.buf.clear();
+            if me.read_line()? == 0 {
+                return Err(ConversionError::Input(format!(
+                    "{path}: ran out of variants while skipping to index {var_start}"
+                )));
+            }
+            me.vidx += 1;
+        }
+        Ok(me)
+    }
+
+    fn read_line(&mut self) -> Result<usize, ConversionError> {
+        self.lines
+            .read_line(&mut self.buf)
+            .map_err(|e| ConversionError::Io {
+                context: format!("reading pvar {}", self.path),
+                source: e,
+            })
+    }
+
+    /// Next variant, or `None` at EOF.
+    pub fn next_variant(&mut self) -> Result<Option<PvarRecord>, ConversionError> {
+        self.buf.clear();
+        if self.read_line()? == 0 {
+            return Ok(None);
+        }
+        let line = self.buf.trim_end_matches(['\n', '\r']);
+        let cols: Vec<&str> = line.split('\t').collect();
+        let want = self.pos_col.max(self.ref_col).max(self.alt_col);
+        if cols.len() <= want {
+            return Err(ConversionError::Input(format!(
+                "{}: variant {} has {} columns, need at least {}",
+                self.path,
+                self.vidx,
+                cols.len(),
+                want + 1
+            )));
+        }
+
+        let pos_1based: u32 = cols[self.pos_col].parse().map_err(|_| {
+            ConversionError::Input(format!(
+                "{}: variant {} has a non-integer POS '{}'",
+                self.path, self.vidx, cols[self.pos_col]
+            ))
+        })?;
+        if pos_1based == 0 {
+            return Err(ConversionError::Input(format!(
+                "{}: variant {} has POS 0; .pvar POS is 1-based",
+                self.path, self.vidx
+            )));
+        }
+
+        let mut reference = cols[self.ref_col].as_bytes().to_vec();
+        reference.make_ascii_uppercase();
+        let alts: Vec<Vec<u8>> = cols[self.alt_col]
+            .split(',')
+            .map(|a| {
+                let mut v = a.as_bytes().to_vec();
+                v.make_ascii_uppercase();
+                v
+            })
+            .collect();
+
+        self.vidx += 1;
+        Ok(Some(PvarRecord {
+            pos: pos_1based - 1,
+            reference,
+            alts,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, body: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = std::fs::File::create(dir.path().join(name)).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        dir
+    }
+
+    const BODY: &str = "\
+##fileformat=PVARv1.0
+#CHROM\tPOS\tID\tREF\tALT
+chr1\t3\t.\tA\tG
+chr1\t7\t.\tC\tCAT
+chr1\t12\t.\tGTA\tG,GT
+";
+
+    #[test]
+    fn reads_pos_ref_alts_zero_based() {
+        let dir = write_tmp("x.pvar", BODY);
+        let p = dir.path().join("x.pvar");
+        let mut r = PvarReader::open(p.to_str().unwrap(), 0).unwrap();
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 2); // 1-based 3 -> 0-based 2
+        assert_eq!(v.reference, b"A");
+        assert_eq!(v.alts, vec![b"G".to_vec()]);
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 6);
+        assert_eq!(v.alts, vec![b"CAT".to_vec()]);
+
+        // Multiallelic ALT is comma-separated.
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 11);
+        assert_eq!(v.reference, b"GTA");
+        assert_eq!(v.alts, vec![b"G".to_vec(), b"GT".to_vec()]);
+
+        assert!(r.next_variant().unwrap().is_none());
+    }
+
+    #[test]
+    fn var_start_skips_leading_variants() {
+        let dir = write_tmp("x.pvar", BODY);
+        let p = dir.path().join("x.pvar");
+        let mut r = PvarReader::open(p.to_str().unwrap(), 2).unwrap();
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 11);
+        assert!(r.next_variant().unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_header_line_is_an_error() {
+        let dir = write_tmp("x.pvar", "chr1\t3\t.\tA\tG\n");
+        let p = dir.path().join("x.pvar");
+        let err = PvarReader::open(p.to_str().unwrap(), 0).unwrap_err();
+        assert!(format!("{err}").contains("#CHROM"));
+    }
+
+    #[test]
+    fn reads_zstd_compressed_pvar() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("x.pvar.zst");
+        let f = std::fs::File::create(&p).unwrap();
+        let mut enc = zstd::stream::write::Encoder::new(f, 3).unwrap();
+        enc.write_all(BODY.as_bytes()).unwrap();
+        enc.finish().unwrap();
+
+        let mut r = PvarReader::open(p.to_str().unwrap(), 0).unwrap();
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 2);
+        assert_eq!(v.reference, b"A");
+    }
+}

--- a/src/pvar.rs
+++ b/src/pvar.rs
@@ -16,7 +16,9 @@ pub struct PvarRecord {
     /// 0-based start position (`.pvar` POS is 1-based on disk).
     pub pos: u32,
     pub reference: Vec<u8>,
-    /// ALT alleles, comma-split. ALT1 is `alts[0]`.
+    /// ALT alleles, comma-split. ALT1 is `alts[0]`. Empty when the `.pvar` ALT
+    /// field is the bare `.` sentinel -- plink2's spelling of "no alternate
+    /// allele" for a monomorphic site (all samples are REF).
     pub alts: Vec<Vec<u8>>,
 }
 
@@ -168,14 +170,23 @@ impl PvarReader {
 
         let mut reference = cols[self.ref_col].as_bytes().to_vec();
         reference.make_ascii_uppercase();
-        let alts: Vec<Vec<u8>> = cols[self.alt_col]
-            .split(',')
-            .map(|a| {
-                let mut v = a.as_bytes().to_vec();
-                v.make_ascii_uppercase();
-                v
-            })
-            .collect();
+        // A bare `.` ALT means "no alternate allele" (monomorphic site), not a
+        // one-character allele literally spelled ".". Only the exact field
+        // value `.` is the sentinel -- a real allele can never contain a
+        // comma, so this can't misfire on a multiallelic ALT.
+        let alt_field = cols[self.alt_col];
+        let alts: Vec<Vec<u8>> = if alt_field == "." {
+            Vec::new()
+        } else {
+            alt_field
+                .split(',')
+                .map(|a| {
+                    let mut v = a.as_bytes().to_vec();
+                    v.make_ascii_uppercase();
+                    v
+                })
+                .collect()
+        };
 
         self.vidx += 1;
         Ok(Some(PvarRecord {
@@ -226,6 +237,44 @@ chr1\t12\t.\tGTA\tG,GT
         assert_eq!(v.pos, 11);
         assert_eq!(v.reference, b"GTA");
         assert_eq!(v.alts, vec![b"G".to_vec(), b"GT".to_vec()]);
+
+        assert!(r.next_variant().unwrap().is_none());
+    }
+
+    const BODY_WITH_MONO: &str = "\
+##fileformat=PVARv1.0
+#CHROM\tPOS\tID\tREF\tALT
+chr1\t3\t.\tA\tG
+chr1\t5\t.\tC\t.
+chr1\t7\t.\tC\tCAT
+";
+
+    #[test]
+    fn dot_alt_is_monomorphic_zero_alts() {
+        // plink2 emits a bare `.` ALT for a monomorphic site (REF present, no
+        // ALT observed). It must decode to zero alts, not the literal string
+        // ".", and must not disturb the rows around it.
+        let dir = write_tmp("mono.pvar", BODY_WITH_MONO);
+        let p = dir.path().join("mono.pvar");
+        let mut r = PvarReader::open(p.to_str().unwrap(), 0).unwrap();
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 2); // 1-based 3 -> 0-based 2
+        assert_eq!(v.reference, b"A");
+        assert_eq!(v.alts, vec![b"G".to_vec()]);
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 4); // 1-based 5 -> 0-based 4
+        assert_eq!(v.reference, b"C");
+        assert!(
+            v.alts.is_empty(),
+            "ALT '.' must decode to an empty alt list"
+        );
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 6);
+        assert_eq!(v.reference, b"C");
+        assert_eq!(v.alts, vec![b"CAT".to_vec()]);
 
         assert!(r.next_variant().unwrap().is_none());
     }

--- a/src/record_source.rs
+++ b/src/record_source.rs
@@ -1,0 +1,38 @@
+//! The seam between "where variant records come from" (VCF via htslib, PGEN via
+//! pgenlib) and the source-agnostic conversion spine (`chunk_assembler`).
+//!
+//! `RawRecord` is deliberately OWNED rather than borrowed: the assembler mutates
+//! its heap while consuming a record, and the VCF path already allocates every one
+//! of these fields per record anyway, so owning costs nothing.
+
+use crate::error::ConversionError;
+
+/// One variant record, decoded to the minimum the conversion spine needs.
+pub struct RawRecord {
+    /// 0-based start position (VCF/pvar POS minus 1).
+    pub pos: u32,
+    /// REF allele bases, uppercase ASCII.
+    pub reference: Vec<u8>,
+    /// ALT alleles in file order. ALT1 is `alts[0]`; note `PendingAtom::
+    /// source_alt_index` is 1-based (ALT1 => 1), matching BCF GT allele codes.
+    pub alts: Vec<Vec<u8>>,
+    /// Allele index per haplotype column, length `num_samples * ploidy`,
+    /// sample-major then ploidy-minor. `0` = REF, `k` = ALT k, `-1` = missing.
+    pub gt: Vec<i32>,
+    /// Raw INFO buffers, widened to f64, one entry per requested INFO `FieldSpec`
+    /// in spec order. `None` = the field is absent from this record. Empty when no
+    /// INFO fields were requested.
+    pub info_raw: Vec<Option<Vec<f64>>>,
+    /// Raw FORMAT buffers, widened to f64: outer index = requested FORMAT
+    /// `FieldSpec` in spec order, inner index = **selected** sample
+    /// (`0..num_samples`, already remapped from the source's own sample order).
+    /// Outer `None` = the field is absent from this record for all samples. Empty
+    /// when no FORMAT fields were requested.
+    pub format_raw: Vec<Option<Vec<Vec<f64>>>>,
+}
+
+/// A cursor over one contig's variant records, in file order.
+pub trait RecordSource {
+    /// Next record, or `None` at end of contig.
+    fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError>;
+}

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -1,190 +1,9 @@
 use crate::error::ConversionError;
 use crate::field::{FieldCategory, FieldSpec, HtslibType};
-use crate::normalize::atomize_record;
-use crate::types::{BitGrid3, DenseChunk, StagedColumn};
-use rayon::prelude::*;
+use crate::record_source::{RawRecord, RecordSource};
 use rust_htslib::bcf::record::Record;
 use rust_htslib::bcf::{IndexedReader, Read};
 use rust_htslib::errors::Error as HtslibError;
-use std::cmp::Reverse;
-use std::collections::BinaryHeap;
-use std::sync::Arc;
-
-// A decomposed atom awaiting emission. Carries a shared handle to its source record's
-// per-column allele indices so genotype presence is computed at chunk-build time.
-struct PendingAtom {
-    pos: u32,
-    ilen: i32,
-    alt: Vec<u8>,
-    source_alt_index: u16,
-    gt: Arc<Vec<i32>>, // len = num_samples * ploidy; allele index per column (-1 = missing)
-    seq: u64,          // stable tiebreak for equal positions
-
-    // Resolved field values for THIS atom (already indexed by source_alt_index
-    // where the underlying VCF field is Number=A). Populated in
-    // `decompose_current_record`, gathered into `DenseChunk::{info,format}_staged`
-    // in `read_next_chunk`'s sequential metadata pass. Empty when no fields of
-    // that category were requested.
-    info_vals: Vec<f64>,   // len == VcfChunkReader::info_fields.len()
-    format_vals: Vec<f64>, // len == VcfChunkReader::format_fields.len() * num_samples, field-major then sample: field*num_samples + sample
-}
-
-impl PartialEq for PendingAtom {
-    fn eq(&self, other: &Self) -> bool {
-        self.pos == other.pos && self.seq == other.seq
-    }
-}
-impl Eq for PendingAtom {}
-impl PartialOrd for PendingAtom {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-impl Ord for PendingAtom {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.pos.cmp(&other.pos).then(self.seq.cmp(&other.seq))
-    }
-}
-
-// Pack variant row `vi`'s presence bits into `words`, where `words[0]` corresponds
-// to global word index `word_base`. Bit for (row vi, column col) lives at global
-// flat index `vi*columns + col`; the local word index subtracts `word_base`.
-// Presence is `gt[col] == source_alt_index`. Bits start zeroed and are only OR-set,
-// and each word is assembled in a register and written once (identical result to a
-// per-bit `or_bit` loop, far fewer stores).
-#[inline]
-fn pack_row(words: &mut [u64], word_base: usize, vi: usize, a: &PendingAtom, columns: usize) {
-    let src = a.source_alt_index as i32;
-    let gtc: &[i32] = &a.gt;
-    let base = vi * columns;
-    let mut col = 0usize;
-    while col < columns {
-        let flat = base + col;
-        let w = (flat >> 6) - word_base;
-        let b = flat & 63;
-        let n = (64 - b).min(columns - col);
-        let mut acc = 0u64;
-        for k in 0..n {
-            // SAFETY: col + k < columns == gtc.len().
-            acc |= ((unsafe { *gtc.get_unchecked(col + k) } == src) as u64) << (b + k);
-        }
-        // SAFETY: w indexes a word within this row's target slice.
-        unsafe {
-            *words.get_unchecked_mut(w) |= acc;
-        }
-        col += n;
-    }
-}
-
-// Sequential full-grid presence packing: one row at a time into the whole `words`
-// slice (global word index == local word index, so `word_base == 0`).
-fn pack_presence_seq(words: &mut [u64], atoms: &[PendingAtom], columns: usize) {
-    for (vi, a) in atoms.iter().enumerate() {
-        pack_row(words, 0, vi, a, columns);
-    }
-}
-
-// Below this many variants in a chunk, parallel packing's per-task overhead
-// outweighs the win — pack sequentially instead. Tunable; measure on gdc/germline.
-const PARALLEL_MIN_VARIANTS: usize = 512;
-
-#[inline]
-fn gcd(mut a: usize, mut b: usize) -> usize {
-    while b != 0 {
-        let t = a % b;
-        a = b;
-        b = t;
-    }
-    a
-}
-
-// Parallel presence packing. Variants are partitioned into word-aligned blocks:
-// row `vi` occupies bits `[vi*columns, (vi+1)*columns)`, so a block boundary at a
-// multiple of `g = 64/gcd(columns,64)` variants lands exactly on a u64 boundary.
-// `par_chunks_mut(words_per_block)` hands each rayon task a word-DISJOINT slice, so
-// there are no shared boundary words and no atomics — the result is bit-identical to
-// `pack_presence_seq`. Block `c` covers variants `[c*g, min((c+1)*g, v))` and words
-// `[c*words_per_block, ...)`, whose global base is `word_base = c*words_per_block`.
-fn pack_presence_par(
-    words: &mut [u64],
-    atoms: &[PendingAtom],
-    columns: usize,
-    pool: &rayon::ThreadPool,
-) {
-    let d = gcd(columns, 64);
-    let g = 64 / d; // variants per word-aligned block
-    let words_per_block = columns / d; // == g * columns / 64, always an integer
-    let v = atoms.len();
-
-    pool.install(|| {
-        words
-            .par_chunks_mut(words_per_block)
-            .enumerate()
-            .for_each(|(c, wchunk)| {
-                let vi_start = c * g;
-                let vi_end = ((c + 1) * g).min(v);
-                let word_base = c * words_per_block;
-                // `vi` is dual-purpose here: it's both the `atoms` index and the row
-                // index `pack_row` needs to compute the flat bit offset, so it can't
-                // be replaced by a plain iterator/enumerate.
-                #[allow(clippy::needless_range_loop)]
-                for vi in vi_start..vi_end {
-                    pack_row(wchunk, word_base, vi, &atoms[vi], columns);
-                }
-            });
-    });
-}
-
-// Delegates to `FieldSpec::missing_sentinel` — single source of truth shared
-// with `dense2sparse_vk`'s genotype-aligned non-carrier fill (src/rvk.rs).
-fn sentinel_default(spec: &FieldSpec) -> f64 {
-    spec.missing_sentinel()
-}
-
-// htslib missing-value detection on an already-widened f64: floats use NaN
-// (covers both htslib's MISSING and VECTOR_END float encodings, which are
-// distinct NaN bit patterns); ints use MISSING (i32::MIN) or VECTOR_END
-// (i32::MIN + 1) — the round-trip through f64 is exact for both since they're
-// in i32 range.
-fn is_htslib_missing(raw_val: f64, is_float: bool) -> bool {
-    if is_float {
-        raw_val.is_nan()
-    } else {
-        let iv = raw_val as i32;
-        iv == i32::MIN || iv == i32::MIN + 1
-    }
-}
-
-// Resolve one atom's value from a record-level raw buffer (already widened to
-// f64): `None` (field absent from the record/sample) or an out-of-range
-// Number=A index falls back to the spec's sentinel/default; a length-1 buffer
-// is a Number=1 scalar, otherwise indexed by `source_alt_index - 1` (Number=A):
-// `source_alt_index` is 1-based (ALT1 → 1, matching BCF GT allele codes; see
-// `normalize::atomize_record`), but htslib's Number=A buffer is 0-based
-// per-ALT (ALT1's value lives at `vals[0]`).
-fn resolve_scalar(vals: Option<&[f64]>, source_alt_index: u16, spec: &FieldSpec) -> f64 {
-    let default_val = sentinel_default(spec);
-    let Some(vals) = vals else {
-        return default_val;
-    };
-    if vals.is_empty() {
-        return default_val;
-    }
-    let raw_val = if vals.len() == 1 {
-        vals[0]
-    } else {
-        // source_alt_index is 1-based; htslib Number=A buffers are 0-based per-ALT.
-        match vals.get(source_alt_index.saturating_sub(1) as usize) {
-            Some(&v) => v,
-            None => return default_val,
-        }
-    };
-    if is_htslib_missing(raw_val, spec.stage_is_float()) {
-        default_val
-    } else {
-        raw_val
-    }
-}
 
 // Decode one INFO field for the CURRENT record, once. `Ok(None)` means the
 // field is absent from this record (a normal, expected occurrence — NOT an
@@ -260,102 +79,9 @@ fn decode_format_raw(
     }
 }
 
-// An atom whose presence bits are already packed into the chunk's BitGrid. `gt`
-// and `source_alt_index` are dropped at that point, so per-chunk staging memory
-// no longer scales with `chunk_size * num_samples * ploidy`.
-struct AtomMeta {
-    pos: u32,
-    ilen: i32,
-    alt: Vec<u8>,
-    info_vals: Vec<f64>,
-    format_vals: Vec<f64>,
-}
-
-// Atoms buffered before their presence bits are flushed into the chunk's BitGrid.
-// Rounded UP to a multiple of the word-aligned block size `g = 64/gcd(columns,64)`
-// at call time, so every flush offset lands on a u64 boundary and
-// `pack_presence_par` keeps its word-disjoint invariant. 1024 keeps the window
-// above `PARALLEL_MIN_VARIANTS` (512) so parallel packing still engages.
-const PACK_WINDOW: usize = 1024;
-
-// Pack `buf`'s presence bits into `genos` starting at variant offset `v0`, then
-// move each atom's metadata into `metas`, dropping `gt`.
-//
-// `v0` MUST be a multiple of the word-aligned block size, so `v0 * columns` is a
-// multiple of 64 and the window owns a whole-word-aligned sub-slice of
-// `genos.words`. Only the FINAL window may have a length that is not a multiple of
-// that block size (its trailing partial word is not shared, because nothing is
-// packed after it).
-fn flush_window(
-    genos: &mut BitGrid3,
-    metas: &mut Vec<AtomMeta>,
-    buf: &mut Vec<PendingAtom>,
-    v0: usize,
-    columns: usize,
-    pool: Option<&rayon::ThreadPool>,
-) {
-    if buf.is_empty() {
-        return;
-    }
-    debug_assert_eq!((v0 * columns) % 64, 0, "flush offset must be word-aligned");
-    let word_base = (v0 * columns) / 64;
-    let n_words = (buf.len() * columns).div_ceil(64);
-    let words = &mut genos.words[word_base..word_base + n_words];
-
-    let parallel = matches!(pool, Some(p) if p.current_num_threads() >= 2)
-        && buf.len() >= PARALLEL_MIN_VARIANTS;
-    if parallel {
-        pack_presence_par(words, buf, columns, pool.unwrap());
-    } else {
-        pack_presence_seq(words, buf, columns);
-    }
-
-    metas.reserve(buf.len());
-    for a in buf.drain(..) {
-        metas.push(AtomMeta {
-            pos: a.pos,
-            ilen: a.ilen,
-            alt: a.alt,
-            info_vals: a.info_vals,
-            format_vals: a.format_vals,
-        });
-    }
-}
-
-pub struct VcfChunkReader {
-    inner_reader: IndexedReader,
-    num_samples: usize,
-    ploidy: usize,
-    sample_indices: Vec<usize>,
-    // full 0-based contig sequence, uppercased. Consumed by `validate_ref`/`left_align`
-    // in `decompose_current_record`.
-    ref_seq: Vec<u8>,
-    // Whether a reference FASTA was provided. When false, `validate_ref` and
-    // `left_align` are skipped and the input is trusted to be pre-normalized.
-    has_reference: bool,
-    // Whether to skip (vs. error on) out-of-scope symbolic/breakend ALTs.
-    skip_out_of_scope: bool,
-    // Running count of out-of-scope ALTs dropped across this contig.
-    dropped_out_of_scope: u64,
-
-    // Requested field specs, partitioned by category (order preserved within
-    // each partition). Index i into `info_fields`/`format_fields` matches
-    // index i into `PendingAtom::info_vals`/`format_vals` and
-    // `DenseChunk::info_staged`/`format_staged`.
-    info_fields: Vec<FieldSpec>,
-    format_fields: Vec<FieldSpec>,
-
-    // Reorder state, persisted across read_next_chunk calls.
-    record: Record,
-    heap: BinaryHeap<Reverse<PendingAtom>>,
-    frontier: u32, // start pos of the most recently read record: all future atoms have pos >= this
-    eof: bool,
-    next_seq: u64,
-}
-
 /// Load `chrom`'s full sequence from the FASTA at `fasta_path`, uppercased to
 /// ASCII (matching the classifiers'/normalizer's expectation). Shared by
-/// `VcfChunkReader::new` (validate_ref/left_align) and the orchestrator's
+/// `ChunkAssembler::new` (validate_ref/left_align) and the orchestrator's
 /// write-time `signatures` annotation — keep both call sites byte-identical.
 pub(crate) fn load_contig_seq(fasta_path: &str, chrom: &str) -> Result<Vec<u8>, ConversionError> {
     // A wrong reference path reaches Rust unchecked (Python does not validate
@@ -393,17 +119,25 @@ pub(crate) fn load_contig_seq(fasta_path: &str, chrom: &str) -> Result<Vec<u8>, 
     Ok(ref_seq)
 }
 
-impl VcfChunkReader {
+pub struct VcfRecordSource {
+    inner_reader: IndexedReader,
+    num_samples: usize,
+    ploidy: usize,
+    sample_indices: Vec<usize>,
+    info_fields: Vec<FieldSpec>,
+    format_fields: Vec<FieldSpec>,
+    record: Record,
+    eof: bool,
+}
+
+impl VcfRecordSource {
     // opens the file, applies the sample filter at the C-level, and jumps to the chromosome.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         vcf_path: &str,
-        fasta_path: Option<&str>,
         chrom: &str,
         samples: &[&str],
         htslib_threads: usize,
         ploidy: usize,
-        skip_out_of_scope: bool,
         fields: &[FieldSpec],
     ) -> Result<Self, ConversionError> {
         // A wrong VCF path reaches Rust when the file was removed after Python's
@@ -450,13 +184,6 @@ impl VcfChunkReader {
             })
             .collect::<Result<_, _>>()?;
 
-        // Reference is optional. With a FASTA, cache the full uppercased contig for
-        // validate_ref/left_align; without one, leave it empty and skip both.
-        let (ref_seq, has_reference) = match fasta_path {
-            Some(path) => (load_contig_seq(path, chrom)?, true),
-            None => (Vec::new(), false),
-        };
-
         let record = reader.empty_record();
 
         let info_fields: Vec<FieldSpec> = fields
@@ -475,51 +202,53 @@ impl VcfChunkReader {
             num_samples: samples.len(),
             ploidy,
             sample_indices,
-            ref_seq,
-            has_reference,
-            skip_out_of_scope,
-            dropped_out_of_scope: 0,
             info_fields,
             format_fields,
             record,
-            heap: BinaryHeap::new(),
-            frontier: 0,
             eof: false,
-            next_seq: 0,
         })
     }
+}
 
-    /// Total out-of-scope ALTs dropped so far (valid after the read loop drains).
-    pub fn dropped_out_of_scope(&self) -> u64 {
-        self.dropped_out_of_scope
-    }
-
-    // Decompose `self.record` into atoms and push them onto the reorder heap, sharing
-    // one decoded genotype vector across all atoms of the record.
-    fn decompose_current_record(&mut self) -> Result<(), ConversionError> {
-        let pos = self.record.pos() as u32;
-
-        // Own the alleles so the record borrow is released before we mutate self.
-        let ref_allele: Vec<u8>;
-        let alts_owned: Vec<Vec<u8>>;
-        {
-            let alleles = self.record.alleles();
-            ref_allele = alleles[0].to_vec();
-            alts_owned = alleles[1..].iter().map(|a| a.to_vec()).collect();
+impl RecordSource for VcfRecordSource {
+    fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError> {
+        if self.eof {
+            return Ok(None);
+        }
+        match self.inner_reader.read(&mut self.record) {
+            None => {
+                self.eof = true;
+                return Ok(None);
+            }
+            Some(Err(e)) => {
+                return Err(ConversionError::Io {
+                    context: "reading next VCF record".to_string(),
+                    source: std::io::Error::other(e.to_string()),
+                });
+            }
+            Some(Ok(())) => {}
         }
 
-        // Decode per-column allele indices (-1 = missing).
+        let pos = self.record.pos() as u32;
+
+        let reference: Vec<u8>;
+        let alts: Vec<Vec<u8>>;
+        {
+            let alleles = self.record.alleles();
+            reference = alleles[0].to_vec();
+            alts = alleles[1..].iter().map(|a| a.to_vec()).collect();
+        }
+
+        // Decode GT straight from the raw BCF integer buffer instead of
+        // `record.genotypes().get(i)`, which allocates a per-sample
+        // `Genotype(Vec<GenotypeAllele>)` for every sample of every record -- the
+        // dominant reader-side allocation churn. BCF GT encoding: an allele is
+        // `(idx + 1) << 1 | phased`, so `e >= 2` decodes to `(e >> 1) - 1`; `e` of
+        // 0/1 is missing and `i32::MIN` is vector-end padding -- both `< 2`, so a
+        // single `e >= 2` test reproduces `GenotypeAllele::index()` exactly.
         let columns = self.num_samples * self.ploidy;
         let mut gt = vec![-1i32; columns];
         {
-            // Decode GT straight from the raw BCF integer buffer instead of
-            // `record.genotypes().get(i)`, which allocates a per-sample
-            // `Genotype(Vec<GenotypeAllele>)` for every sample of every record —
-            // the dominant reader-side allocation churn. BCF GT encoding: an
-            // allele is `(idx + 1) << 1 | phased`, so `e >= 2` decodes to
-            // `(e >> 1) - 1`; `e` of 0/1 is missing and `i32::MIN` is vector-end
-            // padding — both `< 2`, so a single `e >= 2` test reproduces the
-            // `GenotypeAllele::index()` semantics exactly.
             let gts = self.record.format(b"GT").integer().map_err(|e| {
                 ConversionError::Input(format!("Failed to read GT format at pos {pos}: {e}"))
             })?;
@@ -535,349 +264,37 @@ impl VcfChunkReader {
                 }
             }
         }
-        let gt = Arc::new(gt);
 
-        // Fail fast only when a reference is available; without one we trust the
-        // input is already normalized/left-aligned.
-        if self.has_reference {
-            crate::normalize::validate_ref(pos, &ref_allele, &self.ref_seq)?;
-        }
-
-        let alt_refs: Vec<&[u8]> = alts_owned.iter().map(|a| a.as_slice()).collect();
-        let mut atoms = Vec::new();
-        let dropped = atomize_record(
-            pos,
-            &ref_allele,
-            &alt_refs,
-            &mut atoms,
-            self.skip_out_of_scope,
-        )?;
-        self.dropped_out_of_scope += dropped as u64;
-
-        // Decode each requested field's raw buffer ONCE for this record (position-
-        // independent of atomize_record's per-ALT split); per-atom resolution below
-        // only differs in which `source_alt_index` a Number=A buffer is indexed by.
         let info_raw: Vec<Option<Vec<f64>>> = self
             .info_fields
             .iter()
             .map(|spec| decode_info_raw(&self.record, spec))
             .collect::<Result<_, _>>()?;
+
+        // Remap htslib's header-sample-indexed FORMAT buffers into SELECTED-sample
+        // order, so the assembler never needs to know about `sample_indices`.
         let format_raw: Vec<Option<Vec<Vec<f64>>>> = self
             .format_fields
             .iter()
-            .map(|spec| decode_format_raw(&self.record, spec))
+            .map(|spec| {
+                decode_format_raw(&self.record, spec).map(|opt| {
+                    opt.map(|per_header_sample| {
+                        self.sample_indices
+                            .iter()
+                            .map(|&vcf_idx| per_header_sample[vcf_idx].clone())
+                            .collect()
+                    })
+                })
+            })
             .collect::<Result<_, _>>()?;
 
-        for atom in atoms {
-            // Left-align only when a reference is available; otherwise store the atom
-            // at its as-given (right-trimmed) position.
-            let atom = if self.has_reference {
-                crate::normalize::left_align(atom, &self.ref_seq, crate::normalize::L_MAX)
-            } else {
-                atom
-            };
-
-            let info_vals: Vec<f64> = self
-                .info_fields
-                .iter()
-                .zip(info_raw.iter())
-                .map(|(spec, raw)| resolve_scalar(raw.as_deref(), atom.source_alt_index, spec))
-                .collect();
-
-            let mut format_vals = Vec::with_capacity(self.format_fields.len() * self.num_samples);
-            for (spec, raw) in self.format_fields.iter().zip(format_raw.iter()) {
-                for &vcf_idx in &self.sample_indices {
-                    let sample_vals = raw.as_ref().map(|v| v[vcf_idx].as_slice());
-                    format_vals.push(resolve_scalar(sample_vals, atom.source_alt_index, spec));
-                }
-            }
-
-            let seq = self.next_seq;
-            self.next_seq += 1;
-            self.heap.push(Reverse(PendingAtom {
-                pos: atom.pos,
-                ilen: atom.ilen,
-                alt: atom.alt,
-                source_alt_index: atom.source_alt_index,
-                gt: Arc::clone(&gt),
-                seq,
-                info_vals,
-                format_vals,
-            }));
-        }
-        Ok(())
-    }
-
-    // Yield the next atom in global position order, reading and decomposing more
-    // records as needed. Left-alignment (M2b) can move an atom up to `L_MAX` bases below
-    // its record's start, so a future record at start `frontier` may still produce an atom
-    // as low as `frontier - L_MAX`. An atom is therefore safe to emit only once its
-    // position is strictly below `frontier - L_MAX` (saturating), or the input is
-    // exhausted — this preserves the position-sorted invariant the Phase-2 merge relies on.
-    //
-    // Memory note: the heap holds every atom with pos >= frontier - L_MAX until a later
-    // record advances the frontier past that window (or EOF). For coordinate-sorted input
-    // this is bounded by the atoms within an `L_MAX`-wide window of the frontier, plus
-    // atoms sharing a single start position — a run of many records all starting at the
-    // same pos never advances the frontier, so the heap can still grow unboundedly in
-    // that (pre-existing) pathological case.
-    fn next_atom(&mut self) -> Result<Option<PendingAtom>, ConversionError> {
-        loop {
-            if let Some(Reverse(top)) = self.heap.peek() {
-                if self.eof || top.pos < self.frontier.saturating_sub(crate::normalize::L_MAX) {
-                    return Ok(Some(self.heap.pop().unwrap().0));
-                }
-            } else if self.eof {
-                return Ok(None);
-            }
-
-            match self.inner_reader.read(&mut self.record) {
-                Some(Ok(())) => {
-                    self.frontier = self.record.pos() as u32;
-                    self.decompose_current_record()?;
-                }
-                Some(Err(e)) => {
-                    return Err(ConversionError::Io {
-                        context: "reading next VCF record".to_string(),
-                        source: std::io::Error::other(e.to_string()),
-                    });
-                }
-                None => self.eof = true,
-            }
-        }
-    }
-
-    // Pull up to `chunk_size` atoms (already globally position-sorted) and pack them
-    // into a variant-major DenseChunk. Presence bits are packed in windows of
-    // `PACK_WINDOW` atoms so the reader never holds more than one window's worth of
-    // per-column genotype vectors. `pool`, when present and the window is large
-    // enough, hosts parallel packing; otherwise packing is sequential. Output is
-    // bit-identical either way. Returns None once no atoms remain.
-    pub fn read_next_chunk(
-        &mut self,
-        chunk_size: usize,
-        chunk_id: usize,
-        pool: Option<&rayon::ThreadPool>,
-    ) -> Result<Option<DenseChunk>, ConversionError> {
-        let columns = self.num_samples * self.ploidy;
-        // Word-aligned block size: `g` variants span exactly `columns/gcd` u64 words.
-        let g = 64 / gcd(columns, 64);
-        let window = PACK_WINDOW.div_ceil(g) * g;
-
-        // Allocate for the full chunk up front (packed size: chunk_size*columns bits),
-        // then shrink to the true variant count after EOF.
-        let mut genos = BitGrid3::zeros(chunk_size, self.num_samples, self.ploidy);
-        let mut metas: Vec<AtomMeta> = Vec::with_capacity(chunk_size);
-        let mut buf: Vec<PendingAtom> = Vec::with_capacity(window);
-        let mut v = 0usize;
-
-        while v + buf.len() < chunk_size {
-            match self.next_atom()? {
-                Some(a) => {
-                    buf.push(a);
-                    if buf.len() == window {
-                        flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
-                        v += window;
-                    }
-                }
-                None => break,
-            }
-        }
-        if !buf.is_empty() {
-            let n = buf.len();
-            flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
-            v += n;
-        }
-
-        if v == 0 {
-            return Ok(None);
-        }
-        genos.truncate_v(v);
-
-        let num_samples = self.num_samples;
-        let mut pos = Vec::with_capacity(v);
-        let mut ilens = Vec::with_capacity(v);
-        let mut alt = Vec::with_capacity(v * 2);
-        let mut alt_offsets = Vec::with_capacity(v + 1);
-        alt_offsets.push(0u32);
-        let mut info_staged: Vec<StagedColumn> = self
-            .info_fields
-            .iter()
-            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v))
-            .collect();
-        let mut format_staged: Vec<StagedColumn> = self
-            .format_fields
-            .iter()
-            .map(|spec| StagedColumn::with_capacity(spec.stage_is_float(), v * num_samples))
-            .collect();
-
-        // Sequential metadata pass (cheap, ordering-preserving).
-        let mut off = 0u32;
-        for a in metas.iter() {
-            pos.push(a.pos);
-            ilens.push(a.ilen);
-            alt.extend_from_slice(&a.alt);
-            off += a.alt.len() as u32;
-            alt_offsets.push(off);
-
-            for (i, col) in info_staged.iter_mut().enumerate() {
-                col.push_f64(a.info_vals[i]);
-            }
-            for (j, col) in format_staged.iter_mut().enumerate() {
-                for s in 0..num_samples {
-                    col.push_f64(a.format_vals[j * num_samples + s]);
-                }
-            }
-        }
-
-        Ok(Some(DenseChunk {
-            chunk_id,
+        Ok(Some(RawRecord {
             pos,
-            ilens,
-            alt,
-            alt_offsets,
-            genos,
-            info_staged,
-            format_staged,
+            reference,
+            alts,
+            gt,
+            info_raw,
+            format_raw,
         }))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::prelude::*;
-    use std::sync::OnceLock;
-
-    // One shared 4-thread pool for all proptest cases (building a pool per case is slow).
-    fn test_pool() -> &'static rayon::ThreadPool {
-        static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
-        POOL.get_or_init(|| {
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(4)
-                .build()
-                .unwrap()
-        })
-    }
-
-    // Minimal PendingAtom carrying only the fields the packers read.
-    fn atom(gt: Vec<i32>, src: u16) -> PendingAtom {
-        PendingAtom {
-            pos: 0,
-            ilen: 0,
-            alt: Vec::new(),
-            source_alt_index: src,
-            gt: std::sync::Arc::new(gt),
-            seq: 0,
-            info_vals: Vec::new(),
-            format_vals: Vec::new(),
-        }
-    }
-
-    fn atom_at(gt: Vec<i32>, src: u16, pos: u32) -> PendingAtom {
-        PendingAtom {
-            pos,
-            ilen: 0,
-            alt: Vec::new(),
-            source_alt_index: src,
-            gt: std::sync::Arc::new(gt),
-            seq: pos as u64,
-            info_vals: Vec::new(),
-            format_vals: Vec::new(),
-        }
-    }
-
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(300))]
-
-        // Parallel packing reproduces sequential packing bit-for-bit, for arbitrary
-        // shapes (incl. v not a multiple of the word-aligned block size), allele
-        // indices (incl. missing -1 and out-of-range values), and source alts.
-        #[test]
-        fn test_par_packing_matches_seq(
-            num_samples in 1usize..40,
-            ploidy in 1usize..4,
-            v in 1usize..70,
-            seed in any::<u64>(),
-        ) {
-            let columns = num_samples * ploidy;
-            // xorshift64 for deterministic per-case gt/src patterns.
-            let mut state = seed | 1;
-            let mut next = || { state ^= state << 13; state ^= state >> 7; state ^= state << 17; state };
-
-            let mut atoms = Vec::with_capacity(v);
-            for _ in 0..v {
-                let src = (next() % 4) as u16; // small alt index space
-                let gt: Vec<i32> = (0..columns)
-                    .map(|_| match next() % 5 {
-                        0 => -1,            // missing
-                        1 => src as i32,    // present (matches src)
-                        2 => 7,             // out-of-range allele
-                        _ => (next() % 4) as i32,
-                    })
-                    .collect();
-                atoms.push(atom(gt, src));
-            }
-
-            let mut seq = BitGrid3::zeros(v, num_samples, ploidy);
-            pack_presence_seq(&mut seq.words, &atoms, columns);
-
-            let mut par = BitGrid3::zeros(v, num_samples, ploidy);
-            pack_presence_par(&mut par.words, &atoms, columns, test_pool());
-
-            prop_assert_eq!(seq.words, par.words, "columns={}, v={}", columns, v);
-        }
-    }
-
-    // Windowed packing must be bit-identical to packing the whole chunk at once.
-    // `flush_window` is only ever called at word-aligned variant offsets except
-    // for the final (partial) window, which nothing follows — mirror that here.
-    proptest! {
-        #[test]
-        fn windowed_pack_matches_full_pack(
-            n_samples in 1usize..9,
-            ploidy in 1usize..3,
-            srcs in prop::collection::vec(0u16..3u16, 1..200),
-        ) {
-            let columns = n_samples * ploidy;
-            let v = srcs.len();
-
-            // Deterministic gt: column c of variant i carries allele (i + c) % 3.
-            let atoms: Vec<PendingAtom> = srcs
-                .iter()
-                .enumerate()
-                .map(|(i, &src)| {
-                    let gt: Vec<i32> = (0..columns).map(|c| ((i + c) % 3) as i32).collect();
-                    atom_at(gt, src, i as u32)
-                })
-                .collect();
-
-            // Reference: one full-grid sequential pack.
-            let mut expect = BitGrid3::zeros(v, n_samples, ploidy);
-            pack_presence_seq(&mut expect.words, &atoms, columns);
-
-            // Windowed: flush every `window` atoms, where `window` is a multiple of
-            // the word-aligned block size `g`.
-            let g = 64 / gcd(columns, 64);
-            let window = 4 * g;
-            let mut got = BitGrid3::zeros(v, n_samples, ploidy);
-            let mut metas: Vec<AtomMeta> = Vec::new();
-            let mut buf: Vec<PendingAtom> = Vec::new();
-            let mut v0 = 0usize;
-            for a in atoms {
-                buf.push(a);
-                if buf.len() == window {
-                    let n = buf.len();
-                    flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
-                    v0 += n;
-                }
-            }
-            if !buf.is_empty() {
-                flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
-            }
-
-            prop_assert_eq!(got.words, expect.words);
-            prop_assert_eq!(metas.len(), v);
-        }
     }
 }

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -260,6 +260,68 @@ fn decode_format_raw(
     }
 }
 
+// An atom whose presence bits are already packed into the chunk's BitGrid. `gt`
+// and `source_alt_index` are dropped at that point, so per-chunk staging memory
+// no longer scales with `chunk_size * num_samples * ploidy`.
+struct AtomMeta {
+    pos: u32,
+    ilen: i32,
+    alt: Vec<u8>,
+    info_vals: Vec<f64>,
+    format_vals: Vec<f64>,
+}
+
+// Atoms buffered before their presence bits are flushed into the chunk's BitGrid.
+// Rounded UP to a multiple of the word-aligned block size `g = 64/gcd(columns,64)`
+// at call time, so every flush offset lands on a u64 boundary and
+// `pack_presence_par` keeps its word-disjoint invariant. 1024 keeps the window
+// above `PARALLEL_MIN_VARIANTS` (512) so parallel packing still engages.
+const PACK_WINDOW: usize = 1024;
+
+// Pack `buf`'s presence bits into `genos` starting at variant offset `v0`, then
+// move each atom's metadata into `metas`, dropping `gt`.
+//
+// `v0` MUST be a multiple of the word-aligned block size, so `v0 * columns` is a
+// multiple of 64 and the window owns a whole-word-aligned sub-slice of
+// `genos.words`. Only the FINAL window may have a length that is not a multiple of
+// that block size (its trailing partial word is not shared, because nothing is
+// packed after it).
+fn flush_window(
+    genos: &mut BitGrid3,
+    metas: &mut Vec<AtomMeta>,
+    buf: &mut Vec<PendingAtom>,
+    v0: usize,
+    columns: usize,
+    pool: Option<&rayon::ThreadPool>,
+) {
+    if buf.is_empty() {
+        return;
+    }
+    debug_assert_eq!((v0 * columns) % 64, 0, "flush offset must be word-aligned");
+    let word_base = (v0 * columns) / 64;
+    let n_words = (buf.len() * columns).div_ceil(64);
+    let words = &mut genos.words[word_base..word_base + n_words];
+
+    let parallel = matches!(pool, Some(p) if p.current_num_threads() >= 2)
+        && buf.len() >= PARALLEL_MIN_VARIANTS;
+    if parallel {
+        pack_presence_par(words, buf, columns, pool.unwrap());
+    } else {
+        pack_presence_seq(words, buf, columns);
+    }
+
+    metas.reserve(buf.len());
+    for a in buf.drain(..) {
+        metas.push(AtomMeta {
+            pos: a.pos,
+            ilen: a.ilen,
+            alt: a.alt,
+            info_vals: a.info_vals,
+            format_vals: a.format_vals,
+        });
+    }
+}
+
 pub struct VcfChunkReader {
     inner_reader: IndexedReader,
     num_samples: usize,
@@ -586,37 +648,58 @@ impl VcfChunkReader {
     }
 
     // Pull up to `chunk_size` atoms (already globally position-sorted) and pack them
-    // into a variant-major DenseChunk. `pool`, when present and the chunk is large
-    // enough, hosts parallel presence packing (word-aligned variant blocks);
-    // otherwise packing is sequential. Returns None once no atoms remain.
+    // into a variant-major DenseChunk. Presence bits are packed in windows of
+    // `PACK_WINDOW` atoms so the reader never holds more than one window's worth of
+    // per-column genotype vectors. `pool`, when present and the window is large
+    // enough, hosts parallel packing; otherwise packing is sequential. Output is
+    // bit-identical either way. Returns None once no atoms remain.
     pub fn read_next_chunk(
         &mut self,
         chunk_size: usize,
         chunk_id: usize,
         pool: Option<&rayon::ThreadPool>,
     ) -> Result<Option<DenseChunk>, ConversionError> {
-        let mut atoms: Vec<PendingAtom> = Vec::with_capacity(chunk_size);
-        while atoms.len() < chunk_size {
+        let columns = self.num_samples * self.ploidy;
+        // Word-aligned block size: `g` variants span exactly `columns/gcd` u64 words.
+        let g = 64 / gcd(columns, 64);
+        let window = PACK_WINDOW.div_ceil(g) * g;
+
+        // Allocate for the full chunk up front (packed size: chunk_size*columns bits),
+        // then shrink to the true variant count after EOF.
+        let mut genos = BitGrid3::zeros(chunk_size, self.num_samples, self.ploidy);
+        let mut metas: Vec<AtomMeta> = Vec::with_capacity(chunk_size);
+        let mut buf: Vec<PendingAtom> = Vec::with_capacity(window);
+        let mut v = 0usize;
+
+        while v + buf.len() < chunk_size {
             match self.next_atom()? {
-                Some(a) => atoms.push(a),
+                Some(a) => {
+                    buf.push(a);
+                    if buf.len() == window {
+                        flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
+                        v += window;
+                    }
+                }
                 None => break,
             }
         }
-        if atoms.is_empty() {
-            return Ok(None);
+        if !buf.is_empty() {
+            let n = buf.len();
+            flush_window(&mut genos, &mut metas, &mut buf, v, columns, pool);
+            v += n;
         }
 
-        let v = atoms.len();
-        let columns = self.num_samples * self.ploidy;
+        if v == 0 {
+            return Ok(None);
+        }
+        genos.truncate_v(v);
 
+        let num_samples = self.num_samples;
         let mut pos = Vec::with_capacity(v);
         let mut ilens = Vec::with_capacity(v);
         let mut alt = Vec::with_capacity(v * 2);
         let mut alt_offsets = Vec::with_capacity(v + 1);
         alt_offsets.push(0u32);
-        let mut genos = BitGrid3::zeros(v, self.num_samples, self.ploidy);
-
-        let num_samples = self.num_samples;
         let mut info_staged: Vec<StagedColumn> = self
             .info_fields
             .iter()
@@ -630,7 +713,7 @@ impl VcfChunkReader {
 
         // Sequential metadata pass (cheap, ordering-preserving).
         let mut off = 0u32;
-        for a in atoms.iter() {
+        for a in metas.iter() {
             pos.push(a.pos);
             ilens.push(a.ilen);
             alt.extend_from_slice(&a.alt);
@@ -645,17 +728,6 @@ impl VcfChunkReader {
                     col.push_f64(a.format_vals[j * num_samples + s]);
                 }
             }
-        }
-
-        // Presence packing: parallel over word-aligned variant blocks when a
-        // multi-thread pool is available and the chunk is large enough to amortize
-        // the fan-out; identical output to the sequential path either way.
-        let parallel =
-            matches!(pool, Some(p) if p.current_num_threads() >= 2) && v >= PARALLEL_MIN_VARIANTS;
-        if parallel {
-            pack_presence_par(&mut genos.words, &atoms, columns, pool.unwrap());
-        } else {
-            pack_presence_seq(&mut genos.words, &atoms, columns);
         }
 
         Ok(Some(DenseChunk {
@@ -702,6 +774,19 @@ mod tests {
         }
     }
 
+    fn atom_at(gt: Vec<i32>, src: u16, pos: u32) -> PendingAtom {
+        PendingAtom {
+            pos,
+            ilen: 0,
+            alt: Vec::new(),
+            source_alt_index: src,
+            gt: std::sync::Arc::new(gt),
+            seq: pos as u64,
+            info_vals: Vec::new(),
+            format_vals: Vec::new(),
+        }
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(300))]
 
@@ -741,6 +826,58 @@ mod tests {
             pack_presence_par(&mut par.words, &atoms, columns, test_pool());
 
             prop_assert_eq!(seq.words, par.words, "columns={}, v={}", columns, v);
+        }
+    }
+
+    // Windowed packing must be bit-identical to packing the whole chunk at once.
+    // `flush_window` is only ever called at word-aligned variant offsets except
+    // for the final (partial) window, which nothing follows — mirror that here.
+    proptest! {
+        #[test]
+        fn windowed_pack_matches_full_pack(
+            n_samples in 1usize..9,
+            ploidy in 1usize..3,
+            srcs in prop::collection::vec(0u16..3u16, 1..200),
+        ) {
+            let columns = n_samples * ploidy;
+            let v = srcs.len();
+
+            // Deterministic gt: column c of variant i carries allele (i + c) % 3.
+            let atoms: Vec<PendingAtom> = srcs
+                .iter()
+                .enumerate()
+                .map(|(i, &src)| {
+                    let gt: Vec<i32> = (0..columns).map(|c| ((i + c) % 3) as i32).collect();
+                    atom_at(gt, src, i as u32)
+                })
+                .collect();
+
+            // Reference: one full-grid sequential pack.
+            let mut expect = BitGrid3::zeros(v, n_samples, ploidy);
+            pack_presence_seq(&mut expect.words, &atoms, columns);
+
+            // Windowed: flush every `window` atoms, where `window` is a multiple of
+            // the word-aligned block size `g`.
+            let g = 64 / gcd(columns, 64);
+            let window = 4 * g;
+            let mut got = BitGrid3::zeros(v, n_samples, ploidy);
+            let mut metas: Vec<AtomMeta> = Vec::new();
+            let mut buf: Vec<PendingAtom> = Vec::new();
+            let mut v0 = 0usize;
+            for a in atoms {
+                buf.push(a);
+                if buf.len() == window {
+                    let n = buf.len();
+                    flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
+                    v0 += n;
+                }
+            }
+            if !buf.is_empty() {
+                flush_window(&mut got, &mut metas, &mut buf, v0, columns, Some(test_pool()));
+            }
+
+            prop_assert_eq!(got.words, expect.words);
+            prop_assert_eq!(metas.len(), v);
         }
     }
 }

--- a/tests/cli/test_write_cli.py
+++ b/tests/cli/test_write_cli.py
@@ -29,6 +29,23 @@ def _ref(d: Path) -> Path:
     return ref
 
 
+def _pgen(d: Path, vcf: Path) -> Path:
+    subprocess.run(
+        [
+            "plink2",
+            "--make-pgen",
+            "--output-chr",
+            "chrM",
+            "--vcf",
+            str(vcf),
+            "--out",
+            str(d / "in"),
+        ],
+        check=True,
+    )
+    return d / "in.pgen"
+
+
 def _vcf(d: Path, *, symbolic: bool) -> Path:
     body = (
         "##fileformat=VCFv4.2\n"
@@ -147,6 +164,40 @@ def test_write_no_breakend_removed_from_svar2(tmp_path: Path):
     )
     assert r.returncode != 0
     assert "no-breakend" in (r.stdout + r.stderr).lower()
+
+
+def test_write_dispatches_pgen(tmp_path: Path):
+    """`genoray write` already advertises VCF/PGEN in its help; make it true."""
+    ref = _ref(tmp_path)
+    vcf = _vcf(tmp_path, symbolic=False)
+    pgen = _pgen(tmp_path, vcf)
+    out = tmp_path / "pgen.svar2"
+    r = _run(["write", str(pgen), str(out), "--reference", str(ref), "--threads", "1"])
+    assert r.returncode == 0, r.stderr
+    sv = SparseVar2(out)
+    assert sv.contigs == ["chr1"]
+
+
+def test_write_pgen_rejects_nondefault_ploidy(tmp_path: Path):
+    ref = _ref(tmp_path)
+    vcf = _vcf(tmp_path, symbolic=False)
+    pgen = _pgen(tmp_path, vcf)
+    out = tmp_path / "pgen_ploidy.svar2"
+    r = _run(
+        [
+            "write",
+            str(pgen),
+            str(out),
+            "--reference",
+            str(ref),
+            "--ploidy",
+            "1",
+            "--threads",
+            "1",
+        ]
+    )
+    assert r.returncode != 0
+    assert "diploid" in (r.stdout + r.stderr).lower()
 
 
 def test_write_svar1_still_works(tmp_path: Path):

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -174,14 +174,16 @@ pub fn build_contig(
     // left-align repeat condition, so positions stay put and the oracle holds.
     build_fasta_with_index(&fasta, chrom, 1_000_000, records);
     process_chromosome(
-        bcf.to_str().unwrap(),
+        genoray_core::orchestrator::SourceSpec::Vcf {
+            vcf_path: bcf.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
         Some(fasta.to_str().unwrap()),
         chrom,
         out.to_str().unwrap(),
         samples,
         1000, // chunk_size
         ploidy,
-        1,    // htslib_threads
         4096, // long_allele_capacity
         false,
         1,     // processing_threads

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -3,7 +3,8 @@
 mod common;
 
 use common::{SynthRecord, build_bcf_with_index, build_fasta_with_index};
-use genoray_core::vcf_reader::VcfChunkReader;
+use genoray_core::chunk_assembler::ChunkAssembler;
+use genoray_core::vcf_reader::VcfRecordSource;
 use std::path::Path;
 use tempfile::tempdir;
 
@@ -19,13 +20,14 @@ fn drain_reader(
     // Each test builds `bcf_path.with_extension("fa")` from its records *before* calling
     // drain_reader (see the per-test edit below); here we just point the reader at it.
     let fasta_path = bcf_path.with_extension("fa");
-    let mut reader = VcfChunkReader::new(
-        bcf_path.to_str().unwrap(),
+    let source =
+        VcfRecordSource::new(bcf_path.to_str().unwrap(), chrom, samples, 1, ploidy, &[]).unwrap();
+    let mut reader = ChunkAssembler::new(
+        Box::new(source),
+        samples.len(),
+        ploidy,
         Some(fasta_path.to_str().unwrap()),
         chrom,
-        samples,
-        1,
-        ploidy,
         false,
         &[],
     )

--- a/tests/test_convert_skip_e2e.rs
+++ b/tests/test_convert_skip_e2e.rs
@@ -41,14 +41,16 @@ fn convert(
     build_fasta_with_index(&bcf.with_extension("fa"), "chr1", 1000, &recs);
     let sample_refs: Vec<&str> = samples.to_vec();
     process_chromosome(
-        bcf.to_str().unwrap(),
+        genoray_core::orchestrator::SourceSpec::Vcf {
+            vcf_path: bcf.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
         fasta,
         "chr1",
         out.to_str().unwrap(),
         &sample_refs,
         25_000,
         2,
-        1,
         8 * 1024 * 1024,
         skip,
         1,     // processing_threads

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -89,14 +89,16 @@ fn test_e2e_normalized_bcf_pipeline() {
     std::fs::create_dir_all(&out_dir).unwrap();
 
     process_chromosome(
-        bcf_path.to_str().unwrap(),
+        genoray_core::orchestrator::SourceSpec::Vcf {
+            vcf_path: bcf_path.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
         out_dir.to_str().unwrap(),
         &samples,
         100,  // chunk_size
         2,    // ploidy
-        1,    // htslib_threads
         4096, // long_allele_capacity
         false,
         1,     // processing_threads
@@ -180,14 +182,16 @@ fn test_e2e_max_del_postpass() {
     let out_dir = tmp.path().join("out");
     std::fs::create_dir_all(&out_dir).unwrap();
     process_chromosome(
-        bcf_path.to_str().unwrap(),
+        genoray_core::orchestrator::SourceSpec::Vcf {
+            vcf_path: bcf_path.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
         out_dir.to_str().unwrap(),
         &samples,
         100,
         2,
-        1,
         4096,
         false,
         1,     // processing_threads
@@ -255,14 +259,16 @@ fn test_e2e_dense_snp_roundtrip() {
     let out_dir = tmp.path().join("out");
     std::fs::create_dir_all(&out_dir).unwrap();
     process_chromosome(
-        bcf_path.to_str().unwrap(),
+        genoray_core::orchestrator::SourceSpec::Vcf {
+            vcf_path: bcf_path.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
         out_dir.to_str().unwrap(),
         &samples,
         100,
         2,
-        1,
         4096,
         false,
         1,     // processing_threads
@@ -329,14 +335,16 @@ fn test_e2e_mutation_conservation() {
     std::fs::create_dir_all(&out_dir).unwrap();
 
     process_chromosome(
-        bcf_path.to_str().unwrap(),
+        genoray_core::orchestrator::SourceSpec::Vcf {
+            vcf_path: bcf_path.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
         out_dir.to_str().unwrap(),
         &samples,
         100,
         2,
-        1,
         4096,
         false,
         1,     // processing_threads
@@ -766,14 +774,16 @@ fn test_missing_chrom_returns_err() {
     std::fs::create_dir_all(&out_dir).unwrap();
 
     let res = genoray_core::orchestrator::process_chromosome(
-        bcf_path.to_str().unwrap(),
+        genoray_core::orchestrator::SourceSpec::Vcf {
+            vcf_path: bcf_path.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chrZ",
         out_dir.to_str().unwrap(),
         &["s0"],
         1000,
         2,
-        1,
         1 << 20,
         false,
         1,     // processing_threads

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -10,10 +10,11 @@ mod common;
 use common::{
     SynthRecord, build_bcf_with_index, build_fasta_with_index, read_offsets_npy, read_u32_bin,
 };
+use genoray_core::chunk_assembler::ChunkAssembler;
 use genoray_core::process_chromosome;
 use genoray_core::rvk::decode_alt_inline;
 use genoray_core::search::{SearchTree, overlap_range};
-use genoray_core::vcf_reader::VcfChunkReader;
+use genoray_core::vcf_reader::VcfRecordSource;
 
 use tempfile::tempdir;
 
@@ -452,13 +453,21 @@ fn test_reader_extracts_info_format_fields() {
     let sample_refs: Vec<&str> = samples.to_vec();
     // fasta_path = None: skip validate_ref/left_align, so positions stay put
     // and atom order == record order (all SNPs, no atomize splitting).
-    let mut reader = VcfChunkReader::new(
+    let source = VcfRecordSource::new(
         bcf_path.to_str().unwrap(),
-        None,
         "chr1",
         &sample_refs,
         1,
         ploidy,
+        &all,
+    )
+    .unwrap();
+    let mut reader = ChunkAssembler::new(
+        Box::new(source),
+        sample_refs.len(),
+        ploidy,
+        None,
+        "chr1",
         false,
         &all,
     )
@@ -601,13 +610,21 @@ fn test_reader_extracts_multiallelic_number_a_fields() {
     all.extend(fmt.clone());
 
     let sample_refs: Vec<&str> = samples.to_vec();
-    let mut reader = VcfChunkReader::new(
+    let source = VcfRecordSource::new(
         bcf_path.to_str().unwrap(),
-        None,
         "chr1",
         &sample_refs,
         1,
         ploidy,
+        &all,
+    )
+    .unwrap();
+    let mut reader = ChunkAssembler::new(
+        Box::new(source),
+        sample_refs.len(),
+        ploidy,
+        None,
+        "chr1",
         false,
         &all,
     )
@@ -705,13 +722,14 @@ fn test_reader_accepts_pure_del() {
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
     build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
-    let mut reader = VcfChunkReader::new(
-        bcf_path.to_str().unwrap(),
+    let source =
+        VcfRecordSource::new(bcf_path.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+    let mut reader = ChunkAssembler::new(
+        Box::new(source),
+        samples.len(),
+        2,
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
-        &samples,
-        1,
-        2,
         false,
         &[],
     )
@@ -725,7 +743,7 @@ fn test_reader_accepts_pure_del() {
 }
 
 // Boundary error-handling: a chromosome absent from the VCF header must surface
-// as a typed `ConversionError::Input` (SP-3: `VcfChunkReader::new` now returns
+// as a typed `ConversionError::Input` (SP-3: `VcfRecordSource::new` now returns
 // `Result` instead of panicking on `name2rid`, so the reader thread's closure
 // propagates it and the join surfaces the real error, not a swallowed
 // `WorkerPanicked`).
@@ -777,16 +795,7 @@ fn test_missing_vcf_returns_missing_file() {
     let tmp = tempdir().unwrap();
     let missing_path = tmp.path().join("does_not_exist.vcf.gz");
 
-    let res = VcfChunkReader::new(
-        missing_path.to_str().unwrap(),
-        None,
-        "chr1",
-        &["s0"],
-        1,
-        2,
-        false,
-        &[],
-    );
+    let res = VcfRecordSource::new(missing_path.to_str().unwrap(), "chr1", &["s0"], 1, 2, &[]);
 
     assert!(matches!(
         res,

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -4,7 +4,8 @@
 mod common;
 
 use common::{SynthRecord, build_bcf_with_index};
-use genoray_core::vcf_reader::VcfChunkReader;
+use genoray_core::chunk_assembler::ChunkAssembler;
+use genoray_core::vcf_reader::VcfRecordSource;
 use proptest::prelude::*;
 use std::io::Write;
 use std::path::Path;
@@ -24,13 +25,13 @@ fn write_ref(fasta_path: &Path, chrom: &str, seq: &[u8]) {
 }
 
 fn drain(bcf: &Path, fasta: &Path, chrom: &str, samples: &[&str]) -> Vec<(u32, i32)> {
-    let mut reader = VcfChunkReader::new(
-        bcf.to_str().unwrap(),
+    let source = VcfRecordSource::new(bcf.to_str().unwrap(), chrom, samples, 1, 2, &[]).unwrap();
+    let mut reader = ChunkAssembler::new(
+        Box::new(source),
+        samples.len(),
+        2,
         Some(fasta.to_str().unwrap()),
         chrom,
-        samples,
-        1,
-        2,
         false,
         &[],
     )
@@ -234,13 +235,13 @@ fn left_shifts_stay_sorted_across_chunk_boundaries() {
     build_bcf_with_index(&bcf, "chr1", REF_SEQ.len() as u64, &samples, &records);
 
     // chunk_size = 1 forces every atom into its own chunk.
-    let mut reader = VcfChunkReader::new(
-        bcf.to_str().unwrap(),
+    let source = VcfRecordSource::new(bcf.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+    let mut reader = ChunkAssembler::new(
+        Box::new(source),
+        samples.len(),
+        2,
         Some(fasta.to_str().unwrap()),
         "chr1",
-        &samples,
-        1,
-        2,
         false,
         &[],
     )
@@ -301,13 +302,14 @@ proptest! {
             .collect();
         build_bcf_with_index(&bcf, "chr1", seed.len() as u64, &samples, &synth);
 
-        let mut reader = VcfChunkReader::new(
-            bcf.to_str().unwrap(),
+        let source =
+            VcfRecordSource::new(bcf.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+        let mut reader = ChunkAssembler::new(
+            Box::new(source),
+            samples.len(),
+            2,
             Some(fasta.to_str().unwrap()),
             "chr1",
-            &samples,
-            1,
-            2,
             false,
             &[],
         )

--- a/tests/test_svar2_from_pgen.py
+++ b/tests/test_svar2_from_pgen.py
@@ -57,6 +57,18 @@ def sources(tmp_path_factory) -> tuple[Path, Path, Path]:
     return ref, gz, d / "in.pgen"
 
 
+def _assert_ragged_equal(ragged_pgen, ragged_vcf) -> None:
+    """Compare two decoded record Raggeds field-by-field.
+
+    `.data` on a record Ragged (multiple named fields sharing one ragged axis)
+    returns a dict of field -> ndarray, not a single array -- compare per field.
+    """
+    assert ragged_pgen.offsets.tolist() == ragged_vcf.offsets.tolist()
+    assert ragged_pgen.data.keys() == ragged_vcf.data.keys()
+    for field in ragged_vcf.data:
+        assert ragged_pgen.data[field].tolist() == ragged_vcf.data[field].tolist()
+
+
 def test_from_pgen_matches_from_vcf(sources, tmp_path):
     ref, vcf, pgen = sources
     from_vcf = tmp_path / "vcf.svar2"
@@ -72,12 +84,7 @@ def test_from_pgen_matches_from_vcf(sources, tmp_path):
     regions = [(0, len(_REF))]
     ragged_vcf = a.decode("chr1", regions)
     ragged_pgen = b.decode("chr1", regions)
-    assert ragged_pgen.offsets.tolist() == ragged_vcf.offsets.tolist()
-    # `.data` on a record Ragged (multiple named fields sharing one ragged axis)
-    # returns a dict of field -> ndarray, not a single array -- compare per field.
-    assert ragged_pgen.data.keys() == ragged_vcf.data.keys()
-    for field in ragged_vcf.data:
-        assert ragged_pgen.data[field].tolist() == ragged_vcf.data[field].tolist()
+    _assert_ragged_equal(ragged_pgen, ragged_vcf)
 
 
 def test_from_pgen_requires_exactly_one_of_reference_or_no_reference(sources, tmp_path):
@@ -95,3 +102,108 @@ def test_from_pgen_refuses_to_overwrite(sources, tmp_path):
     with pytest.raises(FileExistsError):
         SparseVar2.from_pgen(out, pgen, ref)
     SparseVar2.from_pgen(out, pgen, ref, overwrite=True)  # no raise
+
+
+def test_from_pgen_no_reference_matches_from_vcf(sources, tmp_path):
+    """The no_reference path (no REF validation, no left-alignment) must also agree."""
+    _, vcf, pgen = sources
+    from_vcf = tmp_path / "vcf.svar2"
+    from_pgen = tmp_path / "pgen.svar2"
+
+    SparseVar2.from_vcf(from_vcf, vcf, no_reference=True)
+    SparseVar2.from_pgen(from_pgen, pgen, no_reference=True)
+
+    a = SparseVar2(from_vcf)
+    b = SparseVar2(from_pgen)
+    regions = [(0, len(_REF))]
+    _assert_ragged_equal(b.decode("chr1", regions), a.decode("chr1", regions))
+
+
+def test_from_pgen_reads_zstd_pvar(sources, tmp_path):
+    """plink2 `vzs` writes a .pvar.zst; the Rust streamer must handle it."""
+    ref, vcf, _ = sources
+    d = tmp_path / "zst"
+    d.mkdir()
+    subprocess.run(
+        [
+            "plink2",
+            "--make-pgen",
+            "vzs",
+            "--output-chr",
+            "chrM",
+            "--vcf",
+            str(vcf),
+            "--out",
+            str(d / "in"),
+        ],
+        check=True,
+    )
+    assert (d / "in.pvar.zst").exists()
+
+    out_zst = tmp_path / "zst.svar2"
+    out_ref = tmp_path / "plain.svar2"
+    SparseVar2.from_pgen(out_zst, d / "in.pgen", ref)
+    SparseVar2.from_vcf(out_ref, vcf, ref)
+
+    regions = [(0, len(_REF))]
+    a = SparseVar2(out_ref).decode("chr1", regions)
+    b = SparseVar2(out_zst).decode("chr1", regions)
+    _assert_ragged_equal(b, a)
+
+
+def test_from_pgen_multi_contig(tmp_path):
+    """Contigs are converted from disjoint .pvar index ranges; a two-contig file
+    exercises the range computation and the per-contig PgenReader."""
+    d = tmp_path / "multi"
+    d.mkdir()
+
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n>chr2\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=chr1,length=40>\n"
+        "##contig=<ID=chr2,length=40>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+        "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr2\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
+    )
+    plain = d / "in.vcf"
+    plain.write_text(body)
+    gz = d / "in.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+    subprocess.run(
+        [
+            "plink2",
+            "--make-pgen",
+            "--output-chr",
+            "chrM",
+            "--vcf",
+            str(gz),
+            "--out",
+            str(d / "in"),
+        ],
+        check=True,
+    )
+
+    from_vcf = tmp_path / "mv.svar2"
+    from_pgen = tmp_path / "mp.svar2"
+    SparseVar2.from_vcf(from_vcf, gz, ref)
+    SparseVar2.from_pgen(from_pgen, d / "in.pgen", ref)
+
+    a, b = SparseVar2(from_vcf), SparseVar2(from_pgen)
+    regions = [(0, len(_REF))]
+    for contig in ("chr1", "chr2"):
+        _assert_ragged_equal(b.decode(contig, regions), a.decode(contig, regions))
+
+
+def test_from_pgen_missing_pvar_is_a_clear_error(sources, tmp_path):
+    _, _, pgen = sources
+    lonely = tmp_path / "lonely.pgen"
+    lonely.write_bytes(pgen.read_bytes())
+    with pytest.raises(FileNotFoundError, match="No .pvar or .pvar.zst"):
+        SparseVar2.from_pgen(tmp_path / "x.svar2", lonely, no_reference=True)

--- a/tests/test_svar2_from_pgen.py
+++ b/tests/test_svar2_from_pgen.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from genoray import SparseVar2
+
+# 40 bp reference. 1-based POS 3 = 'A', 7 = 'C', 12..14 = 'GTA'.
+_REF = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"
+
+# Phased, no half-calls, no symbolics: plink2's VCF import is lossless here, so
+# from_pgen and from_vcf must agree exactly. (A half-call like './1' would NOT
+# round-trip: gen_from_vcf.sh passes --vcf-half-call r, which rewrites it.)
+_VCF_BODY = (
+    "##fileformat=VCFv4.2\n"
+    "##contig=<ID=chr1,length=40>\n"
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+    "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+    "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
+    "chr1\t12\t.\tGTA\tG,GT\t.\t.\t.\tGT\t1|2\t0|1\n"
+    "chr1\t20\t.\tT\tA\t.\t.\t.\tGT\t.|.\t1|0\n"
+)
+
+
+@pytest.fixture(scope="module")
+def sources(tmp_path_factory) -> tuple[Path, Path, Path]:
+    """(reference fasta, bgzipped+indexed vcf, pgen) for the same variants."""
+    d = tmp_path_factory.mktemp("frompgen")
+
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    plain = d / "in.vcf"
+    plain.write_text(_VCF_BODY)
+    gz = d / "in.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+
+    subprocess.run(
+        [
+            "plink2",
+            "--make-pgen",
+            "--output-chr",
+            "chrM",
+            "--vcf",
+            str(gz),
+            "--out",
+            str(d / "in"),
+        ],
+        check=True,
+    )
+    return ref, gz, d / "in.pgen"
+
+
+def test_from_pgen_matches_from_vcf(sources, tmp_path):
+    ref, vcf, pgen = sources
+    from_vcf = tmp_path / "vcf.svar2"
+    from_pgen = tmp_path / "pgen.svar2"
+
+    SparseVar2.from_vcf(from_vcf, vcf, ref)
+    SparseVar2.from_pgen(from_pgen, pgen, ref)
+
+    a = SparseVar2(from_vcf)
+    b = SparseVar2(from_pgen)
+    assert a.n_samples == b.n_samples == 2
+
+    regions = [(0, len(_REF))]
+    ragged_vcf = a.decode("chr1", regions)
+    ragged_pgen = b.decode("chr1", regions)
+    assert ragged_pgen.offsets.tolist() == ragged_vcf.offsets.tolist()
+    # `.data` on a record Ragged (multiple named fields sharing one ragged axis)
+    # returns a dict of field -> ndarray, not a single array -- compare per field.
+    assert ragged_pgen.data.keys() == ragged_vcf.data.keys()
+    for field in ragged_vcf.data:
+        assert ragged_pgen.data[field].tolist() == ragged_vcf.data[field].tolist()
+
+
+def test_from_pgen_requires_exactly_one_of_reference_or_no_reference(sources, tmp_path):
+    _, _, pgen = sources
+    with pytest.raises(ValueError, match="exactly one"):
+        SparseVar2.from_pgen(tmp_path / "a.svar2", pgen)
+    with pytest.raises(ValueError, match="exactly one"):
+        SparseVar2.from_pgen(tmp_path / "b.svar2", pgen, "ref.fa", no_reference=True)
+
+
+def test_from_pgen_refuses_to_overwrite(sources, tmp_path):
+    ref, _, pgen = sources
+    out = tmp_path / "exists.svar2"
+    SparseVar2.from_pgen(out, pgen, ref)
+    with pytest.raises(FileExistsError):
+        SparseVar2.from_pgen(out, pgen, ref)
+    SparseVar2.from_pgen(out, pgen, ref, overwrite=True)  # no raise

--- a/tests/test_svar2_from_pgen.py
+++ b/tests/test_svar2_from_pgen.py
@@ -201,6 +201,78 @@ def test_from_pgen_multi_contig(tmp_path):
         _assert_ragged_equal(b.decode(contig, regions), a.decode(contig, regions))
 
 
+# Same variants as `_VCF_BODY`, but with a monomorphic site (REF present, ALT
+# `.` -- no alternate allele) inserted *before* the real variants. plink2
+# writes such sites as a bare `.` ALT in the .pvar; the .pvar's ALT-derived
+# `allele_idx_offsets` must count this as 0 alt alleles for this variant
+# without corrupting every variant that follows it.
+_VCF_BODY_MONO = (
+    "##fileformat=VCFv4.2\n"
+    "##contig=<ID=chr1,length=40>\n"
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+    "chr1\t1\t.\tA\t.\t.\t.\t.\tGT\t0|0\t0|0\n"
+    "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+    "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
+    "chr1\t12\t.\tGTA\tG,GT\t.\t.\t.\tGT\t1|2\t0|1\n"
+    "chr1\t20\t.\tT\tA\t.\t.\t.\tGT\t.|.\t1|0\n"
+)
+
+
+@pytest.fixture(scope="module")
+def sources_mono(tmp_path_factory) -> tuple[Path, Path, Path]:
+    """Same shape as `sources`, but the .pvar's first variant is monomorphic
+    (ALT '.') -- regression coverage for the allele_idx_offsets corruption bug."""
+    d = tmp_path_factory.mktemp("frompgen_mono")
+
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    plain = d / "in.vcf"
+    plain.write_text(_VCF_BODY_MONO)
+    gz = d / "in.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+
+    subprocess.run(
+        [
+            "plink2",
+            "--make-pgen",
+            "--output-chr",
+            "chrM",
+            "--vcf",
+            str(gz),
+            "--out",
+            str(d / "in"),
+        ],
+        check=True,
+    )
+    return ref, gz, d / "in.pgen"
+
+
+def test_from_pgen_monomorphic_site_matches_from_vcf(sources_mono, tmp_path):
+    """A plink2-emitted monomorphic .pvar row (ALT '.') must decode to zero alt
+    alleles, and must not corrupt allele_idx_offsets for the real variants that
+    follow it in the file."""
+    ref, vcf, pgen = sources_mono
+    from_vcf = tmp_path / "vcf.svar2"
+    from_pgen = tmp_path / "pgen.svar2"
+
+    SparseVar2.from_vcf(from_vcf, vcf, ref)
+    SparseVar2.from_pgen(from_pgen, pgen, ref)
+
+    a = SparseVar2(from_vcf)
+    b = SparseVar2(from_pgen)
+    assert a.n_samples == b.n_samples == 2
+
+    regions = [(0, len(_REF))]
+    ragged_vcf = a.decode("chr1", regions)
+    ragged_pgen = b.decode("chr1", regions)
+    _assert_ragged_equal(ragged_pgen, ragged_vcf)
+
+
 def test_from_pgen_missing_pvar_is_a_clear_error(sources, tmp_path):
     _, _, pgen = sources
     lonely = tmp_path / "lonely.pgen"


### PR DESCRIPTION
## Summary

Adds `SparseVar2.from_pgen`, converting a PLINK2 PGEN to an SVAR2 store by reusing the VCF conversion pipeline's normalization / atomization / merge spine behind a new source-agnostic seam. `genoray write` now dispatches on the `.pgen` suffix.

Executed task-by-task from `docs/superpowers/plans/2026-07-12-pgen-to-svar2.md` (9 tasks), each verified before proceeding, followed by a whole-branch review and a fix.

## Architecture

- **`RecordSource` trait + `ChunkAssembler`** (`src/record_source.rs`, `src/chunk_assembler.rs`): `VcfChunkReader` was split into a source-agnostic spine (reorder heap, atom decomposition, presence packing, field staging) and two `RecordSource` impls — `VcfRecordSource` (htslib) and `PgenRecordSource` (pgenlib). The VCF path's stored output is byte-identical after the refactor.
- **Streaming `.pvar`/`.pvar.zst` reader** (`src/pvar.rs`): supplies POS/REF/ALT; genotypes come from the already-depended-on `pgenlib` wheel via its public Python API (`read_alleles_range`). No plink-ng code is linked or vendored — genoray stays MIT; `zstd` (BSD/MIT) is an optional dep behind the `conversion` feature.
- **Windowed presence packing** (`src/vcf_reader.rs`): presence bits pack in word-aligned windows and each atom's per-column genotype vector is dropped as soon as its bits are set, bounding reader staging memory at `window * n_samples * ploidy * 4` bytes instead of `chunk_size * n_samples * ploidy * 4`. Bit-identical output; benefits both `from_vcf` and `from_pgen`.

## Correctness notes discovered during implementation

- **pgenlib `read_alleles_range`** is a 3-arg call into a 2-D `(batch, 2·n_samples)` int32 buffer (no `hap_maj` param); missing code `-9` is mapped to the pipeline's `-1`.
- **Multiallelic PGENs require a file-wide `allele_idx_offsets`** (`np.uintp`, `offsets[i+1] = offsets[i] + 1 + n_alts(i)`), else `PgenReader` raises at construction. Computed once from the `.pvar` and shared across per-contig readers.
- **Monomorphic sites** (`.pvar` ALT `.`) count as **1** ALT slot for `allele_idx_offsets` — pgenlib reserves ≥2 allele slots per variant on disk, and a 0-count segfaults `read_alleles_range` on later multiallelic variants. `PvarReader` separately emits empty `alts` for `.` so the conversion spine records no atoms for it. (Fixed in review; both sides regression-tested.)

## Benchmark (honest)

On a 3202-sample chr21 germline cohort (1,001,385 variants, symbolics filtered, equivalence verified before timing):

| Path | Wall | Peak RSS |
| --- | --- | --- |
| `from_vcf` | 547.0s | 497 MiB |
| `from_pgen` | 152.7s | 1040 MiB |

**PGEN is ~3.6× faster** wall-clock (the reader stops being the bottleneck), at ~2.1× higher peak RSS (flagged as a follow-up, not fixed). Concurrent contig readers do not serialize on the GIL; pgenlib's OpenMP `prange` oversubscribes threads — `OMP_NUM_THREADS` capping recommended for cluster runs.

## Testing

- Full suite: **586 passed**, 2 skipped, 16 xfailed.
- Rust: 201 tests (`cargo test --no-default-features --features conversion`), incl. windowed-pack bit-identity proptest and `.pvar` parser tests.
- Cross-backend equivalence (`from_pgen ≡ from_vcf`) covering multiallelic, missing-GT, indel, no-reference, zstd `.pvar`, multi-contig, and monomorphic-site cases.
- Query-only build (`cargo build --no-default-features`, GenVarLoader's config) stays green; all new modules + `zstd` gated behind `conversion`.
- `skills/genoray-api/SKILL.md` and `CHANGELOG.md` updated per the public-API rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
