### PR TITLE
fix: make long-allele positioned reads cross-platform (Windows)

### DIFF
--- a/src/nrvk.rs
+++ b/src/nrvk.rs
@@ -1,7 +1,40 @@
 use crate::layout::ContigPaths;
 use crossbeam_channel::Sender;
 use std::fs::File;
-use std::os::unix::fs::FileExt;
+
+/// Positioned read that fills `buf` starting at `offset` without moving the
+/// file cursor, so callers can read through a shared `&File`. Wraps the
+/// platform pread primitives: `read_exact_at` on Unix, a `seek_read` loop on
+/// Windows (which, like `read`, may return short).
+#[cfg(unix)]
+fn pread_exact(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    file.read_exact_at(buf, offset)
+}
+
+#[cfg(windows)]
+fn pread_exact(file: &File, mut buf: &mut [u8], mut offset: u64) -> std::io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        match file.seek_read(buf, offset) {
+            Ok(0) => break,
+            Ok(n) => {
+                buf = &mut buf[n..];
+                offset += n as u64;
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    if buf.is_empty() {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "failed to fill whole buffer",
+        ))
+    }
+}
 
 // strictly bounded memory bank for long alleles (non-blocking, double-buffered memory)
 // Public API
@@ -122,9 +155,7 @@ impl LongAlleleReader {
         let end_byte = self.offsets[idx + 1];
         let len = (end_byte - start_byte) as usize;
         let mut buf = vec![0u8; len];
-        self.file
-            .read_exact_at(&mut buf, start_byte)
-            .expect("pread long allele");
+        pread_exact(&self.file, &mut buf, start_byte).expect("pread long allele");
         buf
     }
 
@@ -141,9 +172,7 @@ impl LongAlleleReader {
         let total = *self.offsets.last().unwrap_or(&0) as usize;
         let mut buf = vec![0u8; total];
         if total > 0 {
-            self.file
-                .read_exact_at(&mut buf, 0)
-                .expect("pread long_alleles.bin");
+            pread_exact(&self.file, &mut buf, 0).expect("pread long_alleles.bin");
         }
         buf
     }


### PR DESCRIPTION
## Problem

The svar2 `LongAlleleReader` in `src/nrvk.rs` uses `std::os::unix::fs::FileExt::read_exact_at`, which does not exist on Windows. This breaks `cargo build` on any Windows target:

- `E0433: cannot find 'unix' in 'os'` (`use std::os::unix::fs::FileExt;`)
- `E0599: no method named 'read_exact_at'` (two call sites)

This regressed **Windows wheel builds in downstream GenVarLoader** — its release pipeline's `publish / windows` jobs (arm64, x86, x64) all fail to compile genoray. Windows wheels had shipped fine until the svar2 codec was introduced.

## Fix

Introduce a `#[cfg]`-gated `pread_exact(&File, buf, offset)` helper:
- **Unix**: `FileExt::read_exact_at` (unchanged behavior)
- **Windows**: a `seek_read` loop that fills the buffer (Windows `seek_read`, like `read`, may return short)

Both read through a shared `&File`, so the reader's `&self` API (and the `test_reader_get_allele_shared_borrow` contract) is preserved.

## Verification

- `cargo check -p genoray --lib --target x86_64-pc-windows-gnu` — **previously failed with the 3 errors above, now builds clean**.
- `cargo test -p genoray --lib --no-default-features nrvk` — all 4 `nrvk` tests pass on Unix.
- Native Unix `cargo check` (no-default-features) unchanged.

Downstream: GenVarLoader must bump its pinned genoray `rev` to this commit once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)