### PR TITLE
feat(svar2): add region and sample VCF conversion

### DIFF
--- a/docs/source/svar.md
+++ b/docs/source/svar.md
@@ -15,6 +15,45 @@ SparseVar.from_pgen("out.svar", "file.pgen", max_mem="4g")
 svar = SparseVar("out.svar")
 ```
 
+### Region/sample-restricted SVAR2 conversion
+
+`SparseVar2.from_vcf` can convert an indexed VCF/BCF directly into a subset of
+regions and samples:
+
+```python
+from genoray import SparseVar2
+
+SparseVar2.from_vcf(
+    "subset.svar2",
+    "cohort.vcf.gz",
+    "reference.fa",
+    regions=["chr1:1-1000000", ("chr2", 0, 500_000)],
+    samples=["HG00096", "HG00097"],
+    merge_overlapping=True,
+    threads=8,
+)
+```
+
+Region strings use bcftools-style 1-based inclusive coordinates and are
+converted to 0-based half-open intervals. Tuple, BED, and frame inputs are
+already interpreted as 0-based half-open. `samples` preserves caller order and
+deduplicates repeated names by first occurrence.
+
+The equivalent CLI flags are available on the default SVAR2 writer:
+
+```bash
+genoray write cohort.vcf.gz subset.svar2 \
+  --reference reference.fa \
+  --regions chr1:1-1000000,chr2:1-500000 \
+  --samples HG00096,HG00097 \
+  --threads 8
+```
+
+Use `--regions-file/-R` for BED files and `--samples-file/-S` for one-sample-per-line
+sample lists. `regions_overlap=pos` is the default; `record` is also supported.
+Full post-normalization `variant` ownership is reserved for the follow-up
+sub-contig sharding work.
+
 ## Haploid (ploidy=1) write option
 
 For unphased somatic cohorts where phasing information is unavailable or irrelevant,

--- a/docs/superpowers/plans/2026-07-15-svar2-region-subcontig-vcf.md
+++ b/docs/superpowers/plans/2026-07-15-svar2-region-subcontig-vcf.md
@@ -1,0 +1,296 @@
+# SVAR2 Region And Sub-Contig VCF Conversion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native `SparseVar2.from_vcf(regions=..., samples=...)`, then split one large contig into deterministic padded indexed work units so parse, genotype decode, and internal normalization can all run in parallel.
+
+**Architecture:** Ship this as a PR stack. PR 1 adds the serial indexed API foundation and CLI parity while preserving the existing full-file path. PR 2 introduces padded sub-contig work units with deterministic ownership so each worker fetches, atomizes, left-aligns, and emits only its owned normalized atoms. PR 3 wires bounded ordered merge, structured progress integration, stress tests, and benchmarks.
+
+**Tech Stack:** Python 3.10+, Rust, PyO3, rust-htslib `IndexedReader`, rayon, crossbeam-channel, Polars, cyvcf2, Cyclopts, pytest, cargo tests with `--no-default-features --features conversion`.
+
+## Global Constraints
+
+- Current `origin/main` has no sub-contig parallelism for `SparseVar2.from_vcf`: `VcfRecordSource::new` still calls `fetch(rid, 0, None)`.
+- Current internal normalization (`atomize_record`, `validate_ref`, `left_align`) runs in one reader thread per contig; dlaub is correct that norm is not sub-contig-parallelized.
+- Region string input follows existing Genoray convention: `chrom:start-end` is 1-based inclusive and converts to 0-based half-open. BED, tuples, and frames are 0-based half-open.
+- `threads` remains a total process budget. Do not multiply it independently across contig readers, BGZF threads, packing pools, and merge writers.
+- Existing no-argument behavior must be byte-compatible: `regions=None`, `samples=None`, `threads=1` follows the current full-contig conversion path.
+- PR #113 already owns structured progress. Do not duplicate it; integrate with it after dlaub merges, or keep progress changes isolated in a follow-up PR.
+- CI gate for each PR: use the exact cargo filters listed in that task, focused pytest, `pixi run pytest tests -m "not network"` before final PR readiness, and `pixi run prek run --all-files` before push.
+
+---
+
+## File Structure
+
+| File | Responsibility | Planned Change |
+| --- | --- | --- |
+| `python/genoray/_svar2.py` | Public `SparseVar2` API and VCF metadata discovery | Add `regions`, `samples`, `merge_overlapping`, `regions_overlap`; normalize inputs using v1 helpers; pass selected samples and per-contig ranges to Rust. |
+| `python/genoray/_cli/__main__.py` | `genoray write` CLI | Add `--regions/-r`, `--regions-file/-R`, `--samples/-s`, `--samples-file/-S` for SVAR2 VCF/BCF writes. |
+| `python/genoray/_cli/_view_helpers.py` | CLI parsing helpers | Reuse `parse_regions_arg` for write-region lists. |
+| `src/lib.rs` | PyO3 conversion entrypoint and thread budget dispatch | Extend `run_conversion_pipeline` to accept region ranges for PR 1; later accept shard work units and bounded merge config. |
+| `src/orchestrator.rs` | Conversion pipeline wiring | Add region-aware VCF source specs in PR 1; add range-shard worker orchestration in PR 2. |
+| `src/vcf_reader.rs` | Indexed VCF/BCF record source | PR 1: fetch one or more intervals serially. PR 2: create worker-safe range readers that fetch padded intervals. |
+| `src/chunk_assembler.rs` | Atomize/left-align/reorder/pack | PR 2: expose a worker-safe normalized atom batch path or split shared normalization into a new module. |
+| `src/normalize.rs` | Atomization and left-alignment | Keep rules unchanged; add boundary ownership tests around left-shifted indels. |
+| `tests/test_svar2_from_vcf.py` | Python API tests | Add regions/samples tests, overlap dedupe, unknown sample/contig errors, and no-argument compatibility. |
+| `tests/cli/test_write_cli.py` | CLI tests | Add write-time `--regions`/`--samples` coverage. |
+| `tests/test_*e2e.rs` | Rust conversion tests | Add serial interval fetch, padded shard ownership, deterministic merge, and worker-failure cases. |
+| `docs/source/svar.md` and `docs/roadmap/svar-2.md` | User docs and architecture notes | Document coordinate conventions, sample order, thread budget, and benchmark results. |
+
+---
+
+### Task 1: Serial Region/Sample Foundation (PR 1)
+
+**Files:**
+- Modify: `python/genoray/_svar2.py`
+- Modify: `src/lib.rs`
+- Modify: `src/orchestrator.rs`
+- Modify: `src/vcf_reader.rs`
+- Test: `tests/test_svar2_from_vcf.py`
+
+**Interfaces:**
+- Consumes: `genoray._svar._regions._normalize_regions`, `_normalize_samples`, and `_resolve_kept_rows`.
+- Produces: `SparseVar2.from_vcf(..., regions=None, samples=None, merge_overlapping=False, regions_overlap="pos")`.
+- Produces Rust input: `Vec<(String, u32, u32)>` region ranges, where empty means full contig.
+
+- [ ] **Step 1: Add failing Python tests**
+
+Add tests that build the existing tiny VCF and assert:
+
+```python
+def test_from_vcf_regions_restricts_conversion(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "regioned"
+    SparseVar2.from_vcf(out, vcf, ref, regions="chr1:1-4", threads=1)
+    sv = SparseVar2(out)
+    assert sv.contigs == ["chr1"]
+    counts = sv.var_counts("chr1", [0], [40], samples=["S0"])
+    assert int(counts.sum()) == 1
+```
+
+Also add tests for `samples=["S1"]` preserving output sample metadata, unknown samples raising `ValueError`, and `regions=None` still matching the current full conversion.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pixi run pytest tests/test_svar2_from_vcf.py -k 'regions or samples' -q`
+
+Expected: fail with `TypeError: SparseVar2.from_vcf() got an unexpected keyword argument 'regions'`.
+
+- [ ] **Step 3: Add Python argument normalization**
+
+In `SparseVar2.from_vcf`, add keyword-only parameters:
+
+```python
+regions: str | tuple[str, int, int] | Path | object | None = None,
+samples: str | Sequence[str] | Path | None = None,
+merge_overlapping: bool = False,
+regions_overlap: Literal["pos", "record", "variant"] = "pos",
+```
+
+Resolve samples with `_normalize_samples` when provided. Resolve regions with `_normalize_regions` against `ContigNormalizer(v.seqnames)`, then coalesce with `_resolve_kept_rows` for validation and dedupe. For PR 1, pass per-contig intervals to Rust and preserve contigs in VCF header order after filtering out contigs with no selected variants.
+
+- [ ] **Step 4: Add serial interval fetch in Rust**
+
+Extend `SourceSpec::Vcf` with `regions: Vec<(u32, u32)>`. Update `VcfRecordSource::new` to accept a `Vec<(u32, u32)>`; if empty, keep the current `fetch(rid, 0, None)`. If non-empty, sort/coalesce ranges and fetch them sequentially. `next_record` should advance to the next interval when the current fetch returns EOF.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pixi run pytest tests/test_svar2_from_vcf.py -q
+pixi run bash -lc 'cargo test --no-default-features --features conversion vcf_reader'
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genoray/_svar2.py src/lib.rs src/orchestrator.rs src/vcf_reader.rs tests/test_svar2_from_vcf.py
+git commit -m "feat(svar2): add serial regions and samples to from_vcf"
+```
+
+---
+
+### Task 2: CLI Parity And Docs (PR 1)
+
+**Files:**
+- Modify: `python/genoray/_cli/__main__.py`
+- Modify: `tests/cli/test_write_cli.py`
+- Modify: `docs/source/svar.md`
+
+**Interfaces:**
+- Consumes: Task 1 `SparseVar2.from_vcf(..., regions=..., samples=...)`.
+- Produces: `genoray write SOURCE OUT --regions/-r`, `--regions-file/-R`, `--samples/-s`, `--samples-file/-S`.
+
+- [ ] **Step 1: Add failing CLI tests**
+
+Add tests that run:
+
+```bash
+python -m genoray._cli write in.vcf.gz out.svar2 --reference ref.fa --regions chr1:1-4 --samples S1 --threads 1
+```
+
+Then assert `SparseVar2(out).available_samples == ["S1"]` and the store contains only the expected selected variant.
+
+- [ ] **Step 2: Implement CLI flags**
+
+Mirror the existing `view_svar2` parsing style. For `--regions`, call `parse_regions_arg`; for `--regions-file`, pass the `Path`; for `--samples`, split comma-separated names; for `--samples-file`, pass the `Path`. Reject both inline and file variants together.
+
+- [ ] **Step 3: Run focused CLI/docs tests**
+
+Run:
+
+```bash
+pixi run pytest tests/cli/test_write_cli.py -q
+pixi run pytest tests/test_svar2_from_vcf.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add python/genoray/_cli/__main__.py tests/cli/test_write_cli.py docs/source/svar.md
+git commit -m "feat(cli): expose regions and samples for SVAR2 VCF writes"
+```
+
+---
+
+### Task 3: Padded Sub-Contig Work Units (PR 2)
+
+**Files:**
+- Modify: `src/vcf_reader.rs`
+- Modify: `src/chunk_assembler.rs`
+- Modify: `src/orchestrator.rs`
+- Test: `tests/test_svar2_from_vcf.py`
+- Test: `tests/test_left_align_e2e.rs`
+
+**Interfaces:**
+- Consumes: Task 1 per-contig normalized intervals.
+- Produces: `VcfShard { chrom, fetch_start, fetch_end, own_start, own_end, ordinal }`.
+- Produces ownership rule: keep a normalized atom iff `own_start <= atom.pos < own_end`.
+
+- [ ] **Step 1: Add boundary tests**
+
+Create a VCF fixture where an insertion/deletion left-aligns from the padded fetch interval into a neighboring ownership interval. Assert `threads=1` and `threads=4` produce the same logical decoded variants and no duplicates.
+
+- [ ] **Step 2: Build shard planner**
+
+Add a pure Rust planner that splits large intervals by `chunk_size` or approximate base-pair windows, pads by `normalize::L_MAX`, assigns stable ordinals, and coalesces adjacent requested intervals before splitting.
+
+- [ ] **Step 3: Move normalization into worker batches**
+
+Factor `ChunkAssembler::decompose_record` logic into a worker-callable function that returns normalized atom metadata plus genotype/field payloads. Workers run fetch, GT decode, atomization, validation, left-alignment, and ownership filtering before sending ordered batches.
+
+- [ ] **Step 4: Add ordered bounded merge**
+
+Merge worker batches by `(chrom ordinal, normalized pos, seq tie-breaker)` into the existing dense chunk assembly. Use bounded channels so completed batches cannot accumulate without limit.
+
+- [ ] **Step 5: Run deterministic tests**
+
+Run:
+
+```bash
+pixi run pytest tests/test_svar2_from_vcf.py -k 'regions or boundary or deterministic' -q
+pixi run bash -lc 'cargo test --no-default-features --features conversion left_align_e2e'
+```
+
+Expected: all pass repeatedly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/vcf_reader.rs src/chunk_assembler.rs src/orchestrator.rs tests/test_svar2_from_vcf.py tests/test_left_align_e2e.rs
+git commit -m "perf(svar2): shard VCF conversion within contigs"
+```
+
+---
+
+### Task 4: Thread Budget, Progress, And Failure Handling (PR 3)
+
+**Files:**
+- Modify: `src/budget.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/orchestrator.rs`
+- Modify after PR #113 merges: `python/genoray/_progress.py`, `python/genoray/_svar2.py`
+- Test: `tests/test_svar2_progress.py`
+- Test: `tests/test_svar2_errors.py`
+
+**Interfaces:**
+- Consumes: Task 3 shard planner and PR #113 progress observer contract.
+- Produces: a single process-wide reader/normalizer/BGZF budget and one aggregated progress stream.
+
+- [ ] **Step 1: Add thread-budget tests**
+
+Assert that `threads=32` on one contig allocates multiple VCF shards but does not allocate `32` HTSlib threads per shard. Assert total planned worker plus BGZF plus packing threads is bounded by `threads`.
+
+- [ ] **Step 2: Implement budget allocator**
+
+Extend `ThreadPlan` with `reader_workers`, `htslib_threads_per_reader`, `packing_threads`, and `max_inflight_batches`. Keep existing defaults for full-contig, low-thread runs.
+
+- [ ] **Step 3: Integrate progress**
+
+After PR #113 is merged, emit one aggregate conversion progress stream with decoded, normalized, written, completed work units, active reader count, and final native finalization state.
+
+- [ ] **Step 4: Add worker failure cleanup tests**
+
+Inject a missing contig and a REF mismatch inside one shard. Assert sibling workers stop, output is removed or restored according to existing atomic-output behavior, and the error includes the shard region.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pixi run pytest tests/test_svar2_progress.py tests/test_svar2_errors.py -q
+pixi run bash -lc 'cargo test --no-default-features --features conversion budget'
+pixi run bash -lc 'cargo test --no-default-features --features conversion orchestrator'
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/budget.rs src/lib.rs src/orchestrator.rs python/genoray/_progress.py python/genoray/_svar2.py tests/test_svar2_progress.py tests/test_svar2_errors.py
+git commit -m "feat(svar2): aggregate progress and bounded worker failures"
+```
+
+---
+
+### Task 5: Benchmarks And PR Readiness
+
+**Files:**
+- Create or modify: `scripts/svar2_region_parallel_bench.py`
+- Modify: `docs/roadmap/svar-2.md`
+- Modify: PR descriptions
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: benchmark table for 1, 2, 4, 8, 16, 32 threads and a high-core run on a wide VCF.
+
+- [ ] **Step 1: Add benchmark script**
+
+Benchmark full conversion and region-restricted conversion separately. Report read/decode, normalize, pack, merge/write, finalization, wall time, and peak RSS where available.
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+pixi run pytest tests -m "not network"
+pixi run bash -lc 'cargo test --no-default-features --features conversion'
+pixi run prek run --all-files
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Open PRs**
+
+Open PR 1 after Tasks 1-2. Open PR 2 after Task 3. Open PR 3 after Task 4-5. Request dlaub review on each PR and state that only dlaub can merge.
+
+- [ ] **Step 4: Monitor and fix CI**
+
+Use GitHub Actions logs for any failing checks. Fix failures on the same branch, push, and wait until every check is green.

--- a/python/genoray/_cli/__main__.py
+++ b/python/genoray/_cli/__main__.py
@@ -60,6 +60,24 @@ def write_svar2(
     no_reference: Annotated[
         bool, Parameter(name="--no-reference", negative="")
     ] = False,
+    regions: Annotated[str | None, Parameter(name=["--regions", "-r"])] = None,
+    regions_file: Annotated[
+        Path | None,
+        Parameter(
+            name=["--regions-file", "-R"],
+            validator=validators.Path(exists=True, dir_okay=False, file_okay=True),
+        ),
+    ] = None,
+    samples: Annotated[str | None, Parameter(name=["--samples", "-s"])] = None,
+    samples_file: Annotated[
+        Path | None,
+        Parameter(
+            name=["--samples-file", "-S"],
+            validator=validators.Path(exists=True, dir_okay=False, file_okay=True),
+        ),
+    ] = None,
+    merge_overlapping: bool = False,
+    regions_overlap: Literal["pos", "record", "variant"] = "pos",
     ploidy: int = 2,
     chunk_size: int | None = None,
     threads: Annotated[int | None, Parameter(name=["--threads", "-@"])] = None,
@@ -89,6 +107,25 @@ def write_svar2(
         Skip REF validation and indel left-alignment; the input is trusted to be
         already normalized. Use only for pre-normalized (e.g. ``bcftools norm``)
         inputs.
+    regions
+        VCF/BCF only. Inline region(s): a single ``chrom:start-end`` (1-based
+        inclusive, bcftools convention) or a comma-separated list. Mutually
+        exclusive with --regions-file.
+    regions_file
+        VCF/BCF only. Path to a BED file (0-based half-open) of regions.
+        Mutually exclusive with --regions.
+    samples
+        VCF/BCF only. Comma-separated list of sample names to keep, e.g.
+        ``A,B,C``. Mutually exclusive with --samples-file.
+    samples_file
+        VCF/BCF only. Path to a file of sample names (one per line). Mutually
+        exclusive with --samples.
+    merge_overlapping
+        If set, silently merge overlapping regions instead of raising.
+    regions_overlap
+        How VCF records are fetched for regions: ``pos`` (default) or
+        ``record``. ``variant`` is reserved for the follow-up sub-contig
+        normalization work and currently raises from ``SparseVar2.from_vcf``.
     ploidy
         Ploidy of the samples. Default 2. VCF/BCF only — PGEN is diploid.
     chunk_size
@@ -113,8 +150,33 @@ def write_svar2(
     """
     from genoray import SparseVar2
 
+    from ._view_helpers import parse_regions_arg
+
+    if regions is not None and regions_file is not None:
+        raise ValueError("--regions and --regions-file are mutually exclusive")
+    if samples is not None and samples_file is not None:
+        raise ValueError("--samples and --samples-file are mutually exclusive")
+
+    if regions is not None:
+        regions_arg: pl.DataFrame | Path | None = parse_regions_arg(regions)
+    elif regions_file is not None:
+        regions_arg = regions_file
+    else:
+        regions_arg = None
+
+    if samples is not None:
+        samples_arg: list[str] | Path | None = [s for s in samples.split(",") if s]
+    elif samples_file is not None:
+        samples_arg = samples_file
+    else:
+        samples_arg = None
+
     skip_out_of_scope = skip_symbolics_and_breakends
     if source.suffix == ".pgen":
+        if regions_arg is not None or samples_arg is not None:
+            raise ValueError(
+                "--regions/--samples are currently supported for VCF/BCF only"
+            )
         if ploidy != 2:
             raise ValueError(
                 "PGEN is diploid; --ploidy is only meaningful for VCF/BCF sources."
@@ -136,6 +198,10 @@ def write_svar2(
             out,
             source,
             reference,
+            regions=regions_arg,
+            samples=samples_arg,
+            merge_overlapping=merge_overlapping,
+            regions_overlap=regions_overlap,
             no_reference=no_reference,
             skip_out_of_scope=skip_out_of_scope,
             ploidy=ploidy,

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence as AbcSequence
 from collections import Counter
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -98,6 +100,95 @@ def _ensure_index(source: Path) -> None:
     if csi.exists() or tbi.exists():
         return
     _core.index_vcf(str(source))
+
+
+def _is_region_triplet(value: object) -> bool:
+    return (
+        isinstance(value, tuple)
+        and len(value) == 3
+        and isinstance(value[0], str)
+        and isinstance(value[1], int)
+        and isinstance(value[2], int)
+    )
+
+
+def _normalize_svar2_vcf_regions(
+    regions: "str | tuple[str, int, int] | PathLike | object | None",
+    available_contigs: "Sequence[str]",
+    *,
+    merge_overlapping: bool,
+    regions_overlap: "Literal['pos', 'record', 'variant']",
+) -> list[tuple[str, int, int]]:
+    """Normalize caller regions to coalesced VCF fetch intervals.
+
+    This is intentionally a pre-conversion helper: it reuses the v1 coordinate
+    parser/sample conventions, then returns per-contig 0-based half-open
+    intervals suitable for `IndexedReader.fetch`. Full post-normalization
+    ownership filtering belongs to the sub-contig shard PR.
+    """
+    from genoray._contigs import ContigNormalizer
+    from genoray._svar._regions import _normalize_regions
+
+    if regions is None:
+        return []
+    if regions_overlap not in {"pos", "record", "variant"}:
+        raise ValueError(
+            "regions_overlap must be one of 'pos', 'record', or 'variant'; "
+            f"got {regions_overlap!r}"
+        )
+    if regions_overlap == "variant":
+        raise ValueError(
+            "SparseVar2.from_vcf currently supports regions_overlap='pos' "
+            "and 'record'. Post-normalization 'variant' ownership is part of "
+            "the sub-contig sharding follow-up."
+        )
+
+    cnorm = ContigNormalizer(available_contigs)
+
+    if isinstance(regions, AbcSequence) and not isinstance(
+        regions, (str, bytes, PathLike)
+    ):
+        if _is_region_triplet(regions):
+            frames = [_normalize_regions(regions, cnorm)]
+        else:
+            frames = [_normalize_regions(r, cnorm) for r in regions]
+        regions_df = pl.concat(frames) if frames else pl.DataFrame()
+    else:
+        regions_df = _normalize_regions(regions, cnorm)
+
+    if regions_df.height == 0:
+        raise ValueError("No requested regions match VCF contigs.")
+
+    end_offset = 1 if regions_overlap == "record" else 0
+    rows = (
+        regions_df.with_columns((pl.col("end") + end_offset).alias("end"))
+        .sort(["chrom", "start", "end"])
+        .iter_rows(named=True)
+    )
+
+    merged: list[tuple[str, int, int]] = []
+    for row in rows:
+        chrom = str(row["chrom"])
+        start = int(row["start"])
+        end = int(row["end"])
+        if start < 0:
+            raise ValueError(f"region start must be >= 0; got {start} for {chrom}")
+        if end <= start:
+            raise ValueError(
+                f"region end must be greater than start; got {chrom}:{start}-{end}"
+            )
+
+        if merged and merged[-1][0] == chrom and start <= merged[-1][2]:
+            prev_chrom, prev_start, prev_end = merged[-1]
+            if start < prev_end and not merge_overlapping:
+                raise ValueError(
+                    "regions overlap; pass merge_overlapping=True to dedupe"
+                )
+            merged[-1] = (prev_chrom, prev_start, max(prev_end, end))
+        else:
+            merged.append((chrom, start, end))
+
+    return merged
 
 
 def _canonical_contig_id(name: str) -> str:
@@ -486,6 +577,10 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         source: str | Path,
         reference: str | Path | None = None,
         *,
+        regions: "str | tuple[str, int, int] | PathLike | object | None" = None,
+        samples: "str | Sequence[str] | PathLike | None" = None,
+        merge_overlapping: bool = False,
+        regions_overlap: "Literal['pos', 'record', 'variant']" = "pos",
         no_reference: bool = False,
         skip_out_of_scope: bool = False,
         ploidy: int = 2,
@@ -506,6 +601,18 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         input is trusted to be already normalized. Returns the number of
         out-of-scope (symbolic/breakend) ALTs dropped (0 unless
         `skip_out_of_scope`).
+
+        `regions` restricts conversion to one or more indexed VCF fetch
+        intervals. Region strings use Genoray's existing convention:
+        ``"chrom:start-end"`` is 1-based inclusive and is converted to a
+        0-based half-open interval; tuple/BED/frame inputs are already 0-based
+        half-open. Overlapping regions raise unless
+        `merge_overlapping=True`. `regions_overlap="variant"` is reserved for
+        the follow-up sub-contig normalization work; this entry point currently
+        supports `"pos"` and `"record"`.
+
+        `samples` selects and reorders VCF samples by name, preserving caller
+        order and de-duplicating first occurrences.
 
         signatures: if True, classify SBS96/ID83 codes during the write and
         store the mutcat sidecar (factored into the dense/var_key cost model).
@@ -528,6 +635,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         case-insensitive, so soft-masked (lowercase) reference bases match.
         """
         from cyvcf2 import VCF as _CyVCF
+        from genoray._svar._regions import _normalize_samples
 
         out = Path(out)
         source = Path(source)
@@ -549,8 +657,48 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         _ensure_index(source)
 
         v = _CyVCF(str(source))
-        samples = list(v.samples)
-        contigs = [c for c in natsorted(v.seqnames) if next(v(c), None) is not None]
+        available_samples = list(v.samples)
+        selected_samples = (
+            available_samples
+            if samples is None
+            else _normalize_samples(samples, available_samples)
+        )
+        if not selected_samples:
+            raise ValueError("from_vcf requires at least one sample")
+
+        all_contigs = list(v.seqnames)
+        region_ranges = _normalize_svar2_vcf_regions(
+            regions,
+            all_contigs,
+            merge_overlapping=merge_overlapping,
+            regions_overlap=regions_overlap,
+        )
+
+        if region_ranges:
+            ranges_by_contig: dict[str, list[tuple[int, int]]] = {}
+            for chrom, start, end in region_ranges:
+                ranges_by_contig.setdefault(chrom, []).append((start, end))
+
+            contigs = []
+            for chrom in natsorted(ranges_by_contig):
+                has_variant = any(
+                    next(v(f"{chrom}:{start + 1}-{end}"), None) is not None
+                    for start, end in ranges_by_contig[chrom]
+                )
+                if has_variant:
+                    contigs.append(chrom)
+            if not contigs:
+                raise ValueError(
+                    f"No variants found in requested regions for {source}."
+                )
+
+            region_ranges = [
+                (chrom, start, end)
+                for chrom in contigs
+                for start, end in ranges_by_contig[chrom]
+            ]
+        else:
+            contigs = [c for c in natsorted(v.seqnames) if next(v(c), None) is not None]
         if not contigs:
             raise ValueError(f"No variants found in {source}.")
 
@@ -564,7 +712,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             reference_path,
             contigs,
             str(out),
-            samples,
+            selected_samples,
             chunk_size,
             ploidy,
             threads,  # max_threads; None => auto
@@ -574,6 +722,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             info,
             format_,
             check_ref,
+            region_ranges,
         )
 
     @classmethod

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ fn index_vcf(path: String) -> PyResult<()> {
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string()))]
+#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string(), region_ranges=Vec::new()))]
 fn run_conversion_pipeline(
     py: Python,
     vcf_path: String,
@@ -138,6 +138,7 @@ fn run_conversion_pipeline(
     info_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     check_ref: String,
+    region_ranges: Vec<(String, u32, u32)>,
 ) -> PyResult<usize> {
     let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
 
@@ -147,6 +148,11 @@ fn run_conversion_pipeline(
         crate::field::parse_manifest(raw).map_err(|e| PyValueError::new_err(e.to_string()))?;
 
     let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;
+    let mut ranges_by_chrom: std::collections::HashMap<String, Vec<(u32, u32)>> =
+        std::collections::HashMap::new();
+    for (chrom, start, end) in region_ranges {
+        ranges_by_chrom.entry(chrom).or_default().push((start, end));
+    }
 
     let results: Vec<Result<u64, crate::error::ConversionError>> = py.detach(|| {
         // Step 1 -> HW discovery/override and budgeting
@@ -204,6 +210,7 @@ fn run_conversion_pipeline(
                         orchestrator::SourceSpec::Vcf {
                             vcf_path: vcf_path.clone(),
                             htslib_threads,
+                            regions: ranges_by_chrom.get(chrom).cloned().unwrap_or_default(),
                         },
                         fasta_ref,
                         chrom,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -45,6 +45,7 @@ pub enum SourceSpec {
     Vcf {
         vcf_path: String,
         htslib_threads: usize,
+        regions: Vec<(u32, u32)>,
     },
     Pgen {
         pgen_path: String,
@@ -236,6 +237,7 @@ pub fn process_chromosome(
                     SourceSpec::Vcf {
                         vcf_path,
                         htslib_threads,
+                        regions,
                     } => Box::new(crate::vcf_reader::VcfRecordSource::new(
                         &vcf_path,
                         &chr,
@@ -243,6 +245,7 @@ pub fn process_chromosome(
                         htslib_threads,
                         ploidy,
                         &fields_owned,
+                        regions,
                     )?),
                     SourceSpec::Pgen {
                         pgen_path: _,

--- a/src/vcf_list_reader.rs
+++ b/src/vcf_list_reader.rs
@@ -290,8 +290,15 @@ impl VcfListRecordSource {
         let mut cursors = Vec::with_capacity(vcf_paths.len());
         for (col, (path, &sample)) in vcf_paths.iter().zip(samples.iter()).enumerate() {
             let single_sample = [sample];
-            match VcfRecordSource::new(path, chrom, &single_sample, htslib_threads, ploidy, fields)
-            {
+            match VcfRecordSource::new(
+                path,
+                chrom,
+                &single_sample,
+                htslib_threads,
+                ploidy,
+                fields,
+                Vec::new(),
+            ) {
                 Ok(vcf) => cursors.push(FileCursor {
                     vcf: Some(vcf),
                     buf: VecDeque::new(),

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -154,6 +154,10 @@ pub(crate) fn validate_contigs_in_fasta(
 
 pub struct VcfRecordSource {
     inner_reader: IndexedReader,
+    chrom: String,
+    rid: u32,
+    regions: Vec<(u32, u32)>,
+    current_region: usize,
     num_samples: usize,
     ploidy: usize,
     sample_indices: Vec<usize>,
@@ -161,6 +165,55 @@ pub struct VcfRecordSource {
     format_fields: Vec<FieldSpec>,
     record: Record,
     eof: bool,
+}
+
+fn coalesce_fetch_regions(
+    mut regions: Vec<(u32, u32)>,
+    chrom: &str,
+) -> Result<Vec<(u32, u32)>, ConversionError> {
+    if regions.is_empty() {
+        return Ok(regions);
+    }
+    regions.sort_unstable_by_key(|&(start, end)| (start, end));
+
+    let mut merged: Vec<(u32, u32)> = Vec::with_capacity(regions.len());
+    for (start, end) in regions {
+        if end <= start {
+            return Err(ConversionError::Input(format!(
+                "Invalid fetch interval for {chrom}: start {start} must be less than end {end}"
+            )));
+        }
+        if let Some(last) = merged.last_mut()
+            && start <= last.1
+        {
+            last.1 = last.1.max(end);
+            continue;
+        }
+        merged.push((start, end));
+    }
+    Ok(merged)
+}
+
+fn fetch_region(
+    reader: &mut IndexedReader,
+    rid: u32,
+    chrom: &str,
+    region: Option<(u32, u32)>,
+) -> Result<(), ConversionError> {
+    let (start, end, label) = match region {
+        Some((start, end)) => (
+            start as u64,
+            Some(end as u64),
+            format!("{chrom}:{start}-{end}"),
+        ),
+        None => (0, None, format!("chromosome '{chrom}'")),
+    };
+    reader
+        .fetch(rid, start, end)
+        .map_err(|e| ConversionError::Io {
+            context: format!("fetching region for {label}"),
+            source: std::io::Error::other(e.to_string()),
+        })
 }
 
 impl VcfRecordSource {
@@ -172,6 +225,7 @@ impl VcfRecordSource {
         htslib_threads: usize,
         ploidy: usize,
         fields: &[FieldSpec],
+        regions: Vec<(u32, u32)>,
     ) -> Result<Self, ConversionError> {
         // A wrong VCF path reaches Rust when the file was removed after Python's
         // upstream indexing/open; surface it as FileNotFoundError, not a ".tbi?" Input.
@@ -204,12 +258,8 @@ impl VcfRecordSource {
                     chrom: chrom.to_string(),
                 })?;
 
-        reader
-            .fetch(rid, 0, None)
-            .map_err(|e| ConversionError::Io {
-                context: format!("fetching region for chromosome '{chrom}'"),
-                source: std::io::Error::other(e.to_string()),
-            })?;
+        let regions = coalesce_fetch_regions(regions, chrom)?;
+        fetch_region(&mut reader, rid, chrom, regions.first().copied())?;
 
         let sample_indices: Vec<usize> = samples
             .iter()
@@ -235,6 +285,10 @@ impl VcfRecordSource {
 
         Ok(Self {
             inner_reader: reader,
+            chrom: chrom.to_string(),
+            rid,
+            regions,
+            current_region: 0,
             num_samples: samples.len(),
             ploidy,
             sample_indices,
@@ -244,6 +298,24 @@ impl VcfRecordSource {
             eof: false,
         })
     }
+
+    fn active_region(&self) -> Option<(u32, u32)> {
+        self.regions.get(self.current_region).copied()
+    }
+
+    fn advance_region(&mut self) -> Result<bool, ConversionError> {
+        if self.regions.is_empty() || self.current_region + 1 >= self.regions.len() {
+            return Ok(false);
+        }
+        self.current_region += 1;
+        fetch_region(
+            &mut self.inner_reader,
+            self.rid,
+            &self.chrom,
+            self.regions.get(self.current_region).copied(),
+        )?;
+        Ok(true)
+    }
 }
 
 impl RecordSource for VcfRecordSource {
@@ -251,22 +323,38 @@ impl RecordSource for VcfRecordSource {
         if self.eof {
             return Ok(None);
         }
-        match self.inner_reader.read(&mut self.record) {
-            None => {
-                self.eof = true;
-                return Ok(None);
+        loop {
+            match self.inner_reader.read(&mut self.record) {
+                None => {
+                    if self.advance_region()? {
+                        continue;
+                    }
+                    self.eof = true;
+                    return Ok(None);
+                }
+                Some(Err(e)) => {
+                    return Err(ConversionError::Io {
+                        context: "reading next VCF record".to_string(),
+                        source: std::io::Error::other(e.to_string()),
+                    });
+                }
+                Some(Ok(())) => {}
             }
-            Some(Err(e)) => {
-                return Err(ConversionError::Io {
-                    context: "reading next VCF record".to_string(),
-                    source: std::io::Error::other(e.to_string()),
-                });
+
+            let pos = self.record.pos() as u32;
+            if let Some((start, end)) = self.active_region()
+                && (pos < start || pos >= end)
+            {
+                continue;
             }
-            Some(Ok(())) => {}
+
+            return self.record_to_raw(pos);
         }
+    }
+}
 
-        let pos = self.record.pos() as u32;
-
+impl VcfRecordSource {
+    fn record_to_raw(&self, pos: u32) -> Result<Option<RawRecord>, ConversionError> {
         let reference: Vec<u8>;
         let alts: Vec<Vec<u8>>;
         {

--- a/tests/cli/test_write_cli.py
+++ b/tests/cli/test_write_cli.py
@@ -53,6 +53,7 @@ def _vcf(d: Path, *, symbolic: bool) -> Path:
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
         "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
         "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
     )
     if symbolic:
         # POS 20 (1-based) in _REF is 'T'; the anchor REF base must match the
@@ -84,6 +85,60 @@ def test_write_no_reference(tmp_path: Path):
     r = _run(["write", str(vcf), str(out), "--no-reference", "--threads", "1"])
     assert r.returncode == 0, r.stderr
     assert (out / "meta.json").exists()
+
+
+def test_write_svar2_regions_and_samples(tmp_path: Path):
+    ref = _ref(tmp_path)
+    vcf = _vcf(tmp_path, symbolic=False)
+    out = tmp_path / "regioned"
+    r = _run(
+        [
+            "write",
+            str(vcf),
+            str(out),
+            "--reference",
+            str(ref),
+            "--regions",
+            "chr1:1-4",
+            "--samples",
+            "S0",
+            "--threads",
+            "1",
+        ]
+    )
+    assert r.returncode == 0, r.stderr
+    sv = SparseVar2(out)
+    assert sv.available_samples == ["S0"]
+    assert int(sv.region_counts("chr1", [(0, 40)]).sum()) == 1
+
+
+def test_write_svar2_regions_file_and_samples_file(tmp_path: Path):
+    ref = _ref(tmp_path)
+    vcf = _vcf(tmp_path, symbolic=False)
+    regions = tmp_path / "regions.bed"
+    regions.write_text("chr1\t3\t8\n")
+    samples = tmp_path / "samples.txt"
+    samples.write_text("S1\n")
+    out = tmp_path / "file_args"
+    r = _run(
+        [
+            "write",
+            str(vcf),
+            str(out),
+            "--reference",
+            str(ref),
+            "--regions-file",
+            str(regions),
+            "--samples-file",
+            str(samples),
+            "--threads",
+            "1",
+        ]
+    )
+    assert r.returncode == 0, r.stderr
+    sv = SparseVar2(out)
+    assert sv.available_samples == ["S1"]
+    assert int(sv.region_counts("chr1", [(0, 40)]).sum()) == 2
 
 
 def test_write_requires_reference_xor(tmp_path: Path):
@@ -198,6 +253,24 @@ def test_write_pgen_rejects_nondefault_ploidy(tmp_path: Path):
     )
     assert r.returncode != 0
     assert "diploid" in (r.stdout + r.stderr).lower()
+
+
+def test_write_pgen_rejects_regions_without_plink(tmp_path: Path):
+    pgen = tmp_path / "fake.pgen"
+    pgen.write_bytes(b"")
+    out = tmp_path / "fake.svar2"
+    r = _run(
+        [
+            "write",
+            str(pgen),
+            str(out),
+            "--no-reference",
+            "--regions",
+            "chr1:1-4",
+        ]
+    )
+    assert r.returncode != 0
+    assert "vcf/bcf only" in (r.stdout + r.stderr).lower()
 
 
 def test_write_svar1_still_works(tmp_path: Path):

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -177,6 +177,7 @@ pub fn build_contig(
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(fasta.to_str().unwrap()),
         chrom,

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -20,8 +20,16 @@ fn drain_reader(
     // Each test builds `bcf_path.with_extension("fa")` from its records *before* calling
     // drain_reader (see the per-test edit below); here we just point the reader at it.
     let fasta_path = bcf_path.with_extension("fa");
-    let source =
-        VcfRecordSource::new(bcf_path.to_str().unwrap(), chrom, samples, 1, ploidy, &[]).unwrap();
+    let source = VcfRecordSource::new(
+        bcf_path.to_str().unwrap(),
+        chrom,
+        samples,
+        1,
+        ploidy,
+        &[],
+        Vec::new(),
+    )
+    .unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),

--- a/tests/test_check_ref_e2e.rs
+++ b/tests/test_check_ref_e2e.rs
@@ -69,6 +69,7 @@ fn convert(
         SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(fasta.to_str().unwrap()),
         "chr1",

--- a/tests/test_convert_skip_e2e.rs
+++ b/tests/test_convert_skip_e2e.rs
@@ -44,6 +44,7 @@ fn convert(
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         fasta,
         "chr1",

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -12,6 +12,7 @@ use common::{
 };
 use genoray_core::chunk_assembler::ChunkAssembler;
 use genoray_core::process_chromosome;
+use genoray_core::record_source::RecordSource;
 use genoray_core::rvk::decode_alt_inline;
 use genoray_core::search::{SearchTree, overlap_range};
 use genoray_core::vcf_reader::VcfRecordSource;
@@ -92,6 +93,7 @@ fn test_e2e_normalized_bcf_pipeline() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -152,6 +154,51 @@ fn test_e2e_normalized_bcf_pipeline() {
     assert!(!genoray_core::bits::get_bit(&dindel_geno, 3));
 }
 
+#[test]
+fn test_vcf_record_source_fetches_requested_intervals() {
+    let tmp = tempdir().unwrap();
+    let bcf_path = tmp.path().join("intervals.bcf");
+    let samples = vec!["S0"];
+    let records = vec![
+        SynthRecord {
+            pos: 2,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0],
+        },
+        SynthRecord {
+            pos: 6,
+            ref_allele: b"A",
+            alts: vec![&b"G"[..]],
+            gt: vec![0, 1],
+        },
+        SynthRecord {
+            pos: 10,
+            ref_allele: b"A",
+            alts: vec![&b"T"[..]],
+            gt: vec![1, 1],
+        },
+    ];
+    build_bcf_with_index(&bcf_path, "chr1", 100, &samples, &records);
+
+    let mut source = VcfRecordSource::new(
+        bcf_path.to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+        &[],
+        vec![(0, 4), (6, 7)],
+    )
+    .unwrap();
+
+    let mut got = Vec::new();
+    while let Some(record) = source.next_record().unwrap() {
+        got.push(record.pos);
+    }
+    assert_eq!(got, vec![2, 6]);
+}
+
 // M5 max_del post-pass, end-to-end. Two deletions with known lengths:
 //   pos=100  ATTT → A  (d=3)  gt=[1,0,0,0]  x=1 → rare → var_key/indel (hap 0)
 //   pos=200  ATT  → A  (d=2)  gt=[1,1,1,0]  x=3 → common → dense/indel (shared)
@@ -186,6 +233,7 @@ fn test_e2e_max_del_postpass() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -264,6 +312,7 @@ fn test_e2e_dense_snp_roundtrip() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -341,6 +390,7 @@ fn test_e2e_mutation_conservation() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -472,6 +522,7 @@ fn test_reader_extracts_info_format_fields() {
         1,
         ploidy,
         &all,
+        Vec::new(),
     )
     .unwrap();
     let mut reader = ChunkAssembler::new(
@@ -630,6 +681,7 @@ fn test_reader_extracts_multiallelic_number_a_fields() {
         1,
         ploidy,
         &all,
+        Vec::new(),
     )
     .unwrap();
     let mut reader = ChunkAssembler::new(
@@ -736,8 +788,16 @@ fn test_reader_accepts_pure_del() {
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
     build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
-    let source =
-        VcfRecordSource::new(bcf_path.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+    let source = VcfRecordSource::new(
+        bcf_path.to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+        &[],
+        Vec::new(),
+    )
+    .unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),
@@ -785,6 +845,7 @@ fn test_missing_chrom_returns_err() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chrZ",
@@ -819,7 +880,15 @@ fn test_missing_vcf_returns_missing_file() {
     let tmp = tempdir().unwrap();
     let missing_path = tmp.path().join("does_not_exist.vcf.gz");
 
-    let res = VcfRecordSource::new(missing_path.to_str().unwrap(), "chr1", &["s0"], 1, 2, &[]);
+    let res = VcfRecordSource::new(
+        missing_path.to_str().unwrap(),
+        "chr1",
+        &["s0"],
+        1,
+        2,
+        &[],
+        Vec::new(),
+    );
 
     assert!(matches!(
         res,

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -25,7 +25,8 @@ fn write_ref(fasta_path: &Path, chrom: &str, seq: &[u8]) {
 }
 
 fn drain(bcf: &Path, fasta: &Path, chrom: &str, samples: &[&str]) -> Vec<(u32, i32)> {
-    let source = VcfRecordSource::new(bcf.to_str().unwrap(), chrom, samples, 1, 2, &[]).unwrap();
+    let source =
+        VcfRecordSource::new(bcf.to_str().unwrap(), chrom, samples, 1, 2, &[], Vec::new()).unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),
@@ -236,7 +237,16 @@ fn left_shifts_stay_sorted_across_chunk_boundaries() {
     build_bcf_with_index(&bcf, "chr1", REF_SEQ.len() as u64, &samples, &records);
 
     // chunk_size = 1 forces every atom into its own chunk.
-    let source = VcfRecordSource::new(bcf.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+    let source = VcfRecordSource::new(
+        bcf.to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+        &[],
+        Vec::new(),
+    )
+    .unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),
@@ -304,8 +314,16 @@ proptest! {
             .collect();
         build_bcf_with_index(&bcf, "chr1", seed.len() as u64, &samples, &synth);
 
-        let source =
-            VcfRecordSource::new(bcf.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+        let source = VcfRecordSource::new(
+            bcf.to_str().unwrap(),
+            "chr1",
+            &samples,
+            1,
+            2,
+            &[],
+            Vec::new(),
+        )
+        .unwrap();
         let mut reader = ChunkAssembler::new(
             Box::new(source),
             samples.len(),

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from genoray import SparseVar2
@@ -51,6 +52,102 @@ def test_from_vcf_with_reference_roundtrips(tmp_path: Path):
     sv = SparseVar2(out)
     assert sv.available_samples == ["S0", "S1"]
     assert sv.contigs == ["chr1"]
+
+
+def test_from_vcf_regions_restricts_conversion(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "regioned"
+    dropped = SparseVar2.from_vcf(out, vcf, ref, regions="chr1:1-4", threads=1)
+    assert dropped == 0
+
+    sv = SparseVar2(out)
+    assert sv.contigs == ["chr1"]
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 1
+    rag = sv.decode("chr1", [(0, 40)])
+    assert np.asarray(rag["pos"].data).tolist() == [2]
+
+
+def test_from_vcf_regions_accepts_multiple_specs_and_merges(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "merged"
+    SparseVar2.from_vcf(
+        out,
+        vcf,
+        ref,
+        regions=["chr1:1-4", ("chr1", 3, 8)],
+        merge_overlapping=True,
+        threads=1,
+    )
+
+    sv = SparseVar2(out)
+    assert sv.contigs == ["chr1"]
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 4
+    rag = sv.decode("chr1", [(0, 40)])
+    assert sorted(set(np.asarray(rag["pos"].data).tolist())) == [2, 6]
+
+
+def test_from_vcf_regions_rejects_overlaps_by_default(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    with pytest.raises(ValueError, match="regions overlap"):
+        SparseVar2.from_vcf(
+            tmp_path / "overlap",
+            vcf,
+            ref,
+            regions=["chr1:1-4", ("chr1", 3, 8)],
+            threads=1,
+        )
+
+
+def test_from_vcf_samples_preserve_order(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "samples"
+    dropped = SparseVar2.from_vcf(out, vcf, ref, samples=["S1"], threads=1)
+    assert dropped == 0
+
+    sv = SparseVar2(out)
+    assert sv.available_samples == ["S1"]
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert counts.shape == (1, 1, 2)
+    assert counts.reshape(-1).tolist() == [1, 1]
+
+
+def test_from_vcf_samples_reject_unknown(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    with pytest.raises(ValueError, match="Samples not found"):
+        SparseVar2.from_vcf(tmp_path / "bad_sample", vcf, ref, samples=["missing"])
+
+
+def test_from_vcf_explicit_none_matches_default(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+
+    default_out = tmp_path / "default"
+    explicit_out = tmp_path / "explicit"
+    SparseVar2.from_vcf(default_out, vcf, ref, threads=1)
+    SparseVar2.from_vcf(
+        explicit_out,
+        vcf,
+        ref,
+        regions=None,
+        samples=None,
+        threads=1,
+    )
+
+    default = SparseVar2(default_out)
+    explicit = SparseVar2(explicit_out)
+    assert explicit.contigs == default.contigs
+    assert explicit.available_samples == default.available_samples
+    np.testing.assert_array_equal(
+        explicit.region_counts("chr1", [(0, 40)]),
+        default.region_counts("chr1", [(0, 40)]),
+    )
 
 
 def test_from_vcf_requires_reference_or_opt_out(tmp_path: Path):


### PR DESCRIPTION
## Summary

- Adds `SparseVar2.from_vcf(regions=..., samples=...)` for indexed VCF/BCF conversion.
- Threads coalesced per-contig fetch intervals through the PyO3 conversion pipeline and `VcfRecordSource`.
- Adds `genoray write` CLI parity for `--regions/-r`, `--regions-file/-R`, `--samples/-s`, and `--samples-file/-S`.
- Documents coordinate conventions and the current `regions_overlap=variant` follow-up caveat.

## Notes

This is PR 1 of the planned stack. It intentionally keeps conversion serial within each contig; padded sub-contig worker ownership for parse + normalization is planned as the next PR.

## Validation

- `pixi run maturin develop`
- `pixi run pytest tests/test_svar2_from_vcf.py tests/cli/test_write_cli.py -k 'not pgen or regions_without_plink' -q`\n- `pixi run bash -lc 'export DYLD_FALLBACK_LIBRARY_PATH="$PWD/.pixi/envs/default/lib:${DYLD_FALLBACK_LIBRARY_PATH:-}"; cargo test --no-default-features --features conversion'`\n- `pixi run prek run --all-files --show-diff-on-failure`\n\nLocal note: full `tests/cli/test_write_cli.py` includes two existing PGEN tests that require `plink2`, which is not available in the local macOS Pixi env; the non-PGEN and new PGEN guard coverage was run locally.