### PR TITLE
ci: drop Intel-mac (osx-64) wheel from release matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,8 +50,10 @@ jobs:
             platform: linux-aarch64
           - runner: macos-14
             platform: osx-arm64
-          - runner: macos-13
-            platform: osx-64
+          # No osx-64 (Intel mac): macos-13 is GitHub's last Intel runner and is now
+          # scarce enough to stall releases for tens of minutes. We no longer ship an
+          # Intel-mac wheel; those users build from the sdist (the ci/wheel/pixi.toml
+          # osx-64 recipe still works when run locally on an Intel mac).
     steps:
       - name: Check out release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,14 @@ ruff format genoray tests
 Release CI (`.github/workflows/release.yaml`) builds the Rust extension as
 portable wheels from an **isolated** pixi manifest at `ci/wheel/pixi.toml`
 (declares all four wheel platforms; the main `pixi.toml` stays at linux-64 +
-osx-arm64). Wheels use pyo3 abi3 (`maturin build --features abi3`) → one
-`cpXY-abi3` wheel per platform covers Python 3.10–3.13, then `auditwheel`
-(Linux) / `delocate` (macOS) repair them. The `abi3` cargo feature is opt-in
+osx-arm64). CI builds only **three** of them — linux-64, linux-aarch64, and
+osx-arm64. **No Intel-mac (osx-64) wheel is published**: macos-13 is GitHub's
+last Intel runner and is scarce enough to stall releases, so it was dropped
+from the build matrix. osx-64 stays declared in `ci/wheel/pixi.toml` so Intel-mac
+users can still run that build recipe locally (or install from the sdist). Wheels
+use pyo3 abi3 (`maturin build --features abi3`) → one `cpXY-abi3` wheel per
+platform covers Python 3.10–3.13, then `auditwheel` (Linux) / `delocate` (macOS)
+repair them. The `abi3` cargo feature is opt-in
 only at wheel-build time so lint hooks and the Rust test suite are unaffected.
 Toolchain pins (`rust`, `clangdev=18`) are duplicated between the two manifests
 and must be kept in sync.


### PR DESCRIPTION
## What

Removes the `macos-13` / `osx-64` row from the `build-wheels` matrix in `.github/workflows/release.yaml`. Releases now build **linux-64, linux-aarch64, osx-arm64** wheels + sdist.

## Why

`macos-13` is GitHub's last Intel-mac runner and has become scarce — releases were stalling ~30 min waiting for a slot. Intel Macs are rare enough now that publishing a prebuilt Intel wheel isn't worth blocking every release on.

## Impact

- **Intel-mac users** install from the sdist (source build).
- The `osx-64` target stays declared in `ci/wheel/pixi.toml`, so that exact build recipe still works when run locally on an Intel mac.
- CLAUDE.md's "Release wheels" note updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)