### PR TITLE
feat(svar2): SBS192/SBS384 transcriptional-strand-bias catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
   for COSMIC mutational-signature workflows (SBS96/ID83/DBS78), implemented in
   Rust with a per-record sidecar and streaming count matrix. `from_vcf` gains a
   `signatures=` flag to classify during the write (factored into the cost model).
+- `SparseVar2.annotate_mutations` gains a `gtf=` argument that annotates each SNV
+  with its transcriptional strand class (stored in a 2-bit `strand.bin`
+  sidecar), enabling the strand-resolved `mutation_matrix("SBS192")` and
+  `mutation_matrix("SBS384")` catalogs (SigProfiler `[T, U, N, B]` order; SBS192
+  is the `{T, U}` view). Strand is computed from `feature == "gene"` footprints.
+  `assign_signatures` raises `NotImplementedError` for these kinds (no COSMIC
+  reference set). Write-time `from_vcf(signatures=True)` remains strand-free.
 - `SparseVar2.from_vcf` can extract scalar-numeric INFO/FORMAT fields into the
   store via new `info_fields=`/`format_fields=` kwargs and `InfoField`/
   `FormatField` config types (`genoray.InfoField`, `genoray.FormatField`).

--- a/docs/superpowers/plans/2026-07-13-svar2-sbs192-sbs384.md
+++ b/docs/superpowers/plans/2026-07-13-svar2-sbs192-sbs384.md
@@ -1,0 +1,1673 @@
+# SBS192 / SBS384 Transcriptional-Strand-Bias Catalogs for SparseVar2 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add strand-resolved SBS192/SBS384 mutation catalogs to `SparseVar2`, computed from a GTF gene model supplied to `annotate_mutations`.
+
+**Architecture:** The strand dimension (Transcribed/Untranscribed/Nontranscribed/Bidirectional) is stored per-SNP in a new optional 2-bit `strand.bin` sidecar stream, orthogonal to the existing SBS96 `code.bin`. Python builds a sorted, disjoint strand-class interval partition from the GTF (via `seqpro`) and passes it as a struct-of-arrays across the existing per-contig pyo3 boundary; Rust classifies each SNP with a two-pointer sweep. The unified code space gains one SBS384 block; SBS192 is the `SBS384[:192]` (T,U) view. Counting emits into the SBS384 block alongside SBS96; `mutation_matrix` slices the requested range.
+
+**Tech Stack:** Rust (pyo3, ndarray, rayon, memmap2), Python (numpy, polars, seqpro), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-svar2-sbs192-sbs384-design.md`
+
+## Global Constraints
+
+- **Codebook lockstep:** `python/genoray/_mutcat/codebook.py` and `src/mutcat/mod.rs` MUST agree on offsets and sizes. The Rust test `code_space_matches_codebook` (`src/mutcat/mod.rs`) enforces this — update both together.
+- **Code-space arithmetic (verbatim):** `SBS96_OFFSET=0`, `DBS78_OFFSET=96`, `ID83_OFFSET=174`, `SBS384_OFFSET=257`, `N_CODES=641` (= 257 + 384). Existing offsets do NOT move.
+- **Strand class encoding (verbatim):** stored `strand.bin` value and count `strand_idx` are `T=0, U=1, N=2, B=3`. Interval-partition `values` (GTF side) use a DIFFERENT encoding: `1=+only, 2=−only, 3=both`, gaps ⇒ `0` (N).
+- **`MUTCAT_VERSION`** bumps `3 → 4`. This is a backward-compatible read: SBS384 availability is gated on `strand.bin` presence, never on version equality. (Side effect: v1 `SparseVar` stores stamped with version 3 will re-annotate on next use — expected and acceptable.)
+- **Coordinates:** all intervals 0-based, half-open `[start, stop)`.
+- **Strand applies to SNVs only.** DBS78 and ID83 paths are untouched.
+- **Rust tests** run in the `lint` pixi env and MUST use `--no-default-features --features conversion` (else the pyo3 test binary fails to link with `undefined symbol: _Py_Dealloc`). Always set `CARGO_TARGET_DIR` off the NFS mount to avoid a linker bus error. Canonical form:
+  ```bash
+  pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion <TEST_NAME>'
+  ```
+  `<TEST_NAME>` filters by **test-function name**, not file — a name that matches nothing vacuously "passes" 0 tests, so always pass a name you know exists.
+- **Rebuild the extension** after Rust changes before running Python tests:
+  ```bash
+  pixi run bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && maturin develop --features conversion'
+  ```
+- **Conventional Commits** for every commit (`feat:`, `test:`, `docs:`, `refactor:`).
+- **Public-API rule:** any change reachable from `import genoray` without underscores requires updating `skills/genoray-api/SKILL.md` in this same work (Task 11).
+
+---
+
+## File Structure
+
+- `python/genoray/_mutcat/codebook.py` (modify) — add SBS384/SBS192 labels, offset, `N_CODES`, `Kind`, `code_ranges`, `labels`, bump `MUTCAT_VERSION`.
+- `python/genoray/_mutcat/strand.py` (create) — GTF → sorted disjoint strand-class intervals (pure Python, no Rust dependency).
+- `python/genoray/_svar2_mutcat.py` (modify) — `annotate_mutations(gtf=)`, `mutation_matrix` SBS192/384 + strand guard, `assign_signatures` raises for strand kinds, `_is_strand_annotated`.
+- `src/mutcat/mod.rs` (modify) — SBS384 code space + strand-idx constants + `Kind::Sbs384`.
+- `src/mutcat/classify.rs` (modify) — `snp_strand` classifier.
+- `src/layout.rs` (modify) — `MutcatSub::has_strand`, `mutcat_strand` path.
+- `src/mutcat/sidecar.rs` (modify) — write/read/mmap `strand.bin`, `MutcatView::strand_at`/`has_strand`.
+- `src/mutcat/annotate.rs` (modify) — `StrandIntervals`, `StrandSweeper`, strand-aware SNP annotation; update call sites.
+- `src/mutcat/count.rs` (modify) — `SnvCall.strand`, SBS384 emission, widened asserts.
+- `src/py_mutcat.rs` (modify) — optional strand-interval args on `annotate_mutations`.
+- `src/orchestrator.rs` (modify, 1 line) — pass `None` strand at the write-time annotate call site.
+- `tests/test_svar2_mutcat.py` (modify) — end-to-end SBS192/384 parity + guard tests.
+- `tests/test_mutcat_strand.py` (create) — unit tests for the Python interval builder.
+- `skills/genoray-api/SKILL.md` (modify) — document the new surface.
+- `CHANGELOG.md` (modify) — Unreleased entry.
+
+---
+
+## Task 1: Python codebook — SBS384 / SBS192 code space
+
+**Files:**
+- Modify: `python/genoray/_mutcat/codebook.py`
+- Test: `tests/test_mutcat_codebook_sbs384.py` (create)
+
+**Interfaces:**
+- Produces: `SBS384: list[str]` (384 labels, `[T,U,N,B] × SBS96` order); `SBS384_OFFSET=257`, `N_CODES=641`; `Kind` includes `"SBS192"`, `"SBS384"`; `code_ranges()["SBS192"]==(257,449)`, `code_ranges()["SBS384"]==(257,641)`; `labels("SBS384")==SBS384`, `labels("SBS192")==SBS384[:192]`; `MUTCAT_VERSION==4`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_mutcat_codebook_sbs384.py`:
+
+```python
+from __future__ import annotations
+
+from genoray._mutcat import codebook as cb
+
+
+def test_sbs384_layout():
+    assert cb.SBS384_OFFSET == 257
+    assert cb.N_CODES == 641
+    assert len(cb.SBS384) == 384
+    # [T, U, N, B] blocks of 96, each label "<strand>:<sbs96 label>"
+    assert cb.SBS384[0] == f"T:{cb.SBS96[0]}"
+    assert cb.SBS384[96] == f"U:{cb.SBS96[0]}"
+    assert cb.SBS384[192] == f"N:{cb.SBS96[0]}"
+    assert cb.SBS384[288] == f"B:{cb.SBS96[0]}"
+
+
+def test_sbs192_is_tu_view():
+    assert cb.labels("SBS384") == cb.SBS384
+    assert cb.labels("SBS192") == cb.SBS384[:192]
+    assert cb.code_ranges()["SBS384"] == (257, 641)
+    assert cb.code_ranges()["SBS192"] == (257, 449)
+    assert cb.code_ranges()["SBS96"] == (0, 96)
+
+
+def test_version_bumped():
+    assert cb.MUTCAT_VERSION == 4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_mutcat_codebook_sbs384.py -v`
+Expected: FAIL — `AttributeError: module 'genoray._mutcat.codebook' has no attribute 'SBS384'`.
+
+- [ ] **Step 3: Implement the codebook additions**
+
+In `python/genoray/_mutcat/codebook.py`, after the `ID83` block and its `assert` (currently around line 119), add the SBS384 catalog:
+
+```python
+# ---- SBS-384 (transcriptional strand bias): SigProfiler [T, U, N, B] blocks ----
+# T=Transcribed, U=Untranscribed, N=Nontranscribed (intergenic), B=Bidirectional.
+# Label form "<strand>:<sbs96 label>", e.g. "T:A[C>A]A". SBS-192 is the {T,U} view
+# (SBS384[:192]); no separate stored range.
+_STRANDS = ["T", "U", "N", "B"]
+SBS384: list[str] = [f"{s}:{lbl}" for s in _STRANDS for lbl in SBS96]
+
+assert len(SBS384) == 384
+```
+
+Change the unified-code-space block (currently ending `N_CODES = ID83_OFFSET + len(ID83)  # 257`) to append the SBS384 block:
+
+```python
+# ---- unified int16 code space ----
+SBS96_OFFSET = 0
+DBS78_OFFSET = SBS96_OFFSET + len(SBS96)  # 96
+ID83_OFFSET = DBS78_OFFSET + len(DBS78)  # 174
+SBS384_OFFSET = ID83_OFFSET + len(ID83)  # 257
+N_CODES = SBS384_OFFSET + len(SBS384)  # 641
+```
+
+Bump the version constant:
+
+```python
+MUTCAT_VERSION = 4
+```
+
+Extend the `Kind` literal, `_LABELS`, `code_ranges`, and `labels`:
+
+```python
+Kind = Literal["SBS96", "DBS78", "ID83", "SBS192", "SBS384"]
+
+_LABELS: dict[str, list[str]] = {
+    "SBS96": SBS96,
+    "DBS78": DBS78,
+    "ID83": ID83,
+    "SBS384": SBS384,
+    "SBS192": SBS384[:192],
+}
+```
+
+```python
+def code_ranges() -> dict[Kind, tuple[int, int]]:
+    """Half-open ``[start, end)`` code range per matrix kind.
+
+    ``SBS192`` is the {T, U} sub-view of the ``SBS384`` block, so its range is
+    the first 192 codes of that block.
+    """
+    return {
+        "SBS96": (SBS96_OFFSET, DBS78_OFFSET),
+        "DBS78": (DBS78_OFFSET, ID83_OFFSET),
+        "ID83": (ID83_OFFSET, SBS384_OFFSET),
+        "SBS384": (SBS384_OFFSET, N_CODES),
+        "SBS192": (SBS384_OFFSET, SBS384_OFFSET + 192),
+    }
+```
+
+`labels()` needs no change beyond the `_LABELS` additions (it already looks up `_LABELS[kind]`).
+
+Note: `ID83`'s range end changes from `N_CODES` to `SBS384_OFFSET` (same value, 257) — update the literal `(ID83_OFFSET, N_CODES)` to `(ID83_OFFSET, SBS384_OFFSET)` as shown so it stays correct now that `N_CODES != 257`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest tests/test_mutcat_codebook_sbs384.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_mutcat/codebook.py tests/test_mutcat_codebook_sbs384.py
+git commit -m "feat(mutcat): add SBS384/SBS192 code space to python codebook"
+```
+
+---
+
+## Task 2: Rust codebook mirror — SBS384 code space
+
+**Files:**
+- Modify: `src/mutcat/mod.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `N_SBS384=384`, `SBS384_OFFSET=257`, `N_CODES=641`; strand-idx consts `STRAND_T=0, STRAND_U=1, STRAND_N=2, STRAND_B=3, STRAND_NA=255`; `Kind::Sbs384` with `code_range()==257..641`.
+
+- [ ] **Step 1: Update the code-space test to the new layout**
+
+In `src/mutcat/mod.rs`, replace the two `#[test]` bodies so they assert the new layout:
+
+```rust
+    #[test]
+    fn code_space_matches_codebook() {
+        assert_eq!(SBS96_OFFSET, 0);
+        assert_eq!(DBS78_OFFSET, 96);
+        assert_eq!(ID83_OFFSET, 174);
+        assert_eq!(SBS384_OFFSET, 257);
+        assert_eq!(N_CODES, 641);
+    }
+
+    #[test]
+    fn kind_ranges_are_contiguous_and_sized() {
+        assert_eq!(Kind::Sbs96.code_range(), 0..96);
+        assert_eq!(Kind::Dbs78.code_range(), 96..174);
+        assert_eq!(Kind::Id83.code_range(), 174..257);
+        assert_eq!(Kind::Sbs384.code_range(), 257..641);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion code_space_matches_codebook'`
+Expected: FAIL — `cannot find value SBS384_OFFSET` (compile error).
+
+- [ ] **Step 3: Implement the code-space + strand constants**
+
+In `src/mutcat/mod.rs`, extend the size/offset constants:
+
+```rust
+/// Class-local index counts (COSMIC codebook sizes).
+pub const N_SBS96: usize = 96;
+pub const N_DBS78: usize = 78;
+pub const N_ID83: usize = 83;
+pub const N_SBS384: usize = 384;
+
+/// Unified code-space offsets — mirror codebook.py exactly.
+pub const SBS96_OFFSET: usize = 0;
+pub const DBS78_OFFSET: usize = SBS96_OFFSET + N_SBS96; // 96
+pub const ID83_OFFSET: usize = DBS78_OFFSET + N_DBS78; // 174
+pub const SBS384_OFFSET: usize = ID83_OFFSET + N_ID83; // 257
+pub const N_CODES: usize = SBS384_OFFSET + N_SBS384; // 641
+```
+
+Add strand-class index constants below `NOT_ANNOTATED`:
+
+```rust
+/// Transcriptional strand class indices (stored in `strand.bin`; also the
+/// SBS384 sub-block index). Mirror `[T, U, N, B]` from codebook.py.
+pub const STRAND_T: u8 = 0;
+pub const STRAND_U: u8 = 1;
+pub const STRAND_N: u8 = 2;
+pub const STRAND_B: u8 = 3;
+/// SNV with no strand stream on disk (sidecar annotated without a GTF).
+pub const STRAND_NA: u8 = 255;
+```
+
+Add the `Sbs384` variant and its range:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Sbs96,
+    Dbs78,
+    Id83,
+    Sbs384,
+}
+
+impl Kind {
+    /// Half-open unified-code range for this kind.
+    pub fn code_range(self) -> Range<usize> {
+        match self {
+            Kind::Sbs96 => SBS96_OFFSET..DBS78_OFFSET,
+            Kind::Dbs78 => DBS78_OFFSET..ID83_OFFSET,
+            Kind::Id83 => ID83_OFFSET..SBS384_OFFSET,
+            Kind::Sbs384 => SBS384_OFFSET..N_CODES,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion code_space'`
+Expected: PASS (`code_space_matches_codebook`, `kind_ranges_are_contiguous_and_sized`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mutcat/mod.rs
+git commit -m "feat(mutcat): mirror SBS384 code space + strand constants in rust"
+```
+
+---
+
+## Task 3: Rust strand classifier
+
+**Files:**
+- Modify: `src/mutcat/classify.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub fn snp_strand(refb: u8, gene_class: u8) -> u8` returning `STRAND_{T,U,N,B}`. `gene_class`: `0=none(N)`, `1=+only`, `2=−only`, `3=both(B)`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/mutcat/classify.rs`, inside the existing `#[cfg(test)] mod tests`, add:
+
+```rust
+    #[test]
+    fn snp_strand_matches_sigprofiler_examples() {
+        use crate::mutcat::{STRAND_B, STRAND_N, STRAND_T, STRAND_U};
+        // Gene on + strand (gene_class=1).
+        // A>T folds to T>A; ref base A is a purine (pyrimidine on -), so with the
+        // gene coding-strand = +, the pyrimidine is on the template = Transcribed.
+        assert_eq!(snp_strand(b'A', 1), STRAND_T);
+        // C>G; ref base C is a pyrimidine on + = coding strand = Untranscribed.
+        assert_eq!(snp_strand(b'C', 1), STRAND_U);
+        // Gene on - strand (gene_class=2): the assignments flip.
+        assert_eq!(snp_strand(b'A', 2), STRAND_U);
+        assert_eq!(snp_strand(b'C', 2), STRAND_T);
+        // Both strands -> B; no gene -> N (regardless of ref base).
+        assert_eq!(snp_strand(b'C', 3), STRAND_B);
+        assert_eq!(snp_strand(b'A', 0), STRAND_N);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion snp_strand_matches_sigprofiler_examples'`
+Expected: FAIL — `cannot find function snp_strand`.
+
+- [ ] **Step 3: Implement `snp_strand`**
+
+In `src/mutcat/classify.rs`, add after `sbs96_code` (around line 56). Update the top `use` to include the strand constants:
+
+```rust
+use crate::mutcat::{STRAND_B, STRAND_N, STRAND_T, STRAND_U, UNCLASSIFIED};
+```
+
+```rust
+/// Transcriptional strand class for an SNV: `STRAND_{T,U,N,B}`.
+///
+/// `refb` is the uppercased reference base; `gene_class` is the position's gene
+/// coverage: `0`=no gene (N), `1`=+ strand only, `2`=− strand only, `3`=both (B).
+///
+/// SBS channels are pyrimidine-folded, so the strand of the pyrimidine of the
+/// ref/alt pair decides T vs U: the pyrimidine is on the `+` strand iff `refb`
+/// is C or T. A single-strand gene's coding strand is its own strand; the
+/// mutation is Untranscribed when the pyrimidine sits on that coding strand,
+/// Transcribed otherwise.
+#[inline]
+pub fn snp_strand(refb: u8, gene_class: u8) -> u8 {
+    match gene_class {
+        1 | 2 => {
+            let pyr_on_plus = refb == b'C' || refb == b'T';
+            let gene_on_plus = gene_class == 1;
+            if pyr_on_plus == gene_on_plus {
+                STRAND_U
+            } else {
+                STRAND_T
+            }
+        }
+        3 => STRAND_B,
+        _ => STRAND_N,
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion snp_strand_matches_sigprofiler_examples'`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mutcat/classify.rs
+git commit -m "feat(mutcat): add SNV transcriptional-strand classifier"
+```
+
+---
+
+## Task 4: Rust strand sidecar stream (`strand.bin`)
+
+**Files:**
+- Modify: `src/layout.rs`, `src/mutcat/sidecar.rs`
+
+**Interfaces:**
+- Consumes: `MutcatSub` (existing).
+- Produces: `MutcatSub::has_strand(self) -> bool` (true for `VkSnp`/`DenseSnp`); `ContigPaths::mutcat_strand(&self, MutcatSub) -> PathBuf`; `write_sidecar(paths, sub, codes, ref_codes, strand_codes: Option<&[u8]>)`; `MutcatView::has_strand: bool`, `MutcatView::strand_at(&self, i) -> u8` (returns `STRAND_NA` when absent).
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/mutcat/sidecar.rs` `#[cfg(test)] mod tests`, add a strand round-trip test and update the two existing `write_sidecar` calls (they gain a trailing `None`/`Some`). Replace the `snp_sidecar_round_trips_code_and_ref` test and add a strand test:
+
+```rust
+    #[test]
+    fn snp_sidecar_round_trips_code_and_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let codes = [5u8, 95, 254, 0];
+        let refs = [1u8, 3, 0, 2]; // C,G(→ codec 3),A,T
+        write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs), None).unwrap();
+        let v = open_sidecar(&paths, MutcatSub::VkSnp).unwrap();
+        assert_eq!(v.n, 4);
+        assert!(!v.has_strand);
+        for i in 0..4 {
+            assert_eq!(v.code_at(i), codes[i]);
+            assert_eq!(v.ref_at(i), refs[i]);
+            assert_eq!(v.strand_at(i), crate::mutcat::STRAND_NA);
+        }
+    }
+
+    #[test]
+    fn snp_sidecar_round_trips_strand() {
+        use crate::mutcat::{STRAND_B, STRAND_N, STRAND_T, STRAND_U};
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let codes = [5u8, 95, 254, 0];
+        let refs = [1u8, 3, 0, 2];
+        let strands = [STRAND_T, STRAND_U, STRAND_N, STRAND_B];
+        write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs), Some(&strands)).unwrap();
+        let v = open_sidecar(&paths, MutcatSub::VkSnp).unwrap();
+        assert!(v.has_strand);
+        for i in 0..4 {
+            assert_eq!(v.strand_at(i), strands[i]);
+        }
+    }
+```
+
+Also update the two other `write_sidecar(...)` calls in that test module (`indel_sidecar_has_no_ref`, and any missing-file test) to append `, None`:
+
+```rust
+        write_sidecar(&paths, MutcatSub::VkIndel, &codes, None, None).unwrap();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion snp_sidecar_round_trips_strand'`
+Expected: FAIL — compile error (`write_sidecar` takes 4 args, `has_strand`/`strand_at` missing).
+
+- [ ] **Step 3a: Add `has_strand` + path to `src/layout.rs`**
+
+After the existing `has_ref` method on `impl MutcatSub` (around line 26):
+
+```rust
+    /// SNP sub-streams also carry a 2-bit `strand.bin` when GTF-annotated.
+    pub fn has_strand(self) -> bool {
+        matches!(self, MutcatSub::VkSnp | MutcatSub::DenseSnp)
+    }
+```
+
+After the existing `mutcat_ref` method on `impl ContigPaths` (around line 122):
+
+```rust
+    pub fn mutcat_strand(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub).join("strand.bin")
+    }
+```
+
+- [ ] **Step 3b: Implement `strand.bin` write/read in `src/mutcat/sidecar.rs`**
+
+Update `write_sidecar`'s signature and body to accept + write strand codes:
+
+```rust
+pub fn write_sidecar(
+    paths: &ContigPaths,
+    sub: MutcatSub,
+    codes: &[u8],
+    ref_codes: Option<&[u8]>,
+    strand_codes: Option<&[u8]>,
+) -> std::io::Result<()> {
+    let dir = paths.mutcat_sub_dir(sub);
+    fs::create_dir_all(&dir)?;
+    write_bytes(&paths.mutcat_code(sub), codes)?;
+    if sub.has_ref() {
+        let refs = ref_codes.expect("snp sub-stream requires ref_codes");
+        debug_assert_eq!(refs.len(), codes.len());
+        let packed = pack_snp_keys(refs);
+        write_bytes(&paths.mutcat_ref(sub), &packed)?;
+    }
+    if sub.has_strand() {
+        if let Some(strands) = strand_codes {
+            debug_assert_eq!(strands.len(), codes.len());
+            let packed = pack_snp_keys(strands);
+            write_bytes(&paths.mutcat_strand(sub), &packed)?;
+        }
+    }
+    Ok(())
+}
+```
+
+Extend `MutcatView` and its accessors:
+
+```rust
+pub struct MutcatView {
+    code: Option<Mmap>,
+    ref_packed: Option<Mmap>,
+    strand_packed: Option<Mmap>,
+    pub n: usize,
+    pub has_strand: bool,
+}
+```
+
+Add the `strand_at` accessor next to `ref_at`:
+
+```rust
+    /// 2-bit transcriptional-strand code at snp record `i` (`STRAND_{T,U,N,B}`),
+    /// or `STRAND_NA` if this sidecar has no strand stream (annotated without a GTF).
+    #[inline]
+    pub fn strand_at(&self, i: usize) -> u8 {
+        match &self.strand_packed {
+            Some(m) => unpack_snp_key_at(&m[..], i),
+            None => crate::mutcat::STRAND_NA,
+        }
+    }
+```
+
+Update `open_sidecar` to mmap `strand.bin` when present:
+
+```rust
+pub fn open_sidecar(paths: &ContigPaths, sub: MutcatSub) -> std::io::Result<MutcatView> {
+    let code = mmap_file(&paths.mutcat_code(sub))?;
+    let n = code.as_ref().map(|m| m.len()).unwrap_or(0);
+    let ref_packed = if sub.has_ref() {
+        mmap_file(&paths.mutcat_ref(sub))?
+    } else {
+        None
+    };
+    let strand_packed = if sub.has_strand() {
+        mmap_file(&paths.mutcat_strand(sub))?
+    } else {
+        None
+    };
+    let has_strand = strand_packed.is_some();
+    Ok(MutcatView {
+        code,
+        ref_packed,
+        strand_packed,
+        n,
+        has_strand,
+    })
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion sidecar'`
+Expected: PASS (`snp_sidecar_round_trips_code_and_ref`, `snp_sidecar_round_trips_strand`, `indel_sidecar_has_no_ref`, `missing_sidecar_opens_empty`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/layout.rs src/mutcat/sidecar.rs
+git commit -m "feat(mutcat): add optional 2-bit strand.bin sidecar stream"
+```
+
+---
+
+## Task 5: Rust strand sweep + strand-aware annotation
+
+**Files:**
+- Modify: `src/mutcat/annotate.rs`, `src/py_mutcat.rs`, `src/orchestrator.rs`
+
+**Interfaces:**
+- Consumes: `write_sidecar(.., strand_codes)` (Task 4), `snp_strand` (Task 3).
+- Produces: `pub struct StrandIntervals<'a> { pub starts: &'a [i32], pub stops: &'a [i32], pub values: &'a [u8] }`; `annotate_contig(reader, paths, ref_seq, strand: Option<StrandIntervals>)`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/mutcat/annotate.rs` `#[cfg(test)] mod tests`, add a sweep unit test (the sweeper is the risky new logic; the full annotate path is covered end-to-end by the Python parity test in Task 10):
+
+```rust
+    #[test]
+    fn strand_sweeper_classifies_by_interval() {
+        // intervals: [10,20)->+only(1), [30,40)->both(3). queries must be non-decreasing.
+        let iv = StrandIntervals {
+            starts: &[10, 30],
+            stops: &[20, 40],
+            values: &[1, 3],
+        };
+        let mut sw = StrandSweeper::new(&iv);
+        assert_eq!(sw.class_at(5), 0); // gap before first -> N
+        assert_eq!(sw.class_at(10), 1); // inclusive start
+        assert_eq!(sw.class_at(19), 1); // inside
+        assert_eq!(sw.class_at(20), 0); // exclusive stop -> gap
+        assert_eq!(sw.class_at(35), 3); // inside second
+        assert_eq!(sw.class_at(40), 0); // past all -> gap
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion strand_sweeper_classifies_by_interval'`
+Expected: FAIL — `cannot find StrandIntervals`/`StrandSweeper` (compile error).
+
+- [ ] **Step 3a: Implement `StrandIntervals` + `StrandSweeper` + strand-aware annotate**
+
+In `src/mutcat/annotate.rs`, update the `use` line to include `snp_strand`:
+
+```rust
+use crate::mutcat::classify::{id83_code, sbs96_code, snp_strand};
+```
+
+Add the types near the top (after the imports):
+
+```rust
+/// A contig's gene-strand interval partition (struct-of-arrays), 0-based
+/// half-open, sorted and disjoint. `values`: 1=+only, 2=−only, 3=both; gaps ⇒ N.
+pub struct StrandIntervals<'a> {
+    pub starts: &'a [i32],
+    pub stops: &'a [i32],
+    pub values: &'a [u8],
+}
+
+/// Two-pointer sweep over `StrandIntervals`. `class_at` must be called with
+/// non-decreasing `pos` (SVAR2 records are position-sorted per sub-stream);
+/// build a fresh sweeper per sub-stream so the cursor restarts.
+struct StrandSweeper<'a> {
+    iv: &'a StrandIntervals<'a>,
+    cursor: usize,
+}
+
+impl<'a> StrandSweeper<'a> {
+    fn new(iv: &'a StrandIntervals<'a>) -> Self {
+        Self { iv, cursor: 0 }
+    }
+
+    /// Gene-coverage class at `pos`: interval `values` entry, or `0` (N) in a gap.
+    fn class_at(&mut self, pos: u32) -> u8 {
+        let p = pos as i32;
+        while self.cursor < self.iv.starts.len() && self.iv.stops[self.cursor] <= p {
+            self.cursor += 1;
+        }
+        if self.cursor < self.iv.starts.len() && self.iv.starts[self.cursor] <= p {
+            self.iv.values[self.cursor]
+        } else {
+            0
+        }
+    }
+}
+```
+
+Change `annotate_contig` to take the optional intervals and compute strand codes for the two SNP sub-streams. Replace the function through the two SNP blocks:
+
+```rust
+pub fn annotate_contig(
+    reader: &ContigReader,
+    paths: &ContigPaths,
+    ref_seq: &[u8],
+    strand: Option<StrandIntervals>,
+) -> std::io::Result<()> {
+    let ref_seq: Vec<u8> = ref_seq.to_ascii_uppercase();
+    let ref_seq: &[u8] = &ref_seq;
+    // --- var_key/snp (per call) ---
+    {
+        let (positions, keys) = reader.vk_snp_records();
+        let mut codes = Vec::with_capacity(positions.len());
+        let mut refs = Vec::with_capacity(positions.len());
+        let mut strands: Option<Vec<u8>> =
+            strand.as_ref().map(|_| Vec::with_capacity(positions.len()));
+        let mut sweeper = strand.as_ref().map(StrandSweeper::new);
+        for (i, &pos) in positions.iter().enumerate() {
+            let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
+            codes.push(code);
+            refs.push(refc);
+            if let (Some(sw), Some(st)) = (sweeper.as_mut(), strands.as_mut()) {
+                st.push(snp_strand_at(ref_seq, pos, sw.class_at(pos)));
+            }
+        }
+        write_sidecar(paths, MutcatSub::VkSnp, &codes, Some(&refs), strands.as_deref())?;
+    }
+    // --- dense/snp (per variant) ---
+    if let Some((positions, keys)) = reader.dense_snp_records() {
+        let mut codes = Vec::with_capacity(positions.len());
+        let mut refs = Vec::with_capacity(positions.len());
+        let mut strands: Option<Vec<u8>> =
+            strand.as_ref().map(|_| Vec::with_capacity(positions.len()));
+        let mut sweeper = strand.as_ref().map(StrandSweeper::new);
+        for (i, &pos) in positions.iter().enumerate() {
+            let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
+            codes.push(code);
+            refs.push(refc);
+            if let (Some(sw), Some(st)) = (sweeper.as_mut(), strands.as_mut()) {
+                st.push(snp_strand_at(ref_seq, pos, sw.class_at(pos)));
+            }
+        }
+        write_sidecar(paths, MutcatSub::DenseSnp, &codes, Some(&refs), strands.as_deref())?;
+    }
+    // --- var_key/indel + dense/indel (per record) — no strand ---
+    annotate_indel(reader, paths, ref_seq, MutcatSub::VkIndel)?;
+    annotate_indel(reader, paths, ref_seq, MutcatSub::DenseIndel)?;
+    Ok(())
+}
+```
+
+Add the `snp_strand_at` helper next to `snp_record`:
+
+```rust
+/// Strand class for the SNP at 0-based `pos`, given its gene-coverage `gene_class`.
+/// Reads the (uppercased) ref base; a contig-end / out-of-range pos yields a
+/// harmless class (the record is NOT_ANNOTATED for SBS96 and never counted).
+fn snp_strand_at(ref_seq: &[u8], pos: u32, gene_class: u8) -> u8 {
+    let p = pos as usize;
+    let refb = if p < ref_seq.len() { ref_seq[p] } else { b'N' };
+    snp_strand(refb, gene_class)
+}
+```
+
+Update `annotate_indel`'s single `write_sidecar` call to append `None` for strand:
+
+```rust
+        None => return write_sidecar(paths, sub, &[], None, None),
+    };
+    ...
+    write_sidecar(paths, sub, &codes, None, None)
+```
+
+- [ ] **Step 3b: Update the two `annotate_contig` call sites to pass `None`**
+
+In `src/py_mutcat.rs`, line ~23 (this is temporary — Task 7 wires real intervals):
+
+```rust
+        annotate_contig(&self.inner, &paths, seq, None)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("annotate {chrom}: {e}")))?;
+```
+
+In `src/orchestrator.rs`, line ~549 (write-time path stays strand-free per spec):
+
+```rust
+        crate::mutcat::annotate::annotate_contig(&reader, &paths, &ref_seq, None).map_err(|e| {
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion mutcat'`
+Expected: PASS — includes `strand_sweeper_classifies_by_interval`, `snp_record_matches_direct_classify`, `contig_end_snp_is_not_annotated`, and the sidecar/classify/count tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mutcat/annotate.rs src/py_mutcat.rs src/orchestrator.rs
+git commit -m "feat(mutcat): strand-aware contig annotation via interval sweep"
+```
+
+---
+
+## Task 6: Rust count — emit SBS384
+
+**Files:**
+- Modify: `src/mutcat/count.rs`
+
+**Interfaces:**
+- Consumes: `MutcatView::has_strand`/`strand_at` (Task 4), `SBS384_OFFSET`, `STRAND_NA` (Task 2).
+- Produces: `SnvCall` gains `pub strand: u8`; `emit_snv_codes` additionally emits `SBS384_OFFSET + strand*96 + sbs` for strand-annotated SNVs.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/mutcat/count.rs` `#[cfg(test)] mod tests`, update the `snv` helper to set a strand and add an SBS384 emission test. Replace the `snv` helper:
+
+```rust
+    fn snv(pos: u32, ref_b: u8, alt_b: u8) -> SnvCall {
+        use crate::mutcat::classify::sbs96_code;
+        SnvCall {
+            pos,
+            sbs: sbs96_code(b'A', ref_b, alt_b, b'A'), // dummy flanks for the test
+            ref_i: svar2_codec::encode_snp_2bit(ref_b),
+            alt_i: svar2_codec::encode_snp_2bit(alt_b),
+            strand: crate::mutcat::STRAND_NA,
+        }
+    }
+
+    fn snv_strand(pos: u32, ref_b: u8, alt_b: u8, strand: u8) -> SnvCall {
+        SnvCall {
+            strand,
+            ..snv(pos, ref_b, alt_b)
+        }
+    }
+```
+
+Add the emission test:
+
+```rust
+    #[test]
+    fn isolated_snv_emits_sbs96_and_sbs384_when_strand_annotated() {
+        use crate::mutcat::{SBS384_OFFSET, STRAND_U};
+        // Isolated C>A, no adjacent SNV -> SBS96. sbs code with dummy A_A flanks.
+        let sbs = {
+            use crate::mutcat::classify::sbs96_code;
+            sbs96_code(b'A', b'C', b'A', b'A') as usize
+        };
+        let snvs = [snv_strand(10, b'C', b'A', STRAND_U)];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        assert_eq!(
+            codes,
+            vec![sbs, SBS384_OFFSET + (STRAND_U as usize) * 96 + sbs]
+        );
+    }
+
+    #[test]
+    fn isolated_snv_emits_only_sbs96_when_not_strand_annotated() {
+        // strand == STRAND_NA (via `snv`) -> no SBS384 emission.
+        let snvs = [snv(10, b'C', b'A')];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        assert_eq!(codes.len(), 1);
+        assert!(codes[0] < DBS78_OFFSET);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion isolated_snv_emits'`
+Expected: FAIL — `SnvCall` has no field `strand` (compile error).
+
+- [ ] **Step 3: Implement the strand field + SBS384 emission**
+
+In `src/mutcat/count.rs`, update the `use` to add the new constants:
+
+```rust
+use crate::mutcat::{
+    DBS78_OFFSET, ID83_OFFSET, N_CODES, SBS384_OFFSET, SBS96_OFFSET, STRAND_NA, UNCLASSIFIED,
+};
+```
+
+Add the `strand` field to `SnvCall`:
+
+```rust
+pub struct SnvCall {
+    pub pos: u32,
+    pub sbs: u8,    // SBS96 class-local index or sentinel
+    pub ref_i: u8,  // 2-bit ref base code
+    pub alt_i: u8,  // 2-bit alt base code
+    pub strand: u8, // STRAND_{T,U,N,B}, or STRAND_NA when no strand.bin
+}
+```
+
+In `emit_snv_codes`, extend the SBS emission block (currently lines 52-55) to also emit SBS384:
+
+```rust
+        if (v.sbs as usize) < 96 {
+            out(SBS96_OFFSET + v.sbs as usize);
+            // Strand-resolved SBS384 (same SNV), only when the sidecar carried a
+            // strand stream. DBS-paired SNVs `continue` above, so they never reach
+            // here — SBS384 is emitted for exactly the SNVs that emit SBS96.
+            if v.strand != STRAND_NA {
+                out(SBS384_OFFSET + (v.strand as usize) * 96 + v.sbs as usize);
+            }
+        }
+```
+
+Update the `debug_assert!(N_CODES == 257)` (line ~59) to the new width:
+
+```rust
+        debug_assert!(N_CODES == 641);
+```
+
+Populate `strand` in `count_column_into` for both SNP sources. In the `var_key/snp` gather loop, change the `vk.push(SnvCall { ... })` to:
+
+```rust
+            vk.push(SnvCall {
+                pos,
+                sbs: sidecars.vk_snp.code_at(abs_i),
+                ref_i: sidecars.vk_snp.ref_at(abs_i),
+                alt_i: unpack_snp_key_at(keys, abs_i),
+                strand: if sidecars.vk_snp.has_strand {
+                    sidecars.vk_snp.strand_at(abs_i)
+                } else {
+                    STRAND_NA
+                },
+            });
+```
+
+In the `dense/snp` gather closure, change the `dn.push(SnvCall { ... })` to:
+
+```rust
+            dn.push(SnvCall {
+                pos: positions[dcol],
+                sbs: sidecars.dense_snp.code_at(dcol),
+                ref_i: sidecars.dense_snp.ref_at(dcol),
+                alt_i: unpack_snp_key_at(keys, dcol),
+                strand: if sidecars.dense_snp.has_strand {
+                    sidecars.dense_snp.strand_at(dcol)
+                } else {
+                    STRAND_NA
+                },
+            });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion count'`
+Expected: PASS — new SBS384 tests plus existing `isolated_pair_emits_one_dbs`, `run_of_three_stays_sbs`, `non_adjacent_snvs_are_sbs`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mutcat/count.rs
+git commit -m "feat(mutcat): emit SBS384 codes in streaming count"
+```
+
+---
+
+## Task 7: pyo3 binding — optional strand intervals on `annotate_mutations`
+
+**Files:**
+- Modify: `src/py_mutcat.rs`
+
+**Interfaces:**
+- Consumes: `StrandIntervals`, `annotate_contig` (Task 5).
+- Produces: Rust `PyContigReader.annotate_mutations(base_out_dir, chrom, ref_seq, strand_starts=None, strand_stops=None, strand_values=None)`. All three strand arrays present ⇒ strand annotation; any absent ⇒ strand-free.
+
+- [ ] **Step 1: Write the failing test (Rust smoke via signature)**
+
+This binding is exercised end-to-end by Task 10 (Python). Add a compile-guard by writing the Python-facing test now in `tests/test_svar2_mutcat.py` (it will fail until the binding accepts the new args). Append:
+
+```python
+def test_annotate_accepts_strand_arrays_smoke(tmp_path: Path):
+    import numpy as np
+
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store_strand_smoke.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv2 = SparseVar2(out)
+    reader = sv2._readers["chr1"]
+    seq = Reference.from_path(ref).contig_array("chr1").astype(np.uint8, copy=False)
+    # Empty strand partition (all N) — just proves the 6-arg binding is callable.
+    reader.annotate_mutations(
+        str(out),
+        "chr1",
+        seq,
+        np.empty(0, np.int32),
+        np.empty(0, np.int32),
+        np.empty(0, np.uint8),
+    )
+    assert (out / "chr1" / "mutcat" / "var_key_snp" / "strand.bin").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && maturin develop --features conversion' && pixi run pytest tests/test_svar2_mutcat.py::test_annotate_accepts_strand_arrays_smoke -v`
+Expected: FAIL — `TypeError: annotate_mutations() takes 3 positional arguments but 6 were given`.
+
+- [ ] **Step 3: Implement the optional strand args**
+
+In `src/py_mutcat.rs`, update imports and the `annotate_mutations` method:
+
+```rust
+use numpy::{PyArray2, PyReadonlyArray1, ToPyArray};
+use pyo3::prelude::*;
+
+use crate::layout::ContigPaths;
+use crate::mutcat::N_CODES;
+use crate::mutcat::annotate::{StrandIntervals, annotate_contig};
+use crate::mutcat::count::{Sidecars, count_contig};
+use crate::py_query::PyContigReader;
+```
+
+```rust
+    /// Classify this contig's records against `ref_seq` and write the sidecar.
+    /// If all three `strand_*` arrays are given (a sorted, disjoint gene-strand
+    /// interval partition), also write the 2-bit `strand.bin` enabling SBS192/384.
+    #[pyo3(signature = (base_out_dir, chrom, ref_seq, strand_starts=None, strand_stops=None, strand_values=None))]
+    fn annotate_mutations(
+        &self,
+        base_out_dir: &str,
+        chrom: &str,
+        ref_seq: PyReadonlyArray1<u8>,
+        strand_starts: Option<PyReadonlyArray1<i32>>,
+        strand_stops: Option<PyReadonlyArray1<i32>>,
+        strand_values: Option<PyReadonlyArray1<u8>>,
+    ) -> PyResult<()> {
+        let paths = ContigPaths::new(base_out_dir, chrom);
+        let seq = ref_seq.as_slice()?;
+        // Keep the numpy arrays alive for the duration of the borrow.
+        let strand_arrays = match (strand_starts, strand_stops, strand_values) {
+            (Some(a), Some(b), Some(c)) => Some((a, b, c)),
+            _ => None,
+        };
+        let strand = match &strand_arrays {
+            Some((a, b, c)) => Some(StrandIntervals {
+                starts: a.as_slice()?,
+                stops: b.as_slice()?,
+                values: c.as_slice()?,
+            }),
+            None => None,
+        };
+        annotate_contig(&self.inner, &paths, seq, strand)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("annotate {chrom}: {e}")))?;
+        Ok(())
+    }
+```
+
+(Remove the temporary `None` call added in Task 5 Step 3b — it is replaced by the block above.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && maturin develop --features conversion' && pixi run pytest tests/test_svar2_mutcat.py::test_annotate_accepts_strand_arrays_smoke -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/py_mutcat.rs tests/test_svar2_mutcat.py
+git commit -m "feat(mutcat): accept optional strand intervals in annotate_mutations binding"
+```
+
+---
+
+## Task 8: Python strand-interval builder
+
+**Files:**
+- Create: `python/genoray/_mutcat/strand.py`
+- Test: `tests/test_mutcat_strand.py` (create)
+
+**Interfaces:**
+- Consumes: `ContigNormalizer` (`genoray._contigs`).
+- Produces:
+  - `load_gene_intervals(gtf: str | pl.DataFrame) -> pl.DataFrame` with columns `chrom` (Utf8), `start` (Int64, 0-based), `stop` (Int64, exclusive), `strand` (Utf8).
+  - `contig_strand_intervals(genes: pl.DataFrame, contig: str, c_norm: ContigNormalizer) -> tuple[NDArray[int32], NDArray[int32], NDArray[uint8]]` — sorted, disjoint `(starts, stops, values)`; `values ∈ {1,2,3}` (1=+only, 2=−only, 3=both), gaps omitted (N).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_mutcat_strand.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from genoray._contigs import ContigNormalizer
+from genoray._mutcat.strand import contig_strand_intervals, load_gene_intervals
+
+
+def _genes() -> pl.DataFrame:
+    # 0-based half-open gene footprints on chr1.
+    return pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1"],
+            "start": [0, 30, 25],  # +[0,20), +[30,40), -[25,45)
+            "stop": [20, 40, 45],
+            "strand": ["+", "+", "-"],
+        }
+    )
+
+
+def test_contig_intervals_partition_classes():
+    c_norm = ContigNormalizer(["chr1"])
+    starts, stops, values = contig_strand_intervals(_genes(), "chr1", c_norm)
+    # Expected disjoint partition:
+    #   [0,20)  + only  -> 1
+    #   [25,30) - only  -> 2
+    #   [30,40) both    -> 3
+    #   [40,45) - only  -> 2
+    assert starts.tolist() == [0, 25, 30, 40]
+    assert stops.tolist() == [20, 30, 40, 45]
+    assert values.tolist() == [1, 2, 3, 2]
+    assert starts.dtype == np.int32
+    assert values.dtype == np.uint8
+
+
+def test_contig_name_normalization():
+    # store contig is unprefixed "1"; GTF uses "chr1".
+    c_norm = ContigNormalizer(["1"])
+    starts, stops, values = contig_strand_intervals(_genes(), "1", c_norm)
+    assert starts.size == 4
+
+
+def test_no_genes_on_contig_is_empty():
+    c_norm = ContigNormalizer(["chr2"])
+    starts, stops, values = contig_strand_intervals(_genes(), "chr2", c_norm)
+    assert starts.size == 0 and stops.size == 0 and values.size == 0
+
+
+def test_load_gene_intervals_from_dataframe():
+    gtf = pl.DataFrame(
+        {
+            "seqname": ["chr1", "chr1"],
+            "feature": ["gene", "exon"],
+            "start": [1, 5],  # 1-based
+            "end": [40, 10],
+            "strand": ["+", "+"],
+        }
+    )
+    genes = load_gene_intervals(gtf)
+    assert genes.height == 1  # only feature == "gene"
+    row = genes.row(0, named=True)
+    assert row["chrom"] == "chr1"
+    assert row["start"] == 0  # 1-based 1 -> 0-based 0
+    assert row["stop"] == 40  # inclusive 1-based 40 == exclusive 0-based 40
+    assert row["strand"] == "+"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_mutcat_strand.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'genoray._mutcat.strand'`.
+
+- [ ] **Step 3: Implement `strand.py`**
+
+Create `python/genoray/_mutcat/strand.py`:
+
+```python
+"""Build transcriptional-strand-class intervals from a GTF gene model.
+
+Flattens gene footprints into a sorted, disjoint interval partition per contig,
+each interval tagged with a coverage class (1=+only, 2=−only, 3=both strands).
+Gaps between intervals are class N (nontranscribed) and are not materialized.
+The result crosses the pyo3 boundary as a struct-of-arrays and drives the Rust
+two-pointer strand sweep in ``annotate_contig``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import seqpro as sp
+from numpy.typing import NDArray
+
+from .._contigs import ContigNormalizer
+
+
+def load_gene_intervals(gtf: str | pl.DataFrame) -> pl.DataFrame:
+    """Load ``feature == "gene"`` footprints from a GTF as 0-based half-open rows.
+
+    Parameters
+    ----------
+    gtf
+        Path to a GTF/GTF.gz, or a pre-loaded Polars DataFrame with GTF columns
+        (``seqname``/``chrom``, ``feature``, ``start`` [1-based], ``end``
+        [inclusive], ``strand``).
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``chrom`` (Utf8), ``start`` (Int64, 0-based), ``stop`` (Int64,
+        exclusive), ``strand`` (Utf8, ``"+"``/``"-"``).
+    """
+    if isinstance(gtf, pl.DataFrame):
+        df = gtf.rename({"seqname": "chrom"}, strict=False)
+    else:
+        df = sp.gtf.scan(str(gtf)).collect().rename({"seqname": "chrom"}, strict=False)
+    return df.filter(pl.col("feature") == "gene").select(
+        pl.col("chrom").cast(pl.Utf8),
+        (pl.col("start") - 1).cast(pl.Int64).alias("start"),  # 1-based -> 0-based
+        pl.col("end").cast(pl.Int64).alias("stop"),  # inclusive == exclusive 0-based
+        pl.col("strand").cast(pl.Utf8),
+    )
+
+
+def _empty() -> tuple[NDArray[np.int32], NDArray[np.int32], NDArray[np.uint8]]:
+    return (
+        np.empty(0, np.int32),
+        np.empty(0, np.int32),
+        np.empty(0, np.uint8),
+    )
+
+
+def contig_strand_intervals(
+    genes: pl.DataFrame, contig: str, c_norm: ContigNormalizer
+) -> tuple[NDArray[np.int32], NDArray[np.int32], NDArray[np.uint8]]:
+    """Flatten gene footprints on ``contig`` into a sorted, disjoint partition.
+
+    Genes whose (normalized) chrom maps to ``contig`` are split by strand and
+    merged into maximal runs, each tagged 1 (+only), 2 (−only), or 3 (both).
+    Gaps (class N) are omitted. Returns ``(starts, stops, values)``.
+    """
+    normed = c_norm.norm(genes.get_column("chrom").to_list())
+    g = genes.filter(pl.Series([n == contig for n in normed]))
+    if g.height == 0:
+        return _empty()
+
+    ps = g.filter(pl.col("strand") == "+").get_column("start").to_numpy().astype(np.int64)
+    pe = g.filter(pl.col("strand") == "+").get_column("stop").to_numpy().astype(np.int64)
+    ms = g.filter(pl.col("strand") == "-").get_column("start").to_numpy().astype(np.int64)
+    me = g.filter(pl.col("strand") == "-").get_column("stop").to_numpy().astype(np.int64)
+
+    bp = np.unique(np.concatenate([ps, pe, ms, me]))
+    if bp.size < 2:
+        return _empty()
+
+    def covered(starts: NDArray[np.int64], stops: NDArray[np.int64]) -> NDArray[np.bool_]:
+        # +1 at each start, -1 at each stop over the shared breakpoint grid; the
+        # running sum on segment i = [bp[i], bp[i+1]) is that strand's coverage.
+        diff = np.zeros(bp.size, dtype=np.int64)
+        if starts.size:
+            np.add.at(diff, np.searchsorted(bp, starts), 1)
+            np.add.at(diff, np.searchsorted(bp, stops), -1)
+        return np.cumsum(diff)[:-1] > 0
+
+    pc = covered(ps, pe)
+    mc = covered(ms, me)
+    val = np.where(pc & mc, 3, np.where(pc, 1, np.where(mc, 2, 0))).astype(np.uint8)
+
+    lo = bp[:-1]
+    hi = bp[1:]
+    genic = val != 0
+    if not genic.any():
+        return _empty()
+    lo, hi, val = lo[genic], hi[genic], val[genic]
+
+    # Merge adjacent segments that touch and share a class.
+    starts_out = [int(lo[0])]
+    stops_out = [int(hi[0])]
+    vals_out = [int(val[0])]
+    for i in range(1, val.size):
+        if val[i] == vals_out[-1] and lo[i] == stops_out[-1]:
+            stops_out[-1] = int(hi[i])
+        else:
+            starts_out.append(int(lo[i]))
+            stops_out.append(int(hi[i]))
+            vals_out.append(int(val[i]))
+
+    return (
+        np.asarray(starts_out, np.int32),
+        np.asarray(stops_out, np.int32),
+        np.asarray(vals_out, np.uint8),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest tests/test_mutcat_strand.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_mutcat/strand.py tests/test_mutcat_strand.py
+git commit -m "feat(mutcat): GTF -> strand-class interval builder"
+```
+
+---
+
+## Task 9: Python API wiring — `annotate_mutations(gtf=)`, matrix, assign guard
+
+**Files:**
+- Modify: `python/genoray/_svar2_mutcat.py`
+
+**Interfaces:**
+- Consumes: `contig_strand_intervals`/`load_gene_intervals` (Task 8), `ContigNormalizer`, updated `code_ranges`/`labels` (Task 1), the 6-arg Rust binding (Task 7).
+- Produces:
+  - `annotate_mutations(reference, *, gtf=None, contigs=None)` — writes `strand.bin` when `gtf` given; stamps `meta["mutcat_strand"]`.
+  - `mutation_matrix(kind, *, count=...)` accepts `"SBS192"`/`"SBS384"`; raises `ValueError` if not strand-annotated.
+  - `assign_signatures(kind, ...)` raises `NotImplementedError` for `"SBS192"`/`"SBS384"`.
+  - `_is_strand_annotated() -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_svar2_mutcat.py`:
+
+```python
+def test_assign_signatures_rejects_strand_kinds(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store_assign_strand.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref)  # no gtf
+    with pytest.raises(NotImplementedError, match="SBS192|SBS384|strand"):
+        sv2.assign_signatures("SBS384")
+
+
+def test_sbs384_requires_strand_annotation(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store_no_strand.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref)  # no gtf -> no strand.bin
+    assert not sv2._is_strand_annotated()
+    with pytest.raises(ValueError, match="strand"):
+        sv2.mutation_matrix("SBS384")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest tests/test_svar2_mutcat.py::test_assign_signatures_rejects_strand_kinds tests/test_svar2_mutcat.py::test_sbs384_requires_strand_annotation -v`
+Expected: FAIL — `assign_signatures("SBS384")` currently raises the generic `mutation_matrix` `ValueError("Unknown matrix kind")` (not `NotImplementedError`), and `_is_strand_annotated` does not exist.
+
+- [ ] **Step 3: Implement the API wiring**
+
+In `python/genoray/_svar2_mutcat.py`, update the imports at the top:
+
+```python
+from genoray._contigs import ContigNormalizer
+from genoray._mutcat import MUTCAT_VERSION, N_CODES, code_ranges, labels
+from genoray._mutcat.strand import contig_strand_intervals, load_gene_intervals
+from genoray._reference import Reference
+from genoray._signatures import _load_signature_file, cosmic_signatures, fit_signatures
+```
+
+Replace `annotate_mutations` with the `gtf`-aware version:
+
+```python
+    def annotate_mutations(
+        self,
+        reference: "Reference | str | Path",
+        *,
+        gtf: "str | Path | pl.DataFrame | None" = None,
+        contigs: "list[str] | None" = None,
+    ) -> None:
+        """Classify every variant on the in-scope contigs into SBS-96/DBS-78/ID-83
+        codes and write the per-contig ``mutcat`` sidecar (post-hoc annotation).
+
+        Parameters
+        ----------
+        reference
+            Reference genome. A :class:`~genoray._reference.Reference` instance,
+            or a path to a FASTA file (with a ``.fai`` index alongside it).
+        gtf
+            Optional gene model (path to a GTF/GTF.gz, or a pre-loaded GTF
+            DataFrame). When given, each SNV additionally gets a transcriptional
+            strand class stored in a 2-bit ``strand.bin`` sidecar, enabling the
+            strand-resolved ``"SBS192"``/``"SBS384"`` matrices. Gene footprints
+            are taken from ``feature == "gene"`` rows (full gene body); filter
+            the GTF beforehand to restrict biotypes.
+        contigs
+            If given, only these contigs (intersected with ``self.contigs``) are
+            annotated. ``None`` (default) annotates every contig in the store.
+
+        Notes
+        -----
+        Stamps ``meta.json`` with ``mutcat_version``, ``mutcat_contigs``, and
+        ``mutcat_strand`` (whether a GTF was supplied). The sidecar files
+        themselves are the ground truth checked by :meth:`mutation_matrix`'s
+        guards.
+        """
+        if not isinstance(reference, Reference):
+            reference = Reference.from_path(reference)
+        scope = (
+            self.contigs
+            if contigs is None
+            else [c for c in self.contigs if c in set(contigs)]
+        )
+
+        genes = None
+        c_norm = None
+        if gtf is not None:
+            genes = load_gene_intervals(gtf)
+            c_norm = ContigNormalizer(self.contigs)
+
+        for contig in scope:
+            seq = reference.contig_array(contig).astype(np.uint8, copy=False)
+            if genes is not None and c_norm is not None:
+                starts, stops, values = contig_strand_intervals(genes, contig, c_norm)
+                self._readers[contig].annotate_mutations(
+                    str(self.path), contig, seq, starts, stops, values
+                )
+            else:
+                self._readers[contig].annotate_mutations(str(self.path), contig, seq)
+
+        meta_path = self.path / "meta.json"
+        meta = json.loads(meta_path.read_text())
+        meta["mutcat_version"] = MUTCAT_VERSION
+        meta["mutcat_contigs"] = scope
+        meta["mutcat_strand"] = gtf is not None
+        meta_path.write_text(json.dumps(meta))
+```
+
+Add `_is_strand_annotated` after `_is_annotated`:
+
+```python
+    def _is_strand_annotated(self) -> bool:
+        """Whether every contig has an on-disk ``strand.bin`` (GTF-annotated).
+
+        Ground truth for whether SBS192/SBS384 can be produced. Like
+        ``_is_annotated``, checked on disk rather than via ``meta.json`` because
+        the file is what the Rust count reads.
+        """
+        return all(
+            (self.path / contig / "mutcat" / "var_key_snp" / "strand.bin").exists()
+            for contig in self.contigs
+        )
+```
+
+Update `mutation_matrix`'s signature, kind validation, and add the strand guard. Change the `kind` type and the two guards near the top of the method body:
+
+```python
+    def mutation_matrix(
+        self,
+        kind: Literal["SBS96", "DBS78", "ID83", "SBS192", "SBS384"],
+        *,
+        count: Literal["allele", "sample"] = "allele",
+    ) -> pl.DataFrame:
+```
+
+Replace the `if kind not in (...)` validation and add the strand guard after the existing `_is_annotated` guard:
+
+```python
+        if kind not in ("SBS96", "DBS78", "ID83", "SBS192", "SBS384"):
+            raise ValueError(f"Unknown matrix kind {kind!r}.")
+        if count not in ("allele", "sample"):
+            raise ValueError(
+                f"Unknown count mode {count!r}; choose 'allele' or 'sample'."
+            )
+        if not self._is_annotated():
+            raise ValueError(
+                "SparseVar2 is not annotated for mutational signatures; call "
+                "annotate_mutations(reference) first, or rebuild with "
+                "from_vcf(..., signatures=True)."
+            )
+        if kind in ("SBS192", "SBS384") and not self._is_strand_annotated():
+            raise ValueError(
+                f"{kind} requires transcriptional strand annotation; re-run "
+                "annotate_mutations(reference, gtf=...) with a gene model."
+            )
+```
+
+(The rest of `mutation_matrix` — the `code_ranges()[kind]` slice and DataFrame build — already handles the new kinds via Task 1.)
+
+Update `assign_signatures` to reject strand kinds. Change its `kind` type hint and add the guard at the top of the body:
+
+```python
+    def assign_signatures(
+        self,
+        kind: Literal["SBS96", "DBS78", "ID83"],
+        *,
+        reference: "pl.DataFrame | str | Path | None" = None,
+        count: Literal["allele", "sample"] = "allele",
+        max_delta: float = 0.01,
+        min_activity: float = 0.005,
+        n_jobs: int = 1,
+        backend: str = "loky",
+    ) -> pl.DataFrame:
+```
+
+Add as the first statements of the method body (before `catalogue = self.mutation_matrix(...)`):
+
+```python
+        if kind in ("SBS192", "SBS384"):
+            raise NotImplementedError(
+                f"{kind} is a transcriptional-strand-bias catalog with no COSMIC "
+                "reference signature set for refitting. Use mutation_matrix(kind) "
+                "for strand-bias analysis instead."
+            )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run pytest tests/test_svar2_mutcat.py::test_assign_signatures_rejects_strand_kinds tests/test_svar2_mutcat.py::test_sbs384_requires_strand_annotation -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add python/genoray/_svar2_mutcat.py tests/test_svar2_mutcat.py
+git commit -m "feat(svar2): annotate_mutations(gtf=) + SBS192/384 matrix + assign guard"
+```
+
+---
+
+## Task 10: End-to-end SBS192/384 parity test
+
+**Files:**
+- Modify: `tests/test_svar2_mutcat.py`
+
+**Interfaces:**
+- Consumes: the full stack (Tasks 1–9).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_svar2_mutcat.py`. This builds a dedicated 80 bp reference (reusing `_PARITY_SEQ`), three isolated SNVs, and a two-gene GTF chosen so one SNV falls in a `+` gene (→ Transcribed), one in a `−` gene (→ Untranscribed), and one in an intergenic gap (→ Nontranscribed):
+
+```python
+import numpy as np
+
+
+def _write_strand_gtf(d: Path) -> Path:
+    """A GTF with a + gene [1,40], a - gene [45,80], and a 41-44 intergenic gap.
+
+    Positions (1-based) against _PARITY_SEQ:
+      POS=10 (ref A, purine) in + gene  -> Transcribed  (T)
+      POS=42 (ref G, purine) in the gap -> Nontranscribed(N)
+      POS=60 (ref A, purine) in - gene  -> Untranscribed (U)
+    """
+    gtf = d / "strand.gtf"
+    gtf.write_text(
+        'chr1\ttest\tgene\t1\t40\t.\t+\t.\tgene_id "P";\n'
+        'chr1\ttest\tgene\t45\t80\t.\t-\t.\tgene_id "M";\n'
+    )
+    return gtf
+
+
+def _write_strand_vcf(d: Path) -> Path:
+    vcf_path = d / "strand_in.vcf"
+    h = pysam.VariantHeader()
+    h.add_line(f"##contig=<ID=chr1,length={len(_PARITY_SEQ)}>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+    h.add_sample("S0")
+    # isolated het SNVs (>2bp apart so none pair into a DBS), all on S0.
+    records = [
+        (9, "A", "C", (0, 1)),   # POS=10 in + gene
+        (41, "G", "A", (0, 1)),  # POS=42 in the gap
+        (59, "A", "C", (0, 1)),  # POS=60 in - gene
+    ]
+    with pysam.VariantFile(str(vcf_path), "w", header=h) as vf:
+        for start, ref, alt, gt in records:
+            r = h.new_record(contig="chr1", start=start, alleles=(ref, alt))
+            r.samples["S0"]["GT"] = gt
+            r.samples["S0"].phased = True
+            vf.write(r)
+    vcf_gz = d / "strand_in.vcf.gz"
+    with open(vcf_gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(vcf_path)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(vcf_gz)], check=True)
+    return vcf_gz
+
+
+def test_sbs384_end_to_end(tmp_path: Path):
+    ref = _write_parity_ref(tmp_path)
+    vcf = _write_strand_vcf(tmp_path)
+    gtf = _write_strand_gtf(tmp_path)
+    out = tmp_path / "store_strand.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref, gtf=gtf)
+    assert sv2._is_strand_annotated()
+    assert json.loads((out / "meta.json").read_text())["mutcat_strand"] is True
+
+    sbs96 = sv2.mutation_matrix("SBS96", count="allele")
+    sbs384 = sv2.mutation_matrix("SBS384", count="allele")
+    sbs192 = sv2.mutation_matrix("SBS192", count="allele")
+
+    assert sbs384.height == 384
+    assert sbs192.height == 192
+    assert sbs384["MutationType"].to_list()[:192] == sbs192["MutationType"].to_list()
+
+    v96 = sbs96["S0"].to_numpy()
+    v384 = sbs384["S0"].to_numpy()
+    v192 = sbs192["S0"].to_numpy()
+
+    # SBS192 is exactly the first 192 (T,U) rows of SBS384.
+    assert np.array_equal(v192, v384[:192])
+
+    # Conservation: SBS384 collapsed over the 4 strand blocks == SBS96.
+    assert np.array_equal(v384.reshape(4, 96).sum(axis=0), v96)
+
+    # Three isolated SNVs, one het copy each -> total 3, one per strand class
+    # T / N / U (blocks 0, 2, 1), none Bidirectional (block 3).
+    block_sums = v384.reshape(4, 96).sum(axis=1)
+    assert block_sums.tolist() == [1, 1, 1, 0]  # [T, U, N, B]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+(If Tasks 1–9 are already implemented and committed, this should pass directly. If running this task before the extension is rebuilt:)
+Run: `pixi run bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && maturin develop --features conversion' && pixi run pytest tests/test_svar2_mutcat.py::test_sbs384_end_to_end -v`
+Expected: PASS. If it FAILS on `block_sums`, re-derive the strand of each SNV from `snp_strand` (ref base purine/pyrimidine × gene strand) before adjusting the fixture — do not weaken the conservation assertion.
+
+- [ ] **Step 3: (no implementation — this task is the integration gate)**
+
+If the test fails, debug the responsible earlier task rather than editing the test's invariants (`v192 == v384[:192]`, `v384.reshape(4,96).sum(0) == v96`).
+
+- [ ] **Step 4: Run the whole mutcat suite**
+
+Run: `pixi run pytest tests/test_svar2_mutcat.py -v`
+Expected: PASS (existing parity tests + all new strand tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_svar2_mutcat.py
+git commit -m "test(svar2): end-to-end SBS192/SBS384 conservation + strand-class checks"
+```
+
+---
+
+## Task 11: Documentation — SKILL.md + CHANGELOG
+
+**Files:**
+- Modify: `skills/genoray-api/SKILL.md`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: final public API from Tasks 8–9.
+
+- [ ] **Step 1: Update the svar2 signatures section of SKILL.md**
+
+In `skills/genoray-api/SKILL.md`, in the "Mutational signatures (SBS96 / DBS78 / ID83)" svar2 section (around line 443), extend it to document the strand-resolved catalogs. Add after the existing usage example:
+
+```markdown
+### Strand-resolved catalogs (SBS192 / SBS384)
+
+`SparseVar2` also supports the transcriptional-strand-bias catalogs, which
+require a gene model (GTF) at annotation time:
+
+```python
+sv2.annotate_mutations(reference, gtf="gencode.v45.annotation.gtf.gz")
+sbs384 = sv2.mutation_matrix("SBS384")   # 384 rows: [T, U, N, B] x 96
+sbs192 = sv2.mutation_matrix("SBS192")   # 192 rows: the {T, U} sub-view = SBS384[:192]
+```
+
+- **SBS384** = 96 trinucleotide channels x 4 strand categories, SigProfiler
+  order `[T, U, N, B]`: **T**ranscribed, **U**ntranscribed, **N**ontranscribed
+  (intergenic), **B**idirectional (position covered by genes on both strands).
+- **SBS192** is the `{T, U}` sub-view (`SBS384[:192]`).
+- Strand rule (pyrimidine-folded): a genic SNV is Untranscribed iff the
+  pyrimidine of its ref/alt pair sits on the gene's coding strand, else
+  Transcribed. Gene footprints come from `feature == "gene"` rows (full gene
+  body); pre-filter the GTF to restrict biotypes.
+- Without a `gtf=`, `mutation_matrix("SBS192"/"SBS384")` raises. Write-time
+  `from_vcf(..., signatures=True)` stays strand-free; obtain strand catalogs via
+  a post-hoc `annotate_mutations(reference, gtf=...)`.
+- `assign_signatures("SBS192"/"SBS384")` raises `NotImplementedError`: COSMIC
+  publishes no strand-resolved reference set. Use `mutation_matrix` for
+  strand-bias analysis.
+```
+
+Also, in the v1 `SparseVar` "Mutation catalogues" section, adjust the limitation note at (currently) line 775 so it is scoped to v1:
+
+```markdown
+- No strand-bias separation (SBS-192 / SBS-384) — v1 `SparseVar` only. Use
+  `SparseVar2.annotate_mutations(reference, gtf=...)` for transcriptional
+  strand-resolved catalogs.
+```
+
+- [ ] **Step 2: Add a CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## Unreleased` → `### Added`, add:
+
+```markdown
+- `SparseVar2.annotate_mutations` gains a `gtf=` argument that annotates each SNV
+  with its transcriptional strand class (stored in a 2-bit `strand.bin`
+  sidecar), enabling the strand-resolved `mutation_matrix("SBS192")` and
+  `mutation_matrix("SBS384")` catalogs (SigProfiler `[T, U, N, B]` order; SBS192
+  is the `{T, U}` view). Strand is computed from `feature == "gene"` footprints.
+  `assign_signatures` raises `NotImplementedError` for these kinds (no COSMIC
+  reference set). Write-time `from_vcf(signatures=True)` remains strand-free.
+```
+
+- [ ] **Step 3: Verify docs build / no broken references**
+
+Run: `pixi run pytest tests/test_svar2_mutcat.py -q`
+Expected: PASS (sanity — docs change shouldn't affect tests, but confirms the tree is green before final commit).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/genoray-api/SKILL.md CHANGELOG.md
+git commit -m "docs(svar2): document SBS192/SBS384 strand-resolved catalogs"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full Rust suite:** `pixi run -e lint bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && cargo test --no-default-features --features conversion'` → all green.
+- [ ] **Full Python suite:** `pixi run bash -lc 'export CARGO_TARGET_DIR=/tmp/gcargo && maturin develop --features conversion' && pixi run test` → all green.
+- [ ] **Lint:** `pixi run lint` (runs prek across Rust + Python) → clean. Ensure `CARGO_TARGET_DIR` is exported off NFS for the cargo hooks.
+- [ ] Open the draft PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- SBS384/SBS192 code space + labels → Tasks 1, 2. ✓
+- Strand rule (pyrimidine fold) → Task 3 (`snp_strand`) + Task 10 (`block_sums` check). ✓
+- GTF → sorted disjoint interval SoA → Task 8. ✓
+- Two-pointer sweep, position-sorted, per-sub-stream cursor → Task 5. ✓
+- `strand.bin` 2-bit stream, SNP subs only, written only with GTF → Tasks 4, 5. ✓
+- Count emits SBS384; `mutation_matrix` slices; SBS192 = SBS384[:192] → Tasks 6, 9. ✓
+- `mutation_matrix` guard when not strand-annotated → Task 9 + Task 10. ✓
+- `assign_signatures` raises for strand kinds → Task 9. ✓
+- Backward compat (no layout change to SBS96/DBS78/ID83; old sidecars readable) → Task 4 (`None` strand path), Task 6 (`STRAND_NA`), Global Constraints. ✓
+- `N_CODES == 257` asserts updated → Task 2 (`mod.rs`), Task 6 (`count.rs`). ✓
+- Write-time stays strand-free → Task 5 Step 3b (`orchestrator.rs` passes `None`). ✓
+- `MUTCAT_VERSION` bump → Task 1. ✓
+- Docs (SKILL.md + CHANGELOG) → Task 11. ✓
+- Cost model: no change — post-hoc annotate does not re-run `choose_representation`; write-time is strand-free. (Spec's cost-model note applied only to the deferred write-time path.) ✓
+
+**Type consistency:** `snp_strand(refb, gene_class) -> u8` used identically in Tasks 3/5. `StrandIntervals{starts,stops,values}` fields consistent Tasks 5/7. `SnvCall.strand` field consistent Tasks 6. `code_ranges()`/`labels()` keys `"SBS192"`/`"SBS384"` consistent Tasks 1/9. `strand.bin` path (`var_key_snp/strand.bin`) consistent Tasks 4/9/10. Strand encodings kept distinct: interval `values ∈ {1,2,3}` (GTF) vs stored/count `STRAND_{T,U,N,B} = {0,1,2,3}` — the conversion is `snp_strand` (Task 3). ✓
+
+**Placeholder scan:** none — every code step shows complete code; every run step has an exact command + expected outcome.

--- a/docs/superpowers/specs/2026-07-13-svar2-sbs192-sbs384-design.md
+++ b/docs/superpowers/specs/2026-07-13-svar2-sbs192-sbs384-design.md
@@ -1,0 +1,222 @@
+# SBS192 / SBS384 transcriptional-strand-bias catalogs for SparseVar2
+
+**Date:** 2026-07-13
+**Status:** Approved design
+**Scope:** `SparseVar2` (Rust-backed svar2 signature path) only. v1 `SparseVar` is untouched.
+
+## Motivation
+
+svar2 currently classifies SNVs into the strand-agnostic SBS96 catalog (plus
+DBS78 and ID83). Transcriptional strand bias — the asymmetry between mutations
+on the transcribed (template) vs. untranscribed (coding) strand of genes — is a
+key readout for distinguishing mutational processes (e.g. transcription-coupled
+repair signatures). Capturing it requires splitting each SBS96 channel by the
+strand class of the variant's position, which in turn requires a gene model
+(GTF). This adds the two standard SigProfiler strand-resolved catalogs:
+
+- **SBS384** = 96 trinucleotide channels × 4 strand categories, in SigProfiler
+  order `[T, U, N, B]`:
+  - **T** — Transcribed (pyrimidine on the gene's template strand)
+  - **U** — Untranscribed (pyrimidine on the gene's coding strand)
+  - **N** — Nontranscribed (position in no gene footprint / intergenic)
+  - **B** — Bidirectional (position covered by genes on both strands)
+- **SBS192** = SBS384 restricted to `{T, U}`, i.e. exactly `SBS384[:192]` given
+  the `[T, U, N, B]` block ordering. Implementing the 4-way strand split yields
+  both catalogs; SBS192 needs no separate storage.
+
+### Refit scope (decided)
+
+COSMIC publishes reference signatures in **96-context only**. There are no
+official SBS192/SBS384 reference sets — these catalogs exist for strand-bias
+*analysis*, not refitting. Therefore:
+
+- `mutation_matrix("SBS192" | "SBS384")` **is** the deliverable (the count
+  matrix people feed to strand-bias tests).
+- `assign_signatures("SBS192" | "SBS384")` raises `NotImplementedError` with a
+  message pointing to `mutation_matrix`. SBS96/DBS78/ID83 refit is unchanged.
+
+## The strand rule
+
+SBS channels are pyrimidine-folded (reference base normalized to C or T). For a
+genic SNV, define:
+
+- `pyr_on_plus = refbase ∈ {C, T}` — is the pyrimidine of the ref/alt pair on
+  the `+` (reference) strand?
+- `gene_on_plus = gene strand is +`
+
+Then (matching SigProfiler):
+
+- position covered by genes on **both** strands → **B**
+- position in **no** gene → **N**
+- otherwise a single gene strand:
+  - **Untranscribed (U)** iff `pyr_on_plus == gene_on_plus`
+  - **Transcribed (T)** otherwise
+
+Worked checks (gene on `+` strand):
+- `A>T` folds to `T>A`; ref base `A` is a purine so `pyr_on_plus = false`;
+  `false != true` → **T** (transcribed). ✓
+- `C>G`; ref base `C` is a pyrimidine so `pyr_on_plus = true`;
+  `true == true` → **U** (untranscribed). ✓
+
+Strand applies to **SNVs only**. DBS78 and ID83 are unaffected.
+
+## Public API
+
+On `SparseVar2` (`python/genoray/_svar2_mutcat.py`, `_MutcatMixin`):
+
+- `annotate_mutations(reference, *, gtf=None, contigs=None) -> None`
+  - New optional `gtf=` (path-like). When supplied, a per-record strand class is
+    computed and stored alongside the SBS96 codes, enabling SBS192/384.
+  - `meta.json` gains `mutcat_strand: bool` and the GTF path for provenance.
+  - Without `gtf=`, behavior is exactly as today (SBS96/DBS78/ID83).
+- `mutation_matrix(kind, *, count=...) -> pl.DataFrame`
+  - `kind` Literal gains `"SBS192"`, `"SBS384"`.
+  - If the sidecar was not strand-annotated (`mutcat_strand` false / absent),
+    raises a clear error instructing the user to re-annotate with `gtf=`. It does
+    **not** silently return zeros.
+- `assign_signatures(kind, ...)`
+  - `"SBS192"`/`"SBS384"` → `NotImplementedError` (see refit scope above).
+
+Write-time path:
+
+- `SparseVar2.from_vcf(..., signatures=True, gtf=None)` and
+  `from_pgen(..., signatures=True, gtf=None)` — `gtf=` threaded through
+  (`src/lib.rs` → `orchestrator.rs`) so strand can be annotated during
+  conversion. When `gtf=None`, write-time annotation is strand-free as today.
+
+## GTF → strand intervals (Python side)
+
+Reuse the existing `seqpro.gtf.scan` machinery already used by v1
+`_svar/_annotate.py::_load_gtf`. Per contig, flatten `feature == "gene"`
+footprints (full gene body, introns included — matches SigProfiler's "gene
+footprint") into a **sorted, disjoint interval partition** and pass it across the
+pyo3 boundary as a struct-of-arrays:
+
+```
+strand_starts:  int32[]   # 0-based, half-open [start, stop)
+strand_stops:   int32[]
+strand_values:  uint8[]   # 1 = +only, 2 = −only, 3 = both (B); gaps ⇒ N (0)
+```
+
+- Only genic intervals are materialized; N is the implicit gap. Size is
+  ~gene-count (tens of thousands genome-wide), not contig-length. No per-base
+  array.
+- Construction: for each strand collect gene spans, mark `+1`/`-1` at
+  `start`/`stop`, cumsum to a coverage indicator, combine the two strands'
+  coverage into the 4-way class, and emit maximal runs as `(start, stop, value)`.
+- Default feature filter is `gene`. Biotype selection is the user's
+  responsibility (pre-filter the GTF); documented as such.
+- Contig-name normalization goes through the existing `ContigNormalizer` so
+  `chr`-prefixed vs. unprefixed GTF/reference/variant names interoperate.
+
+### Design rationale (interval SoA vs. per-base array)
+
+An earlier draft passed a per-position `int8` array parallel to `ref_seq`
+(~250 MB for chr1). The interval SoA is the chosen approach: payload is
+proportional to gene count, GTF parsing stays in tested Python, and Rust
+classifies with a two-pointer sweep (below) — no per-base array, no binary
+search.
+
+## Sidecar storage (Rust)
+
+When a GTF is supplied, write a new **2-bit-packed `strand.bin`** stream for the
+SNP sub-streams (`var_key_snp`, `dense_snp`), parallel to the existing 2-bit
+`ref.bin` — one 2-bit value per SNP record encoding `{0:T, 1:U, 2:N, 3:B}`.
+
+- Written **only** when strand-annotated; absent otherwise (backward compatible
+  — older sidecars simply lack the stream and report `mutcat_strand: false`).
+- Indel sub-streams get no strand stream (strand is SNV-only).
+- `MutcatSub`/`has_ref` in `src/layout.rs` gain a parallel `has_strand()` (true
+  for the SNP subs) and a `mutcat_strand` path builder mirroring `mutcat_ref`.
+- `MutcatView` (`src/mutcat/sidecar.rs`) gains a `strand_at(i)` accessor,
+  present only when the stream exists.
+- Cost model (`src/cost_model.rs`): `SIDECAR_BITS_SNP` accounts for +2 bits per
+  SNP when strand annotation is enabled.
+
+## Classification pass (Rust)
+
+`annotate_contig` (`src/mutcat/annotate.rs`) gains the interval SoA
+(`strand_starts`, `strand_stops`, `strand_values`) alongside `ref_seq`, and
+threads it into the SNP path. Because SVAR2 records are position-sorted per
+contig and the intervals are sorted, classification is a **two-pointer sweep**:
+
+- advance the interval cursor while `stop <= pos`
+- the current interval value (or 0/N if `pos` falls in a gap) is the position's
+  strand class
+- combine with the pyrimidine rule (above) using `refb = ref_seq[p]` to produce
+  `{T, U, N, B}`
+
+Complexity O(n_variants + n_intervals), no per-base allocation. The stored SBS96
+code is unchanged; the strand byte is written to `strand.bin`. A SNP that is
+`UNCLASSIFIED`/`NOT_ANNOTATED` for SBS96 gets an arbitrary strand value (it is
+never counted).
+
+`snp_record` returns the strand class in addition to `(code, ref2bit)`; the
+write path packs it into `strand.bin`.
+
+## Codebook + count
+
+Codebook (`python/genoray/_mutcat/codebook.py` and `src/mutcat/mod.rs`, kept in
+lockstep, enforced by `code_space_matches_codebook`):
+
+- Add one **SBS384 block** to the unified code space:
+  `SBS384 = [257, 641)` (i.e. `SBS384_OFFSET = N_CODES_old = 257`,
+  `N_CODES = 641`).
+- Labels in `[T, U, N, B] × SBS96` order, formatted
+  `{strand}:{5'}[{ref}>{alt}]{3'}` (e.g. `T:A[C>A]A`). The exact separator/format
+  is pinned against SigProfiler output during implementation.
+- `SBS192` is a Python-level view = the SBS384 block sliced `[:192]` (the T and U
+  channels). No separate stored range, no separate Rust offset.
+- `Kind` Literals/enums gain `"SBS384"` (and `"SBS192"` at the Python API layer,
+  resolving to the `SBS384[:192]` slice). Bump `MUTCAT_VERSION`.
+
+Count (`src/mutcat/count.rs`, `src/py_mutcat.rs`):
+
+- The accumulator widens to `(n_samples, N_CODES=641)` `i64`.
+- For each valid SNV, in addition to its SBS96 bin, increment
+  `257 + strand_idx*96 + sbs96_code` **when the sidecar has a strand stream**.
+  `strand_idx` uses `[T,U,N,B] = [0,1,2,3]`.
+- When there is no strand stream, no SBS384 emission occurs.
+- `mutation_matrix("SBS384")` slices `[257, 641)`; `"SBS192"` slices the first
+  192 of that block. Both raise (via the API guard on `mutcat_strand`) rather
+  than returning zeros when strand was not annotated.
+- DBS78 pairing and ID83 counting are unchanged.
+
+## Testing
+
+Rust:
+- Strand rule unit tests against hand-worked SigProfiler cases: gene-on-`+`
+  `A>T` → T (transcribed); gene-on-`+` `C>G` → U (untranscribed); gene-on-`−`
+  mirror cases; overlapping opposite-strand genes → B; intergenic → N.
+- Two-pointer sweep tests: variants before / after / between / inside intervals,
+  half-open boundary handling (`pos == start`, `pos == stop`), multi-interval
+  contigs, empty interval set (all N).
+- Sidecar round-trip: `strand.bin` write → `strand_at` read for both SNP subs.
+
+Python:
+- Parity: a small synthetic VCF + FASTA + GTF where the SBS384 matrix collapsed
+  over the 4 strand blocks equals the SBS96 matrix, and `SBS192 == SBS384[:192]`.
+- Contig-name normalization: `chr`-prefixed GTF against unprefixed variants (and
+  vice versa) via `ContigNormalizer`.
+- `mutation_matrix("SBS384")` on a sidecar annotated without `gtf=` raises a
+  clear error.
+- `assign_signatures("SBS384")` raises `NotImplementedError`.
+- Prefer `vcfixture` for the synthetic VCF + ground-truth oracle where it fits.
+
+## Docs
+
+- Update `skills/genoray-api/SKILL.md` — the svar2 signatures section: add
+  SBS192/384, the `annotate_mutations(gtf=...)` kwarg, the strand rule and
+  category definitions, the `from_vcf(gtf=...)` kwarg, and the
+  refit-not-supported note. Clarify that the existing "no SBS-192" limitation
+  note applies to **v1 `SparseVar`** only.
+- Add a `CHANGELOG.md` Unreleased → Added entry.
+
+## Out of scope
+
+- v1 `SparseVar` strand-resolved catalogs (unchanged; keeps its documented
+  no-strand limitation).
+- SBS288 (`96 × {T,U,N}`), SBS1536/SBS6144, replication strand bias.
+- A dedicated strand-asymmetry statistical test helper (users compute it from
+  the returned matrix). Possible future work.
+- Refitting SBS192/384 against any reference (no COSMIC set exists).

--- a/docs/superpowers/specs/2026-07-13-svar2-sbs192-sbs384-design.md
+++ b/docs/superpowers/specs/2026-07-13-svar2-sbs192-sbs384-design.md
@@ -77,12 +77,14 @@ On `SparseVar2` (`python/genoray/_svar2_mutcat.py`, `_MutcatMixin`):
 - `assign_signatures(kind, ...)`
   - `"SBS192"`/`"SBS384"` → `NotImplementedError` (see refit scope above).
 
-Write-time path:
+Write-time path (unchanged):
 
-- `SparseVar2.from_vcf(..., signatures=True, gtf=None)` and
-  `from_pgen(..., signatures=True, gtf=None)` — `gtf=` threaded through
-  (`src/lib.rs` → `orchestrator.rs`) so strand can be annotated during
-  conversion. When `gtf=None`, write-time annotation is strand-free as today.
+- `SparseVar2.from_vcf(..., signatures=True)` / `from_pgen(...)` continue to
+  write **strand-free** sidecars (SBS96/DBS78/ID83) exactly as today. There is
+  no `gtf=` kwarg on the conversion path. To obtain SBS192/384, call
+  `annotate_mutations(reference, gtf=...)` once after conversion — it overwrites
+  the sidecars, adding `strand.bin`. This keeps GTF parsing entirely in Python
+  (via `seqpro`) and leaves the deep Rust conversion pipeline untouched.
 
 ## GTF → strand intervals (Python side)
 
@@ -231,7 +233,8 @@ Python:
 
 - Update `skills/genoray-api/SKILL.md` — the svar2 signatures section: add
   SBS192/384, the `annotate_mutations(gtf=...)` kwarg, the strand rule and
-  category definitions, the `from_vcf(gtf=...)` kwarg, and the
+  category definitions, the note that write-time `signatures=True` stays
+  strand-free (use post-hoc `annotate_mutations(gtf=...)`), and the
   refit-not-supported note. Clarify that the existing "no SBS-192" limitation
   note applies to **v1 `SparseVar`** only.
 - Add a `CHANGELOG.md` Unreleased → Added entry.
@@ -240,6 +243,10 @@ Python:
 
 - v1 `SparseVar` strand-resolved catalogs (unchanged; keeps its documented
   no-strand limitation).
+- Write-time strand annotation via `from_vcf`/`from_pgen`/`from_vcf_list`
+  (`signatures=True` stays strand-free; SBS192/384 comes from a post-hoc
+  `annotate_mutations(reference, gtf=...)`). Deferred to avoid threading a GTF
+  through the Rust conversion pipeline for a one-FASTA-reload saving.
 - SBS288 (`96 × {T,U,N}`), SBS1536/SBS6144, replication strand bias.
 - A dedicated strand-asymmetry statistical test helper (users compute it from
   the returned matrix). Possible future work.

--- a/docs/superpowers/specs/2026-07-13-svar2-sbs192-sbs384-design.md
+++ b/docs/superpowers/specs/2026-07-13-svar2-sbs192-sbs384-design.md
@@ -182,6 +182,30 @@ Count (`src/mutcat/count.rs`, `src/py_mutcat.rs`):
   than returning zeros when strand was not annotated.
 - DBS78 pairing and ID83 counting are unchanged.
 
+## Backward compatibility (no change to existing layout or cost)
+
+Adding this feature does **not** change how SBS96/DBS78/ID83 are stored or
+counted:
+
+- `code.bin` stores **within-kind** codes as today: `sbs96_code` (0–95) for SNPs,
+  `id83_code` (0–82) for indels, sentinels 254/255. All fit `u8`. The SBS384 code
+  is never stored as a single value — SBS96 (`code.bin`, `u8`) and strand
+  (`strand.bin`, 2-bit) are stored separately. SBS96 does **not** need >8-bit
+  encoding.
+- The existing offsets (`SBS96=0, DBS78=96, ID83=174`) are unchanged; the SBS384
+  block is appended at 257. Offsets are applied only at count time when indexing
+  the `i64` accumulator, so widening `N_CODES` 257→641 affects only the transient
+  in-memory count matrix — never on-disk bytes, never a `u8`.
+- A sidecar annotated **without** a GTF is byte-for-byte identical to today.
+  `strand.bin` is purely additive and written only when `gtf=` is supplied.
+- Old sidecars remain valid under the new codebook (stored within-kind codes map
+  to identical unified indices). The `MUTCAT_VERSION` bump is a
+  **backward-compatible read**: SBS384 availability is gated on `strand.bin`
+  presence (`mutcat_strand`), not on version equality — no forced re-annotation.
+- Implementation note: the hard-coded `N_CODES == 257` asserts
+  (`src/mutcat/mod.rs` `code_space_matches_codebook`, `src/mutcat/count.rs`
+  `emit_snv_codes`) update to 641.
+
 ## Testing
 
 Rust:

--- a/python/genoray/_mutcat/codebook.py
+++ b/python/genoray/_mutcat/codebook.py
@@ -118,11 +118,21 @@ ID83: list[str] = _build_id83()
 
 assert len(SBS96) == 96 and len(DBS78) == 78 and len(ID83) == 83
 
+# ---- SBS-384 (transcriptional strand bias): SigProfiler [T, U, N, B] blocks ----
+# T=Transcribed, U=Untranscribed, N=Nontranscribed (intergenic), B=Bidirectional.
+# Label form "<strand>:<sbs96 label>", e.g. "T:A[C>A]A". SBS-192 is the {T,U} view
+# (SBS384[:192]); no separate stored range.
+_STRANDS = ["T", "U", "N", "B"]
+SBS384: list[str] = [f"{s}:{lbl}" for s in _STRANDS for lbl in SBS96]
+
+assert len(SBS384) == 384
+
 # ---- unified int16 code space ----
 SBS96_OFFSET = 0
 DBS78_OFFSET = SBS96_OFFSET + len(SBS96)  # 96
 ID83_OFFSET = DBS78_OFFSET + len(DBS78)  # 174
-N_CODES = ID83_OFFSET + len(ID83)  # 257
+SBS384_OFFSET = ID83_OFFSET + len(ID83)  # 257
+N_CODES = SBS384_OFFSET + len(SBS384)  # 641
 
 
 class Sentinel(IntEnum):
@@ -139,19 +149,31 @@ SBS96_INDEX = {lbl: SBS96_OFFSET + i for i, lbl in enumerate(SBS96)}
 DBS78_INDEX = {lbl: DBS78_OFFSET + i for i, lbl in enumerate(DBS78)}
 ID83_INDEX = {lbl: ID83_OFFSET + i for i, lbl in enumerate(ID83)}
 
-MUTCAT_VERSION = 3
+MUTCAT_VERSION = 4
 
-Kind = Literal["SBS96", "DBS78", "ID83"]
+Kind = Literal["SBS96", "DBS78", "ID83", "SBS192", "SBS384"]
 
-_LABELS: dict[str, list[str]] = {"SBS96": SBS96, "DBS78": DBS78, "ID83": ID83}
+_LABELS: dict[str, list[str]] = {
+    "SBS96": SBS96,
+    "DBS78": DBS78,
+    "ID83": ID83,
+    "SBS384": SBS384,
+    "SBS192": SBS384[:192],
+}
 
 
 def code_ranges() -> dict[Kind, tuple[int, int]]:
-    """Half-open ``[start, end)`` code range per matrix kind."""
+    """Half-open ``[start, end)`` code range per matrix kind.
+
+    ``SBS192`` is the {T, U} sub-view of the ``SBS384`` block, so its range is
+    the first 192 codes of that block.
+    """
     return {
         "SBS96": (SBS96_OFFSET, DBS78_OFFSET),
         "DBS78": (DBS78_OFFSET, ID83_OFFSET),
-        "ID83": (ID83_OFFSET, N_CODES),
+        "ID83": (ID83_OFFSET, SBS384_OFFSET),
+        "SBS384": (SBS384_OFFSET, N_CODES),
+        "SBS192": (SBS384_OFFSET, SBS384_OFFSET + 192),
     }
 
 

--- a/python/genoray/_mutcat/strand.py
+++ b/python/genoray/_mutcat/strand.py
@@ -1,0 +1,131 @@
+"""Build transcriptional-strand-class intervals from a GTF gene model.
+
+Flattens gene footprints into a sorted, disjoint interval partition per contig,
+each interval tagged with a coverage class (1=+only, 2=−only, 3=both strands).
+Gaps between intervals are class N (nontranscribed) and are not materialized.
+The result crosses the pyo3 boundary as a struct-of-arrays and drives the Rust
+two-pointer strand sweep in ``annotate_contig``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import seqpro as sp
+from numpy.typing import NDArray
+
+from .._contigs import ContigNormalizer
+
+
+def load_gene_intervals(gtf: str | pl.DataFrame) -> pl.DataFrame:
+    """Load ``feature == "gene"`` footprints from a GTF as 0-based half-open rows.
+
+    Parameters
+    ----------
+    gtf
+        Path to a GTF/GTF.gz, or a pre-loaded Polars DataFrame with GTF columns
+        (``seqname``/``chrom``, ``feature``, ``start`` [1-based], ``end``
+        [inclusive], ``strand``).
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns ``chrom`` (Utf8), ``start`` (Int64, 0-based), ``stop`` (Int64,
+        exclusive), ``strand`` (Utf8, ``"+"``/``"-"``).
+    """
+    if isinstance(gtf, pl.DataFrame):
+        df = gtf.rename({"seqname": "chrom"}, strict=False)
+    else:
+        df = sp.gtf.scan(str(gtf)).collect().rename({"seqname": "chrom"}, strict=False)
+    return df.filter(pl.col("feature") == "gene").select(
+        pl.col("chrom").cast(pl.Utf8),
+        (pl.col("start") - 1).cast(pl.Int64).alias("start"),  # 1-based -> 0-based
+        pl.col("end").cast(pl.Int64).alias("stop"),  # inclusive == exclusive 0-based
+        pl.col("strand").cast(pl.Utf8),
+    )
+
+
+def _empty() -> tuple[NDArray[np.int32], NDArray[np.int32], NDArray[np.uint8]]:
+    return (
+        np.empty(0, np.int32),
+        np.empty(0, np.int32),
+        np.empty(0, np.uint8),
+    )
+
+
+def contig_strand_intervals(
+    genes: pl.DataFrame, contig: str, c_norm: ContigNormalizer
+) -> tuple[NDArray[np.int32], NDArray[np.int32], NDArray[np.uint8]]:
+    """Flatten gene footprints on ``contig`` into a sorted, disjoint partition.
+
+    Genes whose (normalized) chrom maps to ``contig`` are split by strand and
+    merged into maximal runs, each tagged 1 (+only), 2 (−only), or 3 (both).
+    Gaps (class N) are omitted. Returns ``(starts, stops, values)``.
+    """
+    normed = c_norm.norm(genes.get_column("chrom").to_list())
+    g = genes.filter(pl.Series([n == contig for n in normed]))
+    if g.height == 0:
+        return _empty()
+
+    ps = (
+        g.filter(pl.col("strand") == "+")
+        .get_column("start")
+        .to_numpy()
+        .astype(np.int64)
+    )
+    pe = (
+        g.filter(pl.col("strand") == "+").get_column("stop").to_numpy().astype(np.int64)
+    )
+    ms = (
+        g.filter(pl.col("strand") == "-")
+        .get_column("start")
+        .to_numpy()
+        .astype(np.int64)
+    )
+    me = (
+        g.filter(pl.col("strand") == "-").get_column("stop").to_numpy().astype(np.int64)
+    )
+
+    bp = np.unique(np.concatenate([ps, pe, ms, me]))
+    if bp.size < 2:
+        return _empty()
+
+    def covered(
+        starts: NDArray[np.int64], stops: NDArray[np.int64]
+    ) -> NDArray[np.bool_]:
+        # +1 at each start, -1 at each stop over the shared breakpoint grid; the
+        # running sum on segment i = [bp[i], bp[i+1]) is that strand's coverage.
+        diff = np.zeros(bp.size, dtype=np.int64)
+        if starts.size:
+            np.add.at(diff, np.searchsorted(bp, starts), 1)
+            np.add.at(diff, np.searchsorted(bp, stops), -1)
+        return np.cumsum(diff)[:-1] > 0
+
+    pc = covered(ps, pe)
+    mc = covered(ms, me)
+    val = np.where(pc & mc, 3, np.where(pc, 1, np.where(mc, 2, 0))).astype(np.uint8)
+
+    lo = bp[:-1]
+    hi = bp[1:]
+    genic = val != 0
+    if not genic.any():
+        return _empty()
+    lo, hi, val = lo[genic], hi[genic], val[genic]
+
+    # Merge adjacent segments that touch and share a class.
+    starts_out = [int(lo[0])]
+    stops_out = [int(hi[0])]
+    vals_out = [int(val[0])]
+    for i in range(1, val.size):
+        if val[i] == vals_out[-1] and lo[i] == stops_out[-1]:
+            stops_out[-1] = int(hi[i])
+        else:
+            starts_out.append(int(lo[i]))
+            stops_out.append(int(hi[i]))
+            vals_out.append(int(val[i]))
+
+    return (
+        np.asarray(starts_out, np.int32),
+        np.asarray(stops_out, np.int32),
+        np.asarray(vals_out, np.uint8),
+    )

--- a/python/genoray/_svar2_mutcat.py
+++ b/python/genoray/_svar2_mutcat.py
@@ -16,7 +16,9 @@ from typing import Any, Literal
 import numpy as np
 import polars as pl
 
+from genoray._contigs import ContigNormalizer
 from genoray._mutcat import MUTCAT_VERSION, N_CODES, code_ranges, labels
+from genoray._mutcat.strand import contig_strand_intervals, load_gene_intervals
 from genoray._reference import Reference
 from genoray._signatures import _load_signature_file, cosmic_signatures, fit_signatures
 
@@ -36,7 +38,11 @@ class _MutcatMixin:
     _readers: dict[str, Any]
 
     def annotate_mutations(
-        self, reference: "Reference | str | Path", *, contigs: "list[str] | None" = None
+        self,
+        reference: "Reference | str | Path",
+        *,
+        gtf: "str | Path | pl.DataFrame | None" = None,
+        contigs: "list[str] | None" = None,
     ) -> None:
         """Classify every variant on the in-scope contigs into SBS-96/DBS-78/ID-83
         codes and write the per-contig ``mutcat`` sidecar (post-hoc annotation).
@@ -46,18 +52,23 @@ class _MutcatMixin:
         reference
             Reference genome. A :class:`~genoray._reference.Reference` instance,
             or a path to a FASTA file (with a ``.fai`` index alongside it).
+        gtf
+            Optional gene model (path to a GTF/GTF.gz, or a pre-loaded GTF
+            DataFrame). When given, each SNV additionally gets a transcriptional
+            strand class stored in a 2-bit ``strand.bin`` sidecar, enabling the
+            strand-resolved ``"SBS192"``/``"SBS384"`` matrices. Gene footprints
+            are taken from ``feature == "gene"`` rows (full gene body); filter
+            the GTF beforehand to restrict biotypes.
         contigs
             If given, only these contigs (intersected with ``self.contigs``) are
             annotated. ``None`` (default) annotates every contig in the store.
 
         Notes
         -----
-        Stamps ``meta.json`` with ``mutcat_version`` and ``mutcat_contigs`` so a
-        later :class:`SparseVar2` open can tell the store has been annotated;
-        the sidecar files themselves (one ``code.bin`` per contig) are the
-        ground truth checked by :meth:`mutation_matrix`'s guard, since the
-        write-time ``from_vcf(..., signatures=True)`` path writes sidecars
-        without touching ``meta.json``.
+        Stamps ``meta.json`` with ``mutcat_version``, ``mutcat_contigs``, and
+        ``mutcat_strand`` (whether a GTF was supplied). The sidecar files
+        themselves are the ground truth checked by :meth:`mutation_matrix`'s
+        guards.
         """
         if not isinstance(reference, Reference):
             reference = Reference.from_path(reference)
@@ -66,14 +77,28 @@ class _MutcatMixin:
             if contigs is None
             else [c for c in self.contigs if c in set(contigs)]
         )
+
+        genes = None
+        c_norm = None
+        if gtf is not None:
+            genes = load_gene_intervals(str(gtf) if isinstance(gtf, Path) else gtf)
+            c_norm = ContigNormalizer(self.contigs)
+
         for contig in scope:
             seq = reference.contig_array(contig).astype(np.uint8, copy=False)
-            self._readers[contig].annotate_mutations(str(self.path), contig, seq)
+            if genes is not None and c_norm is not None:
+                starts, stops, values = contig_strand_intervals(genes, contig, c_norm)
+                self._readers[contig].annotate_mutations(
+                    str(self.path), contig, seq, starts, stops, values
+                )
+            else:
+                self._readers[contig].annotate_mutations(str(self.path), contig, seq)
 
         meta_path = self.path / "meta.json"
         meta = json.loads(meta_path.read_text())
         meta["mutcat_version"] = MUTCAT_VERSION
         meta["mutcat_contigs"] = scope
+        meta["mutcat_strand"] = gtf is not None
         meta_path.write_text(json.dumps(meta))
 
     def _is_annotated(self) -> bool:
@@ -90,9 +115,21 @@ class _MutcatMixin:
             for contig in self.contigs
         )
 
+    def _is_strand_annotated(self) -> bool:
+        """Whether every contig has an on-disk ``strand.bin`` (GTF-annotated).
+
+        Ground truth for whether SBS192/SBS384 can be produced. Like
+        ``_is_annotated``, checked on disk rather than via ``meta.json`` because
+        the file is what the Rust count reads.
+        """
+        return all(
+            (self.path / contig / "mutcat" / "var_key_snp" / "strand.bin").exists()
+            for contig in self.contigs
+        )
+
     def mutation_matrix(
         self,
-        kind: Literal["SBS96", "DBS78", "ID83"],
+        kind: Literal["SBS96", "DBS78", "ID83", "SBS192", "SBS384"],
         *,
         count: Literal["allele", "sample"] = "allele",
     ) -> pl.DataFrame:
@@ -106,7 +143,9 @@ class _MutcatMixin:
         Parameters
         ----------
         kind
-            One of ``"SBS96"``, ``"DBS78"``, ``"ID83"``.
+            One of ``"SBS96"``, ``"DBS78"``, ``"ID83"``, ``"SBS192"``,
+            ``"SBS384"``. The last two require :meth:`annotate_mutations` to
+            have been run with ``gtf=`` (transcriptional strand annotation).
         count
             ``"allele"`` counts every non-ref allele copy; ``"sample"`` counts
             each category at most once per sample (presence/absence), OR-combined
@@ -119,8 +158,10 @@ class _MutcatMixin:
             every contig) — calling the underlying Rust ``count_matrix`` on an
             unannotated contig with SNP records panics across the FFI boundary,
             so this is checked up front to raise a clean Python exception instead.
+            Also raised for ``"SBS192"``/``"SBS384"`` if the store has not been
+            strand-annotated (no on-disk ``strand.bin`` for every contig).
         """
-        if kind not in ("SBS96", "DBS78", "ID83"):
+        if kind not in ("SBS96", "DBS78", "ID83", "SBS192", "SBS384"):
             raise ValueError(f"Unknown matrix kind {kind!r}.")
         if count not in ("allele", "sample"):
             raise ValueError(
@@ -131,6 +172,11 @@ class _MutcatMixin:
                 "SparseVar2 is not annotated for mutational signatures; call "
                 "annotate_mutations(reference) first, or rebuild with "
                 "from_vcf(..., signatures=True)."
+            )
+        if kind in ("SBS192", "SBS384") and not self._is_strand_annotated():
+            raise ValueError(
+                f"{kind} requires transcriptional strand annotation; re-run "
+                "annotate_mutations(reference, gtf=...) with a gene model."
             )
 
         per_sample = count == "sample"
@@ -188,6 +234,12 @@ class _MutcatMixin:
             One row per sample: ``Sample``, one column per signature, and
             ``cosine_similarity``.
         """
+        if kind in ("SBS192", "SBS384"):
+            raise NotImplementedError(
+                f"{kind} is a transcriptional-strand-bias catalog with no COSMIC "
+                "reference signature set for refitting. Use mutation_matrix(kind) "
+                "for strand-bias analysis instead."
+            )
         catalogue = self.mutation_matrix(kind, count=count)
         if reference is None:
             ref = cosmic_signatures(kind)

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -594,17 +594,25 @@ df = sv.mutation_matrix("DBS78", count="sample")
 act = sv.assign_signatures("SBS96")                  # mutation_matrix + fit_signatures
 ```
 
-- `annotate_mutations(reference, *, contigs=None) -> None` — `reference` is a
-  `genoray.Reference` or a FASTA path; `contigs=None` (default) annotates every
-  contig. Unlike `SparseVar.annotate_mutations`, there is **no `write_back=`
-  toggle** — SVAR2 always persists the sidecar to disk.
+- `annotate_mutations(reference, *, gtf=None, contigs=None) -> None` —
+  `reference` is a `genoray.Reference` or a FASTA path; `contigs=None`
+  (default) annotates every contig. Unlike `SparseVar.annotate_mutations`,
+  there is **no `write_back=` toggle** — SVAR2 always persists the sidecar to
+  disk. `gtf=` optionally supplies a GTF/GFF gene model path; when given, each
+  SNV is additionally classified by transcriptional-strand class (from
+  `feature == "gene"` footprints) and persisted to a `strand.bin` sidecar,
+  which unlocks the `"SBS192"`/`"SBS384"` catalogs below.
 - `mutation_matrix(kind, *, count="allele"|"sample") -> pl.DataFrame` — a
   `MutationType` column (fixed COSMIC codebook order) plus one column per
-  sample. `kind ∈ {"SBS96", "DBS78", "ID83"}`. `count="allele"` counts every
-  non-ref allele copy; `count="sample"` counts each category at most once per
-  sample, OR-combined across contigs. **Raises `ValueError`** if called before
-  the store is annotated (no on-disk sidecar for every contig) — annotate
-  first, either via `annotate_mutations` or `from_vcf(..., signatures=True)`.
+  sample. `kind ∈ {"SBS96", "DBS78", "ID83", "SBS192", "SBS384"}`.
+  `count="allele"` counts every non-ref allele copy; `count="sample"` counts
+  each category at most once per sample, OR-combined across contigs. **Raises
+  `ValueError`** if called before the store is annotated (no on-disk sidecar
+  for every contig) — annotate first, either via `annotate_mutations` or
+  `from_vcf(..., signatures=True)`. `"SBS192"`/`"SBS384"` additionally require
+  strand annotation (`annotate_mutations(..., gtf=...)`) and raise
+  `ValueError` if the store lacks it. `assign_signatures` does **not** accept
+  `"SBS192"`/`"SBS384"` — see below.
 - `assign_signatures(kind, *, reference=None, count="allele", max_delta=0.01, min_activity=0.005, n_jobs=1, backend="loky") -> pl.DataFrame`
   — `mutation_matrix(kind, count=...)` then `genoray.fit_signatures(...)`.
   `reference` accepts a `pl.DataFrame`, a TSV path, or `None` (defaults to
@@ -617,6 +625,32 @@ act = sv.assign_signatures("SBS96")                  # mutation_matrix + fit_sig
 - No public read-side access to the raw per-genotype `mutcat` codes for
   SVAR2 (unlike v1's `fields=["mutcat"]`) — only the aggregated
   `mutation_matrix` output is exposed.
+
+### Strand-resolved catalogs (SBS192 / SBS384)
+
+`SparseVar2` also supports the transcriptional-strand-bias catalogs, which
+require a gene model (GTF) at annotation time:
+
+```python
+sv2.annotate_mutations(reference, gtf="gencode.v45.annotation.gtf.gz")
+sbs384 = sv2.mutation_matrix("SBS384")   # 384 rows: [T, U, N, B] x 96
+sbs192 = sv2.mutation_matrix("SBS192")   # 192 rows: the {T, U} sub-view = SBS384[:192]
+```
+
+- **SBS384** = 96 trinucleotide channels x 4 strand categories, SigProfiler
+  order `[T, U, N, B]`: **T**ranscribed, **U**ntranscribed, **N**ontranscribed
+  (intergenic), **B**idirectional (position covered by genes on both strands).
+- **SBS192** is the `{T, U}` sub-view (`SBS384[:192]`).
+- Strand rule (pyrimidine-folded): a genic SNV is Untranscribed iff the
+  pyrimidine of its ref/alt pair sits on the gene's coding strand, else
+  Transcribed. Gene footprints come from `feature == "gene"` rows (full gene
+  body); pre-filter the GTF to restrict biotypes.
+- Without a `gtf=`, `mutation_matrix("SBS192"/"SBS384")` raises. Write-time
+  `from_vcf(..., signatures=True)` stays strand-free; obtain strand catalogs via
+  a post-hoc `annotate_mutations(reference, gtf=...)`.
+- `assign_signatures("SBS192"/"SBS384")` raises `NotImplementedError`: COSMIC
+  publishes no strand-resolved reference set. Use `mutation_matrix` for
+  strand-bias analysis.
 
 ### Errors
 
@@ -907,7 +941,9 @@ svar = genoray.SparseVar("out.svar", fields=["mutcat"])
 
 ### v1 scope limits (no strand-bias; calibrated against PCAWG/SigProfiler rules)
 
-- No strand-bias separation (no SBS-192 / transcriptional strand).
+- No strand-bias separation (SBS-192 / SBS-384) — v1 `SparseVar` only. Use
+  `SparseVar2.annotate_mutations(reference, gtf=...)` for transcriptional
+  strand-resolved catalogs.
 - DBS collapse applies only to **isolated adjacent pairs** on the same
   haplotype. Runs of ≥ 3 adjacent SNVs stay as individual SBS entries.
 - Indel channel (ID-83) bucketing follows PCAWG/SigProfiler published rules and

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -26,6 +26,10 @@ impl MutcatSub {
     pub fn has_ref(self) -> bool {
         matches!(self, MutcatSub::VkSnp | MutcatSub::DenseSnp)
     }
+    /// SNP sub-streams also carry a 2-bit `strand.bin` when GTF-annotated.
+    pub fn has_strand(self) -> bool {
+        matches!(self, MutcatSub::VkSnp | MutcatSub::DenseSnp)
+    }
 }
 
 /// The four sub-streams a field sidecar mirrors. Same four directories as
@@ -121,6 +125,9 @@ impl ContigPaths {
     }
     pub fn mutcat_ref(&self, sub: MutcatSub) -> PathBuf {
         self.mutcat_dir(sub).join("ref.bin")
+    }
+    pub fn mutcat_strand(&self, sub: MutcatSub) -> PathBuf {
+        self.mutcat_dir(sub).join("strand.bin")
     }
     /// Directory created before writing a sidecar sub-stream.
     pub fn mutcat_sub_dir(&self, sub: MutcatSub) -> PathBuf {

--- a/src/mutcat/annotate.rs
+++ b/src/mutcat/annotate.rs
@@ -3,10 +3,45 @@
 
 use crate::layout::{ContigPaths, MutcatSub};
 use crate::mutcat::NOT_ANNOTATED;
-use crate::mutcat::classify::{id83_code, sbs96_code};
+use crate::mutcat::classify::{id83_code, sbs96_code, snp_strand};
 use crate::mutcat::sidecar::write_sidecar;
 use crate::query::ContigReader;
 use svar2_codec::{DecodedKey, decode_key, decode_snp_2bit, encode_snp_2bit};
+
+/// A contig's gene-strand interval partition (struct-of-arrays), 0-based
+/// half-open, sorted and disjoint. `values`: 1=+only, 2=−only, 3=both; gaps ⇒ N.
+pub struct StrandIntervals<'a> {
+    pub starts: &'a [i32],
+    pub stops: &'a [i32],
+    pub values: &'a [u8],
+}
+
+/// Two-pointer sweep over `StrandIntervals`. `class_at` must be called with
+/// non-decreasing `pos` (SVAR2 records are position-sorted per sub-stream);
+/// build a fresh sweeper per sub-stream so the cursor restarts.
+struct StrandSweeper<'a> {
+    iv: &'a StrandIntervals<'a>,
+    cursor: usize,
+}
+
+impl<'a> StrandSweeper<'a> {
+    fn new(iv: &'a StrandIntervals<'a>) -> Self {
+        Self { iv, cursor: 0 }
+    }
+
+    /// Gene-coverage class at `pos`: interval `values` entry, or `0` (N) in a gap.
+    fn class_at(&mut self, pos: u32) -> u8 {
+        let p = pos as i32;
+        while self.cursor < self.iv.starts.len() && self.iv.stops[self.cursor] <= p {
+            self.cursor += 1;
+        }
+        if self.cursor < self.iv.starts.len() && self.iv.starts[self.cursor] <= p {
+            self.iv.values[self.cursor]
+        } else {
+            0
+        }
+    }
+}
 
 /// Classify every record of `reader`'s four sub-streams against `ref_seq` (the
 /// whole contig, 0-based ASCII) and write the sidecar under `paths`.
@@ -14,6 +49,7 @@ pub fn annotate_contig(
     reader: &ContigReader,
     paths: &ContigPaths,
     ref_seq: &[u8],
+    strand: Option<StrandIntervals>,
 ) -> std::io::Result<()> {
     // Classifiers match uppercase ACGT only; normalize here so BOTH entry points
     // (write-time from_vcf(signatures=True) and post-hoc annotate_mutations, which
@@ -27,12 +63,24 @@ pub fn annotate_contig(
         let (positions, keys) = reader.vk_snp_records(); // &[u32], packed 2-bit keys
         let mut codes = Vec::with_capacity(positions.len());
         let mut refs = Vec::with_capacity(positions.len());
+        let mut strands: Option<Vec<u8>> =
+            strand.as_ref().map(|_| Vec::with_capacity(positions.len()));
+        let mut sweeper = strand.as_ref().map(StrandSweeper::new);
         for (i, &pos) in positions.iter().enumerate() {
             let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
             codes.push(code);
             refs.push(refc);
+            if let (Some(sw), Some(st)) = (sweeper.as_mut(), strands.as_mut()) {
+                st.push(snp_strand_at(ref_seq, pos, sw.class_at(pos)));
+            }
         }
-        write_sidecar(paths, MutcatSub::VkSnp, &codes, Some(&refs), None)?;
+        write_sidecar(
+            paths,
+            MutcatSub::VkSnp,
+            &codes,
+            Some(&refs),
+            strands.as_deref(),
+        )?;
     }
     // --- dense/snp (per variant) ---
     if let Some((positions, keys)) = reader.dense_snp_records() {
@@ -40,14 +88,26 @@ pub fn annotate_contig(
         // decode via `snp_alt` (unpack_snp_key_at + decode_snp_2bit), never `keys[i]`.
         let mut codes = Vec::with_capacity(positions.len());
         let mut refs = Vec::with_capacity(positions.len());
+        let mut strands: Option<Vec<u8>> =
+            strand.as_ref().map(|_| Vec::with_capacity(positions.len()));
+        let mut sweeper = strand.as_ref().map(StrandSweeper::new);
         for (i, &pos) in positions.iter().enumerate() {
             let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
             codes.push(code);
             refs.push(refc);
+            if let (Some(sw), Some(st)) = (sweeper.as_mut(), strands.as_mut()) {
+                st.push(snp_strand_at(ref_seq, pos, sw.class_at(pos)));
+            }
         }
-        write_sidecar(paths, MutcatSub::DenseSnp, &codes, Some(&refs), None)?;
+        write_sidecar(
+            paths,
+            MutcatSub::DenseSnp,
+            &codes,
+            Some(&refs),
+            strands.as_deref(),
+        )?;
     }
-    // --- var_key/indel + dense/indel (per record) ---
+    // --- var_key/indel + dense/indel (per record) — no strand ---
     annotate_indel(reader, paths, ref_seq, MutcatSub::VkIndel)?;
     annotate_indel(reader, paths, ref_seq, MutcatSub::DenseIndel)?;
     Ok(())
@@ -68,6 +128,15 @@ fn snp_record(ref_seq: &[u8], pos: u32, alt: u8) -> (u8, u8) {
 /// ALT base for record `i` of a 2-bit-packed SNP key buffer (var_key or dense).
 fn snp_alt(packed_keys: &[u8], i: usize) -> u8 {
     decode_snp_2bit(svar2_codec::unpack_snp_key_at(packed_keys, i))
+}
+
+/// Strand class for the SNP at 0-based `pos`, given its gene-coverage `gene_class`.
+/// Reads the (uppercased) ref base; a contig-end / out-of-range pos yields a
+/// harmless class (the record is NOT_ANNOTATED for SBS96 and never counted).
+fn snp_strand_at(ref_seq: &[u8], pos: u32, gene_class: u8) -> u8 {
+    let p = pos as usize;
+    let refb = if p < ref_seq.len() { ref_seq[p] } else { b'N' };
+    snp_strand(refb, gene_class)
 }
 
 fn annotate_indel(
@@ -135,5 +204,22 @@ mod tests {
     fn contig_end_snp_is_not_annotated() {
         let ref_seq = b"CG";
         assert_eq!(snp_record(ref_seq, 0, b'A').0, NOT_ANNOTATED);
+    }
+
+    #[test]
+    fn strand_sweeper_classifies_by_interval() {
+        // intervals: [10,20)->+only(1), [30,40)->both(3). queries must be non-decreasing.
+        let iv = StrandIntervals {
+            starts: &[10, 30],
+            stops: &[20, 40],
+            values: &[1, 3],
+        };
+        let mut sw = StrandSweeper::new(&iv);
+        assert_eq!(sw.class_at(5), 0); // gap before first -> N
+        assert_eq!(sw.class_at(10), 1); // inclusive start
+        assert_eq!(sw.class_at(19), 1); // inside
+        assert_eq!(sw.class_at(20), 0); // exclusive stop -> gap
+        assert_eq!(sw.class_at(35), 3); // inside second
+        assert_eq!(sw.class_at(40), 0); // past all -> gap
     }
 }

--- a/src/mutcat/annotate.rs
+++ b/src/mutcat/annotate.rs
@@ -16,30 +16,38 @@ pub struct StrandIntervals<'a> {
     pub values: &'a [u8],
 }
 
-/// Two-pointer sweep over `StrandIntervals`. `class_at` must be called with
-/// non-decreasing `pos` (SVAR2 records are position-sorted per sub-stream);
-/// build a fresh sweeper per sub-stream so the cursor restarts.
+/// Order-independent lookup over `StrandIntervals` via binary search. `pos`
+/// queries may arrive in ANY order (var_key/snp positions are only sorted
+/// WITHIN each (sample, ploid) column of the CSR array, not globally across
+/// columns — see `src/rvk.rs` `call_positions` parity test), so this must not
+/// assume monotonicity.
 struct StrandSweeper<'a> {
     iv: &'a StrandIntervals<'a>,
-    cursor: usize,
 }
 
 impl<'a> StrandSweeper<'a> {
     fn new(iv: &'a StrandIntervals<'a>) -> Self {
-        Self { iv, cursor: 0 }
+        Self { iv }
     }
 
     /// Gene-coverage class at `pos`: interval `values` entry, or `0` (N) in a gap.
-    fn class_at(&mut self, pos: u32) -> u8 {
+    ///
+    /// Binary search over sorted, disjoint, half-open `[start, stop)`
+    /// intervals: find the last interval whose start is `<= pos`, then check
+    /// whether `pos` still falls before that interval's stop.
+    fn class_at(&self, pos: u32) -> u8 {
         let p = pos as i32;
-        while self.cursor < self.iv.starts.len() && self.iv.stops[self.cursor] <= p {
-            self.cursor += 1;
+        // number of interval starts <= p; candidate interval is idx-1
+        let idx = self.iv.starts.partition_point(|&s| s <= p);
+        if idx == 0 {
+            return 0; // before the first interval -> gap (N)
         }
-        if self.cursor < self.iv.starts.len() && self.iv.starts[self.cursor] <= p {
-            self.iv.values[self.cursor]
+        let i = idx - 1;
+        if self.iv.stops[i] > p {
+            self.iv.values[i]
         } else {
             0
-        }
+        } // inside -> value, else gap
     }
 }
 
@@ -65,12 +73,12 @@ pub fn annotate_contig(
         let mut refs = Vec::with_capacity(positions.len());
         let mut strands: Option<Vec<u8>> =
             strand.as_ref().map(|_| Vec::with_capacity(positions.len()));
-        let mut sweeper = strand.as_ref().map(StrandSweeper::new);
+        let sweeper = strand.as_ref().map(StrandSweeper::new);
         for (i, &pos) in positions.iter().enumerate() {
             let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
             codes.push(code);
             refs.push(refc);
-            if let (Some(sw), Some(st)) = (sweeper.as_mut(), strands.as_mut()) {
+            if let (Some(sw), Some(st)) = (sweeper.as_ref(), strands.as_mut()) {
                 st.push(snp_strand_at(ref_seq, pos, sw.class_at(pos)));
             }
         }
@@ -90,12 +98,12 @@ pub fn annotate_contig(
         let mut refs = Vec::with_capacity(positions.len());
         let mut strands: Option<Vec<u8>> =
             strand.as_ref().map(|_| Vec::with_capacity(positions.len()));
-        let mut sweeper = strand.as_ref().map(StrandSweeper::new);
+        let sweeper = strand.as_ref().map(StrandSweeper::new);
         for (i, &pos) in positions.iter().enumerate() {
             let (code, refc) = snp_record(ref_seq, pos, snp_alt(keys, i));
             codes.push(code);
             refs.push(refc);
-            if let (Some(sw), Some(st)) = (sweeper.as_mut(), strands.as_mut()) {
+            if let (Some(sw), Some(st)) = (sweeper.as_ref(), strands.as_mut()) {
                 st.push(snp_strand_at(ref_seq, pos, sw.class_at(pos)));
             }
         }
@@ -208,18 +216,40 @@ mod tests {
 
     #[test]
     fn strand_sweeper_classifies_by_interval() {
-        // intervals: [10,20)->+only(1), [30,40)->both(3). queries must be non-decreasing.
+        // intervals: [10,20)->+only(1), [30,40)->both(3).
         let iv = StrandIntervals {
             starts: &[10, 30],
             stops: &[20, 40],
             values: &[1, 3],
         };
-        let mut sw = StrandSweeper::new(&iv);
+        let sw = StrandSweeper::new(&iv);
         assert_eq!(sw.class_at(5), 0); // gap before first -> N
         assert_eq!(sw.class_at(10), 1); // inclusive start
         assert_eq!(sw.class_at(19), 1); // inside
         assert_eq!(sw.class_at(20), 0); // exclusive stop -> gap
         assert_eq!(sw.class_at(35), 3); // inside second
         assert_eq!(sw.class_at(40), 0); // past all -> gap
+    }
+
+    // Pins the bug's mechanism: var_key/snp positions are only sorted WITHIN
+    // each (sample, ploid) CSR column, not globally across columns (see
+    // `src/rvk.rs` call_positions parity test, which asserts a decrease at a
+    // column boundary). The old forward-only cursor could not rewind after a
+    // high query and silently mis-resolved every subsequent lower query to
+    // the gap class (0). `class_at` must resolve correctly no matter the
+    // query order.
+    #[test]
+    fn strand_lookup_is_order_independent() {
+        let iv = StrandIntervals {
+            starts: &[10, 30],
+            stops: &[20, 40],
+            values: &[1, 3],
+        };
+        let sw = StrandSweeper::new(&iv);
+        assert_eq!(sw.class_at(35), 3); // high first
+        assert_eq!(sw.class_at(10), 1); // then low -> must still resolve (old cursor got this wrong)
+        assert_eq!(sw.class_at(19), 1);
+        assert_eq!(sw.class_at(25), 0); // gap between intervals
+        assert_eq!(sw.class_at(5), 0); // before all, after a high query
     }
 }

--- a/src/mutcat/annotate.rs
+++ b/src/mutcat/annotate.rs
@@ -32,7 +32,7 @@ pub fn annotate_contig(
             codes.push(code);
             refs.push(refc);
         }
-        write_sidecar(paths, MutcatSub::VkSnp, &codes, Some(&refs))?;
+        write_sidecar(paths, MutcatSub::VkSnp, &codes, Some(&refs), None)?;
     }
     // --- dense/snp (per variant) ---
     if let Some((positions, keys)) = reader.dense_snp_records() {
@@ -45,7 +45,7 @@ pub fn annotate_contig(
             codes.push(code);
             refs.push(refc);
         }
-        write_sidecar(paths, MutcatSub::DenseSnp, &codes, Some(&refs))?;
+        write_sidecar(paths, MutcatSub::DenseSnp, &codes, Some(&refs), None)?;
     }
     // --- var_key/indel + dense/indel (per record) ---
     annotate_indel(reader, paths, ref_seq, MutcatSub::VkIndel)?;
@@ -79,13 +79,13 @@ fn annotate_indel(
     let recs = reader.indel_records(sub); // Option<(&[u32] positions, &[u32] keys)>
     let (positions, keys) = match recs {
         Some(r) => r,
-        None => return write_sidecar(paths, sub, &[], None),
+        None => return write_sidecar(paths, sub, &[], None, None),
     };
     let mut codes = Vec::with_capacity(positions.len());
     for (i, &pos) in positions.iter().enumerate() {
         codes.push(indel_code(reader, ref_seq, pos, keys[i]));
     }
-    write_sidecar(paths, sub, &codes, None)
+    write_sidecar(paths, sub, &codes, None, None)
 }
 
 /// ID83 code for one indel record, reconstructing REF/ALT from key + reference.

--- a/src/mutcat/classify.rs
+++ b/src/mutcat/classify.rs
@@ -2,7 +2,7 @@
 //! python/genoray/_mutcat/classify.py. No I/O; operates on ASCII bytes +
 //! reference slices.
 
-use crate::mutcat::UNCLASSIFIED;
+use crate::mutcat::{STRAND_B, STRAND_N, STRAND_T, STRAND_U, UNCLASSIFIED};
 
 /// A=0 C=1 G=2 T=3, else -1 (N or non-ACGT).
 #[inline]
@@ -53,6 +53,33 @@ pub fn sbs96_code(five: u8, refb: u8, altb: u8, three: u8) -> u8 {
         return UNCLASSIFIED;
     }
     (sub as u8) * 16 + (ff as u8) * 4 + (tt as u8)
+}
+
+/// Transcriptional strand class for an SNV: `STRAND_{T,U,N,B}`.
+///
+/// `refb` is the uppercased reference base; `gene_class` is the position's gene
+/// coverage: `0`=no gene (N), `1`=+ strand only, `2`=− strand only, `3`=both (B).
+///
+/// SBS channels are pyrimidine-folded, so the strand of the pyrimidine of the
+/// ref/alt pair decides T vs U: the pyrimidine is on the `+` strand iff `refb`
+/// is C or T. A single-strand gene's coding strand is its own strand; the
+/// mutation is Untranscribed when the pyrimidine sits on that coding strand,
+/// Transcribed otherwise.
+#[inline]
+pub fn snp_strand(refb: u8, gene_class: u8) -> u8 {
+    match gene_class {
+        1 | 2 => {
+            let pyr_on_plus = refb == b'C' || refb == b'T';
+            let gene_on_plus = gene_class == 1;
+            if pyr_on_plus == gene_on_plus {
+                STRAND_U
+            } else {
+                STRAND_T
+            }
+        }
+        3 => STRAND_B,
+        _ => STRAND_N,
+    }
 }
 
 // ID83 lookup tables, built to match codebook.py ID83 order.
@@ -370,5 +397,22 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn snp_strand_matches_sigprofiler_examples() {
+        use crate::mutcat::{STRAND_B, STRAND_N, STRAND_T, STRAND_U};
+        // Gene on + strand (gene_class=1).
+        // A>T folds to T>A; ref base A is a purine (pyrimidine on -), so with the
+        // gene coding-strand = +, the pyrimidine is on the template = Transcribed.
+        assert_eq!(snp_strand(b'A', 1), STRAND_T);
+        // C>G; ref base C is a pyrimidine on + = coding strand = Untranscribed.
+        assert_eq!(snp_strand(b'C', 1), STRAND_U);
+        // Gene on - strand (gene_class=2): the assignments flip.
+        assert_eq!(snp_strand(b'A', 2), STRAND_U);
+        assert_eq!(snp_strand(b'C', 2), STRAND_T);
+        // Both strands -> B; no gene -> N (regardless of ref base).
+        assert_eq!(snp_strand(b'C', 3), STRAND_B);
+        assert_eq!(snp_strand(b'A', 0), STRAND_N);
     }
 }

--- a/src/mutcat/count.rs
+++ b/src/mutcat/count.rs
@@ -7,7 +7,9 @@ use crate::dense::DenseClass;
 use crate::layout::{ContigPaths, MutcatSub};
 use crate::mutcat::classify::dbs78_code;
 use crate::mutcat::sidecar::{MutcatView, open_sidecar};
-use crate::mutcat::{DBS78_OFFSET, ID83_OFFSET, N_CODES, SBS96_OFFSET, UNCLASSIFIED};
+use crate::mutcat::{
+    DBS78_OFFSET, ID83_OFFSET, N_CODES, SBS96_OFFSET, SBS384_OFFSET, STRAND_NA, UNCLASSIFIED,
+};
 use crate::query::ContigReader;
 use crate::query::sidecar::as_bytes;
 use svar2_codec::{decode_snp_2bit, unpack_snp_key_at};
@@ -16,9 +18,10 @@ use svar2_codec::{decode_snp_2bit, unpack_snp_key_at};
 #[derive(Debug, Clone, Copy)]
 pub struct SnvCall {
     pub pos: u32,
-    pub sbs: u8,   // SBS96 class-local index or sentinel
-    pub ref_i: u8, // 2-bit ref base code
-    pub alt_i: u8, // 2-bit alt base code
+    pub sbs: u8,    // SBS96 class-local index or sentinel
+    pub ref_i: u8,  // 2-bit ref base code
+    pub alt_i: u8,  // 2-bit alt base code
+    pub strand: u8, // STRAND_{T,U,N,B}, or STRAND_NA when no strand.bin
 }
 
 /// Emit one unified mutation code per SNV (SBS, or DBS once for an isolated
@@ -51,12 +54,18 @@ pub fn emit_snv_codes(snvs: &[SnvCall], out: &mut impl FnMut(usize)) {
         }
         if (v.sbs as usize) < 96 {
             out(SBS96_OFFSET + v.sbs as usize);
+            // Strand-resolved SBS384 (same SNV), only when the sidecar carried a
+            // strand stream. DBS-paired SNVs `continue` above, so they never reach
+            // here — SBS384 is emitted for exactly the SNVs that emit SBS96.
+            if v.strand != STRAND_NA {
+                out(SBS384_OFFSET + (v.strand as usize) * 96 + v.sbs as usize);
+            }
         }
         j += 1;
     }
     #[allow(clippy::assertions_on_constants)]
     {
-        debug_assert!(N_CODES == 257);
+        debug_assert!(N_CODES == 641);
     }
 }
 
@@ -157,6 +166,11 @@ fn count_column_into(
                 sbs: sidecars.vk_snp.code_at(abs_i),
                 ref_i: sidecars.vk_snp.ref_at(abs_i),
                 alt_i: unpack_snp_key_at(keys, abs_i),
+                strand: if sidecars.vk_snp.has_strand {
+                    sidecars.vk_snp.strand_at(abs_i)
+                } else {
+                    STRAND_NA
+                },
             });
         }
     }
@@ -171,6 +185,11 @@ fn count_column_into(
                 sbs: sidecars.dense_snp.code_at(dcol),
                 ref_i: sidecars.dense_snp.ref_at(dcol),
                 alt_i: unpack_snp_key_at(keys, dcol),
+                strand: if sidecars.dense_snp.has_strand {
+                    sidecars.dense_snp.strand_at(dcol)
+                } else {
+                    STRAND_NA
+                },
             });
         });
     }
@@ -278,7 +297,42 @@ mod tests {
             sbs: sbs96_code(b'A', ref_b, alt_b, b'A'), // dummy flanks for the test
             ref_i: svar2_codec::encode_snp_2bit(ref_b),
             alt_i: svar2_codec::encode_snp_2bit(alt_b),
+            strand: crate::mutcat::STRAND_NA,
         }
+    }
+
+    fn snv_strand(pos: u32, ref_b: u8, alt_b: u8, strand: u8) -> SnvCall {
+        SnvCall {
+            strand,
+            ..snv(pos, ref_b, alt_b)
+        }
+    }
+
+    #[test]
+    fn isolated_snv_emits_sbs96_and_sbs384_when_strand_annotated() {
+        use crate::mutcat::{SBS384_OFFSET, STRAND_U};
+        // Isolated C>A, no adjacent SNV -> SBS96. sbs code with dummy A_A flanks.
+        let sbs = {
+            use crate::mutcat::classify::sbs96_code;
+            sbs96_code(b'A', b'C', b'A', b'A') as usize
+        };
+        let snvs = [snv_strand(10, b'C', b'A', STRAND_U)];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        assert_eq!(
+            codes,
+            vec![sbs, SBS384_OFFSET + (STRAND_U as usize) * 96 + sbs]
+        );
+    }
+
+    #[test]
+    fn isolated_snv_emits_only_sbs96_when_not_strand_annotated() {
+        // strand == STRAND_NA (via `snv`) -> no SBS384 emission.
+        let snvs = [snv(10, b'C', b'A')];
+        let mut codes = vec![];
+        emit_snv_codes(&snvs, &mut |c| codes.push(c));
+        assert_eq!(codes.len(), 1);
+        assert!(codes[0] < DBS78_OFFSET);
     }
 
     #[test]

--- a/src/mutcat/mod.rs
+++ b/src/mutcat/mod.rs
@@ -12,22 +12,34 @@ use std::ops::Range;
 pub const N_SBS96: usize = 96;
 pub const N_DBS78: usize = 78;
 pub const N_ID83: usize = 83;
+pub const N_SBS384: usize = 384;
 
 /// Unified code-space offsets — mirror codebook.py exactly.
 pub const SBS96_OFFSET: usize = 0;
 pub const DBS78_OFFSET: usize = SBS96_OFFSET + N_SBS96; // 96
 pub const ID83_OFFSET: usize = DBS78_OFFSET + N_DBS78; // 174
-pub const N_CODES: usize = ID83_OFFSET + N_ID83; // 257
+pub const SBS384_OFFSET: usize = ID83_OFFSET + N_ID83; // 257
+pub const N_CODES: usize = SBS384_OFFSET + N_SBS384; // 641
 
 /// Sidecar `u8` sentinels (unsigned; v1's negative int16 sentinels don't survive).
 pub const UNCLASSIFIED: u8 = 254;
 pub const NOT_ANNOTATED: u8 = 255;
+
+/// Transcriptional strand class indices (stored in `strand.bin`; also the
+/// SBS384 sub-block index). Mirror `[T, U, N, B]` from codebook.py.
+pub const STRAND_T: u8 = 0;
+pub const STRAND_U: u8 = 1;
+pub const STRAND_N: u8 = 2;
+pub const STRAND_B: u8 = 3;
+/// SNV with no strand stream on disk (sidecar annotated without a GTF).
+pub const STRAND_NA: u8 = 255;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
     Sbs96,
     Dbs78,
     Id83,
+    Sbs384,
 }
 
 impl Kind {
@@ -36,7 +48,8 @@ impl Kind {
         match self {
             Kind::Sbs96 => SBS96_OFFSET..DBS78_OFFSET,
             Kind::Dbs78 => DBS78_OFFSET..ID83_OFFSET,
-            Kind::Id83 => ID83_OFFSET..N_CODES,
+            Kind::Id83 => ID83_OFFSET..SBS384_OFFSET,
+            Kind::Sbs384 => SBS384_OFFSET..N_CODES,
         }
     }
 }
@@ -50,7 +63,8 @@ mod tests {
         assert_eq!(SBS96_OFFSET, 0);
         assert_eq!(DBS78_OFFSET, 96);
         assert_eq!(ID83_OFFSET, 174);
-        assert_eq!(N_CODES, 257);
+        assert_eq!(SBS384_OFFSET, 257);
+        assert_eq!(N_CODES, 641);
     }
 
     #[test]
@@ -58,5 +72,6 @@ mod tests {
         assert_eq!(Kind::Sbs96.code_range(), 0..96);
         assert_eq!(Kind::Dbs78.code_range(), 96..174);
         assert_eq!(Kind::Id83.code_range(), 174..257);
+        assert_eq!(Kind::Sbs384.code_range(), 257..641);
     }
 }

--- a/src/mutcat/sidecar.rs
+++ b/src/mutcat/sidecar.rs
@@ -16,6 +16,7 @@ pub fn write_sidecar(
     sub: MutcatSub,
     codes: &[u8],
     ref_codes: Option<&[u8]>,
+    strand_codes: Option<&[u8]>,
 ) -> std::io::Result<()> {
     let dir = paths.mutcat_sub_dir(sub);
     fs::create_dir_all(&dir)?;
@@ -25,6 +26,13 @@ pub fn write_sidecar(
         debug_assert_eq!(refs.len(), codes.len());
         let packed = pack_snp_keys(refs);
         write_bytes(&paths.mutcat_ref(sub), &packed)?;
+    }
+    if sub.has_strand()
+        && let Some(strands) = strand_codes
+    {
+        debug_assert_eq!(strands.len(), codes.len());
+        let packed = pack_snp_keys(strands);
+        write_bytes(&paths.mutcat_strand(sub), &packed)?;
     }
     Ok(())
 }
@@ -38,7 +46,9 @@ fn write_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 pub struct MutcatView {
     code: Option<Mmap>,
     ref_packed: Option<Mmap>,
+    strand_packed: Option<Mmap>,
     pub n: usize,
+    pub has_strand: bool,
 }
 
 impl MutcatView {
@@ -59,6 +69,15 @@ impl MutcatView {
             .expect("ref_at on a stream with no ref.bin");
         unpack_snp_key_at(&m[..], i)
     }
+    /// 2-bit transcriptional-strand code at snp record `i` (`STRAND_{T,U,N,B}`),
+    /// or `STRAND_NA` if this sidecar has no strand stream (annotated without a GTF).
+    #[inline]
+    pub fn strand_at(&self, i: usize) -> u8 {
+        match &self.strand_packed {
+            Some(m) => unpack_snp_key_at(&m[..], i),
+            None => crate::mutcat::STRAND_NA,
+        }
+    }
 }
 
 pub fn open_sidecar(paths: &ContigPaths, sub: MutcatSub) -> std::io::Result<MutcatView> {
@@ -69,10 +88,18 @@ pub fn open_sidecar(paths: &ContigPaths, sub: MutcatSub) -> std::io::Result<Mutc
     } else {
         None
     };
+    let strand_packed = if sub.has_strand() {
+        mmap_file(&paths.mutcat_strand(sub))?
+    } else {
+        None
+    };
+    let has_strand = strand_packed.is_some();
     Ok(MutcatView {
         code,
         ref_packed,
+        strand_packed,
         n,
+        has_strand,
     })
 }
 
@@ -86,12 +113,37 @@ mod tests {
         let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
         let codes = [5u8, 95, 254, 0];
         let refs = [1u8, 3, 0, 2]; // C,G(→ codec 3),A,T
-        write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs)).unwrap();
+        write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs), None).unwrap();
         let v = open_sidecar(&paths, MutcatSub::VkSnp).unwrap();
         assert_eq!(v.n, 4);
+        assert!(!v.has_strand);
         for i in 0..4 {
             assert_eq!(v.code_at(i), codes[i]);
             assert_eq!(v.ref_at(i), refs[i]);
+            assert_eq!(v.strand_at(i), crate::mutcat::STRAND_NA);
+        }
+    }
+
+    #[test]
+    fn snp_sidecar_round_trips_strand() {
+        use crate::mutcat::{STRAND_B, STRAND_N, STRAND_T, STRAND_U};
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
+        let codes = [5u8, 95, 254, 0];
+        let refs = [1u8, 3, 0, 2];
+        let strands = [STRAND_T, STRAND_U, STRAND_N, STRAND_B];
+        write_sidecar(
+            &paths,
+            MutcatSub::VkSnp,
+            &codes,
+            Some(&refs),
+            Some(&strands),
+        )
+        .unwrap();
+        let v = open_sidecar(&paths, MutcatSub::VkSnp).unwrap();
+        assert!(v.has_strand);
+        for (i, &want) in strands.iter().enumerate() {
+            assert_eq!(v.strand_at(i), want);
         }
     }
 
@@ -100,7 +152,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let paths = ContigPaths::new(tmp.path().to_str().unwrap(), "chr1");
         let codes = [10u8, 82, 255];
-        write_sidecar(&paths, MutcatSub::VkIndel, &codes, None).unwrap();
+        write_sidecar(&paths, MutcatSub::VkIndel, &codes, None, None).unwrap();
         let v = open_sidecar(&paths, MutcatSub::VkIndel).unwrap();
         assert_eq!(v.n, 3);
         assert_eq!(v.code_at(1), 82);

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -546,7 +546,7 @@ pub fn process_chromosome(
             context: format!("open ContigReader for mutcat annotate {chrom}"),
             source: e,
         })?;
-        crate::mutcat::annotate::annotate_contig(&reader, &paths, &ref_seq).map_err(|e| {
+        crate::mutcat::annotate::annotate_contig(&reader, &paths, &ref_seq, None).map_err(|e| {
             ConversionError::Io {
                 context: format!("annotate mutcat {chrom}"),
                 source: e,

--- a/src/py_mutcat.rs
+++ b/src/py_mutcat.rs
@@ -20,7 +20,7 @@ impl PyContigReader {
     ) -> PyResult<()> {
         let paths = ContigPaths::new(base_out_dir, chrom);
         let seq = ref_seq.as_slice()?;
-        annotate_contig(&self.inner, &paths, seq)
+        annotate_contig(&self.inner, &paths, seq, None)
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("annotate {chrom}: {e}")))?;
         Ok(())
     }

--- a/src/py_mutcat.rs
+++ b/src/py_mutcat.rs
@@ -5,22 +5,41 @@ use pyo3::prelude::*;
 
 use crate::layout::ContigPaths;
 use crate::mutcat::N_CODES;
-use crate::mutcat::annotate::annotate_contig;
+use crate::mutcat::annotate::{StrandIntervals, annotate_contig};
 use crate::mutcat::count::{Sidecars, count_contig};
 use crate::py_query::PyContigReader;
 
 #[pymethods]
 impl PyContigReader {
     /// Classify this contig's records against `ref_seq` and write the sidecar.
+    /// If all three `strand_*` arrays are given (a sorted, disjoint gene-strand
+    /// interval partition), also write the 2-bit `strand.bin` enabling SBS192/384.
+    #[pyo3(signature = (base_out_dir, chrom, ref_seq, strand_starts=None, strand_stops=None, strand_values=None))]
     fn annotate_mutations(
         &self,
         base_out_dir: &str,
         chrom: &str,
         ref_seq: PyReadonlyArray1<u8>,
+        strand_starts: Option<PyReadonlyArray1<i32>>,
+        strand_stops: Option<PyReadonlyArray1<i32>>,
+        strand_values: Option<PyReadonlyArray1<u8>>,
     ) -> PyResult<()> {
         let paths = ContigPaths::new(base_out_dir, chrom);
         let seq = ref_seq.as_slice()?;
-        annotate_contig(&self.inner, &paths, seq, None)
+        // Keep the numpy arrays alive for the duration of the borrow.
+        let strand_arrays = match (strand_starts, strand_stops, strand_values) {
+            (Some(a), Some(b), Some(c)) => Some((a, b, c)),
+            _ => None,
+        };
+        let strand = match &strand_arrays {
+            Some((a, b, c)) => Some(StrandIntervals {
+                starts: a.as_slice()?,
+                stops: b.as_slice()?,
+                values: c.as_slice()?,
+            }),
+            None => None,
+        };
+        annotate_contig(&self.inner, &paths, seq, strand)
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("annotate {chrom}: {e}")))?;
         Ok(())
     }

--- a/tests/bench_mutcat.rs
+++ b/tests/bench_mutcat.rs
@@ -163,7 +163,7 @@ fn inject_sidecars(out: &std::path::Path, chrom: &str) {
         if n > 0 {
             let codes: Vec<u8> = (0..n).map(|i| (i % 96) as u8).collect();
             let refs: Vec<u8> = (0..n).map(|_| encode_snp_2bit(b'C')).collect();
-            write_sidecar(&paths, sub, &codes, Some(&refs)).unwrap();
+            write_sidecar(&paths, sub, &codes, Some(&refs), None).unwrap();
         }
     }
     for (sub, sub_dir) in [
@@ -180,7 +180,7 @@ fn inject_sidecars(out: &std::path::Path, chrom: &str) {
         };
         if n > 0 {
             let codes: Vec<u8> = (0..n).map(|i| (i % 83) as u8).collect();
-            write_sidecar(&paths, sub, &codes, None).unwrap();
+            write_sidecar(&paths, sub, &codes, None, None).unwrap();
         }
     }
 }

--- a/tests/test_mutcat.py
+++ b/tests/test_mutcat.py
@@ -587,7 +587,7 @@ def test_not_annotated_sentinel_and_version():
     # would make this a tautology).
     assert len(set(Sentinel.__members__.values())) == len(Sentinel.__members__)
     # on-disk semantics changed -> version bumped
-    assert MUTCAT_VERSION == 3
+    assert MUTCAT_VERSION == 4
 
 
 def test_classify_variants_contig_scope(tmp_path):

--- a/tests/test_mutcat_codebook_sbs384.py
+++ b/tests/test_mutcat_codebook_sbs384.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from genoray._mutcat import codebook as cb
+
+
+def test_sbs384_layout():
+    assert cb.SBS384_OFFSET == 257
+    assert cb.N_CODES == 641
+    assert len(cb.SBS384) == 384
+    # [T, U, N, B] blocks of 96, each label "<strand>:<sbs96 label>"
+    assert cb.SBS384[0] == f"T:{cb.SBS96[0]}"
+    assert cb.SBS384[96] == f"U:{cb.SBS96[0]}"
+    assert cb.SBS384[192] == f"N:{cb.SBS96[0]}"
+    assert cb.SBS384[288] == f"B:{cb.SBS96[0]}"
+
+
+def test_sbs192_is_tu_view():
+    assert cb.labels("SBS384") == cb.SBS384
+    assert cb.labels("SBS192") == cb.SBS384[:192]
+    assert cb.code_ranges()["SBS384"] == (257, 641)
+    assert cb.code_ranges()["SBS192"] == (257, 449)
+    assert cb.code_ranges()["SBS96"] == (0, 96)
+
+
+def test_version_bumped():
+    assert cb.MUTCAT_VERSION == 4

--- a/tests/test_mutcat_count.rs
+++ b/tests/test_mutcat_count.rs
@@ -76,7 +76,7 @@ fn count_contig_pairs_adjacent_snvs_for_one_sample() {
     let paths = ContigPaths::new(out.to_str().unwrap(), "chr1");
     let codes = [UNCLASSIFIED, UNCLASSIFIED];
     let refs = [encode_snp_2bit(b'A'), encode_snp_2bit(b'C')];
-    write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs)).unwrap();
+    write_sidecar(&paths, MutcatSub::VkSnp, &codes, Some(&refs), None).unwrap();
 
     let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 1, 1).unwrap();
     let sidecars = Sidecars::open(&paths).unwrap();
@@ -168,6 +168,7 @@ fn count_is_thread_count_invariant() {
             MutcatSub::VkSnp,
             &vec![dummy_code; n_vk],
             Some(&vec![dummy_ref; n_vk]),
+            None,
         )
         .unwrap();
     }
@@ -188,6 +189,7 @@ fn count_is_thread_count_invariant() {
             MutcatSub::DenseSnp,
             &vec![dummy_code; n_dense],
             Some(&vec![dummy_ref; n_dense]),
+            None,
         )
         .unwrap();
     }

--- a/tests/test_mutcat_strand.py
+++ b/tests/test_mutcat_strand.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+
+from genoray._contigs import ContigNormalizer
+from genoray._mutcat.strand import contig_strand_intervals, load_gene_intervals
+
+
+def _genes() -> pl.DataFrame:
+    # 0-based half-open gene footprints on chr1.
+    return pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr1", "chr1"],
+            "start": [0, 30, 25],  # +[0,20), +[30,40), -[25,45)
+            "stop": [20, 40, 45],
+            "strand": ["+", "+", "-"],
+        }
+    )
+
+
+def test_contig_intervals_partition_classes():
+    c_norm = ContigNormalizer(["chr1"])
+    starts, stops, values = contig_strand_intervals(_genes(), "chr1", c_norm)
+    # Expected disjoint partition:
+    #   [0,20)  + only  -> 1
+    #   [25,30) - only  -> 2
+    #   [30,40) both    -> 3
+    #   [40,45) - only  -> 2
+    assert starts.tolist() == [0, 25, 30, 40]
+    assert stops.tolist() == [20, 30, 40, 45]
+    assert values.tolist() == [1, 2, 3, 2]
+    assert starts.dtype == np.int32
+    assert values.dtype == np.uint8
+
+
+def test_contig_name_normalization():
+    # store contig is unprefixed "1"; GTF uses "chr1".
+    c_norm = ContigNormalizer(["1"])
+    starts, stops, values = contig_strand_intervals(_genes(), "1", c_norm)
+    assert starts.size == 4
+
+
+def test_no_genes_on_contig_is_empty():
+    c_norm = ContigNormalizer(["chr2"])
+    starts, stops, values = contig_strand_intervals(_genes(), "chr2", c_norm)
+    assert starts.size == 0 and stops.size == 0 and values.size == 0
+
+
+def test_load_gene_intervals_from_dataframe():
+    gtf = pl.DataFrame(
+        {
+            "seqname": ["chr1", "chr1"],
+            "feature": ["gene", "exon"],
+            "start": [1, 5],  # 1-based
+            "end": [40, 10],
+            "strand": ["+", "+"],
+        }
+    )
+    genes = load_gene_intervals(gtf)
+    assert genes.height == 1  # only feature == "gene"
+    row = genes.row(0, named=True)
+    assert row["chrom"] == "chr1"
+    assert row["start"] == 0  # 1-based 1 -> 0-based 0
+    assert row["stop"] == 40  # inclusive 1-based 40 == exclusive 0-based 40
+    assert row["strand"] == "+"

--- a/tests/test_svar2_mutcat.py
+++ b/tests/test_svar2_mutcat.py
@@ -263,3 +263,26 @@ def test_annotate_accepts_strand_arrays_smoke(tmp_path: Path):
         np.empty(0, np.uint8),
     )
     assert (out / "chr1" / "mutcat" / "var_key_snp" / "strand.bin").exists()
+
+
+def test_assign_signatures_rejects_strand_kinds(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store_assign_strand.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref)  # no gtf
+    with pytest.raises(NotImplementedError, match="SBS192|SBS384|strand"):
+        sv2.assign_signatures("SBS384")
+
+
+def test_sbs384_requires_strand_annotation(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store_no_strand.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref)  # no gtf -> no strand.bin
+    assert not sv2._is_strand_annotated()
+    with pytest.raises(ValueError, match="strand"):
+        sv2.mutation_matrix("SBS384")

--- a/tests/test_svar2_mutcat.py
+++ b/tests/test_svar2_mutcat.py
@@ -369,3 +369,68 @@ def test_sbs384_end_to_end(tmp_path: Path):
     # T / N / U (blocks 0, 2, 1), none Bidirectional (block 3).
     block_sums = v384.reshape(4, 96).sum(axis=1)
     assert block_sums.tolist() == [1, 1, 1, 0]  # [T, U, N, B]
+
+
+def test_sbs384_strand_correct_across_haplotype_columns(tmp_path: Path):
+    """Regression for the forward-only `StrandSweeper` cursor bug.
+
+    `var_key/snp` positions are sorted only WITHIN each (sample, ploid) CSR
+    column, not globally across columns: column order is (S0,hap0) then
+    (S0,hap1), so a variant on hap1 at a LOWER position than a variant on
+    hap0 makes the concatenated position stream non-monotonic. A forward-only
+    cursor can't rewind for the hap1 record and silently falls through to the
+    gap class (N) for it.
+
+    One sample, two het SNVs of opposite phase:
+      - POS=60 (0-based 59), A>C, GT=(1,0) -> ALT on hap0, in the - gene
+        [45,80] -> Untranscribed (U).
+      - POS=10 (0-based 9),  A>C, GT=(0,1) -> ALT on hap1, in the + gene
+        [1,40] -> Transcribed (T).
+    Concatenated var_key/snp positions are [60, 10] -- globally
+    non-monotonic, reproducing the bug. With the buggy cursor, hap1's POS=10
+    query (arriving after the cursor has already advanced past 60) resolves
+    to N instead of T, yielding block_sums [0, 1, 1, 0] instead of the
+    correct [1, 1, 0, 0].
+    """
+    ref = _write_parity_ref(tmp_path)
+    gtf = _write_strand_gtf(tmp_path)
+
+    vcf_path = tmp_path / "order_in.vcf"
+    h = pysam.VariantHeader()
+    h.add_line(f"##contig=<ID=chr1,length={len(_PARITY_SEQ)}>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+    h.add_sample("S0")
+    records = [
+        (9, "A", "C", (0, 1)),  # POS=10, ALT on hap1, + gene -> T
+        (59, "A", "C", (1, 0)),  # POS=60, ALT on hap0, - gene -> U
+    ]
+    with pysam.VariantFile(str(vcf_path), "w", header=h) as vf:
+        for start, refb, alt, gt in records:
+            r = h.new_record(contig="chr1", start=start, alleles=(refb, alt))
+            r.samples["S0"]["GT"] = gt
+            r.samples["S0"].phased = True
+            vf.write(r)
+    vcf_gz = tmp_path / "order_in.vcf.gz"
+    with open(vcf_gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(vcf_path)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(vcf_gz)], check=True)
+
+    out = tmp_path / "store_order.svar2"
+    SparseVar2.from_vcf(out, vcf_gz, ref, threads=1)
+
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref, gtf=gtf)
+    assert sv2._is_strand_annotated()
+
+    # Confirm both SNVs actually route through the var_key/snp (sparse)
+    # stream, i.e. this test exercises the CSR-column-boundary case.
+    assert (out / "chr1" / "mutcat" / "var_key_snp" / "strand.bin").exists()
+
+    v384 = sv2.mutation_matrix("SBS384", count="allele")["S0"].to_numpy()
+    block_sums = v384.reshape(4, 96).sum(axis=1)
+    assert block_sums.tolist() == [1, 1, 0, 0]  # [T, U, N, B]
+
+    # Conservation must still hold even when strand classification is wrong
+    # in isolation -- this alone would NOT have caught the bug.
+    v96 = sv2.mutation_matrix("SBS96", count="allele")["S0"].to_numpy()
+    assert np.array_equal(v384.reshape(4, 96).sum(axis=0), v96)

--- a/tests/test_svar2_mutcat.py
+++ b/tests/test_svar2_mutcat.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 from pathlib import Path
 
+import numpy as np
 import polars as pl
 import pysam
 import pytest
@@ -286,3 +287,85 @@ def test_sbs384_requires_strand_annotation(tmp_path: Path):
     assert not sv2._is_strand_annotated()
     with pytest.raises(ValueError, match="strand"):
         sv2.mutation_matrix("SBS384")
+
+
+# ---------------------------------------------------------------------------
+# Task 10: end-to-end SBS192/SBS384 parity test (integration gate)
+# ---------------------------------------------------------------------------
+
+
+def _write_strand_gtf(d: Path) -> Path:
+    """A GTF with a + gene [1,40], a - gene [45,80], and a 41-44 intergenic gap.
+
+    Positions (1-based) against _PARITY_SEQ:
+      POS=10 (ref A, purine) in + gene  -> Transcribed  (T)
+      POS=42 (ref G, purine) in the gap -> Nontranscribed(N)
+      POS=60 (ref A, purine) in - gene  -> Untranscribed (U)
+    """
+    gtf = d / "strand.gtf"
+    gtf.write_text(
+        'chr1\ttest\tgene\t1\t40\t.\t+\t.\tgene_id "P";\n'
+        'chr1\ttest\tgene\t45\t80\t.\t-\t.\tgene_id "M";\n'
+    )
+    return gtf
+
+
+def _write_strand_vcf(d: Path) -> Path:
+    vcf_path = d / "strand_in.vcf"
+    h = pysam.VariantHeader()
+    h.add_line(f"##contig=<ID=chr1,length={len(_PARITY_SEQ)}>")
+    h.add_line('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+    h.add_sample("S0")
+    # isolated het SNVs (>2bp apart so none pair into a DBS), all on S0.
+    records = [
+        (9, "A", "C", (0, 1)),  # POS=10 in + gene
+        (41, "G", "A", (0, 1)),  # POS=42 in the gap
+        (59, "A", "C", (0, 1)),  # POS=60 in - gene
+    ]
+    with pysam.VariantFile(str(vcf_path), "w", header=h) as vf:
+        for start, ref, alt, gt in records:
+            r = h.new_record(contig="chr1", start=start, alleles=(ref, alt))
+            r.samples["S0"]["GT"] = gt
+            r.samples["S0"].phased = True
+            vf.write(r)
+    vcf_gz = d / "strand_in.vcf.gz"
+    with open(vcf_gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(vcf_path)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(vcf_gz)], check=True)
+    return vcf_gz
+
+
+def test_sbs384_end_to_end(tmp_path: Path):
+    ref = _write_parity_ref(tmp_path)
+    vcf = _write_strand_vcf(tmp_path)
+    gtf = _write_strand_gtf(tmp_path)
+    out = tmp_path / "store_strand.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+
+    sv2 = SparseVar2(out)
+    sv2.annotate_mutations(ref, gtf=gtf)
+    assert sv2._is_strand_annotated()
+    assert json.loads((out / "meta.json").read_text())["mutcat_strand"] is True
+
+    sbs96 = sv2.mutation_matrix("SBS96", count="allele")
+    sbs384 = sv2.mutation_matrix("SBS384", count="allele")
+    sbs192 = sv2.mutation_matrix("SBS192", count="allele")
+
+    assert sbs384.height == 384
+    assert sbs192.height == 192
+    assert sbs384["MutationType"].to_list()[:192] == sbs192["MutationType"].to_list()
+
+    v96 = sbs96["S0"].to_numpy()
+    v384 = sbs384["S0"].to_numpy()
+    v192 = sbs192["S0"].to_numpy()
+
+    # SBS192 is exactly the first 192 (T,U) rows of SBS384.
+    assert np.array_equal(v192, v384[:192])
+
+    # Conservation: SBS384 collapsed over the 4 strand blocks == SBS96.
+    assert np.array_equal(v384.reshape(4, 96).sum(axis=0), v96)
+
+    # Three isolated SNVs, one het copy each -> total 3, one per strand class
+    # T / N / U (blocks 0, 2, 1), none Bidirectional (block 3).
+    block_sums = v384.reshape(4, 96).sum(axis=1)
+    assert block_sums.tolist() == [1, 1, 1, 0]  # [T, U, N, B]

--- a/tests/test_svar2_mutcat.py
+++ b/tests/test_svar2_mutcat.py
@@ -241,3 +241,25 @@ def test_write_time_signatures_match_posthoc(tmp_path: Path):
         assert ma.equals(mb), f"{kind} mismatch:\nwrite-time:\n{ma}\npost-hoc:\n{mb}"
         total = ma.select(sa.available_samples).sum().sum_horizontal().item()
         assert total > 0, f"{kind} matrix is unexpectedly all-zero"
+
+
+def test_annotate_accepts_strand_arrays_smoke(tmp_path: Path):
+    import numpy as np
+
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "store_strand_smoke.svar2"
+    SparseVar2.from_vcf(out, vcf, ref, threads=1)
+    sv2 = SparseVar2(out)
+    reader = sv2._readers["chr1"]
+    seq = Reference.from_path(ref).contig_array("chr1").astype(np.uint8, copy=False)
+    # Empty strand partition (all N) — just proves the 6-arg binding is callable.
+    reader.annotate_mutations(
+        str(out),
+        "chr1",
+        seq,
+        np.empty(0, np.int32),
+        np.empty(0, np.int32),
+        np.empty(0, np.uint8),
+    )
+    assert (out / "chr1" / "mutcat" / "var_key_snp" / "strand.bin").exists()

--- a/tests/test_svar_mutations.py
+++ b/tests/test_svar_mutations.py
@@ -653,7 +653,7 @@ def test_annotate_scope_persists_mutcat_contigs(tmp_path):
     with open(d / "metadata.json", "rb") as f:
         meta = SparseVarMetadata.model_validate_json(f.read())
     assert meta.mutcat_contigs == ["chr1"]
-    assert meta.mutcat_version == 3
+    assert meta.mutcat_version == 4
 
 
 def test_annotate_no_scope_persists_none(tmp_path):


### PR DESCRIPTION
## Summary

Adds strand-resolved **SBS192 / SBS384** transcriptional-strand-bias mutation catalogs to `SparseVar2`, computed from a GTF gene model supplied to `annotate_mutations`.

A new optional per-SNP transcriptional-strand class (**T**ranscribed / **U**ntranscribed / **N**ontranscribed / **B**idirectional) is stored in a 2-bit `strand.bin` sidecar stream, orthogonal to the existing SBS96 `code.bin`. Python builds a sorted, disjoint gene-strand interval partition from the GTF (via `seqpro`) and passes it as a struct-of-arrays across the existing per-contig pyo3 boundary; Rust classifies each SNP against those intervals. Counting emits into an SBS384 code block alongside SBS96; `mutation_matrix` slices the requested range. **SBS192 is the `{T, U}` sub-view (`SBS384[:192]`)** — no separate stored range.

## API

```python
sv2.annotate_mutations(reference, gtf="gencode.v45.annotation.gtf.gz")
sbs384 = sv2.mutation_matrix("SBS384")   # 384 rows: [T, U, N, B] x 96
sbs192 = sv2.mutation_matrix("SBS192")   # 192 rows: the {T, U} sub-view
```

- Strand rule (pyrimidine-folded): a genic SNV is Untranscribed iff the pyrimidine of its ref/alt pair sits on the gene's coding strand, else Transcribed. Footprints come from `feature == "gene"` rows.
- Without a `gtf=`, `mutation_matrix("SBS192"/"SBS384")` raises `ValueError`. Write-time `from_vcf(signatures=True)` stays strand-free.
- `assign_signatures("SBS192"/"SBS384")` raises `NotImplementedError` (COSMIC publishes no strand-resolved reference set).

## Design invariants

- **Code-space lockstep** (`codebook.py` ⇄ `src/mutcat/mod.rs`): `SBS96=0, DBS78=96, ID83=174, SBS384=257, N_CODES=641`. Existing offsets do not move. `MUTCAT_VERSION` 3 → 4.
- **Backward-compatible**: SBS384 availability is gated on `strand.bin` presence, never on version equality. Old sidecars read fine (`has_strand=false`, no SBS384 emission); no layout change to `code.bin`/`ref.bin`. (Side effect: v1 stores stamped v3 re-annotate on next use — expected.)
- **Conservation**: SBS384 collapsed over its 4 strand blocks equals SBS96 (asserted end-to-end).

## Implementation

Executed as 11 planned tasks (Python + Rust codebooks, classifier, sidecar, interval sweep, count emission, pyo3 binding, GTF interval builder, API wiring, end-to-end parity, docs), each with a fresh implementer + spec/quality review.

## Testing

- Full Rust suite: green (`--no-default-features --features conversion`).
- Full Python suite: green (635+ passed).
- Lint clean: ruff check/format, cargo fmt/check/clippy; pyrefly 0 errors.
- New coverage: codebook layout, strand classifier (SigProfiler examples), sidecar round-trip, interval sweep, SBS384 count emission, GTF interval builder, and an end-to-end SBS192/384 conservation + strand-class test.

## Notable

The final whole-branch review caught a **correctness bug the per-task reviews structurally could not**: the strand interval sweep used a forward-only cursor, but `var_key/snp` positions are CSR-packed per haplotype column (non-monotonic across column boundaries), so strand was misclassified for every record after the first column. Fixed with an order-independent `partition_point` lookup, plus a Rust unit test and a Python haplotype-column regression (RED proof captured: `[0,1,1,0]` → `[1,1,0,0]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
