### PR TITLE
ci: fix Read the Docs build (build query-only core, skip htslib)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,12 +4,21 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.12"
-
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
+  # Override the default install job. `pip install .` builds the `genoray._core`
+  # pyo3 extension via maturin (Rust is auto-bootstrapped by puccinialin). With
+  # default cargo features that pulls in rust-htslib -> hts-sys, which vendors
+  # htslib and runs bindgen; RTD's build image lacks the C headers bindgen needs
+  # ("fatal error: 'stddef.h' file not found"), so the wheel build fails.
+  #
+  # The docs only need `import genoray` to succeed for autodoc — they never call
+  # the VCF->svar2 conversion pipeline. So build the query-only core
+  # (--no-default-features --features extension-module): no `conversion` feature,
+  # no rust-htslib/htslib/bindgen, no C toolchain required.
+  jobs:
+    install:
+      - python -m pip install --upgrade --no-cache-dir pip
+      - python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt
+      - MATURIN_PEP517_ARGS="--no-default-features --features extension-module" python -m pip install --no-cache-dir .
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
## Problem

The online docs build on Read the Docs is failing. RTD's final install step, `pip install .`, compiles the `genoray._core` pyo3 extension via maturin. With **default** cargo features that pulls in `rust-htslib → hts-sys`, which vendors htslib and runs `bindgen`. RTD's build image lacks the C headers bindgen needs, so the wheel build dies:

```
./htslib/htslib/hts.h:31:10: fatal error: 'stddef.h' file not found
Unable to generate bindings.: ClangDiagnostic(...)
💥 maturin failed
ERROR: Failed building wheel for genoray
```

## Fix

The docs only need `import genoray` to succeed for autodoc — they never call the VCF→svar2 conversion pipeline. So override the RTD `install` job to build the **query-only core**:

```
MATURIN_PEP517_ARGS="--no-default-features --features extension-module" pip install .
```

This drops the `conversion` feature and therefore `rust-htslib`/`hts-sys`/`bindgen` — **no C toolchain required**. Rust itself is still auto-bootstrapped by maturin's puccinialin, so no `build.tools.rust` is needed (RTD doesn't offer `rust` as a build tool anyway).

`build.jobs.install` is overridable per RTD's build-customization docs; only the install job is replaced, so the `sphinx:` build job keeps its default. The requirements install is folded into the same job since it replaces the default `python.install`.

## Verification (local)

- Query-only wheel builds in ~56s with **no `hts-sys`** compiled (only pure-Rust deps): `🛠 Installed genoray-3.0.0`.
- Reproduced exactly what autodoc does — every documented target imports cleanly against the query-only core:
  `VCF, PGEN, SparseVar, SparseVar2, Reference, cosmic_signatures, fit_signatures, genoray.exprs` → all OK.
  `genoray._core.run_conversion_pipeline` is absent (expected, conversion off) and `PyContigReader` is present; nothing at import time touches the missing conversion symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)