### PR TITLE
fix: ungate field_finalize so genoray builds without conversion

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,5 +41,7 @@ jobs:
         with:
           pixi-version: v0.70.2
           environments: lint
+      - name: Cargo check (query-core, no conversion)
+        run: pixi run -e lint check-core
       - name: Cargo test
         run: pixi run -e lint test-rust

--- a/pixi.toml
+++ b/pixi.toml
@@ -94,6 +94,12 @@ lint = "prek run --all-files --show-diff-on-failure"
 # _Py_Dealloc`); `--features conversion` keeps rust-htslib for the e2e tests.
 # Runs in `lint` (no editable-wheel build, full Rust + htslib toolchain).
 test-rust = "cargo test --no-default-features --features conversion"
+# Query-core build guard: compile with NO features (no conversion, no
+# extension-module) — exactly how gvl links `genoray_core` (`default-features =
+# false`). test-rust always keeps `conversion` on, so without this a query-core
+# regression (e.g. an ungated module referencing a conversion-gated one) ships
+# green and only breaks downstream. See the `field_finalize` NOTE in lib.rs.
+check-core = "cargo check --no-default-features"
 
 [feature.doc.dependencies]
 sphinx = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,13 @@ pub mod error;
 #[cfg(feature = "conversion")]
 pub mod executor;
 pub mod field;
-#[cfg(feature = "conversion")]
+// NOTE: `field_finalize` is *not* conversion-only despite housing the write-path
+// `finalize_fields` scan/rewrite code: query-core `field.rs::encode_scalar` (the
+// SVAR2 decode non-carrier fill, used by gvl with `default-features = false`) calls
+// its `encode`/`is_staged_missing` to stay byte-identical to the finalize path, and
+// the module has zero htslib dependency (only `error`/`field`/rayon/std). Gating it
+// broke the query-core build; it stays ungated as shared infra, same reasoning as
+// `py_convert` and `streams` below.
 pub mod field_finalize;
 pub mod layout;
 #[cfg(feature = "conversion")]


### PR DESCRIPTION
## Problem

`genoray_core` fails to compile with `default-features = false` (no `conversion`) — which is exactly how GenVarLoader links it:

```
error[E0433]: cannot find `field_finalize` in `crate`
  --> src/field.rs:146  crate::field_finalize::is_staged_missing(...)
  note: the item is gated behind the `conversion` feature
```

`field.rs::encode_scalar` (ungated — the SVAR2 decode non-carrier fill used downstream) delegates to `field_finalize::encode` / `is_staged_missing` to stay byte-identical to the finalize path, but the whole `field_finalize` module was gated behind `conversion`.

## Fix

Ungate `pub mod field_finalize;`. The module has **zero htslib dependency** (only `error`/`field`/rayon/std), so it compiles fine in the query core. Its write-path functions (`finalize_fields`, scan/rewrite) are simply unused-but-reachable in a no-conversion build. This matches the existing `py_convert` and `streams` carve-outs documented in `lib.rs`.

## Regression guard

`test-rust` always builds with `--features conversion`, so this gap shipped green. Added a `check-core` pixi task (`cargo check --no-default-features`) and a step in the `rust-test` CI job that exercises the exact query-core build gvl links.

Verified locally: `cargo check --no-default-features` passes (was E0433 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)