### PR TITLE
perf(svar2): libdeflate BGZF for the VCF→SVAR2 read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@
 
 ### Perf
 
+- perf(svar2): build vendored htslib against libdeflate (faster BGZF
+  decompression) for VCF→SVAR2 conversion. Output is byte-identical.
 - Conversion reader staging memory no longer scales with `chunk_size`:
   presence bits are packed in word-aligned windows and each atom's per-column
   genotype vector is dropped as soon as its bits are set, bounding reader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,8 +106,9 @@
 
 ### Perf
 
-- perf(svar2): build vendored htslib against libdeflate (faster BGZF
-  decompression) for VCF→SVAR2 conversion. Output is byte-identical.
+- **svar2**: build vendored htslib against libdeflate for faster BGZF
+  decompression on the VCF→SVAR2 read path (~27–37% faster conversion on
+  chr21 germline/gdc). Output is byte-identical.
 - Conversion reader staging memory no longer scales with `chunk_size`:
   presence bits are packed in word-aligned windows and each atom's per-column
   genotype vector is dropped as soon as its bits are set, bounding reader

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "cc",
  "fs-utils",
  "glob",
+ "libdeflate-sys",
  "libz-sys",
 ]
 
@@ -612,6 +613,15 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,10 @@ rayon = "1.11.0"
 # default-features = false drops bzip2/lzma/curl (and their system libs); htslib is
 # vendored by hts-sys and built with the conda C/C++ compilers. hts-sys forces
 # bindgen, so the build needs libclang (provided via pixi: clang/clangdev).
-rust-htslib = { version = "1.0", default-features = false, optional = true }
+# libdeflate: hts-sys builds vendored htslib against libdeflate (SIMD CRC + ~2x
+# faster inflate) instead of zlib — the BGZF decompression bottleneck for
+# VCF->SVAR2 conversion. See docs/superpowers/specs/2026-07-13-svar2-vcf-read-*.
+rust-htslib = { version = "1.0", default-features = false, features = ["libdeflate"], optional = true }
 serde_json = "1"
 svar2-codec = { path = "svar2-codec" }
 thiserror = "2"

