### PR TITLE
perf(svar2): add variant-balanced Rust VCF sharding

### DIFF
--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -94,6 +94,12 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   REF/FASTA disagreement; the reference FASTA threads through `process_chromosome` and the
   PyO3 entry point as a required argument; and `vcf_reader::next_atom`'s emit bound is
   widened by `L_MAX` to keep emission position-sorted.
+  A native region/sub-contig conversion benchmark harness lives at
+  `scripts/svar2_region_parallel_bench.py`. It can run against Carter-scale VCF/BCF
+  inputs from `data/README.md` or generate a deterministic wide-sample synthetic VCF,
+  then sweeps thread counts and chunk sizes in separate worker processes so per-row
+  peak RSS remains meaningful. The harness records end-to-end timing today and is
+  ready to attach native phase timings once structured conversion progress lands.
 - [x] **M3. Per-contig split + sidecar positions + format finalization.** Partition the
   SVAR2 directory by contig; keep positions as sidecar arrays; finalize the on-disk
   format. See [`architecture.md`](architecture.md#on-disk-layout).

--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -100,6 +100,9 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
   then sweeps thread counts and chunk sizes in separate worker processes so per-row
   peak RSS remains meaningful. The harness records end-to-end timing today and is
   ready to attach native phase timings once structured conversion progress lands.
+  Indexed VCF work units are balanced by observed source-record count, not genomic
+  span: a position-only planning scan chooses equal-variant boundaries, preserves
+  equal-POS groups, and clamps normalization padding to requested-region edges.
 - [x] **M3. Per-contig split + sidecar positions + format finalization.** Partition the
   SVAR2 directory by contig; keep positions as sidecar arrays; finalize the on-disk
   format. See [`architecture.md`](architecture.md#on-disk-layout).

--- a/docs/source/svar.md
+++ b/docs/source/svar.md
@@ -15,6 +15,45 @@ SparseVar.from_pgen("out.svar", "file.pgen", max_mem="4g")
 svar = SparseVar("out.svar")
 ```
 
+### Region/sample-restricted SVAR2 conversion
+
+`SparseVar2.from_vcf` can convert an indexed VCF/BCF directly into a subset of
+regions and samples:
+
+```python
+from genoray import SparseVar2
+
+SparseVar2.from_vcf(
+    "subset.svar2",
+    "cohort.vcf.gz",
+    "reference.fa",
+    regions=["chr1:1-1000000", ("chr2", 0, 500_000)],
+    samples=["HG00096", "HG00097"],
+    merge_overlapping=True,
+    threads=8,
+)
+```
+
+Region strings use bcftools-style 1-based inclusive coordinates and are
+converted to 0-based half-open intervals. Tuple, BED, and frame inputs are
+already interpreted as 0-based half-open. `samples` preserves caller order and
+deduplicates repeated names by first occurrence.
+
+The equivalent CLI flags are available on the default SVAR2 writer:
+
+```bash
+genoray write cohort.vcf.gz subset.svar2 \
+  --reference reference.fa \
+  --regions chr1:1-1000000,chr2:1-500000 \
+  --samples HG00096,HG00097 \
+  --threads 8
+```
+
+Use `--regions-file/-R` for BED files and `--samples-file/-S` for one-sample-per-line
+sample lists. `regions_overlap=pos` is the default; `record` is also supported.
+Full post-normalization `variant` ownership is reserved for the follow-up
+sub-contig sharding work.
+
 ## Haploid (ploidy=1) write option
 
 For unphased somatic cohorts where phasing information is unavailable or irrelevant,

--- a/docs/source/svar.md
+++ b/docs/source/svar.md
@@ -51,8 +51,14 @@ genoray write cohort.vcf.gz subset.svar2 \
 
 Use `--regions-file/-R` for BED files and `--samples-file/-S` for one-sample-per-line
 sample lists. `regions_overlap=pos` is the default; `record` is also supported.
-Full post-normalization `variant` ownership is reserved for the follow-up
-sub-contig sharding work.
+Full post-normalization `variant` overlap remains unsupported.
+
+Within each requested region, multi-threaded conversion performs an indexed
+position-only scan and divides work by observed VCF record count rather than by
+base-pair span. This keeps gene-dense and gene-sparse intervals balanced. Equal-POS
+records stay together, requested-region edges are never expanded, and only internal
+shard edges receive a left-alignment halo. `chunk_size` caps records per shard; the
+planner can choose a smaller target to occupy the available worker budget.
 
 ## Haploid (ploidy=1) write option
 

--- a/docs/superpowers/plans/2026-07-15-svar2-region-subcontig-vcf.md
+++ b/docs/superpowers/plans/2026-07-15-svar2-region-subcontig-vcf.md
@@ -170,16 +170,21 @@ git commit -m "feat(cli): expose regions and samples for SVAR2 VCF writes"
 
 **Interfaces:**
 - Consumes: Task 1 per-contig normalized intervals.
-- Produces: `VcfShard { chrom, fetch_start, fetch_end, own_start, own_end, ordinal }`.
+- Produces: `VcfShard { fetch_start, fetch_end, own_start, own_end, ordinal, record_count }`.
 - Produces ownership rule: keep a normalized atom iff `own_start <= atom.pos < own_end`.
 
 - [ ] **Step 1: Add boundary tests**
 
 Create a VCF fixture where an insertion/deletion left-aligns from the padded fetch interval into a neighboring ownership interval. Assert `threads=1` and `threads=4` produce the same logical decoded variants and no duplicates.
 
-- [ ] **Step 2: Build shard planner**
+- [x] **Step 2: Build shard planner**
 
-Add a pure Rust planner that splits large intervals by `chunk_size` or approximate base-pair windows, pads by `normalize::L_MAX`, assigns stable ordinals, and coalesces adjacent requested intervals before splitting.
+Perform a lightweight indexed position scan without decoding sample fields, then
+split each requested interval after approximately equal numbers of source records.
+Never split equal-POS records. Treat `chunk_size` as a maximum record count and use
+`ceil(total_records / worker_budget)` when smaller so available workers stay busy.
+Clamp `normalize::L_MAX` padding to the caller's requested-region edges, assign
+stable ordinals, and retain each shard's exact source-record count.
 
 - [ ] **Step 3: Move normalization into worker batches**
 
@@ -223,13 +228,17 @@ git commit -m "perf(svar2): shard VCF conversion within contigs"
 - Consumes: Task 3 shard planner and PR #113 progress observer contract.
 - Produces: a single process-wide reader/normalizer/BGZF budget and one aggregated progress stream.
 
-- [ ] **Step 1: Add thread-budget tests**
+- [x] **Step 1: Add thread-budget tests**
 
 Assert that `threads=32` on one contig allocates multiple VCF shards but does not allocate `32` HTSlib threads per shard. Assert total planned worker plus BGZF plus packing threads is bounded by `threads`.
 
-- [ ] **Step 2: Implement budget allocator**
+- [x] **Step 2: Implement budget allocator**
 
-Extend `ThreadPlan` with `reader_workers`, `htslib_threads_per_reader`, `packing_threads`, and `max_inflight_batches`. Keep existing defaults for full-contig, low-thread runs.
+Extend `ThreadPlan` with a per-contig `shard_workers` budget. The position scan uses
+the serial path's HTSlib pool; shard workers then replace those HTSlib threads and
+decompress synchronously, so worker plus pipeline threads stay within the process
+budget. Bound normalization batches by cohort width (about 64 MiB of GT indices per
+reader, capped at 1,024 records).
 
 - [ ] **Step 3: Integrate progress**
 

--- a/docs/superpowers/plans/2026-07-15-svar2-region-subcontig-vcf.md
+++ b/docs/superpowers/plans/2026-07-15-svar2-region-subcontig-vcf.md
@@ -1,0 +1,296 @@
+# SVAR2 Region And Sub-Contig VCF Conversion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native `SparseVar2.from_vcf(regions=..., samples=...)`, then split one large contig into deterministic padded indexed work units so parse, genotype decode, and internal normalization can all run in parallel.
+
+**Architecture:** Ship this as a PR stack. PR 1 adds the serial indexed API foundation and CLI parity while preserving the existing full-file path. PR 2 introduces padded sub-contig work units with deterministic ownership so each worker fetches, atomizes, left-aligns, and emits only its owned normalized atoms. PR 3 wires bounded ordered merge, structured progress integration, stress tests, and benchmarks.
+
+**Tech Stack:** Python 3.10+, Rust, PyO3, rust-htslib `IndexedReader`, rayon, crossbeam-channel, Polars, cyvcf2, Cyclopts, pytest, cargo tests with `--no-default-features --features conversion`.
+
+## Global Constraints
+
+- Current `origin/main` has no sub-contig parallelism for `SparseVar2.from_vcf`: `VcfRecordSource::new` still calls `fetch(rid, 0, None)`.
+- Current internal normalization (`atomize_record`, `validate_ref`, `left_align`) runs in one reader thread per contig; dlaub is correct that norm is not sub-contig-parallelized.
+- Region string input follows existing Genoray convention: `chrom:start-end` is 1-based inclusive and converts to 0-based half-open. BED, tuples, and frames are 0-based half-open.
+- `threads` remains a total process budget. Do not multiply it independently across contig readers, BGZF threads, packing pools, and merge writers.
+- Existing no-argument behavior must be byte-compatible: `regions=None`, `samples=None`, `threads=1` follows the current full-contig conversion path.
+- PR #113 already owns structured progress. Do not duplicate it; integrate with it after dlaub merges, or keep progress changes isolated in a follow-up PR.
+- CI gate for each PR: use the exact cargo filters listed in that task, focused pytest, `pixi run pytest tests -m "not network"` before final PR readiness, and `pixi run prek run --all-files` before push.
+
+---
+
+## File Structure
+
+| File | Responsibility | Planned Change |
+| --- | --- | --- |
+| `python/genoray/_svar2.py` | Public `SparseVar2` API and VCF metadata discovery | Add `regions`, `samples`, `merge_overlapping`, `regions_overlap`; normalize inputs using v1 helpers; pass selected samples and per-contig ranges to Rust. |
+| `python/genoray/_cli/__main__.py` | `genoray write` CLI | Add `--regions/-r`, `--regions-file/-R`, `--samples/-s`, `--samples-file/-S` for SVAR2 VCF/BCF writes. |
+| `python/genoray/_cli/_view_helpers.py` | CLI parsing helpers | Reuse `parse_regions_arg` for write-region lists. |
+| `src/lib.rs` | PyO3 conversion entrypoint and thread budget dispatch | Extend `run_conversion_pipeline` to accept region ranges for PR 1; later accept shard work units and bounded merge config. |
+| `src/orchestrator.rs` | Conversion pipeline wiring | Add region-aware VCF source specs in PR 1; add range-shard worker orchestration in PR 2. |
+| `src/vcf_reader.rs` | Indexed VCF/BCF record source | PR 1: fetch one or more intervals serially. PR 2: create worker-safe range readers that fetch padded intervals. |
+| `src/chunk_assembler.rs` | Atomize/left-align/reorder/pack | PR 2: expose a worker-safe normalized atom batch path or split shared normalization into a new module. |
+| `src/normalize.rs` | Atomization and left-alignment | Keep rules unchanged; add boundary ownership tests around left-shifted indels. |
+| `tests/test_svar2_from_vcf.py` | Python API tests | Add regions/samples tests, overlap dedupe, unknown sample/contig errors, and no-argument compatibility. |
+| `tests/cli/test_write_cli.py` | CLI tests | Add write-time `--regions`/`--samples` coverage. |
+| `tests/test_*e2e.rs` | Rust conversion tests | Add serial interval fetch, padded shard ownership, deterministic merge, and worker-failure cases. |
+| `docs/source/svar.md` and `docs/roadmap/svar-2.md` | User docs and architecture notes | Document coordinate conventions, sample order, thread budget, and benchmark results. |
+
+---
+
+### Task 1: Serial Region/Sample Foundation (PR 1)
+
+**Files:**
+- Modify: `python/genoray/_svar2.py`
+- Modify: `src/lib.rs`
+- Modify: `src/orchestrator.rs`
+- Modify: `src/vcf_reader.rs`
+- Test: `tests/test_svar2_from_vcf.py`
+
+**Interfaces:**
+- Consumes: `genoray._svar._regions._normalize_regions`, `_normalize_samples`, and `_resolve_kept_rows`.
+- Produces: `SparseVar2.from_vcf(..., regions=None, samples=None, merge_overlapping=False, regions_overlap="pos")`.
+- Produces Rust input: `Vec<(String, u32, u32)>` region ranges, where empty means full contig.
+
+- [ ] **Step 1: Add failing Python tests**
+
+Add tests that build the existing tiny VCF and assert:
+
+```python
+def test_from_vcf_regions_restricts_conversion(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "regioned"
+    SparseVar2.from_vcf(out, vcf, ref, regions="chr1:1-4", threads=1)
+    sv = SparseVar2(out)
+    assert sv.contigs == ["chr1"]
+    counts = sv.var_counts("chr1", [0], [40], samples=["S0"])
+    assert int(counts.sum()) == 1
+```
+
+Also add tests for `samples=["S1"]` preserving output sample metadata, unknown samples raising `ValueError`, and `regions=None` still matching the current full conversion.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `pixi run pytest tests/test_svar2_from_vcf.py -k 'regions or samples' -q`
+
+Expected: fail with `TypeError: SparseVar2.from_vcf() got an unexpected keyword argument 'regions'`.
+
+- [ ] **Step 3: Add Python argument normalization**
+
+In `SparseVar2.from_vcf`, add keyword-only parameters:
+
+```python
+regions: str | tuple[str, int, int] | Path | object | None = None,
+samples: str | Sequence[str] | Path | None = None,
+merge_overlapping: bool = False,
+regions_overlap: Literal["pos", "record", "variant"] = "pos",
+```
+
+Resolve samples with `_normalize_samples` when provided. Resolve regions with `_normalize_regions` against `ContigNormalizer(v.seqnames)`, then coalesce with `_resolve_kept_rows` for validation and dedupe. For PR 1, pass per-contig intervals to Rust and preserve contigs in VCF header order after filtering out contigs with no selected variants.
+
+- [ ] **Step 4: Add serial interval fetch in Rust**
+
+Extend `SourceSpec::Vcf` with `regions: Vec<(u32, u32)>`. Update `VcfRecordSource::new` to accept a `Vec<(u32, u32)>`; if empty, keep the current `fetch(rid, 0, None)`. If non-empty, sort/coalesce ranges and fetch them sequentially. `next_record` should advance to the next interval when the current fetch returns EOF.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pixi run pytest tests/test_svar2_from_vcf.py -q
+pixi run bash -lc 'cargo test --no-default-features --features conversion vcf_reader'
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add python/genoray/_svar2.py src/lib.rs src/orchestrator.rs src/vcf_reader.rs tests/test_svar2_from_vcf.py
+git commit -m "feat(svar2): add serial regions and samples to from_vcf"
+```
+
+---
+
+### Task 2: CLI Parity And Docs (PR 1)
+
+**Files:**
+- Modify: `python/genoray/_cli/__main__.py`
+- Modify: `tests/cli/test_write_cli.py`
+- Modify: `docs/source/svar.md`
+
+**Interfaces:**
+- Consumes: Task 1 `SparseVar2.from_vcf(..., regions=..., samples=...)`.
+- Produces: `genoray write SOURCE OUT --regions/-r`, `--regions-file/-R`, `--samples/-s`, `--samples-file/-S`.
+
+- [ ] **Step 1: Add failing CLI tests**
+
+Add tests that run:
+
+```bash
+python -m genoray._cli write in.vcf.gz out.svar2 --reference ref.fa --regions chr1:1-4 --samples S1 --threads 1
+```
+
+Then assert `SparseVar2(out).available_samples == ["S1"]` and the store contains only the expected selected variant.
+
+- [ ] **Step 2: Implement CLI flags**
+
+Mirror the existing `view_svar2` parsing style. For `--regions`, call `parse_regions_arg`; for `--regions-file`, pass the `Path`; for `--samples`, split comma-separated names; for `--samples-file`, pass the `Path`. Reject both inline and file variants together.
+
+- [ ] **Step 3: Run focused CLI/docs tests**
+
+Run:
+
+```bash
+pixi run pytest tests/cli/test_write_cli.py -q
+pixi run pytest tests/test_svar2_from_vcf.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add python/genoray/_cli/__main__.py tests/cli/test_write_cli.py docs/source/svar.md
+git commit -m "feat(cli): expose regions and samples for SVAR2 VCF writes"
+```
+
+---
+
+### Task 3: Padded Sub-Contig Work Units (PR 2)
+
+**Files:**
+- Modify: `src/vcf_reader.rs`
+- Modify: `src/chunk_assembler.rs`
+- Modify: `src/orchestrator.rs`
+- Test: `tests/test_svar2_from_vcf.py`
+- Test: `tests/test_left_align_e2e.rs`
+
+**Interfaces:**
+- Consumes: Task 1 per-contig normalized intervals.
+- Produces: `VcfShard { chrom, fetch_start, fetch_end, own_start, own_end, ordinal }`.
+- Produces ownership rule: keep a normalized atom iff `own_start <= atom.pos < own_end`.
+
+- [ ] **Step 1: Add boundary tests**
+
+Create a VCF fixture where an insertion/deletion left-aligns from the padded fetch interval into a neighboring ownership interval. Assert `threads=1` and `threads=4` produce the same logical decoded variants and no duplicates.
+
+- [ ] **Step 2: Build shard planner**
+
+Add a pure Rust planner that splits large intervals by `chunk_size` or approximate base-pair windows, pads by `normalize::L_MAX`, assigns stable ordinals, and coalesces adjacent requested intervals before splitting.
+
+- [ ] **Step 3: Move normalization into worker batches**
+
+Factor `ChunkAssembler::decompose_record` logic into a worker-callable function that returns normalized atom metadata plus genotype/field payloads. Workers run fetch, GT decode, atomization, validation, left-alignment, and ownership filtering before sending ordered batches.
+
+- [ ] **Step 4: Add ordered bounded merge**
+
+Merge worker batches by `(chrom ordinal, normalized pos, seq tie-breaker)` into the existing dense chunk assembly. Use bounded channels so completed batches cannot accumulate without limit.
+
+- [ ] **Step 5: Run deterministic tests**
+
+Run:
+
+```bash
+pixi run pytest tests/test_svar2_from_vcf.py -k 'regions or boundary or deterministic' -q
+pixi run bash -lc 'cargo test --no-default-features --features conversion left_align_e2e'
+```
+
+Expected: all pass repeatedly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/vcf_reader.rs src/chunk_assembler.rs src/orchestrator.rs tests/test_svar2_from_vcf.py tests/test_left_align_e2e.rs
+git commit -m "perf(svar2): shard VCF conversion within contigs"
+```
+
+---
+
+### Task 4: Thread Budget, Progress, And Failure Handling (PR 3)
+
+**Files:**
+- Modify: `src/budget.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/orchestrator.rs`
+- Modify after PR #113 merges: `python/genoray/_progress.py`, `python/genoray/_svar2.py`
+- Test: `tests/test_svar2_progress.py`
+- Test: `tests/test_svar2_errors.py`
+
+**Interfaces:**
+- Consumes: Task 3 shard planner and PR #113 progress observer contract.
+- Produces: a single process-wide reader/normalizer/BGZF budget and one aggregated progress stream.
+
+- [ ] **Step 1: Add thread-budget tests**
+
+Assert that `threads=32` on one contig allocates multiple VCF shards but does not allocate `32` HTSlib threads per shard. Assert total planned worker plus BGZF plus packing threads is bounded by `threads`.
+
+- [ ] **Step 2: Implement budget allocator**
+
+Extend `ThreadPlan` with `reader_workers`, `htslib_threads_per_reader`, `packing_threads`, and `max_inflight_batches`. Keep existing defaults for full-contig, low-thread runs.
+
+- [ ] **Step 3: Integrate progress**
+
+After PR #113 is merged, emit one aggregate conversion progress stream with decoded, normalized, written, completed work units, active reader count, and final native finalization state.
+
+- [ ] **Step 4: Add worker failure cleanup tests**
+
+Inject a missing contig and a REF mismatch inside one shard. Assert sibling workers stop, output is removed or restored according to existing atomic-output behavior, and the error includes the shard region.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pixi run pytest tests/test_svar2_progress.py tests/test_svar2_errors.py -q
+pixi run bash -lc 'cargo test --no-default-features --features conversion budget'
+pixi run bash -lc 'cargo test --no-default-features --features conversion orchestrator'
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/budget.rs src/lib.rs src/orchestrator.rs python/genoray/_progress.py python/genoray/_svar2.py tests/test_svar2_progress.py tests/test_svar2_errors.py
+git commit -m "feat(svar2): aggregate progress and bounded worker failures"
+```
+
+---
+
+### Task 5: Benchmarks And PR Readiness
+
+**Files:**
+- Create or modify: `scripts/svar2_region_parallel_bench.py`
+- Modify: `docs/roadmap/svar-2.md`
+- Modify: PR descriptions
+
+**Interfaces:**
+- Consumes: Tasks 1-4.
+- Produces: benchmark table for 1, 2, 4, 8, 16, 32 threads and a high-core run on a wide VCF.
+
+- [ ] **Step 1: Add benchmark script**
+
+Benchmark full conversion and region-restricted conversion separately. Report read/decode, normalize, pack, merge/write, finalization, wall time, and peak RSS where available.
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+pixi run pytest tests -m "not network"
+pixi run bash -lc 'cargo test --no-default-features --features conversion'
+pixi run prek run --all-files
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Open PRs**
+
+Open PR 1 after Tasks 1-2. Open PR 2 after Task 3. Open PR 3 after Task 4-5. Request dlaub review on each PR and state that only dlaub can merge.
+
+- [ ] **Step 4: Monitor and fix CI**
+
+Use GitHub Actions logs for any failing checks. Fix failures on the same branch, push, and wait until every check is green.

--- a/python/genoray/_cli/__main__.py
+++ b/python/genoray/_cli/__main__.py
@@ -60,6 +60,24 @@ def write_svar2(
     no_reference: Annotated[
         bool, Parameter(name="--no-reference", negative="")
     ] = False,
+    regions: Annotated[str | None, Parameter(name=["--regions", "-r"])] = None,
+    regions_file: Annotated[
+        Path | None,
+        Parameter(
+            name=["--regions-file", "-R"],
+            validator=validators.Path(exists=True, dir_okay=False, file_okay=True),
+        ),
+    ] = None,
+    samples: Annotated[str | None, Parameter(name=["--samples", "-s"])] = None,
+    samples_file: Annotated[
+        Path | None,
+        Parameter(
+            name=["--samples-file", "-S"],
+            validator=validators.Path(exists=True, dir_okay=False, file_okay=True),
+        ),
+    ] = None,
+    merge_overlapping: bool = False,
+    regions_overlap: Literal["pos", "record", "variant"] = "pos",
     ploidy: int = 2,
     chunk_size: int | None = None,
     threads: Annotated[int | None, Parameter(name=["--threads", "-@"])] = None,
@@ -89,6 +107,25 @@ def write_svar2(
         Skip REF validation and indel left-alignment; the input is trusted to be
         already normalized. Use only for pre-normalized (e.g. ``bcftools norm``)
         inputs.
+    regions
+        VCF/BCF only. Inline region(s): a single ``chrom:start-end`` (1-based
+        inclusive, bcftools convention) or a comma-separated list. Mutually
+        exclusive with --regions-file.
+    regions_file
+        VCF/BCF only. Path to a BED file (0-based half-open) of regions.
+        Mutually exclusive with --regions.
+    samples
+        VCF/BCF only. Comma-separated list of sample names to keep, e.g.
+        ``A,B,C``. Mutually exclusive with --samples-file.
+    samples_file
+        VCF/BCF only. Path to a file of sample names (one per line). Mutually
+        exclusive with --samples.
+    merge_overlapping
+        If set, silently merge overlapping regions instead of raising.
+    regions_overlap
+        How VCF records are fetched for regions: ``pos`` (default) or
+        ``record``. ``variant`` is reserved for the follow-up sub-contig
+        normalization work and currently raises from ``SparseVar2.from_vcf``.
     ploidy
         Ploidy of the samples. Default 2. VCF/BCF only — PGEN is diploid.
     chunk_size
@@ -113,8 +150,33 @@ def write_svar2(
     """
     from genoray import SparseVar2
 
+    from ._view_helpers import parse_regions_arg
+
+    if regions is not None and regions_file is not None:
+        raise ValueError("--regions and --regions-file are mutually exclusive")
+    if samples is not None and samples_file is not None:
+        raise ValueError("--samples and --samples-file are mutually exclusive")
+
+    if regions is not None:
+        regions_arg: pl.DataFrame | Path | None = parse_regions_arg(regions)
+    elif regions_file is not None:
+        regions_arg = regions_file
+    else:
+        regions_arg = None
+
+    if samples is not None:
+        samples_arg: list[str] | Path | None = [s for s in samples.split(",") if s]
+    elif samples_file is not None:
+        samples_arg = samples_file
+    else:
+        samples_arg = None
+
     skip_out_of_scope = skip_symbolics_and_breakends
     if source.suffix == ".pgen":
+        if regions_arg is not None or samples_arg is not None:
+            raise ValueError(
+                "--regions/--samples are currently supported for VCF/BCF only"
+            )
         if ploidy != 2:
             raise ValueError(
                 "PGEN is diploid; --ploidy is only meaningful for VCF/BCF sources."
@@ -136,6 +198,10 @@ def write_svar2(
             out,
             source,
             reference,
+            regions=regions_arg,
+            samples=samples_arg,
+            merge_overlapping=merge_overlapping,
+            regions_overlap=regions_overlap,
             no_reference=no_reference,
             skip_out_of_scope=skip_out_of_scope,
             ploidy=ploidy,

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -699,6 +699,16 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             ]
         else:
             contigs = [c for c in natsorted(v.seqnames) if next(v(c), None) is not None]
+            contig_lengths = {
+                chrom: int(length)
+                for chrom, length in zip(v.seqnames, getattr(v, "seqlens", []) or [])
+                if length is not None and int(length) > 0
+            }
+            region_ranges = [
+                (chrom, 0, contig_lengths[chrom])
+                for chrom in contigs
+                if chrom in contig_lengths
+            ]
         if not contigs:
             raise ValueError(f"No variants found in {source}.")
 

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence as AbcSequence
 from collections import Counter
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -98,6 +100,95 @@ def _ensure_index(source: Path) -> None:
     if csi.exists() or tbi.exists():
         return
     _core.index_vcf(str(source))
+
+
+def _is_region_triplet(value: object) -> bool:
+    return (
+        isinstance(value, tuple)
+        and len(value) == 3
+        and isinstance(value[0], str)
+        and isinstance(value[1], int)
+        and isinstance(value[2], int)
+    )
+
+
+def _normalize_svar2_vcf_regions(
+    regions: "str | tuple[str, int, int] | PathLike | object | None",
+    available_contigs: "Sequence[str]",
+    *,
+    merge_overlapping: bool,
+    regions_overlap: "Literal['pos', 'record', 'variant']",
+) -> list[tuple[str, int, int]]:
+    """Normalize caller regions to coalesced VCF fetch intervals.
+
+    This is intentionally a pre-conversion helper: it reuses the v1 coordinate
+    parser/sample conventions, then returns per-contig 0-based half-open
+    intervals suitable for `IndexedReader.fetch`. Full post-normalization
+    ownership filtering belongs to the sub-contig shard PR.
+    """
+    from genoray._contigs import ContigNormalizer
+    from genoray._svar._regions import _normalize_regions
+
+    if regions is None:
+        return []
+    if regions_overlap not in {"pos", "record", "variant"}:
+        raise ValueError(
+            "regions_overlap must be one of 'pos', 'record', or 'variant'; "
+            f"got {regions_overlap!r}"
+        )
+    if regions_overlap == "variant":
+        raise ValueError(
+            "SparseVar2.from_vcf currently supports regions_overlap='pos' "
+            "and 'record'. Post-normalization 'variant' ownership is part of "
+            "the sub-contig sharding follow-up."
+        )
+
+    cnorm = ContigNormalizer(available_contigs)
+
+    if isinstance(regions, AbcSequence) and not isinstance(
+        regions, (str, bytes, PathLike)
+    ):
+        if _is_region_triplet(regions):
+            frames = [_normalize_regions(regions, cnorm)]
+        else:
+            frames = [_normalize_regions(r, cnorm) for r in regions]
+        regions_df = pl.concat(frames) if frames else pl.DataFrame()
+    else:
+        regions_df = _normalize_regions(regions, cnorm)
+
+    if regions_df.height == 0:
+        raise ValueError("No requested regions match VCF contigs.")
+
+    end_offset = 1 if regions_overlap == "record" else 0
+    rows = (
+        regions_df.with_columns((pl.col("end") + end_offset).alias("end"))
+        .sort(["chrom", "start", "end"])
+        .iter_rows(named=True)
+    )
+
+    merged: list[tuple[str, int, int]] = []
+    for row in rows:
+        chrom = str(row["chrom"])
+        start = int(row["start"])
+        end = int(row["end"])
+        if start < 0:
+            raise ValueError(f"region start must be >= 0; got {start} for {chrom}")
+        if end <= start:
+            raise ValueError(
+                f"region end must be greater than start; got {chrom}:{start}-{end}"
+            )
+
+        if merged and merged[-1][0] == chrom and start <= merged[-1][2]:
+            prev_chrom, prev_start, prev_end = merged[-1]
+            if start < prev_end and not merge_overlapping:
+                raise ValueError(
+                    "regions overlap; pass merge_overlapping=True to dedupe"
+                )
+            merged[-1] = (prev_chrom, prev_start, max(prev_end, end))
+        else:
+            merged.append((chrom, start, end))
+
+    return merged
 
 
 def _canonical_contig_id(name: str) -> str:
@@ -486,6 +577,10 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         source: str | Path,
         reference: str | Path | None = None,
         *,
+        regions: "str | tuple[str, int, int] | PathLike | object | None" = None,
+        samples: "str | Sequence[str] | PathLike | None" = None,
+        merge_overlapping: bool = False,
+        regions_overlap: "Literal['pos', 'record', 'variant']" = "pos",
         no_reference: bool = False,
         skip_out_of_scope: bool = False,
         ploidy: int = 2,
@@ -506,6 +601,18 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         input is trusted to be already normalized. Returns the number of
         out-of-scope (symbolic/breakend) ALTs dropped (0 unless
         `skip_out_of_scope`).
+
+        `regions` restricts conversion to one or more indexed VCF fetch
+        intervals. Region strings use Genoray's existing convention:
+        ``"chrom:start-end"`` is 1-based inclusive and is converted to a
+        0-based half-open interval; tuple/BED/frame inputs are already 0-based
+        half-open. Overlapping regions raise unless
+        `merge_overlapping=True`. `regions_overlap="variant"` is reserved for
+        the follow-up sub-contig normalization work; this entry point currently
+        supports `"pos"` and `"record"`.
+
+        `samples` selects and reorders VCF samples by name, preserving caller
+        order and de-duplicating first occurrences.
 
         signatures: if True, classify SBS96/ID83 codes during the write and
         store the mutcat sidecar (factored into the dense/var_key cost model).
@@ -528,6 +635,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         case-insensitive, so soft-masked (lowercase) reference bases match.
         """
         from cyvcf2 import VCF as _CyVCF
+        from genoray._svar._regions import _normalize_samples
 
         out = Path(out)
         source = Path(source)
@@ -549,8 +657,48 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         _ensure_index(source)
 
         v = _CyVCF(str(source))
-        samples = list(v.samples)
-        contigs = [c for c in natsorted(v.seqnames) if next(v(c), None) is not None]
+        available_samples = list(v.samples)
+        selected_samples = (
+            available_samples
+            if samples is None
+            else _normalize_samples(samples, available_samples)
+        )
+        if not selected_samples:
+            raise ValueError("from_vcf requires at least one sample")
+
+        all_contigs = list(v.seqnames)
+        region_ranges = _normalize_svar2_vcf_regions(
+            regions,
+            all_contigs,
+            merge_overlapping=merge_overlapping,
+            regions_overlap=regions_overlap,
+        )
+
+        if region_ranges:
+            ranges_by_contig: dict[str, list[tuple[int, int]]] = {}
+            for chrom, start, end in region_ranges:
+                ranges_by_contig.setdefault(chrom, []).append((start, end))
+
+            contigs = []
+            for chrom in natsorted(ranges_by_contig):
+                has_variant = any(
+                    next(v(f"{chrom}:{start + 1}-{end}"), None) is not None
+                    for start, end in ranges_by_contig[chrom]
+                )
+                if has_variant:
+                    contigs.append(chrom)
+            if not contigs:
+                raise ValueError(
+                    f"No variants found in requested regions for {source}."
+                )
+
+            region_ranges = [
+                (chrom, start, end)
+                for chrom in contigs
+                for start, end in ranges_by_contig[chrom]
+            ]
+        else:
+            contigs = [c for c in natsorted(v.seqnames) if next(v(c), None) is not None]
         if not contigs:
             raise ValueError(f"No variants found in {source}.")
 
@@ -564,7 +712,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             reference_path,
             contigs,
             str(out),
-            samples,
+            selected_samples,
             chunk_size,
             ploidy,
             threads,  # max_threads; None => auto
@@ -574,6 +722,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             info,
             format_,
             check_ref,
+            region_ranges,
         )
 
     @classmethod

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -123,8 +123,8 @@ def _normalize_svar2_vcf_regions(
 
     This is intentionally a pre-conversion helper: it reuses the v1 coordinate
     parser/sample conventions, then returns per-contig 0-based half-open
-    intervals suitable for `IndexedReader.fetch`. Full post-normalization
-    ownership filtering belongs to the sub-contig shard PR.
+    intervals suitable for the native indexed position scan and variant-count
+    shard planner.
     """
     from genoray._contigs import ContigNormalizer
     from genoray._svar._regions import _normalize_regions
@@ -614,6 +614,13 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         `samples` selects and reorders VCF samples by name, preserving caller
         order and de-duplicating first occurrences.
 
+        For a splittable contig, Genoray first scans indexed record positions
+        without decoding genotypes, then derives approximately equal-variant
+        coordinate shards. `chunk_size` is the maximum records per shard and
+        packed output chunk; the planner may choose a smaller shard target to
+        occupy the `threads` budget. Requested-region boundaries remain hard
+        limits, while internal boundaries receive a normalization halo.
+
         signatures: if True, classify SBS96/ID83 codes during the write and
         store the mutcat sidecar (factored into the dense/var_key cost model).
         Requires a reference; raises if `no_reference=True`.
@@ -725,7 +732,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             selected_samples,
             chunk_size,
             ploidy,
-            threads,  # max_threads; None => auto
+            threads,  # total process thread budget; None => auto
             long_allele_capacity,
             skip_out_of_scope,
             signatures,

--- a/scripts/svar2_region_parallel_bench.py
+++ b/scripts/svar2_region_parallel_bench.py
@@ -1,0 +1,371 @@
+"""Benchmark native region/sub-contig ``SparseVar2.from_vcf`` conversion.
+
+The handoff for native SVAR2 regions asks for a scaling benchmark that separates
+the new indexed VCF path from older post-hoc ``write_view`` measurements. This
+script records one end-to-end conversion measurement per subprocess so peak RSS
+is meaningful for every thread/chunk-size row.
+
+Examples
+--------
+
+Run against an existing wide VCF/BCF:
+
+    pixi run python scripts/svar2_region_parallel_bench.py \
+        --vcf data/chr21.bcf \
+        --reference /carter/users/dlaub/data/1kGP/GRCh38_full_analysis_set_plus_decoy_hla.fa \
+        --regions chr21:1-50000000 \
+        --out-dir /scratch/$USER/genoray-region-bench \
+        --threads 1 2 4 8 16 32 \
+        --chunk-sizes 25000
+
+Generate a deterministic synthetic wide-sample VCF first:
+
+    pixi run python scripts/svar2_region_parallel_bench.py \
+        --make-synthetic \
+        --synthetic-samples 5000 \
+        --synthetic-variants 10000 \
+        --out-dir /tmp/genoray-region-bench \
+        --threads 1 2 4 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import resource
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_THREADS = [1, 2, 4, 8, 16, 32]
+DEFAULT_CHUNK_SIZES = [25_000]
+
+
+def _dir_bytes(root: Path) -> int:
+    return sum(p.stat().st_size for p in root.rglob("*") if p.is_file())
+
+
+def _peak_rss_bytes() -> int:
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if platform.system() == "Darwin":
+        return int(rss)
+    return int(rss) * 1024
+
+
+def _variant_count(store: Path, contig: str) -> int:
+    import genoray._core as _core
+
+    ii, _sd, _xf, _xs = _core.svar2_variant_stats(str(store), contig, [0])
+    return int(ii.size)
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _run_checked(cmd: list[str], *, stdout: Any | None = None) -> None:
+    subprocess.run(cmd, check=True, stdout=stdout)
+
+
+def _write_synthetic_input(
+    root: Path,
+    *,
+    contig: str,
+    n_samples: int,
+    n_variants: int,
+    carrier_stride: int,
+) -> tuple[Path, Path]:
+    """Create a bgzipped/indexed VCF plus matching all-A FASTA reference."""
+
+    if n_samples < 1:
+        raise ValueError("--synthetic-samples must be positive")
+    if n_variants < 1:
+        raise ValueError("--synthetic-variants must be positive")
+    if carrier_stride < 1:
+        raise ValueError("--carrier-stride must be positive")
+
+    root.mkdir(parents=True, exist_ok=True)
+    length = n_variants + 100
+    ref = root / "synthetic.fa"
+    _write_text(ref, f">{contig}\n{'A' * length}\n")
+    _run_checked(["samtools", "faidx", str(ref)])
+
+    sample_names = [f"S{i:06d}" for i in range(n_samples)]
+    plain = root / "synthetic.vcf"
+    with plain.open("w") as fh:
+        fh.write("##fileformat=VCFv4.2\n")
+        fh.write(f"##contig=<ID={contig},length={length}>\n")
+        fh.write('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n')
+        fh.write(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
+            + "\t".join(sample_names)
+            + "\n"
+        )
+        for vi in range(n_variants):
+            pos = vi + 1
+            genotypes = (
+                "0/1" if (vi + si) % carrier_stride == 0 else "0/0"
+                for si in range(n_samples)
+            )
+            fh.write(
+                f"{contig}\t{pos}\t.\tA\tC\t.\t.\t.\tGT\t" + "\t".join(genotypes) + "\n"
+            )
+
+    gz = root / "synthetic.vcf.gz"
+    with gz.open("wb") as out:
+        _run_checked(["bgzip", "-f", "-c", str(plain)], stdout=out)
+    _run_checked(["bcftools", "index", "-f", str(gz)])
+    return gz, ref
+
+
+def _sample_file_for_count(vcf: Path, root: Path, count: int) -> Path:
+    import cyvcf2
+
+    samples = list(cyvcf2.VCF(str(vcf)).samples)
+    if count < 1 or count > len(samples):
+        raise ValueError(f"sample count {count} is outside 1..{len(samples)} for {vcf}")
+    path = root / f"samples_first_{count}.txt"
+    path.write_text("\n".join(samples[:count]) + "\n")
+    return path
+
+
+def _pathlike_arg(value: str | None) -> str | Path | None:
+    if value is None:
+        return None
+    path = Path(value)
+    return path if path.exists() else value
+
+
+def _run_worker(args: argparse.Namespace) -> None:
+    from genoray import SparseVar2
+
+    out = Path(args.output)
+    if out.exists():
+        shutil.rmtree(out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    reference = None if args.no_reference else args.reference
+    t0 = time.perf_counter()
+    dropped = SparseVar2.from_vcf(
+        out,
+        args.vcf,
+        reference,
+        regions=_pathlike_arg(args.regions),
+        samples=_pathlike_arg(args.samples),
+        no_reference=args.no_reference,
+        skip_out_of_scope=args.skip_out_of_scope,
+        chunk_size=args.chunk_size,
+        threads=args.thread_count,
+        overwrite=True,
+    )
+    wall_s = time.perf_counter() - t0
+
+    meta = json.loads((out / "meta.json").read_text())
+    contigs = list(meta.get("contigs", []))
+    variants = sum(_variant_count(out, contig) for contig in contigs)
+    rec = {
+        "vcf": str(args.vcf),
+        "reference": None if args.no_reference else str(args.reference),
+        "regions": args.regions,
+        "samples": args.samples,
+        "thread_count": args.thread_count,
+        "chunk_size": args.chunk_size,
+        "repeat": args.repeat_index,
+        "wall_s": round(wall_s, 3),
+        "peak_rss_gb": round(_peak_rss_bytes() / 1e9, 3),
+        "out_size_gb": round(_dir_bytes(out) / 1e9, 3),
+        "dropped_out_of_scope": int(dropped),
+        "n_samples": len(meta.get("samples", [])),
+        "contigs": contigs,
+        "variants": variants,
+        "phase_timings": {"end_to_end_wall_s": round(wall_s, 3)},
+        "phase_timing_note": (
+            "Native phase timings are not exposed yet; wire this to structured "
+            "progress after PR #113 lands."
+        ),
+    }
+    print("RESULT " + json.dumps(rec, sort_keys=True), flush=True)
+
+
+def _driver_command(
+    args: argparse.Namespace,
+    *,
+    thread_count: int,
+    chunk_size: int,
+    repeat_index: int,
+    output: Path,
+    samples: str | None,
+) -> list[str]:
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        "--vcf",
+        str(args.vcf),
+        "--output",
+        str(output),
+        "--thread-count",
+        str(thread_count),
+        "--chunk-size",
+        str(chunk_size),
+        "--repeat-index",
+        str(repeat_index),
+    ]
+    if args.no_reference:
+        cmd.append("--no-reference")
+    else:
+        cmd += ["--reference", str(args.reference)]
+    if args.regions:
+        cmd += ["--regions", args.regions]
+    if samples:
+        cmd += ["--samples", samples]
+    if args.skip_out_of_scope:
+        cmd.append("--skip-out-of-scope")
+    return cmd
+
+
+def _print_markdown(rows: list[dict[str, Any]]) -> None:
+    print(
+        "\n| threads | chunk_size | repeat | wall_s | peak_rss_gb | out_size_gb | variants | samples | note |"
+    )
+    print("|---:|---:|---:|---:|---:|---:|---:|---:|---|")
+    for row in rows:
+        if row.get("failed"):
+            print(
+                f"| {row['thread_count']} | {row['chunk_size']} | {row['repeat']} | "
+                f"- | - | - | - | - | rc={row['returncode']} |"
+            )
+            continue
+        print(
+            f"| {row['thread_count']} | {row['chunk_size']} | {row['repeat']} | "
+            f"{row['wall_s']} | {row['peak_rss_gb']} | {row['out_size_gb']} | "
+            f"{row['variants']} | {row['n_samples']} |  |"
+        )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vcf", type=Path)
+    parser.add_argument("--reference", type=Path)
+    parser.add_argument("--regions")
+    parser.add_argument(
+        "--samples", help="Sample name, comma list, or sample-list file"
+    )
+    parser.add_argument("--sample-count", type=int)
+    parser.add_argument("--out-dir", type=Path)
+    parser.add_argument("--output", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--threads", type=int, nargs="+", default=DEFAULT_THREADS)
+    parser.add_argument(
+        "--chunk-sizes", type=int, nargs="+", default=DEFAULT_CHUNK_SIZES
+    )
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--jsonl", type=Path)
+    parser.add_argument("--keep-outputs", action="store_true")
+    parser.add_argument("--no-reference", action="store_true")
+    parser.add_argument("--skip-out-of-scope", action="store_true")
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--thread-count", type=int, help=argparse.SUPPRESS)
+    parser.add_argument("--chunk-size", type=int, help=argparse.SUPPRESS)
+    parser.add_argument("--repeat-index", type=int, default=0, help=argparse.SUPPRESS)
+
+    parser.add_argument("--make-synthetic", action="store_true")
+    parser.add_argument("--synthetic-contig", default="chrBench")
+    parser.add_argument("--synthetic-samples", type=int, default=2_000)
+    parser.add_argument("--synthetic-variants", type=int, default=10_000)
+    parser.add_argument("--carrier-stride", type=int, default=32)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if args.worker:
+        if args.vcf is None or args.output is None:
+            raise SystemExit("--worker requires --vcf and --output")
+        if not args.no_reference and args.reference is None:
+            raise SystemExit(
+                "--worker requires --reference unless --no-reference is set"
+            )
+        _run_worker(args)
+        return
+
+    if args.out_dir is None:
+        raise SystemExit("--out-dir is required")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.make_synthetic:
+        args.vcf, args.reference = _write_synthetic_input(
+            args.out_dir / "synthetic_input",
+            contig=args.synthetic_contig,
+            n_samples=args.synthetic_samples,
+            n_variants=args.synthetic_variants,
+            carrier_stride=args.carrier_stride,
+        )
+
+    if args.vcf is None:
+        raise SystemExit("provide --vcf or --make-synthetic")
+    if not args.no_reference and args.reference is None:
+        raise SystemExit("provide --reference or --no-reference")
+    if args.repeats < 1:
+        raise SystemExit("--repeats must be positive")
+
+    samples = args.samples
+    if args.sample_count is not None:
+        samples = str(_sample_file_for_count(args.vcf, args.out_dir, args.sample_count))
+
+    rows: list[dict[str, Any]] = []
+    for chunk_size in args.chunk_sizes:
+        for thread_count in args.threads:
+            for repeat_index in range(args.repeats):
+                label = f"t{thread_count}_c{chunk_size}_r{repeat_index}"
+                output = args.out_dir / f"from_vcf_{label}.svar2"
+                cmd = _driver_command(
+                    args,
+                    thread_count=thread_count,
+                    chunk_size=chunk_size,
+                    repeat_index=repeat_index,
+                    output=output,
+                    samples=samples,
+                )
+                print(
+                    f"=== threads={thread_count} chunk={chunk_size} repeat={repeat_index} ==="
+                )
+                proc = subprocess.run(cmd, capture_output=True, text=True)
+                sys.stderr.write(proc.stderr[-4000:])
+                line = next(
+                    (ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT ")),
+                    None,
+                )
+                if line is None:
+                    row = {
+                        "failed": True,
+                        "thread_count": thread_count,
+                        "chunk_size": chunk_size,
+                        "repeat": repeat_index,
+                        "returncode": proc.returncode,
+                        "stdout_tail": proc.stdout[-2000:],
+                    }
+                    print(
+                        f"  FAILED rc={proc.returncode}; stdout tail:\n{proc.stdout[-1500:]}"
+                    )
+                else:
+                    row = json.loads(line[len("RESULT ") :])
+                    print("  " + json.dumps(row, sort_keys=True), flush=True)
+                rows.append(row)
+                if args.jsonl is not None:
+                    with args.jsonl.open("a") as fh:
+                        fh.write(json.dumps(row, sort_keys=True) + "\n")
+                if not args.keep_outputs and output.exists():
+                    shutil.rmtree(output)
+
+    _print_markdown(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -246,7 +246,7 @@ dropped = SparseVar2.from_vcf(
 dropped = SparseVar2.from_vcf("out.svar2", "file.vcf.gz", no_reference=True)
 ```
 
-Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None, check_ref="e") -> int`
+Signature: `from_vcf(out, source, reference=None, *, regions=None, samples=None, merge_overlapping=False, regions_overlap="pos", no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None, check_ref="e") -> int`
 
 - `source` — a bgzipped VCF (`.vcf.gz`) or BCF (`.bcf`). Auto-indexes (`.csi`) if
   no `.csi`/`.tbi` is found. For a PLINK2 PGEN source, use `from_pgen` instead
@@ -268,6 +268,13 @@ Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_ou
   runs past the contig end) and continues, logging a per-contig count.
   Comparison is case-insensitive (soft-masked lowercase reference bases
   match). Any other value raises `ValueError` before conversion starts.
+- `regions=` accepts region strings, 0-based half-open tuples, BED-like paths,
+  and frames. `samples=` selects/reorders samples by name. Multi-threaded indexed
+  conversion scans positions first and balances parser shards by source-record
+  count; `chunk_size` is the maximum records per shard and output chunk.
+- `threads` is a total process budget. Variant-shard workers replace the serial
+  reader's HTSlib background threads rather than creating an HTSlib pool per
+  worker.
 - No dosages, no `haploid=` OR-collapse, no `max_mem`-based chunking (use
   `chunk_size` instead) — these remain `SparseVar` (SVAR 1.0)-only for now.
 - `signatures=False` — when `True`, classifies every SNP/indel into its

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -19,10 +19,9 @@ pub struct ThreadPlan {
     pub concurrent_chroms: usize,
     pub htslib_threads: usize,
     // Cores left idle after the pipeline + htslib threads across all concurrent
-    // chroms. Sizes the reader-side processing pool: bounded per-record
+    // chroms. For splittable VCF contigs this caps concurrent shard readers;
+    // otherwise it sizes the reader-side processing pool used for bounded
     // normalization batches plus intra-chunk presence packing.
-    // Floored at 1 so the pool always builds; parallel work self-gates off
-    // when this is < 2.
     pub processing_threads: usize,
 }
 

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -19,8 +19,9 @@ pub struct ThreadPlan {
     pub concurrent_chroms: usize,
     pub htslib_threads: usize,
     // Cores left idle after the pipeline + htslib threads across all concurrent
-    // chroms. Sizes the reader's intra-chunk packing pool (see vcf_reader.rs).
-    // Floored at 1 so the pool always builds; parallel packing self-gates off
+    // chroms. Sizes the reader-side processing pool: bounded per-record
+    // normalization batches plus intra-chunk presence packing.
+    // Floored at 1 so the pool always builds; parallel work self-gates off
     // when this is < 2.
     pub processing_threads: usize,
 }

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -18,6 +18,10 @@ const MIN_THREADS_PER_CHROM: usize = PIPELINE_THREADS_PER_CHROM + MIN_HTSLIB_THR
 pub struct ThreadPlan {
     pub concurrent_chroms: usize,
     pub htslib_threads: usize,
+    // Per-contig reader workers when indexed VCF sharding replaces the single
+    // HTSlib reader. Each worker decompresses synchronously, so these consume
+    // the same cores otherwise reserved for HTSlib plus reader-side processing.
+    pub shard_workers: usize,
     // Cores left idle after the pipeline + htslib threads across all concurrent
     // chroms. For splittable VCF contigs this caps concurrent shard readers;
     // otherwise it sizes the reader-side processing pool used for bounded
@@ -37,9 +41,11 @@ pub fn plan_thread_budget(available_cores: usize, n_chroms: usize) -> ThreadPlan
         let htslib = std::cmp::max(1, usable_cores.saturating_sub(PIPELINE_THREADS_PER_CHROM));
         let htslib = std::cmp::min(htslib, MAX_HTSLIB_THREADS);
         let processing = processing_threads(usable_cores, 1, htslib);
+        let shard_workers = shard_workers(usable_cores, 1);
         ThreadPlan {
             concurrent_chroms: 1,
             htslib_threads: htslib,
+            shard_workers,
             processing_threads: processing,
         }
     } else {
@@ -50,12 +56,22 @@ pub fn plan_thread_budget(available_cores: usize, n_chroms: usize) -> ThreadPlan
         let htslib_unclamped = cores_per_chrom.saturating_sub(PIPELINE_THREADS_PER_CHROM);
         let htslib = htslib_unclamped.clamp(MIN_HTSLIB_THREADS, MAX_HTSLIB_THREADS);
         let processing = processing_threads(usable_cores, concurrent, htslib);
+        let shard_workers = shard_workers(usable_cores, concurrent);
         ThreadPlan {
             concurrent_chroms: concurrent,
             htslib_threads: htslib,
+            shard_workers,
             processing_threads: processing,
         }
     }
+}
+
+fn shard_workers(usable_cores: usize, concurrent: usize) -> usize {
+    usable_cores
+        .checked_div(concurrent.max(1))
+        .unwrap_or(0)
+        .saturating_sub(PIPELINE_THREADS_PER_CHROM)
+        .max(1)
 }
 
 /// Cores left idle after `concurrent` chroms each claim the pipeline threads plus
@@ -76,6 +92,7 @@ mod tests {
             ThreadPlan {
                 concurrent_chroms: 1,
                 htslib_threads: 1,
+                shard_workers: 1,
                 processing_threads: 1,
             }
         );
@@ -88,6 +105,7 @@ mod tests {
             ThreadPlan {
                 concurrent_chroms: 1,
                 htslib_threads: 1,
+                shard_workers: 1,
                 processing_threads: 1,
             }
         );
@@ -100,6 +118,7 @@ mod tests {
             ThreadPlan {
                 concurrent_chroms: 10,
                 htslib_threads: 2,
+                shard_workers: 2,
                 processing_threads: 4,
             }
         );
@@ -140,6 +159,13 @@ mod tests {
         // processing = max(1, 32 - 12) = 20.
         let plan = plan_thread_budget(33, 1);
         assert_eq!(plan.processing_threads, 20);
+    }
+
+    #[test]
+    fn test_shard_workers_replace_htslib_threads_without_exceeding_budget() {
+        assert_eq!(plan_thread_budget(33, 1).shard_workers, 28);
+        assert_eq!(plan_thread_budget(126, 1).shard_workers, 121);
+        assert_eq!(plan_thread_budget(65, 22).shard_workers, 2);
     }
 
     #[test]

--- a/src/chunk_assembler.rs
+++ b/src/chunk_assembler.rs
@@ -28,6 +28,7 @@ struct PendingAtom {
 }
 
 struct DecomposedRecord {
+    source_pos: u32,
     atoms: Vec<PendingAtom>,
     dropped_out_of_scope: u64,
     ref_excluded: Option<String>,
@@ -258,8 +259,9 @@ pub struct ChunkAssembler {
     num_samples: usize,
     ploidy: usize,
     /// Full 0-based contig sequence, uppercased; empty when no reference was given.
-    ref_seq: Vec<u8>,
+    ref_seq: Arc<Vec<u8>>,
     has_reference: bool,
+    owned_range: Option<(u32, u32)>,
     skip_out_of_scope: bool,
     check_ref: crate::normalize::CheckRef,
     ref_excluded: u64,
@@ -293,6 +295,7 @@ fn decompose_raw_record(
             crate::normalize::RefDecision::Keep => {}
             crate::normalize::RefDecision::Exclude(err) => {
                 return Ok(DecomposedRecord {
+                    source_pos: pos,
                     atoms: Vec::new(),
                     dropped_out_of_scope: 0,
                     ref_excluded: Some(err.to_string()),
@@ -350,6 +353,7 @@ fn decompose_raw_record(
     }
 
     Ok(DecomposedRecord {
+        source_pos: pos,
         atoms: pending,
         dropped_out_of_scope: dropped as u64,
         ref_excluded: None,
@@ -369,15 +373,44 @@ impl ChunkAssembler {
         fields: &[FieldSpec],
     ) -> Result<Self, ConversionError> {
         let (ref_seq, has_reference) = match fasta_path {
-            Some(path) => (crate::vcf_reader::load_contig_seq(path, chrom)?, true),
-            None => (Vec::new(), false),
+            Some(path) => (
+                Arc::new(crate::vcf_reader::load_contig_seq(path, chrom)?),
+                true,
+            ),
+            None => (Arc::new(Vec::new()), false),
         };
-        Ok(Self {
+        Ok(Self::with_reference(
             source,
             num_samples,
             ploidy,
             ref_seq,
             has_reference,
+            skip_out_of_scope,
+            check_ref,
+            fields,
+            None,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn with_reference(
+        source: Box<dyn RecordSource + Send>,
+        num_samples: usize,
+        ploidy: usize,
+        ref_seq: Arc<Vec<u8>>,
+        has_reference: bool,
+        skip_out_of_scope: bool,
+        check_ref: crate::normalize::CheckRef,
+        fields: &[FieldSpec],
+        owned_range: Option<(u32, u32)>,
+    ) -> Self {
+        Self {
+            source,
+            num_samples,
+            ploidy,
+            ref_seq,
+            has_reference,
+            owned_range,
             skip_out_of_scope,
             check_ref,
             ref_excluded: 0,
@@ -396,7 +429,7 @@ impl ChunkAssembler {
             frontier: 0,
             eof: false,
             next_seq: 0,
-        })
+        }
     }
 
     /// Total out-of-scope (symbolic/breakend) ALTs dropped so far. Valid after the
@@ -444,7 +477,7 @@ impl ChunkAssembler {
                         decompose_raw_record(
                             rec,
                             record_seq,
-                            &self.ref_seq,
+                            self.ref_seq.as_slice(),
                             self.has_reference,
                             self.skip_out_of_scope,
                             self.check_ref,
@@ -462,7 +495,7 @@ impl ChunkAssembler {
                     decompose_raw_record(
                         rec,
                         record_seq,
-                        &self.ref_seq,
+                        self.ref_seq.as_slice(),
                         self.has_reference,
                         self.skip_out_of_scope,
                         self.check_ref,
@@ -475,20 +508,29 @@ impl ChunkAssembler {
         };
 
         for record in decomposed {
-            if let Some(err) = record.ref_excluded {
-                self.ref_excluded += 1;
-                if self.ref_excluded == 1 {
-                    println!(
-                        "Notice: check_ref=x excluding record(s) whose REF disagrees \
-                         with the reference (first: {err}); further exclusions on this \
-                         contig are counted, not printed."
-                    );
+            let source_record_owned = self
+                .owned_range
+                .is_none_or(|(start, end)| record.source_pos >= start && record.source_pos < end);
+            if source_record_owned {
+                self.dropped_out_of_scope += record.dropped_out_of_scope;
+                if let Some(err) = record.ref_excluded {
+                    self.ref_excluded += 1;
+                    if self.ref_excluded == 1 && self.owned_range.is_none() {
+                        println!(
+                            "Notice: check_ref=x excluding record(s) whose REF disagrees \
+                             with the reference (first: {err}); further exclusions on this \
+                             contig are counted, not printed."
+                        );
+                    }
                 }
-                continue;
             }
-            self.dropped_out_of_scope += record.dropped_out_of_scope;
             for atom in record.atoms {
-                self.heap.push(Reverse(atom));
+                let atom_owned = self
+                    .owned_range
+                    .is_none_or(|(start, end)| atom.pos >= start && atom.pos < end);
+                if atom_owned {
+                    self.heap.push(Reverse(atom));
+                }
             }
         }
         Ok(())

--- a/src/chunk_assembler.rs
+++ b/src/chunk_assembler.rs
@@ -208,7 +208,18 @@ struct AtomMeta {
 // `pack_presence_par` keeps its word-disjoint invariant. 1024 keeps the window
 // above `PARALLEL_MIN_VARIANTS` (512) so parallel packing still engages.
 const PACK_WINDOW: usize = 1024;
-const NORMALIZE_BATCH_RECORDS: usize = 1024;
+const MAX_NORMALIZE_BATCH_RECORDS: usize = 1024;
+const NORMALIZE_BATCH_TARGET_BYTES: usize = 64 * 1024 * 1024;
+
+fn normalization_batch_records(num_samples: usize, ploidy: usize) -> usize {
+    let gt_bytes_per_record = num_samples
+        .saturating_mul(ploidy)
+        .saturating_mul(std::mem::size_of::<i32>());
+    if gt_bytes_per_record == 0 {
+        return MAX_NORMALIZE_BATCH_RECORDS;
+    }
+    (NORMALIZE_BATCH_TARGET_BYTES / gt_bytes_per_record).clamp(1, MAX_NORMALIZE_BATCH_RECORDS)
+}
 
 // Pack `buf`'s presence bits into `genos` starting at variant offset `v0`, then
 // move each atom's metadata into `metas`, dropping `gt`.
@@ -448,8 +459,9 @@ impl ChunkAssembler {
         &mut self,
         pool: Option<&rayon::ThreadPool>,
     ) -> Result<(), ConversionError> {
-        let mut records = Vec::with_capacity(NORMALIZE_BATCH_RECORDS);
-        while records.len() < NORMALIZE_BATCH_RECORDS {
+        let batch_records = normalization_batch_records(self.num_samples, self.ploidy);
+        let mut records = Vec::with_capacity(batch_records);
+        while records.len() < batch_records {
             match self.source.next_record()? {
                 Some(rec) => {
                     self.frontier = rec.pos;
@@ -697,6 +709,14 @@ mod tests {
             info_vals: Vec::new(),
             format_vals: Vec::new(),
         }
+    }
+
+    #[test]
+    fn normalization_batch_is_memory_bounded_for_wide_cohorts() {
+        assert_eq!(normalization_batch_records(500_000, 2), 16);
+        assert_eq!(normalization_batch_records(10_000_000, 2), 1);
+        assert_eq!(normalization_batch_records(5_000, 2), 1024);
+        assert_eq!(normalization_batch_records(1, 2), 1024);
     }
 
     proptest! {

--- a/src/chunk_assembler.rs
+++ b/src/chunk_assembler.rs
@@ -27,6 +27,12 @@ struct PendingAtom {
     format_vals: Vec<f64>, // len == VcfChunkReader::format_fields.len() * num_samples, field-major then sample: field*num_samples + sample
 }
 
+struct DecomposedRecord {
+    atoms: Vec<PendingAtom>,
+    dropped_out_of_scope: u64,
+    ref_excluded: Option<String>,
+}
+
 impl PartialEq for PendingAtom {
     fn eq(&self, other: &Self) -> bool {
         self.pos == other.pos && self.seq == other.seq
@@ -201,6 +207,7 @@ struct AtomMeta {
 // `pack_presence_par` keeps its word-disjoint invariant. 1024 keeps the window
 // above `PARALLEL_MIN_VARIANTS` (512) so parallel packing still engages.
 const PACK_WINDOW: usize = 1024;
+const NORMALIZE_BATCH_RECORDS: usize = 1024;
 
 // Pack `buf`'s presence bits into `genos` starting at variant offset `v0`, then
 // move each atom's metadata into `metas`, dropping `gt`.
@@ -265,6 +272,90 @@ pub struct ChunkAssembler {
     next_seq: u64,
 }
 
+#[allow(clippy::too_many_arguments)]
+fn decompose_raw_record(
+    rec: RawRecord,
+    record_seq: u64,
+    ref_seq: &[u8],
+    has_reference: bool,
+    skip_out_of_scope: bool,
+    check_ref: crate::normalize::CheckRef,
+    info_fields: &[FieldSpec],
+    format_fields: &[FieldSpec],
+    num_samples: usize,
+) -> Result<DecomposedRecord, ConversionError> {
+    let pos = rec.pos;
+
+    // Fail fast only when a reference is available; without one we trust the
+    // input is already normalized/left-aligned.
+    if has_reference {
+        match crate::normalize::apply_check_ref(check_ref, pos, &rec.reference, ref_seq)? {
+            crate::normalize::RefDecision::Keep => {}
+            crate::normalize::RefDecision::Exclude(err) => {
+                return Ok(DecomposedRecord {
+                    atoms: Vec::new(),
+                    dropped_out_of_scope: 0,
+                    ref_excluded: Some(err.to_string()),
+                });
+            }
+        }
+    }
+    let gt = Arc::new(rec.gt);
+
+    let alt_refs: Vec<&[u8]> = rec.alts.iter().map(|a| a.as_slice()).collect();
+    let mut atoms = Vec::new();
+    let dropped = atomize_record(
+        pos,
+        &rec.reference,
+        &alt_refs,
+        &mut atoms,
+        skip_out_of_scope,
+    )?;
+
+    let mut pending = Vec::with_capacity(atoms.len());
+    for (atom_ix, atom) in atoms.into_iter().enumerate() {
+        let atom = if has_reference {
+            crate::normalize::left_align(atom, ref_seq, crate::normalize::L_MAX)
+        } else {
+            atom
+        };
+
+        let info_vals: Vec<f64> = info_fields
+            .iter()
+            .zip(rec.info_raw.iter())
+            .map(|(spec, raw)| resolve_scalar(raw.as_deref(), atom.source_alt_index, spec))
+            .collect();
+
+        let mut format_vals = Vec::with_capacity(format_fields.len() * num_samples);
+        for (spec, raw) in format_fields.iter().zip(rec.format_raw.iter()) {
+            for s in 0..num_samples {
+                let sample_vals = raw.as_ref().map(|v| v[s].as_slice());
+                format_vals.push(resolve_scalar(sample_vals, atom.source_alt_index, spec));
+            }
+        }
+
+        let seq = record_seq
+            .saturating_mul(1u64 << 32)
+            .saturating_add(atom_ix as u64);
+        pending.push(PendingAtom {
+            pos: atom.pos,
+            ilen: atom.ilen,
+            alt: atom.alt,
+            source_alt_index: atom.source_alt_index,
+            gt: Arc::clone(&gt),
+            seq,
+            info_vals,
+            format_vals,
+        });
+    }
+
+    Ok(DecomposedRecord {
+        atoms: pending,
+        dropped_out_of_scope: dropped as u64,
+        ref_excluded: None,
+    })
+}
+
 impl ChunkAssembler {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -320,81 +411,85 @@ impl ChunkAssembler {
         self.ref_excluded
     }
 
-    // Decompose one record into atoms and push them onto the reorder heap, sharing
-    // one decoded genotype vector across all atoms of the record.
-    fn decompose_record(&mut self, rec: RawRecord) -> Result<(), ConversionError> {
-        let pos = rec.pos;
-        let gt = Arc::new(rec.gt);
-
-        // Fail fast only when a reference is available; without one we trust the
-        // input is already normalized/left-aligned.
-        if self.has_reference {
-            match crate::normalize::apply_check_ref(
-                self.check_ref,
-                pos,
-                &rec.reference,
-                &self.ref_seq,
-            )? {
-                crate::normalize::RefDecision::Keep => {}
-                crate::normalize::RefDecision::Exclude(e) => {
-                    self.ref_excluded += 1;
-                    if self.ref_excluded == 1 {
-                        println!(
-                            "Notice: check_ref=x excluding record(s) whose REF disagrees \
-                             with the reference (first: {e}); further exclusions on this \
-                             contig are counted, not printed."
-                        );
-                    }
-                    return Ok(());
+    fn fill_normalize_batch(
+        &mut self,
+        pool: Option<&rayon::ThreadPool>,
+    ) -> Result<(), ConversionError> {
+        let mut records = Vec::with_capacity(NORMALIZE_BATCH_RECORDS);
+        while records.len() < NORMALIZE_BATCH_RECORDS {
+            match self.source.next_record()? {
+                Some(rec) => {
+                    self.frontier = rec.pos;
+                    let record_seq = self.next_seq;
+                    self.next_seq += 1;
+                    records.push((record_seq, rec));
+                }
+                None => {
+                    self.eof = true;
+                    break;
                 }
             }
         }
+        if records.is_empty() {
+            return Ok(());
+        }
 
-        let alt_refs: Vec<&[u8]> = rec.alts.iter().map(|a| a.as_slice()).collect();
-        let mut atoms = Vec::new();
-        let dropped = atomize_record(
-            pos,
-            &rec.reference,
-            &alt_refs,
-            &mut atoms,
-            self.skip_out_of_scope,
-        )?;
-        self.dropped_out_of_scope += dropped as u64;
+        let parallel =
+            matches!(pool, Some(p) if p.current_num_threads() >= 2) && records.len() >= 2;
+        let decomposed: Vec<DecomposedRecord> = if parallel {
+            pool.unwrap().install(|| {
+                records
+                    .into_par_iter()
+                    .map(|(record_seq, rec)| {
+                        decompose_raw_record(
+                            rec,
+                            record_seq,
+                            &self.ref_seq,
+                            self.has_reference,
+                            self.skip_out_of_scope,
+                            self.check_ref,
+                            &self.info_fields,
+                            &self.format_fields,
+                            self.num_samples,
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })?
+        } else {
+            records
+                .into_iter()
+                .map(|(record_seq, rec)| {
+                    decompose_raw_record(
+                        rec,
+                        record_seq,
+                        &self.ref_seq,
+                        self.has_reference,
+                        self.skip_out_of_scope,
+                        self.check_ref,
+                        &self.info_fields,
+                        &self.format_fields,
+                        self.num_samples,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        };
 
-        for atom in atoms {
-            let atom = if self.has_reference {
-                crate::normalize::left_align(atom, &self.ref_seq, crate::normalize::L_MAX)
-            } else {
-                atom
-            };
-
-            let info_vals: Vec<f64> = self
-                .info_fields
-                .iter()
-                .zip(rec.info_raw.iter())
-                .map(|(spec, raw)| resolve_scalar(raw.as_deref(), atom.source_alt_index, spec))
-                .collect();
-
-            let mut format_vals = Vec::with_capacity(self.format_fields.len() * self.num_samples);
-            for (spec, raw) in self.format_fields.iter().zip(rec.format_raw.iter()) {
-                for s in 0..self.num_samples {
-                    let sample_vals = raw.as_ref().map(|v| v[s].as_slice());
-                    format_vals.push(resolve_scalar(sample_vals, atom.source_alt_index, spec));
+        for record in decomposed {
+            if let Some(err) = record.ref_excluded {
+                self.ref_excluded += 1;
+                if self.ref_excluded == 1 {
+                    println!(
+                        "Notice: check_ref=x excluding record(s) whose REF disagrees \
+                         with the reference (first: {err}); further exclusions on this \
+                         contig are counted, not printed."
+                    );
                 }
+                continue;
             }
-
-            let seq = self.next_seq;
-            self.next_seq += 1;
-            self.heap.push(Reverse(PendingAtom {
-                pos: atom.pos,
-                ilen: atom.ilen,
-                alt: atom.alt,
-                source_alt_index: atom.source_alt_index,
-                gt: Arc::clone(&gt),
-                seq,
-                info_vals,
-                format_vals,
-            }));
+            self.dropped_out_of_scope += record.dropped_out_of_scope;
+            for atom in record.atoms {
+                self.heap.push(Reverse(atom));
+            }
         }
         Ok(())
     }
@@ -403,8 +498,12 @@ impl ChunkAssembler {
     // up to `L_MAX` bases below its record's start, so an atom is safe to emit only
     // once its position is strictly below `frontier - L_MAX` (saturating), or the
     // input is exhausted. This preserves the position-sorted invariant the Phase-2
-    // merge relies on. (Unchanged from the pre-refactor VcfChunkReader.)
-    fn next_atom(&mut self) -> Result<Option<PendingAtom>, ConversionError> {
+    // merge relies on. Refill happens in bounded record batches so normalization
+    // can use the reader-side processing pool without changing the emit rule.
+    fn next_atom(
+        &mut self,
+        pool: Option<&rayon::ThreadPool>,
+    ) -> Result<Option<PendingAtom>, ConversionError> {
         loop {
             if let Some(Reverse(top)) = self.heap.peek() {
                 if self.eof || top.pos < self.frontier.saturating_sub(crate::normalize::L_MAX) {
@@ -414,13 +513,7 @@ impl ChunkAssembler {
                 return Ok(None);
             }
 
-            match self.source.next_record()? {
-                Some(rec) => {
-                    self.frontier = rec.pos;
-                    self.decompose_record(rec)?;
-                }
-                None => self.eof = true,
-            }
+            self.fill_normalize_batch(pool)?;
         }
     }
 
@@ -449,7 +542,7 @@ impl ChunkAssembler {
         let mut v = 0usize;
 
         while v + buf.len() < chunk_size {
-            match self.next_atom()? {
+            match self.next_atom(pool)? {
                 Some(a) => {
                     buf.push(a);
                     if buf.len() == window {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ fn run_conversion_pipeline(
         let plan = crate::budget::plan_thread_budget(available_cores, chroms.len());
         let concurrent_chroms = plan.concurrent_chroms;
         let htslib_threads = plan.htslib_threads;
+        let shard_workers = plan.shard_workers;
         let processing_threads = plan.processing_threads;
 
         let total_active =
@@ -181,8 +182,9 @@ fn run_conversion_pipeline(
         println!("Using: {} cores.", available_cores);
         println!(
             "Pipeline Config: {} concurrent chromosomes | {} HTSlib decompression threads each \
-             ({} pipeline/BGZF threads, {} reader-side processing/shard threads).",
-            concurrent_chroms, htslib_threads, total_active, processing_threads,
+             ({} pipeline/BGZF threads, {} normalization/packing threads, {} variant-shard \
+             workers when sharding replaces HTSlib).",
+            concurrent_chroms, htslib_threads, total_active, processing_threads, shard_workers,
         );
 
         // Step 2 -> Rayon Pool
@@ -207,6 +209,7 @@ fn run_conversion_pipeline(
                         orchestrator::SourceSpec::Vcf {
                             vcf_path: vcf_path.clone(),
                             htslib_threads,
+                            shard_workers,
                             regions: ranges_by_chrom.get(chrom).cloned().unwrap_or_default(),
                         },
                         fasta_ref,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,11 +181,8 @@ fn run_conversion_pipeline(
         println!("Using: {} cores.", available_cores);
         println!(
             "Pipeline Config: {} concurrent chromosomes | {} HTSlib decompression threads each \
-             ({} total active, {} reserved for OS/idle).",
-            concurrent_chroms,
-            htslib_threads,
-            total_active,
-            available_cores.saturating_sub(total_active),
+             ({} pipeline/BGZF threads, {} reader-side processing/shard threads).",
+            concurrent_chroms, htslib_threads, total_active, processing_threads,
         );
 
         // Step 2 -> Rayon Pool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ fn index_vcf(path: String) -> PyResult<()> {
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string()))]
+#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string(), region_ranges=Vec::new()))]
 fn run_conversion_pipeline(
     py: Python,
     vcf_path: String,
@@ -138,6 +138,7 @@ fn run_conversion_pipeline(
     info_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     check_ref: String,
+    region_ranges: Vec<(String, u32, u32)>,
 ) -> PyResult<usize> {
     let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
 
@@ -147,6 +148,11 @@ fn run_conversion_pipeline(
         crate::field::parse_manifest(raw).map_err(|e| PyValueError::new_err(e.to_string()))?;
 
     let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;
+    let mut ranges_by_chrom: std::collections::HashMap<String, Vec<(u32, u32)>> =
+        std::collections::HashMap::new();
+    for (chrom, start, end) in region_ranges {
+        ranges_by_chrom.entry(chrom).or_default().push((start, end));
+    }
 
     let results: Vec<Result<u64, crate::error::ConversionError>> = py.detach(|| {
         // Step 1 -> HW discovery/override and budgeting
@@ -204,6 +210,7 @@ fn run_conversion_pipeline(
                         orchestrator::SourceSpec::Vcf {
                             vcf_path: vcf_path.clone(),
                             htslib_threads,
+                            regions: ranges_by_chrom.get(chrom).cloned().unwrap_or_default(),
                         },
                         fasta_ref,
                         chrom,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -1,5 +1,5 @@
 // src/orchestrator.rs
-use crossbeam_channel::{Sender, TrySendError, bounded};
+use crossbeam_channel::{Receiver, Sender, TrySendError, bounded, select};
 use std::fs;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -46,6 +46,7 @@ pub enum SourceSpec {
     Vcf {
         vcf_path: String,
         htslib_threads: usize,
+        shard_workers: usize,
         regions: Vec<(u32, u32)>,
     },
     Pgen {
@@ -128,10 +129,18 @@ enum VcfShardMessage {
     },
 }
 
+fn vcf_shard_worker_count(shard_count: usize, thread_budget: usize) -> usize {
+    if shard_count == 0 {
+        0
+    } else {
+        shard_count.min(thread_budget.max(1))
+    }
+}
+
 fn send_vcf_shard_message(
-    tx: &Sender<Result<VcfShardMessage, ConversionError>>,
+    tx: &Sender<VcfShardMessage>,
     cancel: &AtomicBool,
-    mut msg: Result<VcfShardMessage, ConversionError>,
+    mut msg: VcfShardMessage,
 ) -> bool {
     loop {
         match tx.try_send(msg) {
@@ -148,14 +157,72 @@ fn send_vcf_shard_message(
     }
 }
 
+enum VcfShardReceiveError {
+    Fatal(ConversionError),
+    Disconnected(String),
+}
+
+fn recv_vcf_shard_message(
+    rx: &Receiver<VcfShardMessage>,
+    fatal_rx: &Receiver<ConversionError>,
+) -> Result<VcfShardMessage, VcfShardReceiveError> {
+    select! {
+        recv(fatal_rx) -> msg => match msg {
+            Ok(err) => Err(VcfShardReceiveError::Fatal(err)),
+            Err(err) => Err(VcfShardReceiveError::Disconnected(format!(
+                "VCF shard fatal-error channel disconnected: {err}"
+            ))),
+        },
+        recv(rx) -> msg => msg.map_err(|err| VcfShardReceiveError::Disconnected(err.to_string())),
+    }
+}
+
+fn send_dense_chunk(
+    tx: &Sender<crate::types::DenseChunk>,
+    chunk: crate::types::DenseChunk,
+    context: &str,
+) -> Result<(), ConversionError> {
+    tx.send(chunk).map_err(|_| ConversionError::Io {
+        context: context.to_string(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "dense chunk consumer disconnected",
+        ),
+    })
+}
+
+fn join_vcf_shard_workers(
+    handles: Vec<(String, thread::JoinHandle<()>)>,
+    result: Result<u64, ConversionError>,
+    channel_disconnected: bool,
+) -> Result<u64, ConversionError> {
+    let mut first_panic = None;
+    for (thread_name, handle) in handles {
+        if handle.join().is_err() && first_panic.is_none() {
+            first_panic = Some(thread_name);
+        }
+    }
+    if let Some(thread) = first_panic
+        && (channel_disconnected || result.is_ok())
+    {
+        return Err(ConversionError::WorkerPanicked { thread });
+    }
+    result
+}
+
 fn with_vcf_shard_context(
     err: ConversionError,
     chrom: &str,
     shard: crate::vcf_reader::VcfShard,
 ) -> ConversionError {
     let label = format!(
-        "VCF shard {chrom} ordinal {} ownership [{}, {}) fetch [{}, {})",
-        shard.ordinal, shard.own_start, shard.own_end, shard.fetch_start, shard.fetch_end
+        "VCF shard {chrom} ordinal {} records {} ownership [{}, {}) fetch [{}, {})",
+        shard.ordinal,
+        shard.record_count,
+        shard.own_start,
+        shard.own_end,
+        shard.fetch_start,
+        shard.fetch_end
     );
     match err {
         ConversionError::Input(msg) => ConversionError::Input(format!("{label} failed: {msg}")),
@@ -187,10 +254,11 @@ fn with_vcf_shard_context(
 fn read_vcf_shards_to_dense(
     vcf_path: &str,
     chrom: &str,
-    samples: &[&str],
+    sample_names: Arc<Vec<String>>,
     ploidy: usize,
-    fields: &[crate::field::FieldSpec],
+    fields: Arc<Vec<crate::field::FieldSpec>>,
     shards: Vec<crate::vcf_reader::VcfShard>,
+    thread_budget: usize,
     chunk_size: usize,
     fasta_path: Option<&str>,
     skip_out_of_scope: bool,
@@ -205,82 +273,97 @@ fn read_vcf_shards_to_dense(
         None => (Arc::new(Vec::new()), false),
     };
     let cancel = Arc::new(AtomicBool::new(false));
-    let sample_names: Vec<String> = samples.iter().map(|&s| s.to_string()).collect();
-    let fields_owned = fields.to_vec();
 
+    let worker_count = vcf_shard_worker_count(shards.len(), thread_budget);
+    type VcfShardJob = (crate::vcf_reader::VcfShard, Sender<VcfShardMessage>);
+    let (job_tx, job_rx) = bounded::<VcfShardJob>(shards.len().max(1));
+    let (fatal_tx, fatal_rx) = bounded::<ConversionError>(1);
     let mut receivers = Vec::with_capacity(shards.len());
-    let mut handles = Vec::with_capacity(shards.len());
     for shard in shards {
-        let (tx, rx) = bounded::<Result<VcfShardMessage, ConversionError>>(2);
+        let (tx, rx) = bounded::<VcfShardMessage>(1);
         receivers.push(rx);
+        job_tx
+            .send((shard, tx))
+            .expect("VCF shard job queue must remain connected while seeding");
+    }
+    drop(job_tx);
 
+    let mut handles = Vec::with_capacity(worker_count);
+    for worker_index in 0..worker_count {
         let vcf_path = vcf_path.to_string();
         let chrom = chrom.to_string();
-        let sample_names = sample_names.clone();
-        let fields = fields_owned.clone();
+        let sample_names = Arc::clone(&sample_names);
+        let fields = Arc::clone(&fields);
         let ref_seq = Arc::clone(&ref_seq);
         let cancel = Arc::clone(&cancel);
-        let thread_name = format!("vshard-{}-{}", chrom, shard.ordinal);
+        let job_rx = job_rx.clone();
+        let fatal_tx = fatal_tx.clone();
+        let thread_name = format!("vshard-{}-worker-{}", chrom, worker_index);
 
         let handle = thread::Builder::new()
             .name(thread_name.clone())
             .spawn(move || {
-                let run = || -> Result<(u64, u64), ConversionError> {
-                    let s_refs: Vec<&str> = sample_names.iter().map(|s| s.as_str()).collect();
-                    let source = crate::vcf_reader::VcfRecordSource::new(
-                        &vcf_path,
-                        &chrom,
-                        &s_refs,
-                        1,
-                        ploidy,
-                        &fields,
-                        vec![(shard.fetch_start, shard.fetch_end)],
-                    )?;
-                    let mut reader = crate::chunk_assembler::ChunkAssembler::with_reference(
-                        Box::new(source),
-                        s_refs.len(),
-                        ploidy,
-                        ref_seq,
-                        has_reference,
-                        skip_out_of_scope,
-                        check_ref,
-                        &fields,
-                        Some((shard.own_start, shard.own_end)),
-                    );
-                    let mut local_chunk_id = 0;
-                    while !cancel.load(Ordering::Relaxed) {
-                        match reader.read_next_chunk(chunk_size, local_chunk_id, None)? {
-                            Some(chunk) => {
-                                if !send_vcf_shard_message(
-                                    &tx,
-                                    &cancel,
-                                    Ok(VcfShardMessage::Chunk(chunk)),
-                                ) {
-                                    break;
-                                }
-                                local_chunk_id += 1;
-                            }
-                            None => break,
-                        }
-                    }
-                    Ok((reader.dropped_out_of_scope(), reader.ref_excluded()))
-                };
-
-                match run() {
-                    Ok((dropped_out_of_scope, ref_excluded)) => {
-                        let _ = send_vcf_shard_message(
-                            &tx,
-                            &cancel,
-                            Ok(VcfShardMessage::Done {
-                                dropped_out_of_scope,
-                                ref_excluded,
-                            }),
+                while !cancel.load(Ordering::Relaxed) {
+                    let Ok((shard, tx)) = job_rx.recv() else {
+                        break;
+                    };
+                    let run = || -> Result<(u64, u64), ConversionError> {
+                        let s_refs: Vec<&str> = sample_names.iter().map(|s| s.as_str()).collect();
+                        let source = crate::vcf_reader::VcfRecordSource::new(
+                            &vcf_path,
+                            &chrom,
+                            &s_refs,
+                            0,
+                            ploidy,
+                            fields.as_slice(),
+                            vec![(shard.fetch_start, shard.fetch_end)],
+                        )?;
+                        let mut reader = crate::chunk_assembler::ChunkAssembler::with_reference(
+                            Box::new(source),
+                            s_refs.len(),
+                            ploidy,
+                            Arc::clone(&ref_seq),
+                            has_reference,
+                            skip_out_of_scope,
+                            check_ref,
+                            fields.as_slice(),
+                            Some((shard.own_start, shard.own_end)),
                         );
-                    }
-                    Err(e) => {
-                        let e = with_vcf_shard_context(e, &chrom, shard);
-                        let _ = send_vcf_shard_message(&tx, &cancel, Err(e));
-                        cancel.store(true, Ordering::Relaxed);
+                        let mut local_chunk_id = 0;
+                        while !cancel.load(Ordering::Relaxed) {
+                            match reader.read_next_chunk(chunk_size, local_chunk_id, None)? {
+                                Some(chunk) => {
+                                    if !send_vcf_shard_message(
+                                        &tx,
+                                        &cancel,
+                                        VcfShardMessage::Chunk(chunk),
+                                    ) {
+                                        break;
+                                    }
+                                    local_chunk_id += 1;
+                                }
+                                None => break,
+                            }
+                        }
+                        Ok((reader.dropped_out_of_scope(), reader.ref_excluded()))
+                    };
+
+                    match run() {
+                        Ok((dropped_out_of_scope, ref_excluded)) => {
+                            let _ = send_vcf_shard_message(
+                                &tx,
+                                &cancel,
+                                VcfShardMessage::Done {
+                                    dropped_out_of_scope,
+                                    ref_excluded,
+                                },
+                            );
+                        }
+                        Err(e) => {
+                            let e = with_vcf_shard_context(e, &chrom, shard);
+                            let _ = fatal_tx.try_send(e);
+                            cancel.store(true, Ordering::Relaxed);
+                        }
                     }
                 }
             })
@@ -290,31 +373,38 @@ fn read_vcf_shards_to_dense(
 
     let mut result: Result<u64, ConversionError> = Ok(0);
     let mut ref_excluded_total = 0u64;
+    let mut channel_disconnected = false;
     let mut next_chunk_id = 0usize;
+    let dense_send_context = format!("send parallel VCF dense chunk for {chrom}");
     for rx in &receivers {
         loop {
-            match rx.recv() {
-                Ok(Ok(VcfShardMessage::Chunk(mut chunk))) => {
+            match recv_vcf_shard_message(rx, &fatal_rx) {
+                Ok(VcfShardMessage::Chunk(mut chunk)) => {
                     chunk.chunk_id = next_chunk_id;
-                    tx_dense.send(chunk).unwrap();
+                    if let Err(err) = send_dense_chunk(tx_dense, chunk, &dense_send_context) {
+                        result = Err(err);
+                        cancel.store(true, Ordering::Relaxed);
+                        break;
+                    }
                     next_chunk_id += 1;
                 }
-                Ok(Ok(VcfShardMessage::Done {
+                Ok(VcfShardMessage::Done {
                     dropped_out_of_scope,
                     ref_excluded,
-                })) => {
+                }) => {
                     if let Ok(total) = &mut result {
                         *total += dropped_out_of_scope;
                     }
                     ref_excluded_total += ref_excluded;
                     break;
                 }
-                Ok(Err(e)) => {
+                Err(VcfShardReceiveError::Fatal(e)) => {
                     result = Err(e);
                     cancel.store(true, Ordering::Relaxed);
                     break;
                 }
-                Err(e) => {
+                Err(VcfShardReceiveError::Disconnected(e)) => {
+                    channel_disconnected = true;
                     result = Err(ConversionError::Input(format!(
                         "VCF shard worker channel disconnected on {chrom}: {e}"
                     )));
@@ -327,18 +417,18 @@ fn read_vcf_shards_to_dense(
             break;
         }
     }
+    if result.is_ok()
+        && let Ok(err) = fatal_rx.try_recv()
+    {
+        result = Err(err);
+    }
     if result.is_err() {
         cancel.store(true, Ordering::Relaxed);
     }
     drop(receivers);
+    drop(fatal_tx);
 
-    for (thread_name, handle) in handles {
-        if handle.join().is_err() && result.is_ok() {
-            result = Err(ConversionError::WorkerPanicked {
-                thread: thread_name,
-            });
-        }
-    }
+    let result = join_vcf_shard_workers(handles, result, channel_disconnected);
     if result.is_ok() && ref_excluded_total > 0 {
         println!(
             "[{chrom}] check_ref=x: excluded {ref_excluded_total} record(s) whose REF \
@@ -434,8 +524,13 @@ pub fn process_chromosome(
             let fasta = fasta_path.map(|s| s.to_string());
             let chr = chrom.to_string();
             // Convert references into owned Strings that can safely live forever in the thread
-            let s_owned: Vec<String> = samples.iter().map(|&s| s.to_string()).collect();
-            let fields_owned: Vec<crate::field::FieldSpec> = fields.to_vec();
+            let s_owned = Arc::new(
+                samples
+                    .iter()
+                    .map(|&sample| sample.to_string())
+                    .collect::<Vec<_>>(),
+            );
+            let fields_owned = Arc::new(fields.to_vec());
 
             move || -> Result<u64, ConversionError> {
                 // passing the thread budget down to HTSLib
@@ -448,22 +543,45 @@ pub fn process_chromosome(
                     SourceSpec::Vcf {
                         vcf_path,
                         htslib_threads,
+                        shard_workers,
                         regions,
                     } => {
-                        let shards = crate::vcf_reader::plan_vcf_shards(
-                            &regions,
-                            &chr,
-                            processing_threads,
-                            chunk_size as u32,
-                        )?;
-                        if shards.len() > 1 {
+                        let shard_plan = if shard_workers > 1 {
+                            let positions = crate::vcf_reader::scan_vcf_region_positions(
+                                &vcf_path,
+                                &chr,
+                                htslib_threads,
+                                regions.clone(),
+                            )?;
+                            Some(crate::vcf_reader::plan_vcf_shards_by_variant_count(
+                                &positions,
+                                shard_workers,
+                                chunk_size,
+                            )?)
+                        } else {
+                            None
+                        };
+                        if let Some(plan) = shard_plan
+                            && plan.shards.len() > 1
+                        {
+                            let worker_count =
+                                vcf_shard_worker_count(plan.shards.len(), shard_workers);
+                            println!(
+                                "[{chr}] VCF variant plan: {} records -> {} shard jobs \
+                                 (target {} records) across {} reader workers.",
+                                plan.total_records,
+                                plan.shards.len(),
+                                plan.target_records,
+                                worker_count,
+                            );
                             return read_vcf_shards_to_dense(
                                 &vcf_path,
                                 &chr,
-                                &s_refs,
+                                Arc::clone(&s_owned),
                                 ploidy,
-                                &fields_owned,
-                                shards,
+                                Arc::clone(&fields_owned),
+                                plan.shards,
+                                shard_workers,
                                 chunk_size,
                                 fasta.as_deref(),
                                 skip_out_of_scope,
@@ -477,7 +595,7 @@ pub fn process_chromosome(
                             &s_refs,
                             htslib_threads,
                             ploidy,
-                            &fields_owned,
+                            fields_owned.as_slice(),
                             regions,
                         )?)
                     }
@@ -512,7 +630,7 @@ pub fn process_chromosome(
                             htslib_threads,
                             skip_out_of_scope,
                             check_ref,
-                            &fields_owned,
+                            fields_owned.as_slice(),
                         )?;
                         Box::new(VcfListDroppedProxy {
                             inner: vcf_list,
@@ -566,13 +684,14 @@ pub fn process_chromosome(
                     &chr,
                     skip_out_of_scope,
                     check_ref,
-                    &fields_owned,
+                    fields_owned.as_slice(),
                 )?;
                 let mut chunk_id = 0;
+                let dense_send_context = format!("send serial VCF dense chunk for {chr}");
                 while let Some(dense_chunk) =
                     reader.read_next_chunk(chunk_size, chunk_id, Some(&pool))?
                 {
-                    tx_dense.send(dense_chunk).unwrap();
+                    send_dense_chunk(&tx_dense, dense_chunk, &dense_send_context)?;
                     chunk_id += 1;
                 }
                 let ref_excluded =
@@ -938,4 +1057,50 @@ pub fn run_vcf_list(
     })?;
 
     Ok(total_dropped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vcf_shard_workers_never_exceed_thread_budget() {
+        assert_eq!(vcf_shard_worker_count(300, 126), 126);
+        assert_eq!(vcf_shard_worker_count(8, 126), 8);
+        assert_eq!(vcf_shard_worker_count(8, 0), 1);
+        assert_eq!(vcf_shard_worker_count(0, 126), 0);
+    }
+
+    #[test]
+    fn fatal_shard_error_interrupts_a_silent_earlier_shard() {
+        let (_shard_tx, shard_rx) = bounded::<VcfShardMessage>(1);
+        let (fatal_tx, fatal_rx) = bounded::<ConversionError>(1);
+        fatal_tx
+            .send(ConversionError::Input("later shard failed".to_string()))
+            .unwrap();
+
+        match recv_vcf_shard_message(&shard_rx, &fatal_rx) {
+            Err(VcfShardReceiveError::Fatal(ConversionError::Input(msg))) => {
+                assert_eq!(msg, "later shard failed");
+            }
+            _ => panic!("expected the fatal shard error"),
+        }
+    }
+
+    #[test]
+    fn worker_panic_replaces_generic_channel_disconnect() {
+        let thread_name = "vshard-test-worker".to_string();
+        let handle = thread::Builder::new()
+            .name(thread_name.clone())
+            .spawn(|| panic!("test panic"))
+            .unwrap();
+        let disconnected = Err(ConversionError::Input(
+            "VCF shard worker channel disconnected".to_string(),
+        ));
+
+        match join_vcf_shard_workers(vec![(thread_name.clone(), handle)], disconnected, true) {
+            Err(ConversionError::WorkerPanicked { thread }) => assert_eq!(thread, thread_name),
+            _ => panic!("expected WorkerPanicked"),
+        }
+    }
 }

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -391,24 +391,6 @@ pub fn process_chromosome(
         stop_sampler.clone(),
     );
 
-    // Dedicated rayon pool for reader-side CPU work: bounded per-record
-    // normalization batches plus intra-chunk presence packing. Sized to the idle
-    // cores (budget::plan_thread_budget). Built even at size 1 so the reader
-    // always has a handle; parallel work self-gates off below 2 threads.
-    // NOTE (multi-contig): process_chromosome runs once per concurrent contig, and
-    // each builds a pool of `processing_threads` — the *global* idle-core count — so
-    // N concurrent contigs allocate N pools and can oversubscribe. This is deliberate
-    // and harmless for the single-contig target (concurrent == 1, exact fit). If
-    // multi-contig normalization starts competing for these threads, divide by
-    // concurrent_chroms here.
-    let processing_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(processing_threads.max(1))
-            .thread_name(|i| format!("pack-{}", i))
-            .build()
-            .expect("build processing pool"),
-    );
-
     // Step 1 -> The Producer
     let reader_thread = thread::Builder::new()
         .name(format!("read-{}", chrom))
@@ -417,7 +399,6 @@ pub fn process_chromosome(
             let chr = chrom.to_string();
             // Convert references into owned Strings that can safely live forever in the thread
             let s_owned: Vec<String> = samples.iter().map(|&s| s.to_string()).collect();
-            let pool = Arc::clone(&processing_pool);
             let fields_owned: Vec<crate::field::FieldSpec> = fields.to_vec();
 
             move || -> Result<u64, ConversionError> {
@@ -529,6 +510,18 @@ pub fn process_chromosome(
                         &format_src_dtypes,
                     )?),
                 };
+
+                // Dedicated rayon pool for reader-side CPU work: bounded per-record
+                // normalization batches plus intra-chunk presence packing. The
+                // sharded VCF branch above returns before this point because its
+                // independent indexed readers consume the same `processing_threads`
+                // budget directly; building both would double-reserve cores.
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(processing_threads.max(1))
+                    .thread_name(|i| format!("pack-{}", i))
+                    .build()
+                    .expect("build processing pool");
+
                 let mut reader = crate::chunk_assembler::ChunkAssembler::new(
                     src,
                     s_refs.len(),

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -1,9 +1,10 @@
 // src/orchestrator.rs
-use crossbeam_channel::bounded;
+use crossbeam_channel::{Sender, TrySendError, bounded};
 use std::fs;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
+use std::time::Duration;
 
 use crate::enum_map::EnumKey;
 use crate::error::ConversionError;
@@ -117,6 +118,198 @@ impl crate::record_source::RecordSource for VcfListDroppedProxy {
         }
         Ok(rec)
     }
+}
+
+enum VcfShardMessage {
+    Chunk(crate::types::DenseChunk),
+    Done {
+        dropped_out_of_scope: u64,
+        ref_excluded: u64,
+    },
+}
+
+fn send_vcf_shard_message(
+    tx: &Sender<Result<VcfShardMessage, ConversionError>>,
+    cancel: &AtomicBool,
+    mut msg: Result<VcfShardMessage, ConversionError>,
+) -> bool {
+    loop {
+        match tx.try_send(msg) {
+            Ok(()) => return true,
+            Err(TrySendError::Full(m)) => {
+                if cancel.load(Ordering::Relaxed) {
+                    return false;
+                }
+                msg = m;
+                thread::sleep(Duration::from_millis(2));
+            }
+            Err(TrySendError::Disconnected(_)) => return false,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn read_vcf_shards_to_dense(
+    vcf_path: &str,
+    chrom: &str,
+    samples: &[&str],
+    ploidy: usize,
+    fields: &[crate::field::FieldSpec],
+    shards: Vec<crate::vcf_reader::VcfShard>,
+    chunk_size: usize,
+    fasta_path: Option<&str>,
+    skip_out_of_scope: bool,
+    check_ref: crate::normalize::CheckRef,
+    tx_dense: &Sender<crate::types::DenseChunk>,
+) -> Result<u64, ConversionError> {
+    let (ref_seq, has_reference) = match fasta_path {
+        Some(path) => (
+            Arc::new(crate::vcf_reader::load_contig_seq(path, chrom)?),
+            true,
+        ),
+        None => (Arc::new(Vec::new()), false),
+    };
+    let cancel = Arc::new(AtomicBool::new(false));
+    let sample_names: Vec<String> = samples.iter().map(|&s| s.to_string()).collect();
+    let fields_owned = fields.to_vec();
+
+    let mut receivers = Vec::with_capacity(shards.len());
+    let mut handles = Vec::with_capacity(shards.len());
+    for shard in shards {
+        let (tx, rx) = bounded::<Result<VcfShardMessage, ConversionError>>(2);
+        receivers.push(rx);
+
+        let vcf_path = vcf_path.to_string();
+        let chrom = chrom.to_string();
+        let sample_names = sample_names.clone();
+        let fields = fields_owned.clone();
+        let ref_seq = Arc::clone(&ref_seq);
+        let cancel = Arc::clone(&cancel);
+        let thread_name = format!("vshard-{}-{}", chrom, shard.ordinal);
+
+        let handle = thread::Builder::new()
+            .name(thread_name.clone())
+            .spawn(move || {
+                let run = || -> Result<(u64, u64), ConversionError> {
+                    let s_refs: Vec<&str> = sample_names.iter().map(|s| s.as_str()).collect();
+                    let source = crate::vcf_reader::VcfRecordSource::new(
+                        &vcf_path,
+                        &chrom,
+                        &s_refs,
+                        1,
+                        ploidy,
+                        &fields,
+                        vec![(shard.fetch_start, shard.fetch_end)],
+                    )?;
+                    let mut reader = crate::chunk_assembler::ChunkAssembler::with_reference(
+                        Box::new(source),
+                        s_refs.len(),
+                        ploidy,
+                        ref_seq,
+                        has_reference,
+                        skip_out_of_scope,
+                        check_ref,
+                        &fields,
+                        Some((shard.own_start, shard.own_end)),
+                    );
+                    let mut local_chunk_id = 0;
+                    while !cancel.load(Ordering::Relaxed) {
+                        match reader.read_next_chunk(chunk_size, local_chunk_id, None)? {
+                            Some(chunk) => {
+                                if !send_vcf_shard_message(
+                                    &tx,
+                                    &cancel,
+                                    Ok(VcfShardMessage::Chunk(chunk)),
+                                ) {
+                                    break;
+                                }
+                                local_chunk_id += 1;
+                            }
+                            None => break,
+                        }
+                    }
+                    Ok((reader.dropped_out_of_scope(), reader.ref_excluded()))
+                };
+
+                match run() {
+                    Ok((dropped_out_of_scope, ref_excluded)) => {
+                        let _ = send_vcf_shard_message(
+                            &tx,
+                            &cancel,
+                            Ok(VcfShardMessage::Done {
+                                dropped_out_of_scope,
+                                ref_excluded,
+                            }),
+                        );
+                    }
+                    Err(e) => {
+                        let _ = send_vcf_shard_message(&tx, &cancel, Err(e));
+                        cancel.store(true, Ordering::Relaxed);
+                    }
+                }
+            })
+            .expect("spawn VCF shard worker");
+        handles.push((thread_name, handle));
+    }
+
+    let mut result: Result<u64, ConversionError> = Ok(0);
+    let mut ref_excluded_total = 0u64;
+    let mut next_chunk_id = 0usize;
+    for rx in &receivers {
+        loop {
+            match rx.recv() {
+                Ok(Ok(VcfShardMessage::Chunk(mut chunk))) => {
+                    chunk.chunk_id = next_chunk_id;
+                    tx_dense.send(chunk).unwrap();
+                    next_chunk_id += 1;
+                }
+                Ok(Ok(VcfShardMessage::Done {
+                    dropped_out_of_scope,
+                    ref_excluded,
+                })) => {
+                    if let Ok(total) = &mut result {
+                        *total += dropped_out_of_scope;
+                    }
+                    ref_excluded_total += ref_excluded;
+                    break;
+                }
+                Ok(Err(e)) => {
+                    result = Err(e);
+                    cancel.store(true, Ordering::Relaxed);
+                    break;
+                }
+                Err(e) => {
+                    result = Err(ConversionError::Input(format!(
+                        "VCF shard worker channel disconnected on {chrom}: {e}"
+                    )));
+                    cancel.store(true, Ordering::Relaxed);
+                    break;
+                }
+            }
+        }
+        if result.is_err() {
+            break;
+        }
+    }
+    if result.is_err() {
+        cancel.store(true, Ordering::Relaxed);
+    }
+    drop(receivers);
+
+    for (thread_name, handle) in handles {
+        if handle.join().is_err() && result.is_ok() {
+            result = Err(ConversionError::WorkerPanicked {
+                thread: thread_name,
+            });
+        }
+    }
+    if result.is_ok() && ref_excluded_total > 0 {
+        println!(
+            "[{chrom}] check_ref=x: excluded {ref_excluded_total} record(s) whose REF \
+             disagreed with the reference FASTA."
+        );
+    }
+    result
 }
 
 //The rust pipeline (Per chromosome conversion from Dense to Sparse)
@@ -239,15 +432,38 @@ pub fn process_chromosome(
                         vcf_path,
                         htslib_threads,
                         regions,
-                    } => Box::new(crate::vcf_reader::VcfRecordSource::new(
-                        &vcf_path,
-                        &chr,
-                        &s_refs,
-                        htslib_threads,
-                        ploidy,
-                        &fields_owned,
-                        regions,
-                    )?),
+                    } => {
+                        let shards = crate::vcf_reader::plan_vcf_shards(
+                            &regions,
+                            &chr,
+                            processing_threads,
+                            chunk_size as u32,
+                        )?;
+                        if shards.len() > 1 {
+                            return read_vcf_shards_to_dense(
+                                &vcf_path,
+                                &chr,
+                                &s_refs,
+                                ploidy,
+                                &fields_owned,
+                                shards,
+                                chunk_size,
+                                fasta.as_deref(),
+                                skip_out_of_scope,
+                                check_ref,
+                                &tx_dense,
+                            );
+                        }
+                        Box::new(crate::vcf_reader::VcfRecordSource::new(
+                            &vcf_path,
+                            &chr,
+                            &s_refs,
+                            htslib_threads,
+                            ploidy,
+                            &fields_owned,
+                            regions,
+                        )?)
+                    }
                     SourceSpec::Pgen {
                         pgen_path: _,
                         pvar_path,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -198,15 +198,16 @@ pub fn process_chromosome(
         stop_sampler.clone(),
     );
 
-    // Dedicated rayon pool for the reader's intra-chunk presence packing. Sized to
-    // the idle cores (budget::plan_thread_budget). Built even at size 1 so the
-    // reader always has a handle; parallel packing self-gates off below 2 threads.
+    // Dedicated rayon pool for reader-side CPU work: bounded per-record
+    // normalization batches plus intra-chunk presence packing. Sized to the idle
+    // cores (budget::plan_thread_budget). Built even at size 1 so the reader
+    // always has a handle; parallel work self-gates off below 2 threads.
     // NOTE (multi-contig): process_chromosome runs once per concurrent contig, and
     // each builds a pool of `processing_threads` — the *global* idle-core count — so
     // N concurrent contigs allocate N pools and can oversubscribe. This is deliberate
-    // and harmless: the target is the single-contig case (concurrent == 1, exact fit),
-    // and profiling (roadmap M14) shows packing is <0.05% of reader time, so the extra
-    // threads sit idle. Divide by concurrent_chroms here if packing ever grows costly.
+    // and harmless for the single-contig target (concurrent == 1, exact fit). If
+    // multi-contig normalization starts competing for these threads, divide by
+    // concurrent_chroms here.
     let processing_pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(processing_threads.max(1))

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -45,6 +45,7 @@ pub enum SourceSpec {
     Vcf {
         vcf_path: String,
         htslib_threads: usize,
+        regions: Vec<(u32, u32)>,
     },
     Pgen {
         pgen_path: String,
@@ -236,6 +237,7 @@ pub fn process_chromosome(
                     SourceSpec::Vcf {
                         vcf_path,
                         htslib_threads,
+                        regions,
                     } => Box::new(crate::vcf_reader::VcfRecordSource::new(
                         &vcf_path,
                         &chr,
@@ -243,6 +245,7 @@ pub fn process_chromosome(
                         htslib_threads,
                         ploidy,
                         &fields_owned,
+                        regions,
                     )?),
                     SourceSpec::Pgen {
                         pgen_path: _,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -148,6 +148,41 @@ fn send_vcf_shard_message(
     }
 }
 
+fn with_vcf_shard_context(
+    err: ConversionError,
+    chrom: &str,
+    shard: crate::vcf_reader::VcfShard,
+) -> ConversionError {
+    let label = format!(
+        "VCF shard {chrom} ordinal {} ownership [{}, {}) fetch [{}, {})",
+        shard.ordinal, shard.own_start, shard.own_end, shard.fetch_start, shard.fetch_end
+    );
+    match err {
+        ConversionError::Input(msg) => ConversionError::Input(format!("{label} failed: {msg}")),
+        ConversionError::ContigNotInHeader { chrom: missing } => ConversionError::Input(format!(
+            "{label} failed: Chromosome '{missing}' not found in VCF header"
+        )),
+        ConversionError::Io { context, source } => ConversionError::Io {
+            context: format!("{label} failed while {context}"),
+            source,
+        },
+        ConversionError::MissingFile { path } => ConversionError::MissingFile {
+            path: format!("{path} ({label})"),
+        },
+        ConversionError::WorkerPanicked { thread } => ConversionError::WorkerPanicked {
+            thread: format!("{thread} ({label})"),
+        },
+        ConversionError::Npy { path, source } => ConversionError::Npy {
+            path: format!("{path} ({label})"),
+            source,
+        },
+        ConversionError::ReadNpy { path, source } => ConversionError::ReadNpy {
+            path: format!("{path} ({label})"),
+            source,
+        },
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn read_vcf_shards_to_dense(
     vcf_path: &str,
@@ -243,6 +278,7 @@ fn read_vcf_shards_to_dense(
                         );
                     }
                     Err(e) => {
+                        let e = with_vcf_shard_context(e, &chrom, shard);
                         let _ = send_vcf_shard_message(&tx, &cancel, Err(e));
                         cancel.store(true, Ordering::Relaxed);
                     }

--- a/src/vcf_list_reader.rs
+++ b/src/vcf_list_reader.rs
@@ -290,8 +290,15 @@ impl VcfListRecordSource {
         let mut cursors = Vec::with_capacity(vcf_paths.len());
         for (col, (path, &sample)) in vcf_paths.iter().zip(samples.iter()).enumerate() {
             let single_sample = [sample];
-            match VcfRecordSource::new(path, chrom, &single_sample, htslib_threads, ploidy, fields)
-            {
+            match VcfRecordSource::new(
+                path,
+                chrom,
+                &single_sample,
+                htslib_threads,
+                ploidy,
+                fields,
+                Vec::new(),
+            ) {
                 Ok(vcf) => cursors.push(FileCursor {
                     vcf: Some(vcf),
                     buf: VecDeque::new(),

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -174,6 +174,21 @@ pub(crate) struct VcfShard {
     pub own_start: u32,
     pub own_end: u32,
     pub ordinal: usize,
+    pub record_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VcfRegionPositions {
+    pub start: u32,
+    pub end: u32,
+    pub positions: Vec<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VcfShardPlan {
+    pub shards: Vec<VcfShard>,
+    pub total_records: usize,
+    pub target_records: usize,
 }
 
 pub(crate) fn coalesce_fetch_regions(
@@ -203,44 +218,95 @@ pub(crate) fn coalesce_fetch_regions(
     Ok(merged)
 }
 
-pub(crate) fn plan_vcf_shards(
-    regions: &[(u32, u32)],
-    chrom: &str,
-    max_shards: usize,
-    target_bp: u32,
-) -> Result<Vec<VcfShard>, ConversionError> {
-    let regions = coalesce_fetch_regions(regions.to_vec(), chrom)?;
-    if regions.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let max_shards = max_shards.max(1);
-    let target_bp = target_bp.max(1);
-    let total_span: u64 = regions
-        .iter()
-        .map(|&(start, end)| u64::from(end - start))
-        .sum();
-    let target_span = total_span
-        .div_ceil(max_shards as u64)
-        .max(u64::from(target_bp))
-        .min(u64::from(u32::MAX)) as u32;
-
-    let mut out = Vec::new();
-    for (region_start, region_end) in regions {
-        let mut own_start = region_start;
-        while own_start < region_end {
-            let own_end = own_start.saturating_add(target_span).min(region_end);
-            out.push(VcfShard {
-                fetch_start: own_start.saturating_sub(crate::normalize::L_MAX),
-                fetch_end: own_end.saturating_add(crate::normalize::L_MAX),
-                own_start,
-                own_end,
-                ordinal: out.len(),
-            });
-            own_start = own_end;
+pub(crate) fn plan_vcf_shards_by_variant_count(
+    regions: &[VcfRegionPositions],
+    worker_budget: usize,
+    max_records_per_shard: usize,
+) -> Result<VcfShardPlan, ConversionError> {
+    for region in regions {
+        if region.end <= region.start {
+            return Err(ConversionError::Input(format!(
+                "Invalid VCF planning interval: start {} must be less than end {}",
+                region.start, region.end
+            )));
+        }
+        if region.positions.windows(2).any(|pair| pair[0] > pair[1]) {
+            return Err(ConversionError::Input(format!(
+                "VCF positions are not sorted inside [{}, {})",
+                region.start, region.end
+            )));
+        }
+        if let Some(&pos) = region
+            .positions
+            .iter()
+            .find(|&&pos| pos < region.start || pos >= region.end)
+        {
+            return Err(ConversionError::Input(format!(
+                "VCF position {pos} falls outside planning interval [{}, {})",
+                region.start, region.end
+            )));
         }
     }
-    Ok(out)
+
+    let total_records: usize = regions.iter().map(|region| region.positions.len()).sum();
+    let target_records = if total_records == 0 {
+        1
+    } else {
+        total_records
+            .div_ceil(worker_budget.max(1))
+            .min(max_records_per_shard.max(1))
+            .max(1)
+    };
+
+    let mut shards = Vec::new();
+    for region in regions {
+        let mut record_start = 0usize;
+        let mut own_start = region.start;
+        while record_start < region.positions.len() {
+            let mut record_end = (record_start + target_records).min(region.positions.len());
+            while record_end < region.positions.len()
+                && region.positions[record_end] == region.positions[record_end - 1]
+            {
+                record_end += 1;
+            }
+
+            let own_end = if record_end == region.positions.len() {
+                region.end
+            } else {
+                region.positions[record_end]
+            };
+            let fetch_start = if own_start == region.start {
+                region.start
+            } else {
+                own_start
+                    .saturating_sub(crate::normalize::L_MAX)
+                    .max(region.start)
+            };
+            let fetch_end = if own_end == region.end {
+                region.end
+            } else {
+                own_end
+                    .saturating_add(crate::normalize::L_MAX)
+                    .min(region.end)
+            };
+            shards.push(VcfShard {
+                fetch_start,
+                fetch_end,
+                own_start,
+                own_end,
+                ordinal: shards.len(),
+                record_count: record_end - record_start,
+            });
+            own_start = own_end;
+            record_start = record_end;
+        }
+    }
+
+    Ok(VcfShardPlan {
+        shards,
+        total_records,
+        target_records,
+    })
 }
 
 fn fetch_region(
@@ -263,6 +329,92 @@ fn fetch_region(
             context: format!("fetching region for {label}"),
             source: std::io::Error::other(e.to_string()),
         })
+}
+
+fn configure_htslib_threads(
+    reader: &mut IndexedReader,
+    thread_count: usize,
+) -> Result<(), ConversionError> {
+    if thread_count == 0 {
+        return Ok(());
+    }
+    reader
+        .set_threads(thread_count)
+        .map_err(|e| ConversionError::Io {
+            context: format!("allocating {thread_count} HTSlib background threads"),
+            source: std::io::Error::other(e.to_string()),
+        })
+}
+
+pub(crate) fn scan_vcf_region_positions(
+    vcf_path: &str,
+    chrom: &str,
+    htslib_threads: usize,
+    regions: Vec<(u32, u32)>,
+) -> Result<Vec<VcfRegionPositions>, ConversionError> {
+    if !std::path::Path::new(vcf_path).exists() {
+        return Err(ConversionError::MissingFile {
+            path: vcf_path.to_string(),
+        });
+    }
+
+    let mut reader = IndexedReader::from_path(vcf_path).map_err(|e| {
+        ConversionError::Input(format!(
+            "Failed to open VCF/BCF index for '{vcf_path}' while planning variant-count shards: {e}"
+        ))
+    })?;
+    configure_htslib_threads(&mut reader, htslib_threads)?;
+    let rid = reader.header().name2rid(chrom.as_bytes()).map_err(|_| {
+        ConversionError::ContigNotInHeader {
+            chrom: chrom.to_string(),
+        }
+    })?;
+
+    let requested = coalesce_fetch_regions(regions, chrom)?;
+    let scan_regions = if requested.is_empty() {
+        vec![(0, u32::MAX)]
+    } else {
+        requested
+    };
+    let whole_contig = scan_regions.len() == 1 && scan_regions[0] == (0, u32::MAX);
+    let mut planned = Vec::with_capacity(scan_regions.len());
+    for (start, end) in scan_regions {
+        fetch_region(
+            &mut reader,
+            rid,
+            chrom,
+            if whole_contig {
+                None
+            } else {
+                Some((start, end))
+            },
+        )?;
+        let mut record = reader.empty_record();
+        let mut positions = Vec::new();
+        loop {
+            match reader.read(&mut record) {
+                None => break,
+                Some(Err(e)) => {
+                    return Err(ConversionError::Io {
+                        context: format!("scanning VCF positions for {chrom}:[{start}, {end})"),
+                        source: std::io::Error::other(e.to_string()),
+                    });
+                }
+                Some(Ok(())) => {
+                    let pos = record.pos() as u32;
+                    if pos >= start && pos < end {
+                        positions.push(pos);
+                    }
+                }
+            }
+        }
+        planned.push(VcfRegionPositions {
+            start,
+            end,
+            positions,
+        });
+    }
+    Ok(planned)
 }
 
 impl VcfRecordSource {
@@ -291,12 +443,7 @@ impl VcfRecordSource {
             ))
         })?;
 
-        reader
-            .set_threads(htslib_threads)
-            .map_err(|e| ConversionError::Io {
-                context: format!("allocating {htslib_threads} HTSlib background threads"),
-                source: std::io::Error::other(e.to_string()),
-            })?;
+        configure_htslib_threads(&mut reader, htslib_threads)?;
 
         let header = reader.header().clone();
 
@@ -477,39 +624,70 @@ mod tests {
     use super::*;
 
     #[test]
-    fn shard_planner_covers_owned_ranges_with_padded_fetches() {
-        let shards = plan_vcf_shards(&[(0, 12)], "chr1", 3, 3).unwrap();
+    fn variant_count_shards_balance_dense_and_sparse_coordinates() {
+        let regions = vec![
+            VcfRegionPositions {
+                start: 0,
+                end: 100,
+                positions: vec![1, 2, 3, 4],
+            },
+            VcfRegionPositions {
+                start: 1_000_000,
+                end: 2_000_000,
+                positions: vec![1_100_000, 1_300_000, 1_600_000, 1_900_000],
+            },
+        ];
+
+        let plan = plan_vcf_shards_by_variant_count(&regions, 4, 25_000).unwrap();
+        assert_eq!(plan.total_records, 8);
+        assert_eq!(plan.target_records, 2);
         assert_eq!(
-            shards
+            plan.shards
                 .iter()
-                .map(|s| (s.own_start, s.own_end, s.ordinal))
+                .map(|shard| shard.record_count)
                 .collect::<Vec<_>>(),
-            vec![(0, 4, 0), (4, 8, 1), (8, 12, 2)]
+            vec![2, 2, 2, 2]
         );
-        assert_eq!(shards[0].fetch_start, 0);
-        assert!(shards[0].fetch_end >= shards[1].own_start);
-        assert!(shards[1].fetch_start <= shards[0].own_end);
-        assert!(shards[1].fetch_end >= shards[2].own_start);
     }
 
     #[test]
-    fn shard_planner_coalesces_overlapping_regions_before_split() {
-        let shards = plan_vcf_shards(&[(8, 12), (0, 5), (4, 9)], "chr1", 4, 20).unwrap();
-        assert_eq!(shards.len(), 1);
-        assert_eq!((shards[0].own_start, shards[0].own_end), (0, 12));
+    fn variant_count_shards_do_not_split_equal_position_records() {
+        let regions = vec![VcfRegionPositions {
+            start: 0,
+            end: 100,
+            positions: vec![10, 10, 10, 20, 30, 40],
+        }];
+
+        let plan = plan_vcf_shards_by_variant_count(&regions, 3, 2).unwrap();
+        assert_eq!(
+            plan.shards
+                .iter()
+                .map(|shard| shard.record_count)
+                .collect::<Vec<_>>(),
+            vec![3, 2, 1]
+        );
+        assert_eq!(
+            plan.shards
+                .iter()
+                .map(|shard| (shard.own_start, shard.own_end))
+                .collect::<Vec<_>>(),
+            vec![(0, 20), (20, 40), (40, 100)]
+        );
     }
 
     #[test]
-    fn shard_planner_treats_max_shards_as_an_upper_bound() {
-        let shards = plan_vcf_shards(&[(0, 100)], "chr1", 4, 1).unwrap();
-        assert_eq!(shards.len(), 4);
-        assert!(shards.len() <= 4);
-        assert_eq!(
-            shards
-                .iter()
-                .map(|s| (s.own_start, s.own_end))
-                .collect::<Vec<_>>(),
-            vec![(0, 25), (25, 50), (50, 75), (75, 100)]
-        );
+    fn variant_count_shard_padding_stays_inside_requested_region() {
+        let regions = vec![VcfRegionPositions {
+            start: 100,
+            end: 200,
+            positions: vec![110, 120, 130, 140],
+        }];
+
+        let plan = plan_vcf_shards_by_variant_count(&regions, 2, 2).unwrap();
+        assert_eq!(plan.shards.len(), 2);
+        assert_eq!(plan.shards[0].fetch_start, 100);
+        assert_eq!(plan.shards[1].fetch_end, 200);
+        assert!(plan.shards[0].fetch_end >= plan.shards[1].own_start);
+        assert!(plan.shards[1].fetch_start <= plan.shards[0].own_end);
     }
 }

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -498,4 +498,18 @@ mod tests {
         assert_eq!(shards.len(), 1);
         assert_eq!((shards[0].own_start, shards[0].own_end), (0, 12));
     }
+
+    #[test]
+    fn shard_planner_treats_max_shards_as_an_upper_bound() {
+        let shards = plan_vcf_shards(&[(0, 100)], "chr1", 4, 1).unwrap();
+        assert_eq!(shards.len(), 4);
+        assert!(shards.len() <= 4);
+        assert_eq!(
+            shards
+                .iter()
+                .map(|s| (s.own_start, s.own_end))
+                .collect::<Vec<_>>(),
+            vec![(0, 25), (25, 50), (50, 75), (75, 100)]
+        );
+    }
 }

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -167,7 +167,16 @@ pub struct VcfRecordSource {
     eof: bool,
 }
 
-fn coalesce_fetch_regions(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VcfShard {
+    pub fetch_start: u32,
+    pub fetch_end: u32,
+    pub own_start: u32,
+    pub own_end: u32,
+    pub ordinal: usize,
+}
+
+pub(crate) fn coalesce_fetch_regions(
     mut regions: Vec<(u32, u32)>,
     chrom: &str,
 ) -> Result<Vec<(u32, u32)>, ConversionError> {
@@ -192,6 +201,46 @@ fn coalesce_fetch_regions(
         merged.push((start, end));
     }
     Ok(merged)
+}
+
+pub(crate) fn plan_vcf_shards(
+    regions: &[(u32, u32)],
+    chrom: &str,
+    max_shards: usize,
+    target_bp: u32,
+) -> Result<Vec<VcfShard>, ConversionError> {
+    let regions = coalesce_fetch_regions(regions.to_vec(), chrom)?;
+    if regions.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let max_shards = max_shards.max(1);
+    let target_bp = target_bp.max(1);
+    let total_span: u64 = regions
+        .iter()
+        .map(|&(start, end)| u64::from(end - start))
+        .sum();
+    let target_span = total_span
+        .div_ceil(max_shards as u64)
+        .max(u64::from(target_bp))
+        .min(u64::from(u32::MAX)) as u32;
+
+    let mut out = Vec::new();
+    for (region_start, region_end) in regions {
+        let mut own_start = region_start;
+        while own_start < region_end {
+            let own_end = own_start.saturating_add(target_span).min(region_end);
+            out.push(VcfShard {
+                fetch_start: own_start.saturating_sub(crate::normalize::L_MAX),
+                fetch_end: own_end.saturating_add(crate::normalize::L_MAX),
+                own_start,
+                own_end,
+                ordinal: out.len(),
+            });
+            own_start = own_end;
+        }
+    }
+    Ok(out)
 }
 
 fn fetch_region(
@@ -420,5 +469,33 @@ impl VcfRecordSource {
             info_raw,
             format_raw,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shard_planner_covers_owned_ranges_with_padded_fetches() {
+        let shards = plan_vcf_shards(&[(0, 12)], "chr1", 3, 3).unwrap();
+        assert_eq!(
+            shards
+                .iter()
+                .map(|s| (s.own_start, s.own_end, s.ordinal))
+                .collect::<Vec<_>>(),
+            vec![(0, 4, 0), (4, 8, 1), (8, 12, 2)]
+        );
+        assert_eq!(shards[0].fetch_start, 0);
+        assert!(shards[0].fetch_end >= shards[1].own_start);
+        assert!(shards[1].fetch_start <= shards[0].own_end);
+        assert!(shards[1].fetch_end >= shards[2].own_start);
+    }
+
+    #[test]
+    fn shard_planner_coalesces_overlapping_regions_before_split() {
+        let shards = plan_vcf_shards(&[(8, 12), (0, 5), (4, 9)], "chr1", 4, 20).unwrap();
+        assert_eq!(shards.len(), 1);
+        assert_eq!((shards[0].own_start, shards[0].own_end), (0, 12));
     }
 }

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -154,6 +154,10 @@ pub(crate) fn validate_contigs_in_fasta(
 
 pub struct VcfRecordSource {
     inner_reader: IndexedReader,
+    chrom: String,
+    rid: u32,
+    regions: Vec<(u32, u32)>,
+    current_region: usize,
     num_samples: usize,
     ploidy: usize,
     sample_indices: Vec<usize>,
@@ -161,6 +165,55 @@ pub struct VcfRecordSource {
     format_fields: Vec<FieldSpec>,
     record: Record,
     eof: bool,
+}
+
+fn coalesce_fetch_regions(
+    mut regions: Vec<(u32, u32)>,
+    chrom: &str,
+) -> Result<Vec<(u32, u32)>, ConversionError> {
+    if regions.is_empty() {
+        return Ok(regions);
+    }
+    regions.sort_unstable_by_key(|&(start, end)| (start, end));
+
+    let mut merged: Vec<(u32, u32)> = Vec::with_capacity(regions.len());
+    for (start, end) in regions {
+        if end <= start {
+            return Err(ConversionError::Input(format!(
+                "Invalid fetch interval for {chrom}: start {start} must be less than end {end}"
+            )));
+        }
+        if let Some(last) = merged.last_mut()
+            && start <= last.1
+        {
+            last.1 = last.1.max(end);
+            continue;
+        }
+        merged.push((start, end));
+    }
+    Ok(merged)
+}
+
+fn fetch_region(
+    reader: &mut IndexedReader,
+    rid: u32,
+    chrom: &str,
+    region: Option<(u32, u32)>,
+) -> Result<(), ConversionError> {
+    let (start, end, label) = match region {
+        Some((start, end)) => (
+            start as u64,
+            Some(end as u64),
+            format!("{chrom}:{start}-{end}"),
+        ),
+        None => (0, None, format!("chromosome '{chrom}'")),
+    };
+    reader
+        .fetch(rid, start, end)
+        .map_err(|e| ConversionError::Io {
+            context: format!("fetching region for {label}"),
+            source: std::io::Error::other(e.to_string()),
+        })
 }
 
 impl VcfRecordSource {
@@ -172,6 +225,7 @@ impl VcfRecordSource {
         htslib_threads: usize,
         ploidy: usize,
         fields: &[FieldSpec],
+        regions: Vec<(u32, u32)>,
     ) -> Result<Self, ConversionError> {
         // A wrong VCF path reaches Rust when the file was removed after Python's
         // upstream indexing/open; surface it as FileNotFoundError, not a ".tbi?" Input.
@@ -204,12 +258,8 @@ impl VcfRecordSource {
                     chrom: chrom.to_string(),
                 })?;
 
-        reader
-            .fetch(rid, 0, None)
-            .map_err(|e| ConversionError::Io {
-                context: format!("fetching region for chromosome '{chrom}'"),
-                source: std::io::Error::other(e.to_string()),
-            })?;
+        let regions = coalesce_fetch_regions(regions, chrom)?;
+        fetch_region(&mut reader, rid, chrom, regions.first().copied())?;
 
         let sample_indices: Vec<usize> = samples
             .iter()
@@ -235,6 +285,10 @@ impl VcfRecordSource {
 
         Ok(Self {
             inner_reader: reader,
+            chrom: chrom.to_string(),
+            rid,
+            regions,
+            current_region: 0,
             num_samples: samples.len(),
             ploidy,
             sample_indices,
@@ -244,6 +298,24 @@ impl VcfRecordSource {
             eof: false,
         })
     }
+
+    fn active_region(&self) -> Option<(u32, u32)> {
+        self.regions.get(self.current_region).copied()
+    }
+
+    fn advance_region(&mut self) -> Result<bool, ConversionError> {
+        if self.regions.is_empty() || self.current_region + 1 >= self.regions.len() {
+            return Ok(false);
+        }
+        self.current_region += 1;
+        fetch_region(
+            &mut self.inner_reader,
+            self.rid,
+            &self.chrom,
+            self.regions.get(self.current_region).copied(),
+        )?;
+        Ok(true)
+    }
 }
 
 impl RecordSource for VcfRecordSource {
@@ -251,22 +323,38 @@ impl RecordSource for VcfRecordSource {
         if self.eof {
             return Ok(None);
         }
-        match self.inner_reader.read(&mut self.record) {
-            None => {
-                self.eof = true;
-                return Ok(None);
+        loop {
+            match self.inner_reader.read(&mut self.record) {
+                None => {
+                    if self.advance_region()? {
+                        continue;
+                    }
+                    self.eof = true;
+                    return Ok(None);
+                }
+                Some(Err(e)) => {
+                    return Err(ConversionError::Io {
+                        context: "reading next VCF record".to_string(),
+                        source: std::io::Error::other(e.to_string()),
+                    });
+                }
+                Some(Ok(())) => {}
             }
-            Some(Err(e)) => {
-                return Err(ConversionError::Io {
-                    context: "reading next VCF record".to_string(),
-                    source: std::io::Error::other(e.to_string()),
-                });
+
+            let pos = self.record.pos() as u32;
+            if let Some((start, end)) = self.active_region()
+                && (pos < start || pos >= end)
+            {
+                continue;
             }
-            Some(Ok(())) => {}
+
+            return self.record_to_raw(pos);
         }
+    }
+}
 
-        let pos = self.record.pos() as u32;
-
+impl VcfRecordSource {
+    fn record_to_raw(&self, pos: u32) -> Result<Option<RawRecord>, ConversionError> {
         let reference: Vec<u8>;
         let alts: Vec<Vec<u8>>;
         {

--- a/tests/cli/test_write_cli.py
+++ b/tests/cli/test_write_cli.py
@@ -53,6 +53,7 @@ def _vcf(d: Path, *, symbolic: bool) -> Path:
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
         "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
         "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
     )
     if symbolic:
         # POS 20 (1-based) in _REF is 'T'; the anchor REF base must match the
@@ -84,6 +85,60 @@ def test_write_no_reference(tmp_path: Path):
     r = _run(["write", str(vcf), str(out), "--no-reference", "--threads", "1"])
     assert r.returncode == 0, r.stderr
     assert (out / "meta.json").exists()
+
+
+def test_write_svar2_regions_and_samples(tmp_path: Path):
+    ref = _ref(tmp_path)
+    vcf = _vcf(tmp_path, symbolic=False)
+    out = tmp_path / "regioned"
+    r = _run(
+        [
+            "write",
+            str(vcf),
+            str(out),
+            "--reference",
+            str(ref),
+            "--regions",
+            "chr1:1-4",
+            "--samples",
+            "S0",
+            "--threads",
+            "1",
+        ]
+    )
+    assert r.returncode == 0, r.stderr
+    sv = SparseVar2(out)
+    assert sv.available_samples == ["S0"]
+    assert int(sv.region_counts("chr1", [(0, 40)]).sum()) == 1
+
+
+def test_write_svar2_regions_file_and_samples_file(tmp_path: Path):
+    ref = _ref(tmp_path)
+    vcf = _vcf(tmp_path, symbolic=False)
+    regions = tmp_path / "regions.bed"
+    regions.write_text("chr1\t3\t8\n")
+    samples = tmp_path / "samples.txt"
+    samples.write_text("S1\n")
+    out = tmp_path / "file_args"
+    r = _run(
+        [
+            "write",
+            str(vcf),
+            str(out),
+            "--reference",
+            str(ref),
+            "--regions-file",
+            str(regions),
+            "--samples-file",
+            str(samples),
+            "--threads",
+            "1",
+        ]
+    )
+    assert r.returncode == 0, r.stderr
+    sv = SparseVar2(out)
+    assert sv.available_samples == ["S1"]
+    assert int(sv.region_counts("chr1", [(0, 40)]).sum()) == 2
 
 
 def test_write_requires_reference_xor(tmp_path: Path):
@@ -198,6 +253,24 @@ def test_write_pgen_rejects_nondefault_ploidy(tmp_path: Path):
     )
     assert r.returncode != 0
     assert "diploid" in (r.stdout + r.stderr).lower()
+
+
+def test_write_pgen_rejects_regions_without_plink(tmp_path: Path):
+    pgen = tmp_path / "fake.pgen"
+    pgen.write_bytes(b"")
+    out = tmp_path / "fake.svar2"
+    r = _run(
+        [
+            "write",
+            str(pgen),
+            str(out),
+            "--no-reference",
+            "--regions",
+            "chr1:1-4",
+        ]
+    )
+    assert r.returncode != 0
+    assert "vcf/bcf only" in (r.stdout + r.stderr).lower()
 
 
 def test_write_svar1_still_works(tmp_path: Path):

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -177,6 +177,7 @@ pub fn build_contig(
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         Some(fasta.to_str().unwrap()),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -177,6 +177,7 @@ pub fn build_contig(
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(fasta.to_str().unwrap()),
         chrom,

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -20,8 +20,16 @@ fn drain_reader(
     // Each test builds `bcf_path.with_extension("fa")` from its records *before* calling
     // drain_reader (see the per-test edit below); here we just point the reader at it.
     let fasta_path = bcf_path.with_extension("fa");
-    let source =
-        VcfRecordSource::new(bcf_path.to_str().unwrap(), chrom, samples, 1, ploidy, &[]).unwrap();
+    let source = VcfRecordSource::new(
+        bcf_path.to_str().unwrap(),
+        chrom,
+        samples,
+        1,
+        ploidy,
+        &[],
+        Vec::new(),
+    )
+    .unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),

--- a/tests/test_check_ref_e2e.rs
+++ b/tests/test_check_ref_e2e.rs
@@ -69,6 +69,7 @@ fn convert(
         SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(fasta.to_str().unwrap()),
         "chr1",

--- a/tests/test_check_ref_e2e.rs
+++ b/tests/test_check_ref_e2e.rs
@@ -69,6 +69,7 @@ fn convert(
         SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         Some(fasta.to_str().unwrap()),

--- a/tests/test_convert_skip_e2e.rs
+++ b/tests/test_convert_skip_e2e.rs
@@ -44,6 +44,7 @@ fn convert(
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         fasta,

--- a/tests/test_convert_skip_e2e.rs
+++ b/tests/test_convert_skip_e2e.rs
@@ -44,6 +44,7 @@ fn convert(
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         fasta,
         "chr1",

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -93,6 +93,7 @@ fn test_e2e_normalized_bcf_pipeline() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
@@ -233,6 +234,7 @@ fn test_e2e_max_del_postpass() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
@@ -312,6 +314,7 @@ fn test_e2e_dense_snp_roundtrip() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
@@ -390,6 +393,7 @@ fn test_e2e_mutation_conservation() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
@@ -845,6 +849,7 @@ fn test_missing_chrom_returns_err() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            shard_workers: 1,
             regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -12,6 +12,7 @@ use common::{
 };
 use genoray_core::chunk_assembler::ChunkAssembler;
 use genoray_core::process_chromosome;
+use genoray_core::record_source::RecordSource;
 use genoray_core::rvk::decode_alt_inline;
 use genoray_core::search::{SearchTree, overlap_range};
 use genoray_core::vcf_reader::VcfRecordSource;
@@ -92,6 +93,7 @@ fn test_e2e_normalized_bcf_pipeline() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -152,6 +154,51 @@ fn test_e2e_normalized_bcf_pipeline() {
     assert!(!genoray_core::bits::get_bit(&dindel_geno, 3));
 }
 
+#[test]
+fn test_vcf_record_source_fetches_requested_intervals() {
+    let tmp = tempdir().unwrap();
+    let bcf_path = tmp.path().join("intervals.bcf");
+    let samples = vec!["S0"];
+    let records = vec![
+        SynthRecord {
+            pos: 2,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0],
+        },
+        SynthRecord {
+            pos: 6,
+            ref_allele: b"A",
+            alts: vec![&b"G"[..]],
+            gt: vec![0, 1],
+        },
+        SynthRecord {
+            pos: 10,
+            ref_allele: b"A",
+            alts: vec![&b"T"[..]],
+            gt: vec![1, 1],
+        },
+    ];
+    build_bcf_with_index(&bcf_path, "chr1", 100, &samples, &records);
+
+    let mut source = VcfRecordSource::new(
+        bcf_path.to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+        &[],
+        vec![(0, 4), (6, 7)],
+    )
+    .unwrap();
+
+    let mut got = Vec::new();
+    while let Some(record) = source.next_record().unwrap() {
+        got.push(record.pos);
+    }
+    assert_eq!(got, vec![2, 6]);
+}
+
 // M5 max_del post-pass, end-to-end. Two deletions with known lengths:
 //   pos=100  ATTT → A  (d=3)  gt=[1,0,0,0]  x=1 → rare → var_key/indel (hap 0)
 //   pos=200  ATT  → A  (d=2)  gt=[1,1,1,0]  x=3 → common → dense/indel (shared)
@@ -186,6 +233,7 @@ fn test_e2e_max_del_postpass() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -264,6 +312,7 @@ fn test_e2e_dense_snp_roundtrip() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -341,6 +390,7 @@ fn test_e2e_mutation_conservation() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
@@ -472,6 +522,7 @@ fn test_reader_extracts_info_format_fields() {
         1,
         ploidy,
         &all,
+        Vec::new(),
     )
     .unwrap();
     let mut reader = ChunkAssembler::new(
@@ -630,6 +681,7 @@ fn test_reader_extracts_multiallelic_number_a_fields() {
         1,
         ploidy,
         &all,
+        Vec::new(),
     )
     .unwrap();
     let mut reader = ChunkAssembler::new(
@@ -736,8 +788,16 @@ fn test_reader_accepts_pure_del() {
     build_bcf_with_index(&bcf_path, "chr1", 10_000, &samples, &records);
     build_fasta_with_index(&bcf_path.with_extension("fa"), "chr1", 10_000, &records);
 
-    let source =
-        VcfRecordSource::new(bcf_path.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+    let source = VcfRecordSource::new(
+        bcf_path.to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+        &[],
+        Vec::new(),
+    )
+    .unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),
@@ -785,6 +845,7 @@ fn test_missing_chrom_returns_err() {
         genoray_core::orchestrator::SourceSpec::Vcf {
             vcf_path: bcf_path.to_str().unwrap().to_string(),
             htslib_threads: 1,
+            regions: Vec::new(),
         },
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chrZ",
@@ -819,7 +880,15 @@ fn test_missing_vcf_returns_missing_file() {
     let tmp = tempdir().unwrap();
     let missing_path = tmp.path().join("does_not_exist.vcf.gz");
 
-    let res = VcfRecordSource::new(missing_path.to_str().unwrap(), "chr1", &["s0"], 1, 2, &[]);
+    let res = VcfRecordSource::new(
+        missing_path.to_str().unwrap(),
+        "chr1",
+        &["s0"],
+        1,
+        2,
+        &[],
+        Vec::new(),
+    );
 
     assert!(matches!(
         res,

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -25,7 +25,8 @@ fn write_ref(fasta_path: &Path, chrom: &str, seq: &[u8]) {
 }
 
 fn drain(bcf: &Path, fasta: &Path, chrom: &str, samples: &[&str]) -> Vec<(u32, i32)> {
-    let source = VcfRecordSource::new(bcf.to_str().unwrap(), chrom, samples, 1, 2, &[]).unwrap();
+    let source =
+        VcfRecordSource::new(bcf.to_str().unwrap(), chrom, samples, 1, 2, &[], Vec::new()).unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),
@@ -236,7 +237,16 @@ fn left_shifts_stay_sorted_across_chunk_boundaries() {
     build_bcf_with_index(&bcf, "chr1", REF_SEQ.len() as u64, &samples, &records);
 
     // chunk_size = 1 forces every atom into its own chunk.
-    let source = VcfRecordSource::new(bcf.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+    let source = VcfRecordSource::new(
+        bcf.to_str().unwrap(),
+        "chr1",
+        &samples,
+        1,
+        2,
+        &[],
+        Vec::new(),
+    )
+    .unwrap();
     let mut reader = ChunkAssembler::new(
         Box::new(source),
         samples.len(),
@@ -304,8 +314,16 @@ proptest! {
             .collect();
         build_bcf_with_index(&bcf, "chr1", seed.len() as u64, &samples, &synth);
 
-        let source =
-            VcfRecordSource::new(bcf.to_str().unwrap(), "chr1", &samples, 1, 2, &[]).unwrap();
+        let source = VcfRecordSource::new(
+            bcf.to_str().unwrap(),
+            "chr1",
+            &samples,
+            1,
+            2,
+            &[],
+            Vec::new(),
+        )
+        .unwrap();
         let mut reader = ChunkAssembler::new(
             Box::new(source),
             samples.len(),

--- a/tests/test_svar2_errors.py
+++ b/tests/test_svar2_errors.py
@@ -52,14 +52,18 @@ def test_ref_mismatch_raises_value_error(tmp_path: Path):
 
 def test_sharded_ref_mismatch_includes_shard_region(tmp_path: Path):
     ref = _write_ref(tmp_path)
-    # threads=16 leaves a non-trivial reader-side shard budget for this
-    # one-contig input, so the REF mismatch is raised from a VCF shard worker.
-    vcf = _write_vcf(tmp_path, "chr1\t3\t.\tG\tT\t.\t.\t.\tGT\t0|1\t0|0\n")
+    # Two distinct positions and chunk_size=1 force two VCF shard jobs; the
+    # second record's mismatch must retain that worker's ownership context.
+    vcf = _write_vcf(
+        tmp_path,
+        "chr1\t2\t.\tC\tT\t.\t.\t.\tGT\t0|1\t0|0\n"
+        "chr1\t3\t.\tG\tT\t.\t.\t.\tGT\t0|1\t0|0\n",
+    )
     with pytest.raises(
         ValueError,
         match=r"VCF shard chr1.*ownership \[\d+, \d+\).*fetch \[\d+, \d+\).*failed: REF 'G'.*disagrees",
     ):
-        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=16, chunk_size=5)
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=16, chunk_size=1)
 
 
 def test_missing_reference_raises_file_not_found(tmp_path: Path):

--- a/tests/test_svar2_errors.py
+++ b/tests/test_svar2_errors.py
@@ -50,6 +50,18 @@ def test_ref_mismatch_raises_value_error(tmp_path: Path):
         SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=1)
 
 
+def test_sharded_ref_mismatch_includes_shard_region(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    # threads=16 leaves a non-trivial reader-side shard budget for this
+    # one-contig input, so the REF mismatch is raised from a VCF shard worker.
+    vcf = _write_vcf(tmp_path, "chr1\t3\t.\tG\tT\t.\t.\t.\tGT\t0|1\t0|0\n")
+    with pytest.raises(
+        ValueError,
+        match=r"VCF shard chr1.*ownership \[0, .*failed: REF 'G'.*disagrees",
+    ):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=16, chunk_size=5)
+
+
 def test_missing_reference_raises_file_not_found(tmp_path: Path):
     vcf = _write_vcf(tmp_path, "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n")
     with pytest.raises(FileNotFoundError):

--- a/tests/test_svar2_errors.py
+++ b/tests/test_svar2_errors.py
@@ -57,7 +57,7 @@ def test_sharded_ref_mismatch_includes_shard_region(tmp_path: Path):
     vcf = _write_vcf(tmp_path, "chr1\t3\t.\tG\tT\t.\t.\t.\tGT\t0|1\t0|0\n")
     with pytest.raises(
         ValueError,
-        match=r"VCF shard chr1.*ownership \[0, .*failed: REF 'G'.*disagrees",
+        match=r"VCF shard chr1.*ownership \[\d+, \d+\).*fetch \[\d+, \d+\).*failed: REF 'G'.*disagrees",
     ):
         SparseVar2.from_vcf(tmp_path / "store", vcf, ref, threads=16, chunk_size=5)
 

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from genoray import SparseVar2
@@ -51,6 +52,102 @@ def test_from_vcf_with_reference_roundtrips(tmp_path: Path):
     sv = SparseVar2(out)
     assert sv.available_samples == ["S0", "S1"]
     assert sv.contigs == ["chr1"]
+
+
+def test_from_vcf_regions_restricts_conversion(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "regioned"
+    dropped = SparseVar2.from_vcf(out, vcf, ref, regions="chr1:1-4", threads=1)
+    assert dropped == 0
+
+    sv = SparseVar2(out)
+    assert sv.contigs == ["chr1"]
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 1
+    rag = sv.decode("chr1", [(0, 40)])
+    assert np.asarray(rag["pos"].data).tolist() == [2]
+
+
+def test_from_vcf_regions_accepts_multiple_specs_and_merges(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "merged"
+    SparseVar2.from_vcf(
+        out,
+        vcf,
+        ref,
+        regions=["chr1:1-4", ("chr1", 3, 8)],
+        merge_overlapping=True,
+        threads=1,
+    )
+
+    sv = SparseVar2(out)
+    assert sv.contigs == ["chr1"]
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 4
+    rag = sv.decode("chr1", [(0, 40)])
+    assert sorted(set(np.asarray(rag["pos"].data).tolist())) == [2, 6]
+
+
+def test_from_vcf_regions_rejects_overlaps_by_default(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    with pytest.raises(ValueError, match="regions overlap"):
+        SparseVar2.from_vcf(
+            tmp_path / "overlap",
+            vcf,
+            ref,
+            regions=["chr1:1-4", ("chr1", 3, 8)],
+            threads=1,
+        )
+
+
+def test_from_vcf_samples_preserve_order(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    out = tmp_path / "samples"
+    dropped = SparseVar2.from_vcf(out, vcf, ref, samples=["S1"], threads=1)
+    assert dropped == 0
+
+    sv = SparseVar2(out)
+    assert sv.available_samples == ["S1"]
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert counts.shape == (1, 1, 2)
+    assert counts.reshape(-1).tolist() == [1, 1]
+
+
+def test_from_vcf_samples_reject_unknown(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    with pytest.raises(ValueError, match="Samples not found"):
+        SparseVar2.from_vcf(tmp_path / "bad_sample", vcf, ref, samples=["missing"])
+
+
+def test_from_vcf_explicit_none_matches_default(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+
+    default_out = tmp_path / "default"
+    explicit_out = tmp_path / "explicit"
+    SparseVar2.from_vcf(default_out, vcf, ref, threads=1)
+    SparseVar2.from_vcf(
+        explicit_out,
+        vcf,
+        ref,
+        regions=None,
+        samples=None,
+        threads=1,
+    )
+
+    default = SparseVar2(default_out)
+    explicit = SparseVar2(explicit_out)
+    assert explicit.contigs == default.contigs
+    assert explicit.available_samples == default.available_samples
+    np.testing.assert_array_equal(
+        explicit.region_counts("chr1", [(0, 40)]),
+        default.region_counts("chr1", [(0, 40)]),
+    )
 
 
 def test_from_vcf_requires_reference_or_opt_out(tmp_path: Path):

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -393,6 +393,27 @@ def test_from_vcf_check_ref_exclude_continues(tmp_path: Path):
     assert int(counts.sum()) == 4
 
 
+def test_from_vcf_sharded_check_ref_exclude_counts_owned_record_once(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf_bad_ref(tmp_path)
+    out = tmp_path / "sharded_store"
+
+    SparseVar2.from_vcf(
+        out,
+        vcf,
+        ref,
+        check_ref="x",
+        threads=16,
+        chunk_size=1,
+    )
+
+    assert "excluded 1 record(s)" in capfd.readouterr().out
+    counts = SparseVar2(out).region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 4
+
+
 def test_from_vcf_check_ref_invalid_value_raises(tmp_path: Path):
     ref = _write_ref(tmp_path)
     vcf = _write_vcf_bad_ref(tmp_path)

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -9,6 +9,7 @@ import pytest
 from genoray import SparseVar2
 
 _REF = "ACAGTACATGGGTACTAGCTAGGCTAACCGGTTAACCGGT"
+_BOUNDARY_REF = "CAAAATCAGAGT"
 
 
 def _write_ref(d: Path) -> Path:
@@ -39,6 +40,31 @@ def _write_vcf(d: Path, *, symbolic: bool, indexed: bool) -> Path:
         subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
     if indexed:
         subprocess.run(["bcftools", "index", str(gz)], check=True)
+    return gz
+
+
+def _write_boundary_ref(d: Path) -> Path:
+    ref = d / "boundary.fa"
+    ref.write_text(f">chr1\n{_BOUNDARY_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+    return ref
+
+
+def _write_boundary_vcf(d: Path) -> Path:
+    body = (
+        "##fileformat=VCFv4.2\n"
+        f"##contig=<ID=chr1,length={len(_BOUNDARY_REF)}>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\n"
+        "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\n"
+        "chr1\t9\t.\tGAG\tG\t.\t.\t.\tGT\t1|0\n"
+    )
+    plain = d / "boundary.vcf"
+    plain.write_text(body)
+    gz = d / "boundary.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
     return gz
 
 
@@ -179,6 +205,40 @@ def test_from_vcf_parallel_normalization_matches_single_thread(tmp_path: Path):
             np.asarray(par_dec[field].lengths),
             np.asarray(seq_dec[field].lengths),
         )
+
+
+def test_from_vcf_sharded_normalization_owns_left_shifted_boundary_atom(
+    tmp_path: Path,
+):
+    ref = _write_boundary_ref(tmp_path)
+    vcf = _write_boundary_vcf(tmp_path)
+
+    seq_out = tmp_path / "seq_boundary"
+    shard_out = tmp_path / "shard_boundary"
+    SparseVar2.from_vcf(seq_out, vcf, ref, threads=1, chunk_size=3)
+    SparseVar2.from_vcf(shard_out, vcf, ref, threads=16, chunk_size=3)
+
+    seq = SparseVar2(seq_out)
+    shard = SparseVar2(shard_out)
+    assert shard.available_samples == seq.available_samples
+    assert shard.contigs == seq.contigs
+    np.testing.assert_array_equal(
+        shard.region_counts("chr1", [(0, len(_BOUNDARY_REF))]),
+        seq.region_counts("chr1", [(0, len(_BOUNDARY_REF))]),
+    )
+
+    seq_dec = seq.decode("chr1", [(0, len(_BOUNDARY_REF))])
+    shard_dec = shard.decode("chr1", [(0, len(_BOUNDARY_REF))])
+    for field in ("pos", "ilen", "allele"):
+        np.testing.assert_array_equal(
+            np.asarray(shard_dec[field].data),
+            np.asarray(seq_dec[field].data),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(shard_dec[field].lengths),
+            np.asarray(seq_dec[field].lengths),
+        )
+    assert sorted(set(np.asarray(shard_dec["pos"].data).tolist())) == [6, 7]
 
 
 def test_from_vcf_requires_reference_or_opt_out(tmp_path: Path):

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -241,6 +241,57 @@ def test_from_vcf_sharded_normalization_owns_left_shifted_boundary_atom(
     assert sorted(set(np.asarray(shard_dec["pos"].data).tolist())) == [6, 7]
 
 
+def test_from_vcf_fragmented_regions_use_variant_balanced_reader_pool(
+    tmp_path: Path, capfd: pytest.CaptureFixture[str]
+):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+    regions = [("chr1", start, start + 1) for start in range(0, 40, 2)]
+
+    serial_out = tmp_path / "fragmented_serial"
+    parallel_out = tmp_path / "fragmented_parallel"
+    SparseVar2.from_vcf(
+        serial_out,
+        vcf,
+        ref,
+        regions=regions,
+        threads=1,
+        chunk_size=1,
+    )
+    capfd.readouterr()
+    SparseVar2.from_vcf(
+        parallel_out,
+        vcf,
+        ref,
+        regions=regions,
+        threads=16,
+        chunk_size=1,
+    )
+    captured = capfd.readouterr()
+    assert (
+        "VCF variant plan: 2 records -> 2 shard jobs "
+        "(target 1 records) across 2 reader workers"
+    ) in captured.out
+
+    serial = SparseVar2(serial_out)
+    parallel = SparseVar2(parallel_out)
+    np.testing.assert_array_equal(
+        parallel.region_counts("chr1", [(0, 40)]),
+        serial.region_counts("chr1", [(0, 40)]),
+    )
+    serial_dec = serial.decode("chr1", [(0, 40)])
+    parallel_dec = parallel.decode("chr1", [(0, 40)])
+    for field in ("pos", "ilen", "allele"):
+        np.testing.assert_array_equal(
+            np.asarray(parallel_dec[field].data),
+            np.asarray(serial_dec[field].data),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(parallel_dec[field].lengths),
+            np.asarray(serial_dec[field].lengths),
+        )
+
+
 def test_from_vcf_requires_reference_or_opt_out(tmp_path: Path):
     vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
     with pytest.raises(ValueError, match="reference"):

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -150,6 +150,37 @@ def test_from_vcf_explicit_none_matches_default(tmp_path: Path):
     )
 
 
+def test_from_vcf_parallel_normalization_matches_single_thread(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
+
+    seq_out = tmp_path / "seq"
+    par_out = tmp_path / "par"
+    SparseVar2.from_vcf(seq_out, vcf, ref, threads=1)
+    SparseVar2.from_vcf(par_out, vcf, ref, threads=16)
+
+    seq = SparseVar2(seq_out)
+    par = SparseVar2(par_out)
+    assert par.available_samples == seq.available_samples
+    assert par.contigs == seq.contigs
+    np.testing.assert_array_equal(
+        par.region_counts("chr1", [(0, 40)]),
+        seq.region_counts("chr1", [(0, 40)]),
+    )
+
+    seq_dec = seq.decode("chr1", [(0, 40)])
+    par_dec = par.decode("chr1", [(0, 40)])
+    for field in ("pos", "ilen", "allele"):
+        np.testing.assert_array_equal(
+            np.asarray(par_dec[field].data),
+            np.asarray(seq_dec[field].data),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(par_dec[field].lengths),
+            np.asarray(seq_dec[field].lengths),
+        )
+
+
 def test_from_vcf_requires_reference_or_opt_out(tmp_path: Path):
     vcf = _write_vcf(tmp_path, symbolic=False, indexed=True)
     with pytest.raises(ValueError, match="reference"):


### PR DESCRIPTION
## Summary

- Adds true parallel VCF conversion within a contig using a bounded native Rust worker pool. Each worker opens an indexed HTSlib reader, parses and normalizes its assigned source records, and sends bounded dense chunks to the existing executor.
- Balances shards by observed source-record count, not genomic interval width. A native HTSlib position-only pre-scan builds exact shard boundaries while keeping equal-position records together.
- Preserves deterministic output by draining per-shard channels in stable ordinal order and assigning global `DenseChunk.chunk_id` values before the existing executor/writer sees them.
- Uses padded indexed fetches for left alignment, but assigns source-record and normalized-atom ownership explicitly so overlap cannot duplicate output, dropped-ALT counts, or `check_ref="x"` exclusion counts.
- Keeps the hot path in Rust. There are no Python record loops, subprocess workers, or BCFtools fallbacks.
- Treats `threads` as a total conversion budget. Shard workers replace per-reader HTSlib/Rayon pools; the serial fallback pool is created only if sharding does not run.
- Shares the reference sequence, sample names, and field metadata across workers with `Arc`, uses one queued dense chunk per shard, and bounds normalization batches to a 64 MiB raw-GT target (maximum 1024 records).
- Adds shard-specific error context and cancellation so the first worker failure interrupts an earlier silent shard without deadlocking the ordered collector.
- Adds planner, boundary-normalization, panic/error, memory-budget, and sharded `check_ref` regression coverage plus a reusable benchmark harness.

## Dependency

This is stacked on #114 (`feat(svar2): add region and sample VCF conversion`), which is green. Because the stack comes from a fork, GitHub cannot use #114's fork branch as the base in `d-laub/genoray`; until #114 merges, this PR's raw diff also includes the foundation commits.

## Design details

The position pre-scan stores one `u32` per source record (about 4 bytes per record) and does not decode genotype, INFO, or FORMAT payloads. Parsing then makes a second indexed pass in parallel. `target_records` is the smaller of `ceil(total_records / workers)` and `chunk_size`; equal-POS groups may exceed the target so they are never split.

Normalization fetch padding is clamped to each user-requested region. Source-level counters use the original VCF position's ownership range, while normalized atoms use their post-left-alignment output position. This distinction is what makes padded parallel normalization exact.

The 64 MiB normalization cap bounds only the raw GT work batch. Dense output memory still scales with `chunk_size * samples * ploidy`; callers processing very wide cohorts should set `chunk_size` accordingly.

## Benchmark

Synthetic indexed VCF, 5,000 samples x 10,000 variants, default chunk size, final implementation:

| Threads | Wall time | Peak RSS |
|---:|---:|---:|
| 1 | 10.616 s | 0.575 GB |
| 8 | 5.575 s | 0.859 GB |
| 16 | 5.581 s | 1.439 GB |

Eight threads are 1.90x faster than one on this small workload. Sixteen plateaus because 10,000 variants do not provide enough work to amortize more readers; the worker count is bounded and intended for much larger cohort VCFs.

## Validation

- `pixi run maturin develop`
- `pixi run pytest tests/test_svar2_from_vcf.py tests/test_svar2_errors.py -q` (26 passed)
- `pixi run pytest tests -q` (699 passed, 2 skipped, 16 xfailed)
- `DYLD_FALLBACK_LIBRARY_PATH="$CONDA_PREFIX/lib" cargo test --no-default-features --features conversion` in the Pixi lint environment (253 unit tests plus all integration targets passed)
- `pixi run prek run --all-files --show-diff-on-failure` (all hooks passed, including `cargo fmt`, `cargo check`, `cargo clippy`, and Pyrefly)

## Commits in this layer

- `70809b8` parallel normalization batches
- `f30bd77` within-contig indexed VCF sharding
- `4849cd7` total thread-budget enforcement
- `49ef858` benchmark harness
- `2d20a25` shard-specific error context
- `70ada30` deterministic concurrent-error test behavior
- `dde873e` exact variant-count planning, bounded worker pool, shared metadata, and memory-aware batches
- `469599d` sharded `check_ref` regression coverage