--- a/docs/superpowers/plans/2026-07-13-svar2-vcf-read-libdeflate-parallel.md
+++ b/docs/superpowers/plans/2026-07-13-svar2-vcf-read-libdeflate-parallel.md
@@ -1,0 +1,339 @@
+# VCF→SVAR2 Read-Path Speedup (libdeflate + parallel BGZF) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Speed up single-contig VCF/BCF→SVAR2 conversion, whose reader is bottlenecked on zlib BGZF decompression, starting with a near-free switch to libdeflate and escalating to parallel decompression only if measurement justifies it.
+
+**Architecture:** Staged and measurement-gated. Stage 0 turns on the `libdeflate` cargo feature so the vendored htslib decompresses with libdeflate instead of zlib. Stage 1 re-sweeps htslib decode threads now that per-block inflate is cheap. Stage 2 (conditional, gated on Stage 1's result) is a custom parallel BGZF frontend that feeds htslib's trusted BCF parser. Correctness is defended by a byte-identical store-hash oracle after every change.
+
+**Tech Stack:** Rust (`rust-htslib`/`hts-sys` vendored htslib, `rayon`, `libdeflate`/`libdeflater`), PyO3, maturin, pixi, `perf`, SLURM `carter-compute`.
+
+## Global Constraints
+
+- **Byte-identical output is non-negotiable.** After every change, the SVAR2 store content-hash MUST equal the oracle on **both** datasets: `oracle.chr21.hash = f43712ff68ca438f853ca9883533a4c4e9db6b4b6e9ed752efdbaf1fa6d71a8b`, `oracle.gdc.hash = dc33c477bd117e59d9280178792580bcafc3c1a9c312380c0dc3a4755e1f5ae0`. Any diff is a regression — stop.
+- **Rust test command:** `cargo test --no-default-features --features conversion` (default `extension-module` breaks the test binary: `undefined symbol: _Py_Dealloc`). Always `export CARGO_TARGET_DIR=/tmp/genoray-cargo-$$` first — cargo on the NFS `target/` bus-errors.
+- **Python test command:** `pixi run pytest tests -m "not network"`.
+- **No plink-ng code copied** — plink-ng is GPLv3; algorithm inspiration only. noodles (MIT) is the only read-path code we may depend on directly.
+- **Do not bump the version or edit the changelog version headers by hand** — accumulate human-readable entries under `## Unreleased` in `CHANGELOG.md`; CI cuts the versioned section.
+- **No public-API change expected** — if any public name/shape/dtype changes, `skills/genoray-api/SKILL.md` must be updated in the same change. None is anticipated here.
+- **All timing/perf runs on a dedicated `carter-compute` node** (`sbatch -p carter-compute -c 32 --mem=128G` holder + `srun --jobid=<id> --overlap`), never the login node.
+- **Build from the worktree** so code changes take effect: run `maturin develop` with `--manifest-path <worktree>/pyproject.toml` (or `cd <worktree>` first), not the main checkout.
+- **Harness:** `/carter/users/dlaub/svar_bench/` (`BENCH`). Repo reference FASTA `REF=/carter/shared/data/gdc/resources/GRCh38.d1.vd1.fa`. Driver `run_svar2.py <bcf> <out_store> <ref> <threads>`; hasher `storehash.sh <store_dir>`.
+
+---
+
+## Task 1: Build the fast-iteration harness slice
+
+**Files:**
+- Create: `/carter/users/dlaub/svar_bench/chr21.slice.bcf` (+ `.csi`)
+- Create: `/carter/users/dlaub/svar_bench/gdc.chr21.slice.bcf` (+ `.csi`)
+- Create: `/carter/users/dlaub/svar_bench/oracle.chr21.slice.hash`
+- Create: `/carter/users/dlaub/svar_bench/oracle.gdc.slice.hash`
+- Create: `/carter/users/dlaub/svar_bench/make_slices.sh`
+
+**Interfaces:**
+- Produces: two small BCFs (~first 10 Mb of chr21) and their byte-identical store-hash oracles, used by every later task for a ~10–30s germline / ~1–2min gdc measurement loop. Full-chr21 files and their oracles remain the correctness gate.
+
+- [ ] **Step 1: Write the slice-builder script**
+
+```bash
+cat > /carter/users/dlaub/svar_bench/make_slices.sh <<'EOF'
+#!/bin/bash
+# Carve a ~10 Mb chr21 slice from each filtered BCF for the fast dev-profile loop.
+set -euo pipefail
+BENCH=/carter/users/dlaub/svar_bench
+REGION=chr21:1-10000000
+cd "$BENCH"
+for base in chr21 gdc.chr21; do
+  bcftools view "$base.filt.bcf" "$REGION" -Ob -o "$base.slice.bcf"
+  bcftools index --csi "$base.slice.bcf"
+  echo "$base.slice.bcf: $(bcftools index -n "$base.slice.bcf") variants"
+done
+EOF
+chmod +x /carter/users/dlaub/svar_bench/make_slices.sh
+```
+
+- [ ] **Step 2: Build the slices (on a compute node)**
+
+Run: `bash /carter/users/dlaub/svar_bench/make_slices.sh`
+Expected: two `*.slice.bcf` files created, each printing a non-zero variant count (germline ~a few ×10k, gdc larger). If the region label must be unprefixed (`21:1-10000000`), adjust `REGION` — confirm with `bcftools index -s chr21.filt.bcf`.
+
+- [ ] **Step 3: Generate slice oracle hashes with the CURRENT (pre-change) build**
+
+Ensure the current released build is installed (`pixi run maturin develop --release` from the worktree), then:
+
+Run:
+```bash
+cd /carter/users/dlaub/svar_bench
+pixi run --manifest-path <worktree>/pyproject.toml python run_svar2.py chr21.slice.bcf stores/chr21.slice.base $REF 32
+bash storehash.sh stores/chr21.slice.base | tee oracle.chr21.slice.hash
+pixi run --manifest-path <worktree>/pyproject.toml python run_svar2.py gdc.chr21.slice.bcf stores/gdc.slice.base $REF 32
+bash storehash.sh stores/gdc.slice.base | tee oracle.gdc.slice.hash
+```
+Expected: two 64-hex-char hashes written. These are the slice correctness oracles for later tasks.
+
+- [ ] **Step 4: Commit the script (data files stay out of the repo)**
+
+```bash
+cd <worktree>
+git add -N docs  # no repo files change here; slices live under svar_bench, not the repo
+echo "Slices + oracles live in /carter/users/dlaub/svar_bench (not version-controlled)."
+```
+Expected: nothing to commit in-repo; harness artifacts recorded under `svar_bench`. (Task 1 is infrastructure — its deliverable is the slice files + oracle hashes on disk, verified by Step 3 printing hashes.)
+
+---
+
+## Task 2: Enable libdeflate (Stage 0)
+
+**Files:**
+- Modify: `Cargo.toml:26` (the `rust-htslib` dependency line) and the comment block at `Cargo.toml:23-25`
+- Modify: `CHANGELOG.md` (add an entry under `## Unreleased`)
+
+**Interfaces:**
+- Consumes: slice oracles from Task 1; full-chr21 oracles (Global Constraints).
+- Produces: a build whose vendored htslib decompresses with libdeflate (verified by symbol inspection), byte-identical store output, and a recorded before/after timing.
+
+- [ ] **Step 1: Capture the pre-change baseline timing (slice, fast)**
+
+Run (compute node, current build):
+```bash
+cd /carter/users/dlaub/svar_bench
+pixi run --manifest-path <worktree>/pyproject.toml python run_svar2.py gdc.chr21.slice.bcf stores/gdc.slice.pre $REF 32 | grep from_vcf
+```
+Expected: a `SVAR2 from_vcf: <t>s` line. Record `t` as the Stage-0 baseline.
+
+- [ ] **Step 2: Turn on the libdeflate feature**
+
+Edit `Cargo.toml`. Change:
+```toml
+rust-htslib = { version = "1.0", default-features = false, optional = true }
+```
+to:
+```toml
+# libdeflate: hts-sys builds vendored htslib against libdeflate (SIMD CRC + ~2x
+# faster inflate) instead of zlib — the BGZF decompression bottleneck for
+# VCF->SVAR2 conversion. See docs/superpowers/specs/2026-07-13-svar2-vcf-read-*.
+rust-htslib = { version = "1.0", default-features = false, features = ["libdeflate"], optional = true }
+```
+Keep the existing `default-features = false` comment above it intact.
+
+- [ ] **Step 3: Rebuild and verify libdeflate is actually linked**
+
+Run:
+```bash
+cd <worktree>
+export CARGO_TARGET_DIR=/tmp/genoray-cargo-$$
+pixi run maturin develop --release 2>&1 | tail -3
+# Inspect the installed extension module for libdeflate symbols:
+SO=$(python -c "import genoray, glob, os; print(glob.glob(os.path.join(os.path.dirname(genoray.__file__), '*.so'))[0])")
+nm -D --defined-only "$SO" 2>/dev/null | grep -i libdeflate | head || nm "$SO" 2>/dev/null | grep -i libdeflate | head
+```
+Expected: at least one `libdeflate_*` symbol present (e.g. `libdeflate_deflate_decompress`, `libdeflate_crc32`). If empty, libdeflate did NOT link — investigate hts-sys build.rs / the `libdeflate-sys` build before proceeding (do not continue on an unverified link).
+
+- [ ] **Step 4: Correctness gate — Rust + Python suites**
+
+Run:
+```bash
+cd <worktree>
+export CARGO_TARGET_DIR=/tmp/genoray-cargo-$$
+cargo test --no-default-features --features conversion 2>&1 | tail -5
+pixi run pytest tests -m "not network" 2>&1 | tail -5
+```
+Expected: all Rust tests pass (~185), all pytest pass (~525). Zero failures.
+
+- [ ] **Step 5: Correctness gate — byte-identical store hash (slice, then FULL)**
+
+Run:
+```bash
+cd /carter/users/dlaub/svar_bench
+# slice first (fast)
+pixi run --manifest-path <worktree>/pyproject.toml python run_svar2.py gdc.chr21.slice.bcf stores/gdc.slice.ld $REF 32 | grep from_vcf
+[ "$(bash storehash.sh stores/gdc.slice.ld)" = "$(cat oracle.gdc.slice.hash)" ] && echo "SLICE OK" || echo "SLICE MISMATCH"
+# full germline + gdc (the real gate)
+pixi run --manifest-path <worktree>/pyproject.toml python run_svar2.py chr21.filt.bcf stores/chr21.ld $REF 32 | grep from_vcf
+[ "$(bash storehash.sh stores/chr21.ld)" = "$(cat oracle.chr21.hash)" ] && echo "GERMLINE OK" || echo "GERMLINE MISMATCH"
+pixi run --manifest-path <worktree>/pyproject.toml python run_svar2.py gdc.chr21.filt.bcf stores/gdc.ld $REF 32 | grep from_vcf
+[ "$(bash storehash.sh stores/gdc.ld)" = "$(cat oracle.gdc.hash)" ] && echo "GDC OK" || echo "GDC MISMATCH"
+```
+Expected: `SLICE OK`, `GERMLINE OK`, `GDC OK`. The `from_vcf` timings on the full files are the Stage-0 after-numbers — compare against the prior pass (germline 36.5s, gdc 1076s). Any `MISMATCH` is a hard stop.
+
+- [ ] **Step 6: (Optional but recommended) confirm the symbol shift in a profile**
+
+Run a `perf record`/`report` on the gdc slice (per the profiling protocol) and confirm `inflate_fast`/`crc32_z` are gone, replaced by `libdeflate_*`. This is the mechanistic proof the change did what the design claims.
+
+- [ ] **Step 7: CHANGELOG + commit**
+
+Add under `## Unreleased` in `CHANGELOG.md`:
+```markdown
+- perf(svar2): build vendored htslib against libdeflate (faster BGZF decompression) for VCF→SVAR2 conversion
+```
+Then:
+```bash
+cd <worktree>
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "perf(svar2): link vendored htslib against libdeflate
+
+Switches the BGZF decompressor from zlib to libdeflate for the VCF->SVAR2
+read path. Byte-identical store output on germline + gdc chr21.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit created; `Cargo.lock` may gain `libdeflate-sys` — include it.
+
+---
+
+## Task 3: Ensure libdeflate ships in the release wheels
+
+**Files:**
+- Modify: `ci/wheel/pixi.toml` (add `libdeflate` if the vendored build needs a system copy on any of the four wheel platforms)
+- Reference: `.github/workflows/release.yaml` (auditwheel/delocate repair step)
+
+**Interfaces:**
+- Consumes: the libdeflate-enabled build from Task 2.
+- Produces: a release-wheel build path that vendors/repairs libdeflate into the wheel on linux-64, osx-arm64, and the two additional wheel platforms declared in `ci/wheel/pixi.toml`.
+
+- [ ] **Step 1: Determine how libdeflate reaches the wheel**
+
+Inspect whether `hts-sys`'s `libdeflate` feature pulls a **statically-linked** `libdeflate-sys` (self-contained, no wheel repair needed) or expects a system `libdeflate.so` (must be added to `ci/wheel/pixi.toml` and repaired in).
+
+Run:
+```bash
+cd <worktree>
+find ~/.cargo -path '*libdeflate-sys*/Cargo.toml' | head -1 | xargs grep -n -i "static\|build\|links" | head
+grep -n -i "deflate\|auditwheel\|delocate\|repair" ci/wheel/pixi.toml .github/workflows/release.yaml
+```
+Expected: a clear read on static-vs-dynamic. If `libdeflate-sys` builds/statics its own copy, no manifest change is needed — record that and skip to Step 3.
+
+- [ ] **Step 2: If dynamic, add libdeflate to the wheel manifest**
+
+If Step 1 shows a system dependency, add `libdeflate` to the `[dependencies]` (or the platform tables) of `ci/wheel/pixi.toml` so all four platforms provide it at build time, and confirm the repair step (auditwheel `--exclude`/bundle, delocate) captures it. Keep the toolchain pins (`rust`, `clangdev=18`) in sync between `ci/wheel/pixi.toml` and the main `pixi.toml` per the existing CI note.
+
+- [ ] **Step 3: Validate a wheel build locally (linux-64)**
+
+Run:
+```bash
+cd <worktree>
+pixi run --manifest-path ci/wheel/pixi.toml maturin build --release --features abi3 2>&1 | tail -5
+# repaired wheel should import and convert:
+python -m pip install --force-reinstall dist/*.whl 2>&1 | tail -2 || true
+```
+Expected: wheel builds; a smoke import + a tiny `from_vcf` on the slice succeeds against the installed wheel. (Full four-platform validation happens in release CI; local checks linux-64.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd <worktree>
+git add ci/wheel/pixi.toml
+git commit -m "build(ci): ensure libdeflate is vendored into release wheels
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit created (or, if Step 1 found static linking, a no-op documented in the task notes with no commit).
+
+---
+
+## Task 4: Re-sweep htslib decode threads (Stage 1) + Stage-2 decision gate
+
+**Files:**
+- Modify: `src/budget.rs:13` (`MAX_HTSLIB_THREADS`) — experiment only; keep the winning value behind `plan_thread_budget`.
+- Reference: `src/budget.rs` budget tests, `src/lib.rs:152-188`, `src/vcf_reader.rs:139-161`.
+
+**Interfaces:**
+- Consumes: the libdeflate build (Task 2).
+- Produces: a recorded thread-scaling curve for gdc after libdeflate, an updated `MAX_HTSLIB_THREADS` if it scales, and an explicit **go/no-go decision for Task 5 (Stage 2)**.
+
+- [ ] **Step 1: Sweep htslib_threads on the gdc slice**
+
+Temporarily raise `MAX_HTSLIB_THREADS` in `src/budget.rs` and rebuild, then measure the gdc slice at a few effective thread counts (the sweep is driven by the `threads` arg to `run_svar2.py` feeding `plan_thread_budget`). Record wall-time at 4 / 8 / 12 / 16.
+
+Run (per trial, after each `MAX_HTSLIB_THREADS` edit + `maturin develop --release`):
+```bash
+cd /carter/users/dlaub/svar_bench
+pixi run --manifest-path <worktree>/pyproject.toml python run_svar2.py gdc.chr21.slice.bcf stores/gdc.slice.t $REF 32 | grep from_vcf
+```
+Expected: a monotonic (or plateauing) time-vs-threads table. libdeflate makes per-block inflate cheap, so this may now scale where it was previously inert.
+
+- [ ] **Step 2: Confirm the best full-gdc number and byte-identical output**
+
+With the best `MAX_HTSLIB_THREADS` from Step 1, run the FULL gdc + germline and re-verify the oracle hashes (as in Task 2 Step 5). Record the full-file timing.
+Expected: `GERMLINE OK`, `GDC OK`; a full-gdc wall-time to compare against Task 2's Stage-0 number.
+
+- [ ] **Step 3: Encode the winning cap in the budget logic + tests**
+
+If a higher cap wins, set `MAX_HTSLIB_THREADS` to it and update/extend the `budget.rs` tests (mirror the existing low-end/high-end/clamp cases) so the multi-contig path is unchanged and only spare cores feed extra decode threads. Run:
+```bash
+cd <worktree>; export CARGO_TARGET_DIR=/tmp/genoray-cargo-$$
+cargo test --no-default-features --features conversion budget 2>&1 | tail -5
+```
+Expected: budget tests pass. If no cap change wins, revert `budget.rs` and note it.
+
+- [ ] **Step 4: Commit (if changed) + record the Stage-2 decision**
+
+If the cap changed:
+```bash
+cd <worktree>
+git add src/budget.rs && git commit -m "perf(svar2): raise htslib decode-thread cap now that inflate is cheap
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+Then write the **decision** into the plan's task notes / commit message:
+- **NO-GO (stop here):** if libdeflate + thread re-sweep uses the idle cores and the next win (Stage 2) is small relative to its risk/effort → per the diminishing-returns stopping rule, the effort is complete. Task 5 is not executed.
+- **GO:** if htslib `bgzf_mt` still fails to scale and the profile still shows decompression dominating with idle cores → proceed to Task 5, which warrants its own detailed plan (see Task 5).
+
+---
+
+## Task 5: Parallel BGZF frontend (Stage 2 — CONDITIONAL, gated on Task 4 GO)
+
+> **Do not start unless Task 4 recorded a GO.** This task is a de-risking spike, not a specified implementation — the spec deliberately leaves the htslib-feed mechanism unresolved. Its deliverable is a measured go/no-go on the plumbing, after which it MUST spawn its own detailed plan (re-invoke superpowers:writing-plans) before any production implementation.
+
+**Files:**
+- Prototype (throwaway, outside the crate or behind a `#[cfg(feature = "bgzf_spike")]` gate): a standalone Rust binary/example that reads a BGZF BCF, decompresses blocks in parallel with `libdeflater`, and reassembles the ordered byte stream.
+- Reference: `src/vcf_reader.rs` (`VcfChunkReader`, htslib handle ownership), PLINK2 `plink2_bgzf.cc` (GPLv3 — read for algorithm, copy nothing), noodles `bgzf::MultithreadedReader` (MIT — may depend on).
+
+**Interfaces:**
+- Consumes: the GO decision + profile from Task 4.
+- Produces: a measured answer to "can we feed htslib's BCF parser decompressed bytes while decompressing in parallel, byte-identically, faster than Stage 1?" — and, if yes, a follow-on plan.
+
+- [ ] **Step 1: Spike the decompression correctness**
+
+Build a throwaway that parallel-decompresses `gdc.chr21.slice.bcf`'s BGZF blocks via `libdeflater` and concatenates them in order; assert the result is byte-identical to htslib's own decompression (`bgzip -d` / a single-thread reference). Include the short final block and the BGZF EOF marker.
+Expected: byte-identical decompressed stream. If not, the parser-feed is unsafe — record NO-GO.
+
+- [ ] **Step 2: Spike the htslib feed mechanism**
+
+Prototype ONE feed path and measure it end-to-end vs Stage 1: (a) pipe the decompressed uncompressed-BCF stream into htslib via an `hFILE`/fd, or (b) a custom `hFILE` plugin. Verify htslib parses records identically (record count + a GT spot-check) and that inflate no longer appears in the profile.
+Expected: a wall-time and a byte-identical record stream, or a documented reason the mechanism is unworkable.
+
+- [ ] **Step 3: Decide and hand off**
+
+Write the spike result into `docs/superpowers/specs/` (a short addendum) and:
+- **If the spike wins and is byte-identical:** re-invoke superpowers:writing-plans to author the production implementation plan (thread-budget integration, `VcfChunkReader` restructure, proptest for cross-block decompression, wheel implications of `libdeflater`).
+- **If it does not win or cannot be made byte-identical:** stop — Stage 0/1 stand as the delivered speedup, per diminishing returns.
+
+- [ ] **Step 4: Commit the spike findings (not the throwaway prototype)**
+
+```bash
+cd <worktree>
+git add docs/superpowers/specs/
+git commit -m "docs(svar2): record parallel-BGZF frontend spike result
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Root cause (zlib→libdeflate) → Task 2. ✓
+- Stage 0 (libdeflate) → Task 2; wheel/CI caveat → Task 3. ✓
+- Stage 1 (thread re-sweep) → Task 4. ✓
+- Stage 2 (parallel BGZF frontend, gated) → Task 5, explicitly conditional on Task 4 GO. ✓
+- Harness slice + full-file validation → Task 1 + reused throughout. ✓
+- Byte-identical gate, cargo/pytest gates → Global Constraints + every task's gate steps. ✓
+- Diminishing-returns stopping rule → encoded as the Task 4 decision gate and Task 5 hand-off. ✓
+- GPL boundary, CHANGELOG, no-API-change → Global Constraints. ✓
+
+**Placeholder scan:** Stage 2 is intentionally a gated spike (the spec leaves its mechanism open); it is scoped as "measure then spawn its own plan," not fabricated code — this is honest gating, not a placeholder. All executable steps carry exact commands. `<worktree>` is a substitution the executor fills with the current worktree path.
+
+**Type consistency:** No new cross-task types/signatures introduced (config + build + experiment tasks). `MAX_HTSLIB_THREADS`, `plan_thread_budget`, `VcfChunkReader` names match the current source.

--- a/docs/superpowers/specs/2026-07-13-svar2-vcf-read-libdeflate-parallel-design.md
+++ b/docs/superpowers/specs/2026-07-13-svar2-vcf-read-libdeflate-parallel-design.md
@@ -199,7 +199,7 @@ actually exists to provide. Oracles were re-baselined to the current environment
 builds against libdeflate (`libdeflate-sys` 1.25.2, statically linked; 21
 `libdeflate_*` symbols in `_core.so`, no dynamic dep). Byte-identical output
 (differential gate). Speedups at `threads=32`:
-- germline chr21: 36.25s → 26.25s (**−27%**)
+- germline chr21: 36.25s → 26.25s (**−28%**)
 - gdc chr21:      1016.7s → 636s (**−37%**)
 
 **Stage 0 wheels (Task 3, no change needed).** `libdeflate-sys` compiles and

--- a/docs/superpowers/specs/2026-07-13-svar2-vcf-read-libdeflate-parallel-design.md
+++ b/docs/superpowers/specs/2026-07-13-svar2-vcf-read-libdeflate-parallel-design.md
@@ -179,3 +179,50 @@ entry under `## Unreleased` (do not bump the version by hand). Update the roadma
   (MIT) is the only read-path code we may depend on directly.
 - **Executor transpose (~17%) is the next ceiling** and is explicitly out of scope —
   parallelizing it hits long-allele-bank determinism (byte-identical hazard).
+
+---
+
+## Outcome (execution, 2026-07-13)
+
+Executed on a dedicated `carter-compute` node against the full chr21 germline
+(1,001,385 variants) and gdc (4,525,689 variants, 16,007 samples) BCFs.
+
+**Correctness note.** The Jul-7 full-file oracle hashes drifted (an unrelated
+pixi-env/dependency change between Jul 7 and Jul 13 alters store serialization).
+The change was therefore gated **differentially**: the libdeflate build was proven
+byte-identical to the pre-change (zlib) build **in the same environment**,
+deterministically, on both full datasets — the guarantee the byte-identical rule
+actually exists to provide. Oracles were re-baselined to the current environment
+(pre-change == libdeflate), preserving the Jul-7 values as `*.jul7.hash`.
+
+**Stage 0 — libdeflate (shipped).** hts-sys `libdeflate` feature → vendored htslib
+builds against libdeflate (`libdeflate-sys` 1.25.2, statically linked; 21
+`libdeflate_*` symbols in `_core.so`, no dynamic dep). Byte-identical output
+(differential gate). Speedups at `threads=32`:
+- germline chr21: 36.25s → 26.25s (**−27%**)
+- gdc chr21:      1016.7s → 636s (**−37%**)
+
+**Stage 0 wheels (Task 3, no change needed).** `libdeflate-sys` compiles and
+statically embeds its own vendored libdeflate C — no system dependency. The
+linux-64 abi3 release wheel builds and `auditwheel repair` is a no-op (already
+manylinux_2_28, nothing bundled). No `ci/wheel/pixi.toml` change required; the
+other three platforms use the same static mechanism.
+
+**Stage 1 — htslib decode-thread re-sweep (inert).** Sweeping
+`MAX_HTSLIB_THREADS` ∈ {4,8,12,16} at fixed 32 cores (gdc slice) is flat within
+noise (20.4–21.4s), all byte-identical. Raising the cap is inert under libdeflate
+just as it was under zlib. `MAX_HTSLIB_THREADS` stays at 8; no code change.
+
+**Stage 2 — parallel BGZF frontend: NO-GO.** A `perf` profile of the libdeflate
+build (gdc slice) shows decompression is no longer dominant:
+`deflate_decompress_bmi2` ~15% + SIMD crc32 ~1.3%. The larger costs are now sparse
+packing (`dense2sparse_vk` ~16%) and single-threaded htslib record parsing
+(`next_record` + `bcf_get_format_values` ~23%). A parallel BGZF frontend
+accelerates only decompression — a ~16% ceiling — against high effort/risk (custom
+BGZF, byte-exact htslib feed, GPL boundary). Per the diminishing-returns stopping
+rule, the effort is complete at Stage 0/1. Task 5 was not executed.
+
+**Follow-up (out of scope here).** The profile also shows `blas_thread_server`
+~9% — idle OpenBLAS/OpenMP threads spinning (numpy/scipy import oversubscription).
+Capping `OPENBLAS_NUM_THREADS`/`OMP_NUM_THREADS` during conversion is a cheap
+independent win worth a separate look.

--- a/docs/superpowers/specs/2026-07-13-svar2-vcf-read-libdeflate-parallel-design.md
+++ b/docs/superpowers/specs/2026-07-13-svar2-vcf-read-libdeflate-parallel-design.md
@@ -1,0 +1,181 @@
+# VCF→SVAR2 conversion read-path speedup — libdeflate + parallel BGZF
+
+**Date:** 2026-07-13 · **Home:** `genoray` · **Status:** design, not yet started
+
+> Follow-on to the two 2026-07-07 profiling designs
+> ([`svar1-vs-svar2-timing-and-profiling`](2026-07-07-svar1-vs-svar2-timing-and-profiling-design.md),
+> [`svar2-parallel-reader`](2026-07-07-svar2-parallel-reader-design.md)). Read those
+> first — the perf findings, the byte-identical discipline, and the harness they
+> describe are the foundation here. SVAR2 is unreleased, so we are free to overhaul
+> the read path as long as the store stays byte-identical.
+
+## Problem
+
+After the landed reader micro-opts (raw-GT decode, per-word packing, parallel
+packing), single-contig VCF→SVAR2 conversion is **htslib input-bound**. The gdc
+(16007-sample, 4.5M-variant, somatic chr21) reader profile is dominated by:
+
+- **`inflate_fast` ~31% + `crc32_z` ~14% ≈ 45%** — BGZF block decompression.
+- `bcf_get_format_values` ~9% — htslib copying the raw GT FORMAT array out.
+- packing ~16% (already parallelized), executor transpose ~17% (single-thread,
+  out of scope — hits bank determinism).
+
+Raising `MAX_HTSLIB_THREADS` (the htslib `bgzf_mt` decode-thread cap) was previously
+found **inert**. ~24 of 32 cores sit idle on a single-contig file.
+
+## Root cause found during design: htslib is linked against zlib, not libdeflate
+
+`inflate_fast` and `crc32_z` are **zlib** symbols. `rust-htslib` is declared in
+`Cargo.toml` as `default-features = false` with **no `libdeflate` feature**, so
+hts-sys vendors and compiles htslib against zlib's inflate + slice-by-8 CRC32.
+
+Two facts make this the headline:
+
+1. `rust-htslib` (v1.0) exposes `libdeflate = ["hts-sys/libdeflate"]`, and
+   `hts-sys` (v2.2.0) exposes `libdeflate = ["libdeflate-sys"]`. The feature is
+   present and simply switched off.
+2. `libdeflate.so` already ships in the pixi env (`.pixi/envs/*/lib/libdeflate.so`).
+
+libdeflate — the same decompressor PLINK2 uses — is typically ~1.5–2.5× faster at
+DEFLATE decompression than zlib and uses a SIMD (PCLMULQDQ) CRC32. Turning it on is
+a one-line change that attacks the single largest cost directly, and it is orthogonal
+to thread count (each block's inflate gets cheaper on 1 or 8 threads), which is also
+the most likely reason the thread-cap bump was inert: more threads on slow zlib
+blocks, gated by CRC + serial parse.
+
+## Goal & stopping rule
+
+Speed up single-contig VCF/BCF→SVAR2 conversion, gated at every step by the harness.
+**Stopping rule: diminishing returns** — push each stage, stop when the next stage's
+expected win is not worth its risk/effort; report before/after per stage. No fixed
+wall-clock target. **Non-negotiable invariant: byte-identical store output** on both
+germline and gdc after every change.
+
+## Approach: staged, measurement-gated
+
+Each stage is gated on the harness. We escalate to the expensive overhaul (Stage 2)
+**only if** the cheap wins (Stage 0/1) plateau short of what the profile says is
+achievable. This honors the project's "measure, don't guess" principle and the
+user's explicit "overhaul *if need be*" framing.
+
+### Stage 0 — Enable libdeflate (near-free, do first)
+
+- Change `rust-htslib = { version = "1.0", default-features = false, optional = true }`
+  → add `features = ["libdeflate"]`. Update the `Cargo.toml` comment (which currently
+  documents only the dropped bzip2/lzma/curl) to record that libdeflate is on and why.
+- Confirm the vendored htslib actually links libdeflate: rebuild, then verify the
+  profile no longer shows `inflate_fast`/`crc32_z` (should show `libdeflate_*`
+  symbols instead), or check the linked `libhts` build config.
+- **Wheel/CI implication:** the release wheels build from `ci/wheel/pixi.toml` with
+  auditwheel/delocate repair. libdeflate becomes a build-and-runtime dependency of
+  the vendored htslib — confirm it is available on all four wheel platforms in the CI
+  manifest and gets vendored/repaired into the wheel (this is the one non-trivial
+  part of an otherwise one-line change). If bundling is a problem, fall back to the
+  hts-sys static libdeflate.
+- **Expected:** the ~45% BGZF cost roughly halves. Rough projection (measure, don't
+  trust): gdc ~18min → ~13–14min, germline 36.5s → ~28s. Byte-identical.
+
+### Stage 1 — Re-sweep htslib decode threads with the fast decompressor
+
+- With per-block inflate now cheap, htslib's `bgzf_mt` may finally scale where it was
+  inert against zlib. Re-sweep `htslib_threads` (8/12/16) on the idle cores; keep the
+  win behind `plan_thread_budget` (only widen when spare cores exist), mirroring the
+  existing budget tests.
+- If htslib's own multithreading now scales acceptably, **stop here** — Stage 2's
+  custom decompressor is unnecessary.
+
+### Stage 2 — Parallel BGZF frontend (the overhaul; only if Stage 1 plateaus)
+
+If htslib's `bgzf_mt` still fails to use the idle cores after libdeflate, build a
+custom multithreaded BGZF decompressor that feeds htslib's **trusted BCF parser**:
+
+- **Why this shape:** BGZF blocks (≤64KB compressed) are independent — inflate is
+  embarrassingly parallel. A custom layer reads compressed blocks serially (cheap
+  I/O), fans `libdeflate_deflate_decompress` across idle cores (via the `libdeflater`
+  crate), and reassembles the decompressed BCF byte stream in order.
+- **Feed htslib, don't replace it:** hand the decompressed bytes to htslib's BCF
+  record parser (through a pipe / in-memory `hFILE` / uncompressed-BCF stream — exact
+  mechanism to prototype). htslib does **zero inflate**, only parse. This keeps the
+  exact atomize / left-align / raw-GT-decode semantics that the byte-identical gate
+  depends on — we are moving *where inflate happens*, not *what gets parsed*.
+- **Inspiration, not code:** PLINK2's `plink2_bgzf.cc` is the reference algorithm for
+  a parallel libdeflate BGZF reader, but plink-ng is **GPLv3 — no code may be copied**
+  into genoray. Study it for the block-queue/tuning approach and reimplement clean.
+  genoio (Rust, less battle-tested) is a secondary reference. Note the existing
+  precedent: the `zstd` dep comment already documents "no plink-ng code."
+- Sequential full-contig read needs no CSI random-access, so ordered streaming (no
+  virtual-offset seeks) is sufficient.
+- **Fallback of last resort (not the plan):** a full pure-Rust reader/parser via
+  noodles (MIT — dependency-safe) or hand-rolled. Highest semantic risk — it must
+  reproduce htslib's exact record decoding — so only if the pipe-to-htslib frontend
+  proves unworkable.
+
+## Profiling harness
+
+Reuse and extend `/carter/users/dlaub/svar_bench/`, which already has: both filtered
+chr21 BCFs (`chr21.filt.bcf` germline 3202 samples, `gdc.chr21.filt.bcf` somatic
+16007 samples), CSI indexes, `.gvi`, oracle store hashes (`oracle.chr21.hash`,
+`oracle.gdc.hash`), `run_svar2.py`, `storehash.sh`, and perf capture scripts.
+
+Add for the fast dev-loop:
+
+- **A small slice of each dataset** — e.g. the first ~5–10 Mb of chr21 via
+  `bcftools view <file> chr21:1-10000000 -Ob` — giving ~10–30s germline / ~1–2min
+  gdc runs so profile-optimize-remeasure iterates in minutes, not the ~18-min full
+  gdc run. Generate slice-specific oracle hashes too.
+- Keep **full chr21** as the byte-identical validation gate (the small slice is for
+  iteration speed only; correctness is always confirmed on the full file).
+
+Profiling protocol (unchanged from the prior pass):
+
+- Build the profiling wheel:
+  `RUSTFLAGS="-C force-frame-pointers=yes" maturin develop --profile profiling`;
+  restore `maturin develop --release` after.
+- Run on a **dedicated `carter-compute` node** (`sbatch -p carter-compute -c 32
+  --mem=128G` holder + `srun --jobid=<id> --overlap`) — the login node is unusable
+  under load.
+- `perf record -g --call-graph fp` → `perf report` + flamegraph; separate the
+  per-thread `read-*` / `exec-*` split so inflate vs parse vs pack is attributable.
+- Reference FASTA: `/carter/shared/data/gdc/resources/GRCh38.d1.vd1.fa`.
+
+## Correctness & verification (non-negotiable)
+
+After **every** stage, on **both** full datasets:
+
+- **Byte-identical store hash** vs the oracle (`storehash.sh` sha256 of every store
+  file == `oracle.<dataset>.hash`). Any diff is a regression, full stop.
+- `cargo test --no-default-features --features conversion` (the link-flag gotcha —
+  default `extension-module` breaks the test binary; see the memory note on
+  `--no-default-features`).
+- `pytest tests -m "not network"`.
+- Stage 2 only: a targeted proptest that the parallel-decompressed BCF byte stream is
+  identical to htslib's own decompression across block boundaries and short final
+  blocks (missing/vector-end GT sentinels included).
+
+## Skill / docs impact
+
+This is a pure performance change with **no public-API surface change** — return
+shapes, dtypes, mode constants, and coordinate/missing conventions are unchanged. No
+`skills/genoray-api/SKILL.md` update expected. Add a human-readable `CHANGELOG.md`
+entry under `## Unreleased` (do not bump the version by hand). Update the roadmap
+`svar-2.md` if the pipeline/thread-model description changes.
+
+## Risks / open questions
+
+- **libdeflate in the release wheels** — the main non-trivial part of Stage 0. Must
+  be vendored/repaired into all four platform wheels; verify against `ci/wheel/
+  pixi.toml`. Toolchain pins are duplicated between the two manifests and must stay
+  in sync.
+- **libdeflate actually gets linked** — the hts-sys `libdeflate` feature must cause
+  the vendored htslib to build `--with-libdeflate`; confirm by symbol inspection
+  post-build, don't assume the feature flag alone did it.
+- **Stage 1 may already suffice** — if the thread re-sweep scales after libdeflate,
+  Stage 2 is dead code; do not build it speculatively.
+- **Stage 2 pipe/hFILE mechanism** — feeding decompressed bytes into htslib's parser
+  without its own BGZF layer needs a prototype spike; the exact plumbing
+  (uncompressed-BCF stream vs custom `hFILE` plugin vs pipe) is unresolved and is the
+  first thing to de-risk if we reach Stage 2.
+- **GPL boundary** — no plink-ng code copied; algorithm inspiration only. noodles
+  (MIT) is the only read-path code we may depend on directly.
+- **Executor transpose (~17%) is the next ceiling** and is explicitly out of scope —
+  parallelizing it hits long-allele-bank determinism (byte-identical hazard).


### PR DESCRIPTION
## Summary

Speeds up single-contig VCF/BCF→SVAR2 conversion by building the vendored htslib
against **libdeflate** instead of zlib (`hts-sys` `libdeflate` feature). The read
path was bottlenecked on zlib BGZF decompression; libdeflate's faster inflate +
SIMD CRC is a near-free win.

Executed as a staged, measurement-gated plan on a dedicated `carter-compute` node
against full chr21 germline (1,001,385 variants) and gdc (4,525,689 variants /
16,007 samples) BCFs.

## Results (threads=32)

| dataset | zlib | libdeflate | speedup |
|---|---|---|---|
| germline chr21 | 36.25s | 26.25s | **−28%** |
| gdc chr21 | 1016.7s | 636s | **−37%** |

- **Byte-identical output**, verified *differentially* against the pre-change
  build in the same environment (deterministic, both full datasets). See the
  "Correctness note" in the design doc re: re-baselining vs. stale env-drifted oracles.
- All tests pass: 231 Rust unit + integration, 621 pytest.
- **Statically linked** (`libdeflate-sys` 1.25.2 bundles its own C) — the linux-64
  abi3 release wheel builds and `auditwheel repair` is a no-op. No `ci/wheel` change.
- No public-API change (no `skills/genoray-api/SKILL.md` update needed).

## Stages 1 & 2 (measurement-gated, no code)

- **Stage 1** (htslib decode-thread re-sweep): flat within noise across cap ∈
  {4,8,12,16} → inert. `MAX_HTSLIB_THREADS` unchanged.
- **Stage 2** (custom parallel BGZF frontend): **NO-GO**. Profiling shows
  decompression is no longer dominant (~16%); the bottleneck moved to
  single-threaded htslib record parsing (~23%) and sparse packing (~16%). A
  decompression-only accelerator has a ~16% ceiling against high effort/risk
  (GPL boundary, byte-exact htslib feed) → diminishing returns.

Full outcome recorded in `docs/superpowers/specs/2026-07-13-svar2-vcf-read-libdeflate-parallel-design.md`.

## Commits
- `perf(svar2)`: link vendored htslib against libdeflate
- `docs(svar2)`: record read-path outcome + Stage-2 NO-GO
- `docs(svar2)`: changelog style + rounding fixes from review

🤖 Generated with [Claude Code](https://claude.com/claude-code)