### PR TITLE
feat: check_ref (e/x) for all SVAR2 conversion methods (#116)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-check-ref-svar2-conversion.md
+++ b/docs/superpowers/plans/2026-07-15-check-ref-svar2-conversion.md
@@ -1,0 +1,992 @@
+# check_ref for SVAR2 conversion methods — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `check_ref` policy (`"e"` = error, current default; `"x"` = exclude offending record and continue) to all four SVAR2 conversion entry points (`from_vcf`, `from_pgen`, `from_svar1`, `from_vcf_list`), so a single REF-vs-FASTA disagreement no longer aborts the whole build.
+
+**Architecture:** One shared decision helper (`apply_check_ref`) in `src/normalize.rs` replaces the two unconditional `validate_ref(...)?` call sites (`chunk_assembler.rs` for vcf/pgen/svar1; `vcf_list_reader.rs` for vcf_list). A `CheckRef` mode is threaded from the four pyo3 pipeline functions → `process_chromosome` / `run_vcf_list` → the assemblers. Excluded-record counts are logged (per-contig count + first offending locus); the Python return type (int = out-of-scope drops) is unchanged.
+
+**Tech Stack:** Rust (pyo3, rust-htslib), Python (cyclopts CLI). Build via `pixi`. Rust extension is `genoray_core` / `_core`.
+
+## Global Constraints
+
+- **Conventional Commits** for every commit (`feat:`, `fix:`, `test:`, `docs:`, `refactor:`).
+- **Never edit `CHANGELOG.md`** — commitizen owns it.
+- **Public-API changes MUST update `skills/genoray-api/SKILL.md`** in the same PR (Task 6).
+- **Default is `"e"`** — behavior for existing callers must be byte-identical (non-breaking).
+- **Rust tests** run with `pixi run bash -lc 'cargo test --no-default-features --features conversion <name>'` — the bare pyo3 test binary fails to link without `--no-default-features` (undefined `_Py_Dealloc`). The conversion pipeline code is behind `#[cfg(feature = "conversion")]`, so the `conversion` feature is required for these tests.
+- **Guard against the NFS linker bus error**: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target` before any `cargo`/commit that triggers Rust hooks.
+- **prek hooks** must be installed before committing (`pixi run prek-install`); they run `cargo fmt`/`clippy`/`ruff`/`pyrefly` on staged files.
+- **`test-rust <arg>` filters by TEST NAME, not file** — a nonmatching name vacuously passes 0 tests. Prefer `cargo test --test <file_stem>` to run a whole integration-test file.
+- **REF comparison is already case-insensitive** in `validate_ref` — do not add case handling.
+
+---
+
+## File Structure
+
+- `src/normalize.rs` — **modify**: add `CheckRef` enum, `RefDecision` enum, `apply_check_ref`, `FromStr for CheckRef`, unit tests. (Task 1)
+- `src/chunk_assembler.rs` — **modify**: `ChunkAssembler` gains a `check_ref` field + `ref_excluded` counter; `new` gains a param; `decompose_record` uses `apply_check_ref`; add `ref_excluded()` getter. (Task 2)
+- `src/orchestrator.rs` — **modify**: `process_chromosome` gains a `check_ref: CheckRef` param, passed to `ChunkAssembler::new` and (Task 4) `VcfListRecordSource::new`; reader thread logs the per-contig excluded count; `run_vcf_list` threads the mode; `VcfListDroppedProxy` mirrors a `ref_excluded` atomic (Task 4). (Tasks 2, 4)
+- `src/lib.rs` — **modify**: the four `#[pyo3]` pipeline fns gain a `check_ref: String` param, parsed to `CheckRef`. (Tasks 2, 3, 4)
+- `src/vcf_list_reader.rs` — **modify**: `FileCursor` + `VcfListRecordSource` gain check_ref awareness + `ref_excluded` counters. (Task 4)
+- `python/genoray/_svar2.py` — **modify**: `check_ref: Literal["e","x"] = "e"` kwarg on all four `from_*` methods + a `_validate_check_ref` helper + docstrings. (Tasks 2, 3, 4)
+- `python/genoray/_cli/__main__.py` — **modify**: `--check-ref` flag on `genoray write`. (Task 5)
+- `skills/genoray-api/SKILL.md` — **modify**: document the new kwarg. (Task 6)
+- `tests/test_check_ref_e2e.rs` — **create**: Rust e2e for the shared chunk_assembler path (Task 2) + a vcf_list variant (Task 4).
+- `tests/test_svar2_from_vcf.py` — **modify**: Python behavior test (Task 2).
+- `tests/test_svar2_from_vcf_list.py` — **modify**: Python behavior test (Task 4).
+
+---
+
+## Task 1: `CheckRef` primitives in `normalize.rs`
+
+**Files:**
+- Modify: `src/normalize.rs` (add after `validate_ref`, ~line 103)
+- Test: `src/normalize.rs` `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: existing `validate_ref(pos: u32, ref_allele: &[u8], ref_seq: &[u8]) -> Result<(), NormalizeError>`, `NormalizeError`.
+- Produces:
+  - `pub enum CheckRef { Error, Exclude }` (derives `Debug, Clone, Copy, PartialEq, Eq`)
+  - `pub enum RefDecision { Keep, Exclude(NormalizeError) }`
+  - `pub fn apply_check_ref(mode: CheckRef, pos: u32, ref_allele: &[u8], ref_seq: &[u8]) -> Result<RefDecision, NormalizeError>`
+  - `impl std::str::FromStr for CheckRef { type Err = String; ... }`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Add to the `mod tests` block in `src/normalize.rs`:
+
+```rust
+    #[test]
+    fn apply_check_ref_error_mode_propagates_mismatch() {
+        let ref_seq = b"ACGTAC";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Error, 2, b"AA", ref_seq),
+            Err(NormalizeError::RefMismatch { pos: 2, .. })
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_error_mode_propagates_out_of_contig() {
+        let ref_seq = b"ACGT";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Error, 3, b"TAC", ref_seq),
+            Err(NormalizeError::RefOutOfContig { .. })
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_exclude_mode_excludes_mismatch() {
+        let ref_seq = b"ACGTAC";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Exclude, 2, b"AA", ref_seq),
+            Ok(RefDecision::Exclude(NormalizeError::RefMismatch { pos: 2, .. }))
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_exclude_mode_excludes_out_of_contig() {
+        let ref_seq = b"ACGT";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Exclude, 3, b"TAC", ref_seq),
+            Ok(RefDecision::Exclude(NormalizeError::RefOutOfContig { .. }))
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_keeps_matching_ref_in_both_modes() {
+        let ref_seq = b"ACGTAC";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Error, 2, b"GT", ref_seq),
+            Ok(RefDecision::Keep)
+        ));
+        assert!(matches!(
+            apply_check_ref(CheckRef::Exclude, 2, b"GT", ref_seq),
+            Ok(RefDecision::Keep)
+        ));
+    }
+
+    #[test]
+    fn check_ref_from_str_parses_e_and_x() {
+        assert_eq!("e".parse::<CheckRef>(), Ok(CheckRef::Error));
+        assert_eq!("x".parse::<CheckRef>(), Ok(CheckRef::Exclude));
+        assert!("z".parse::<CheckRef>().is_err());
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target && pixi run bash -lc 'cargo test --no-default-features --features conversion --lib apply_check_ref check_ref_from_str'`
+Expected: FAIL — `cannot find function apply_check_ref` / `cannot find type CheckRef`.
+
+- [ ] **Step 3: Implement the primitives**
+
+Insert after `validate_ref` (after line 103) in `src/normalize.rs`:
+
+```rust
+/// Policy for how a REF/FASTA disagreement is handled during conversion,
+/// mirroring the `e`/`x` subset of `bcftools norm --check-ref`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckRef {
+    /// Abort the build on the first disagreement (the historical behavior).
+    Error,
+    /// Drop the offending record and continue.
+    Exclude,
+}
+
+impl std::str::FromStr for CheckRef {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "e" => Ok(CheckRef::Error),
+            "x" => Ok(CheckRef::Exclude),
+            other => Err(format!(
+                "invalid check_ref {other:?}; expected \"e\" (error) or \"x\" (exclude)"
+            )),
+        }
+    }
+}
+
+/// Per-record outcome of applying a [`CheckRef`] policy. `Exclude` carries the
+/// originating [`NormalizeError`] so the caller can log the first offending
+/// locus without re-running validation.
+#[derive(Debug)]
+pub enum RefDecision {
+    /// REF matches the reference — process the record normally.
+    Keep,
+    /// REF disagrees under [`CheckRef::Exclude`] — skip this whole record.
+    Exclude(NormalizeError),
+}
+
+/// Apply the [`CheckRef`] policy to one record's REF. Returns `Err` only under
+/// [`CheckRef::Error`] (propagating `RefMismatch` / `RefOutOfContig`); under
+/// [`CheckRef::Exclude`] a disagreement (either kind) becomes
+/// `Ok(RefDecision::Exclude(_))`. A matching REF is always `Ok(RefDecision::Keep)`.
+pub fn apply_check_ref(
+    mode: CheckRef,
+    pos: u32,
+    ref_allele: &[u8],
+    ref_seq: &[u8],
+) -> Result<RefDecision, NormalizeError> {
+    match validate_ref(pos, ref_allele, ref_seq) {
+        Ok(()) => Ok(RefDecision::Keep),
+        Err(e) => match mode {
+            CheckRef::Error => Err(e),
+            CheckRef::Exclude => Ok(RefDecision::Exclude(e)),
+        },
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target && pixi run bash -lc 'cargo test --no-default-features --features conversion --lib apply_check_ref check_ref_from_str'`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+export CARGO_TARGET_DIR=/tmp/genoray-checkref-target
+git add src/normalize.rs
+git commit -m "feat: add CheckRef policy and apply_check_ref helper"
+```
+
+---
+
+## Task 2: Thread `check_ref` through the single-source engine + `from_vcf`
+
+This task wires the shared `ChunkAssembler` path end-to-end and exposes the kwarg on `from_vcf`. `process_chromosome` gains a param, so **all four** of its callers must pass it — the three not yet exposed to Python (`run_pgen`/`run_svar1`/`run_vcf_list` call sites) pass `CheckRef::Error` as a placeholder, flipped to the real mode in Tasks 3–4.
+
+**Files:**
+- Modify: `src/chunk_assembler.rs` (struct ~249-264, `new` ~266-303, `decompose_record` ~313-321, add getter)
+- Modify: `src/orchestrator.rs` (`process_chromosome` sig ~120-133, `ChunkAssembler::new` call ~305-313, reader-thread tail ~321, `run_vcf_list`'s `process_chromosome` call ~633-649)
+- Modify: `src/lib.rs` (`run_conversion_pipeline` pyo3 ~123-215; and the `process_chromosome` calls inside `run_pgen_conversion_pipeline` ~320 and `run_svar1_conversion_pipeline` ~910+ — pass `CheckRef::Error` placeholder)
+- Modify: `python/genoray/_svar2.py` (`from_vcf` ~474-558, add `_validate_check_ref` helper)
+- Create: `tests/test_check_ref_e2e.rs`
+- Modify: `tests/test_svar2_from_vcf.py`
+
+**Interfaces:**
+- Consumes: `normalize::{CheckRef, RefDecision, apply_check_ref}` (Task 1).
+- Produces:
+  - `ChunkAssembler::new(..., skip_out_of_scope: bool, check_ref: CheckRef, fields: &[FieldSpec])` — **new `check_ref` param inserted before `fields`**.
+  - `ChunkAssembler::ref_excluded(&self) -> u64`
+  - `process_chromosome(..., skip_out_of_scope: bool, check_ref: CheckRef, processing_threads: usize, signatures: bool, fields: &[FieldSpec])` — **new `check_ref` param inserted after `skip_out_of_scope`**.
+  - `run_conversion_pipeline(...)` pyo3 gains trailing `check_ref: String` param.
+  - Python `SparseVar2.from_vcf(..., check_ref: Literal["e","x"] = "e")`.
+  - `_validate_check_ref(check_ref: str) -> str` module helper in `_svar2.py`.
+
+- [ ] **Step 1: Write the failing Rust e2e test** (`tests/test_check_ref_e2e.rs`)
+
+```rust
+mod common;
+
+use common::{SynthRecord, build_bcf_with_index, build_fasta_with_index};
+use genoray_core::normalize::CheckRef;
+use genoray_core::orchestrator::{SourceSpec, process_chromosome};
+use tempfile::TempDir;
+
+// Three records; the middle one's REF ("G") will disagree with the FASTA
+// (which carries "T" at that position), reproducing issue #116.
+fn bcf_records() -> Vec<SynthRecord<'static>> {
+    vec![
+        SynthRecord { pos: 100, ref_allele: b"A", alts: vec![&b"C"[..]], gt: vec![1, 0, 0, 0] },
+        SynthRecord { pos: 200, ref_allele: b"G", alts: vec![&b"GTTT"[..]], gt: vec![1, 1, 0, 0] },
+        SynthRecord { pos: 300, ref_allele: b"T", alts: vec![&b"A"[..]], gt: vec![0, 0, 1, 0] },
+    ]
+}
+
+// Same loci, but the FASTA truth at pos 200 is "T" (not the record's "G").
+fn fasta_records() -> Vec<SynthRecord<'static>> {
+    vec![
+        SynthRecord { pos: 100, ref_allele: b"A", alts: vec![], gt: vec![] },
+        SynthRecord { pos: 200, ref_allele: b"T", alts: vec![], gt: vec![] },
+        SynthRecord { pos: 300, ref_allele: b"T", alts: vec![], gt: vec![] },
+    ]
+}
+
+fn convert(out: &std::path::Path, check_ref: CheckRef) -> Result<u64, genoray_core::error::ConversionError> {
+    let tmp = out.parent().unwrap();
+    let bcf = tmp.join("in.bcf");
+    let fasta = tmp.join("in.fa");
+    let samples = ["S0", "S1"];
+    build_bcf_with_index(&bcf, "chr1", 1000, &samples, &bcf_records());
+    build_fasta_with_index(&fasta, "chr1", 1000, &fasta_records());
+    let sample_refs: Vec<&str> = samples.to_vec();
+    process_chromosome(
+        SourceSpec::Vcf { vcf_path: bcf.to_str().unwrap().to_string(), htslib_threads: 1 },
+        Some(fasta.to_str().unwrap()),
+        "chr1",
+        out.to_str().unwrap(),
+        &sample_refs,
+        25_000,
+        2,
+        8 * 1024 * 1024,
+        false,     // skip_out_of_scope
+        check_ref, // NEW
+        1,         // processing_threads
+        false,     // signatures
+        &[],       // fields
+    )
+}
+
+#[test]
+fn ref_mismatch_errors_under_e() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("store");
+    assert!(convert(&out, CheckRef::Error).is_err(), "check_ref=e must abort on a REF mismatch");
+}
+
+#[test]
+fn ref_mismatch_excluded_under_x() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("store");
+    // Succeeds; the two clean SNPs (pos 100, 300) are still written.
+    convert(&out, CheckRef::Exclude).unwrap();
+    assert!(out.join("chr1/var_key/snp/positions.bin").exists(), "clean SNPs still converted");
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails to compile**
+
+Run: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target && pixi run bash -lc 'cargo test --no-default-features --features conversion --test test_check_ref_e2e'`
+Expected: FAIL — `process_chromosome` takes 12 args, not 13 (the `check_ref` arg does not exist yet).
+
+- [ ] **Step 3: Add the `check_ref` field + counter + getter to `ChunkAssembler`**
+
+In `src/chunk_assembler.rs`, add two fields to the `ChunkAssembler` struct (after `skip_out_of_scope: bool,`):
+
+```rust
+    check_ref: crate::normalize::CheckRef,
+    ref_excluded: u64,
+```
+
+In `ChunkAssembler::new`, add a `check_ref` parameter **before** `fields`:
+
+```rust
+    pub fn new(
+        source: Box<dyn RecordSource + Send>,
+        num_samples: usize,
+        ploidy: usize,
+        fasta_path: Option<&str>,
+        chrom: &str,
+        skip_out_of_scope: bool,
+        check_ref: crate::normalize::CheckRef,
+        fields: &[FieldSpec],
+    ) -> Result<Self, ConversionError> {
+```
+
+and set both new fields in the returned `Self { ... }` (after `skip_out_of_scope,`):
+
+```rust
+            check_ref,
+            ref_excluded: 0,
+```
+
+Add the getter next to `dropped_out_of_scope`:
+
+```rust
+    /// Records excluded because their REF disagreed with the reference under
+    /// `CheckRef::Exclude`. Valid after the read loop drains.
+    pub fn ref_excluded(&self) -> u64 {
+        self.ref_excluded
+    }
+```
+
+Replace the `validate_ref` block in `decompose_record` (currently lines 317-321):
+
+```rust
+        // Fail fast only when a reference is available; without one we trust the
+        // input is already normalized/left-aligned.
+        if self.has_reference {
+            match crate::normalize::apply_check_ref(
+                self.check_ref,
+                pos,
+                &rec.reference,
+                &self.ref_seq,
+            )? {
+                crate::normalize::RefDecision::Keep => {}
+                crate::normalize::RefDecision::Exclude(e) => {
+                    self.ref_excluded += 1;
+                    if self.ref_excluded == 1 {
+                        println!(
+                            "Notice: check_ref=x excluding record(s) whose REF disagrees \
+                             with the reference (first: {e}); further exclusions on this \
+                             contig are counted, not printed."
+                        );
+                    }
+                    return Ok(());
+                }
+            }
+        }
+```
+
+- [ ] **Step 4: Thread `check_ref` through `process_chromosome` and its callers**
+
+In `src/orchestrator.rs`, add the param to `process_chromosome` (after `skip_out_of_scope: bool,` ~line 129):
+
+```rust
+    skip_out_of_scope: bool,
+    check_ref: crate::normalize::CheckRef,
+    processing_threads: usize,
+```
+
+Pass it to `ChunkAssembler::new` (~line 305-313), inserting before `&fields_owned`:
+
+```rust
+                let mut reader = crate::chunk_assembler::ChunkAssembler::new(
+                    src,
+                    s_refs.len(),
+                    ploidy,
+                    fasta.as_deref(),
+                    &chr,
+                    skip_out_of_scope,
+                    check_ref,
+                    &fields_owned,
+                )?;
+```
+
+`check_ref` is `Copy`, so capturing it in the reader-thread closure needs no clone; add `let check_ref = check_ref;` is unnecessary — it moves in as a `Copy` value. (If the borrow checker complains about the move into the `spawn` closure, add `let check_ref = check_ref;` just above the closure alongside the other `let` bindings at ~line 217.)
+
+Log the per-contig excluded count: after the `while let Some(dense_chunk)` loop (right before `Ok(reader.dropped_out_of_scope() + ...)` at ~line 321):
+
+```rust
+                let ref_excluded = reader.ref_excluded();
+                if ref_excluded > 0 {
+                    println!(
+                        "[{chr}] check_ref=x: excluded {ref_excluded} record(s) whose REF \
+                         disagreed with the reference FASTA."
+                    );
+                }
+                Ok(reader.dropped_out_of_scope() + vcf_list_dropped.load(Ordering::Relaxed))
+```
+
+Update `run_vcf_list`'s `process_chromosome` call (~line 633-649), inserting `crate::normalize::CheckRef::Error` after `skip_out_of_scope,` (placeholder; Task 4 replaces it):
+
+```rust
+            skip_out_of_scope,
+            crate::normalize::CheckRef::Error,
+            processing_threads,
+```
+
+- [ ] **Step 5: Thread `check_ref` through the pyo3 fns**
+
+In `src/lib.rs`, `run_conversion_pipeline`:
+- Add `check_ref="e".to_string()` to the end of the `#[pyo3(signature = (...))]` list (after `format_fields=Vec::new()`).
+- Add the param `check_ref: String,` at the end of the fn args (after `format_fields`).
+- Parse it right after the `parse_manifest` call (~line 145):
+
+```rust
+    let check_ref: crate::normalize::CheckRef =
+        check_ref.parse().map_err(PyValueError::new_err)?;
+```
+
+- Pass `check_ref` in the `process_chromosome` call (~line 199-215), inserting after `skip_out_of_scope,` (line 211). `check_ref` is `Copy`; it can be captured by the `par_iter().map()` closure directly.
+
+In `run_pgen_conversion_pipeline` (~line 320) and `run_svar1_conversion_pipeline` (~line 910+), insert `crate::normalize::CheckRef::Error` after `skip_out_of_scope,` in their `process_chromosome` calls (placeholders; Task 3 replaces them). Do **not** add a pyo3 param to these two yet.
+
+- [ ] **Step 6: Run the Rust e2e test to verify it passes**
+
+Run: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target && pixi run bash -lc 'cargo test --no-default-features --features conversion --test test_check_ref_e2e'`
+Expected: PASS (2 tests). Also confirm the whole crate still builds: `pixi run bash -lc 'cargo test --no-default-features --features conversion --test test_convert_skip_e2e'` → PASS (unchanged).
+
+- [ ] **Step 7: Add the Python `check_ref` kwarg + helper + docstring to `from_vcf`**
+
+In `python/genoray/_svar2.py`, add a module-level helper (near the other module-level helpers, e.g. above the `SparseVar2` class):
+
+```python
+def _validate_check_ref(check_ref: str) -> str:
+    """Validate a `check_ref` mode string. Returns it unchanged on success."""
+    if check_ref not in ("e", "x"):
+        raise ValueError(
+            f'check_ref must be "e" (error) or "x" (exclude), got {check_ref!r}'
+        )
+    return check_ref
+```
+
+Ensure `Literal` is imported (`from typing import Literal` — add if absent).
+
+Add the kwarg to `from_vcf`'s signature (after `format_fields=...`):
+
+```python
+        format_fields: Sequence[str | FormatField] | None = None,
+        check_ref: Literal["e", "x"] = "e",
+```
+
+Add to the docstring (after the `info_fields, format_fields:` paragraph):
+
+```
+        check_ref: policy for a record whose REF disagrees with the reference
+        FASTA (ignored when `no_reference=True`). `"e"` (default) raises and
+        aborts the build — matching `bcftools norm --check-ref e`. `"x"` drops
+        the offending record (including a REF that runs past the contig end)
+        and continues, logging a per-contig count. Comparison is
+        case-insensitive, so soft-masked (lowercase) reference bases match.
+```
+
+Validate and pass it in the `_core.run_conversion_pipeline(...)` call (append as the last argument):
+
+```python
+        _validate_check_ref(check_ref)
+        return _core.run_conversion_pipeline(
+            str(source),
+            reference_path,
+            contigs,
+            str(out),
+            samples,
+            chunk_size,
+            ploidy,
+            threads,
+            long_allele_capacity,
+            skip_out_of_scope,
+            signatures,
+            info,
+            format_,
+            check_ref,
+        )
+```
+
+- [ ] **Step 8: Write the failing Python behavior test**
+
+`tests/test_svar2_from_vcf.py` already defines `_write_ref(d)` (writes `_REF = "ACAGTACATGGGTAC..."` as `chr1` + `.fai`). In that reference, 1-based position 10 is `G`. Add a bad-REF VCF writer and three tests to the file:
+
+```python
+def _write_vcf_bad_ref(d: Path) -> Path:
+    # Clean records at pos 3 (REF=A) and 7 (REF=C) match _REF; the record at
+    # pos 10 declares REF=A but _REF[10] is 'G' — a REF/FASTA disagreement
+    # (issue #116). Rows stay position-sorted for `bcftools index`.
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=chr1,length=40>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+        "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
+        "chr1\t10\t.\tA\tT\t.\t.\t.\tGT\t0|1\t0|0\n"  # REF=A, but _REF[10]='G'
+    )
+    plain = d / "bad.vcf"
+    plain.write_text(body)
+    gz = d / "bad.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+    return gz
+
+
+def test_from_vcf_check_ref_error_aborts(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf_bad_ref(tmp_path)
+    with pytest.raises(Exception):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, check_ref="e", threads=1)
+
+
+def test_from_vcf_check_ref_exclude_continues(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf_bad_ref(tmp_path)
+    out = tmp_path / "store"
+    SparseVar2.from_vcf(out, vcf, ref, check_ref="x", threads=1)
+    assert (out / "meta.json").exists()  # completed despite the bad record
+    sv = SparseVar2(out)
+    # The two clean records survive; the pos-10 mismatch is excluded.
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 2
+
+
+def test_from_vcf_check_ref_invalid_value_raises(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf_bad_ref(tmp_path)
+    with pytest.raises(ValueError, match="check_ref"):
+        SparseVar2.from_vcf(tmp_path / "s", vcf, ref, check_ref="z", threads=1)  # type: ignore[arg-type]
+```
+
+(`region_counts` is used elsewhere in this file — confirm the exact signature there if the count assertion needs adjusting.)
+
+- [ ] **Step 9: Run the Python test to verify it fails then passes**
+
+Run (before building): `pixi run pytest tests/test_svar2_from_vcf.py -k check_ref -v` → FAIL (kwarg not yet in the installed extension).
+Rebuild the extension so the new pyo3 signature is importable: `pixi run bash -lc 'maturin develop --features conversion'` (foreground; do not background — long builds that get backgrounded flake).
+Run again: `pixi run pytest tests/test_svar2_from_vcf.py -k check_ref -v` → PASS (3 tests).
+
+- [ ] **Step 10: Commit**
+
+```bash
+export CARGO_TARGET_DIR=/tmp/genoray-checkref-target
+git add src/chunk_assembler.rs src/orchestrator.rs src/lib.rs python/genoray/_svar2.py tests/test_check_ref_e2e.rs tests/test_svar2_from_vcf.py tests/conftest.py
+git commit -m "feat: check_ref option for from_vcf (single-source engine)"
+```
+
+---
+
+## Task 3: Expose `check_ref` on `from_pgen` and `from_svar1`
+
+The engine already honors `check_ref` (Task 2); this flips the two placeholder `CheckRef::Error` calls to real parsed modes and adds the Python kwargs. PGEN/SVAR1 use the same `ChunkAssembler`, so behavior is already proven by the Rust e2e — these tests are lighter (threading + validation smoke).
+
+**Files:**
+- Modify: `src/lib.rs` (`run_pgen_conversion_pipeline` ~257-343, `run_svar1_conversion_pipeline` ~832-960)
+- Modify: `python/genoray/_svar2.py` (`from_pgen` ~560-671, `from_svar1` ~841-930)
+
+**Interfaces:**
+- Consumes: `process_chromosome`'s `check_ref` param (Task 2), `_validate_check_ref` (Task 2).
+- Produces: `run_pgen_conversion_pipeline`/`run_svar1_conversion_pipeline` pyo3 fns gain a trailing `check_ref: String`; Python `from_pgen`/`from_svar1` gain `check_ref: Literal["e","x"] = "e"`.
+
+- [ ] **Step 1: Thread `check_ref` through `run_pgen_conversion_pipeline`**
+
+In `src/lib.rs`:
+- Append `check_ref` to the `#[pyo3(signature = (...))]` of `run_pgen_conversion_pipeline` (it has no defaults — add bare `check_ref` at the end of the tuple).
+- Add `check_ref: String,` as the last fn arg (after `pgen_readers`).
+- Parse it near the top (after the length checks, ~line 282):
+
+```rust
+    let check_ref: crate::normalize::CheckRef =
+        check_ref.parse().map_err(PyValueError::new_err)?;
+```
+
+- Replace the placeholder `crate::normalize::CheckRef::Error` in its `process_chromosome` call with `check_ref`.
+
+- [ ] **Step 2: Thread `check_ref` through `run_svar1_conversion_pipeline`**
+
+Same three edits in `run_svar1_conversion_pipeline`: append `check_ref` to the signature tuple, add `check_ref: String,` (after `format_src_dtypes`), parse it after `parse_manifest` (~line 879), and replace its placeholder `CheckRef::Error` with `check_ref`.
+
+- [ ] **Step 3: Add the Python kwargs + docstrings**
+
+In `python/genoray/_svar2.py`, add `check_ref: Literal["e", "x"] = "e"` to both `from_pgen` and `from_svar1` signatures (as the last keyword arg), add the same docstring paragraph as `from_vcf` (Task 2 Step 7), call `_validate_check_ref(check_ref)` before the `_core` call, and append `check_ref` as the last positional argument to `_core.run_pgen_conversion_pipeline(...)` and `_core.run_svar1_conversion_pipeline(...)` respectively.
+
+- [ ] **Step 4: Rebuild and write smoke tests**
+
+Rebuild: `pixi run bash -lc 'maturin develop --features conversion'` (foreground).
+
+The `check_ref` behavior for these methods runs through the same `ChunkAssembler` already proven by the Rust e2e (Task 2) and the `from_vcf` Python test — so these are **smoke tests** for the threading + validation, not full mismatch fixtures (constructing a PGEN/SVAR1 whose stored REF disagrees with a FASTA is not worth the fixture cost here). Two per method:
+
+1. an existing clean PGEN/SVAR1 conversion test in the file, re-run with `check_ref="x"` added, still succeeds (asserts `(out / "meta.json").exists()`);
+2. the same call with `check_ref="z"` raises `ValueError` matching `"check_ref"`.
+
+Concretely: open `tests/test_svar2_from_pgen.py`, find the simplest existing passing conversion test (one that builds a PGEN + reference and calls `SparseVar2.from_pgen`), and copy its fixture setup into two new tests named `test_from_pgen_check_ref_accepts_x` and `test_from_pgen_check_ref_invalid_raises`, adding the `check_ref=` kwarg as above. Do the same in `tests/test_svar2_from_svar1.py` for `from_svar1` (`test_from_svar1_check_ref_accepts_x` / `..._invalid_raises`). Reuse the file's own fixture/helper functions verbatim — do not invent new ones.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pixi run pytest tests/test_svar2_from_pgen.py tests/test_svar2_from_svar1.py -k check_ref -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+export CARGO_TARGET_DIR=/tmp/genoray-checkref-target
+git add src/lib.rs python/genoray/_svar2.py tests/test_svar2_from_pgen.py tests/test_svar2_from_svar1.py
+git commit -m "feat: check_ref option for from_pgen and from_svar1"
+```
+
+---
+
+## Task 4: `check_ref` for `from_vcf_list` (k-way merge path)
+
+The merge validates each per-file record in `FileCursor::advance` (`vcf_list_reader.rs`). This threads `check_ref` there, counts exclusions per cursor, exposes the total via the existing proxy pattern, and wires the mode from Python.
+
+**Files:**
+- Modify: `src/vcf_list_reader.rs` (`FileCursor` struct ~68-79, `advance` ~88-186, `VcfListRecordSource` struct ~228-237 + `new` ~245-316 + add `ref_excluded()` + call site ~508-514)
+- Modify: `src/orchestrator.rs` (`VcfListDroppedProxy` ~90-116, `VcfListRecordSource::new` call ~264-273, reader-thread proxy wiring ~229/274-278, `run_vcf_list` sig ~576-590 + `process_chromosome` call ~633-649)
+- Modify: `src/lib.rs` (`run_vcf_list_conversion_pipeline` ~787-822)
+- Modify: `python/genoray/_svar2.py` (`from_vcf_list` ~673-838)
+- Modify: `tests/test_check_ref_e2e.rs` (add a vcf_list variant)
+- Modify: `tests/test_svar2_from_vcf_list.py`
+
+**Interfaces:**
+- Consumes: `normalize::{CheckRef, RefDecision, apply_check_ref}`, `run_vcf_list`, `process_chromosome`.
+- Produces:
+  - `FileCursor` gains `ref_excluded: u64`.
+  - `FileCursor::advance(..., skip_out_of_scope: bool, check_ref: CheckRef, info_specs, format_specs)` — new `check_ref` param.
+  - `VcfListRecordSource::new(..., skip_out_of_scope: bool, check_ref: CheckRef, fields)` — new `check_ref` param; stored as a field; `ref_excluded(&self) -> u64` getter.
+  - `run_vcf_list(..., skip_out_of_scope: bool, check_ref: CheckRef, signatures, ...)` — new param.
+  - `run_vcf_list_conversion_pipeline` pyo3 gains trailing `check_ref: String`.
+  - Python `from_vcf_list(..., check_ref: Literal["e","x"] = "e")`.
+
+- [ ] **Step 1: Write the failing Rust e2e vcf_list variant**
+
+Append to `tests/test_check_ref_e2e.rs`:
+
+```rust
+use common::build_bcf_with_index as build_single;
+
+// Two single-sample files; file B carries a REF at pos 200 that disagrees with
+// the FASTA (which says "T"). Under x, B's bad record is dropped; the merge
+// still produces a store.
+#[test]
+fn vcf_list_ref_mismatch_excluded_under_x() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("store");
+    let fasta = tmp.path().join("in.fa");
+    build_fasta_with_index(&fasta, "chr1", 1000, &fasta_records());
+
+    let a = tmp.path().join("a.bcf");
+    let b = tmp.path().join("b.bcf");
+    build_single(&a, "chr1", 1000,
+        &["A"],
+        &[SynthRecord { pos: 100, ref_allele: b"A", alts: vec![&b"C"[..]], gt: vec![1, 0] }]);
+    build_single(&b, "chr1", 1000,
+        &["B"],
+        &[SynthRecord { pos: 200, ref_allele: b"G", alts: vec![&b"GTTT"[..]], gt: vec![1, 0] }]);
+
+    let dropped = genoray_core::orchestrator::run_vcf_list(
+        &[a.to_str().unwrap().to_string(), b.to_str().unwrap().to_string()],
+        Some(fasta.to_str().unwrap()),
+        &["chr1".to_string()],
+        out.to_str().unwrap(),
+        &["A".to_string(), "B".to_string()],
+        25_000,
+        2,
+        Some(1),
+        8 * 1024 * 1024,
+        false,               // skip_out_of_scope
+        CheckRef::Exclude,   // NEW
+        false,               // signatures
+        Vec::new(),          // info_fields
+        Vec::new(),          // format_fields
+    )
+    .unwrap();
+    assert_eq!(dropped, 0, "no out-of-scope ALTs; the REF-mismatch is excluded, not counted here");
+    assert!(out.join("meta.json").exists(), "merge completed despite the bad record");
+}
+```
+
+(Note the single-sample builder call: `build_bcf_with_index` accepts a `samples` slice of length 1 for these files.)
+
+- [ ] **Step 2: Run it to verify it fails to compile**
+
+Run: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target && pixi run bash -lc 'cargo test --no-default-features --features conversion --test test_check_ref_e2e'`
+Expected: FAIL — `run_vcf_list` takes 13 args, not 14.
+
+- [ ] **Step 3: Make `FileCursor` check_ref-aware**
+
+In `src/vcf_list_reader.rs`:
+- Add `ref_excluded: u64,` to the `FileCursor` struct (after `dropped: u64,`).
+- Initialize `ref_excluded: 0,` at both `FileCursor { ... }` construction sites in `VcfListRecordSource::new` (the `Ok(vcf)` arm and the `ContigNotInHeader` arm).
+- Add `check_ref: crate::normalize::CheckRef,` to `advance`'s params (after `skip_out_of_scope: bool,`).
+- Replace the `validate_ref` block (currently lines 114-116) with:
+
+```rust
+                    if let Some(rs) = ref_seq {
+                        match crate::normalize::apply_check_ref(check_ref, rec.pos, &rec.reference, rs)? {
+                            crate::normalize::RefDecision::Keep => {}
+                            crate::normalize::RefDecision::Exclude(e) => {
+                                self.ref_excluded += 1;
+                                if self.ref_excluded == 1 {
+                                    println!(
+                                        "Notice: check_ref=x excluding record(s) in {} \
+                                         whose REF disagrees with the reference (first: {e}).",
+                                        self.path
+                                    );
+                                }
+                                // This record contributes no atoms; fall through to
+                                // the buffer pop, exactly like an all-`*`/dropped ALT
+                                // record — the caller re-advances.
+                                return Ok(self.buf.pop_front());
+                            }
+                        }
+                    }
+```
+
+- [ ] **Step 4: Make `VcfListRecordSource` check_ref-aware**
+
+In `src/vcf_list_reader.rs`:
+- Add `check_ref: crate::normalize::CheckRef,` to the `VcfListRecordSource` struct (after `skip_out_of_scope: bool,`).
+- Add `check_ref: crate::normalize::CheckRef,` to `new`'s params (after `skip_out_of_scope: bool,`) and set `check_ref,` in the returned `Self { ... }`.
+- Add the getter after `dropped_out_of_scope`:
+
+```rust
+    /// Total REF-mismatch records excluded across every file so far
+    /// (`CheckRef::Exclude`). Valid after the read loop drains.
+    pub fn ref_excluded(&self) -> u64 {
+        self.cursors.iter().map(|c| c.ref_excluded).sum()
+    }
+```
+
+- Pass `self.check_ref` in the `advance` call (~line 508-514), after `self.skip_out_of_scope,`:
+
+```rust
+                    if let Some(atom) = self.cursors[i].advance(
+                        ref_seq,
+                        self.ploidy,
+                        self.skip_out_of_scope,
+                        self.check_ref,
+                        &self.info_specs,
+                        &self.format_specs,
+                    )? {
+```
+
+- [ ] **Step 5: Wire the proxy + `process_chromosome` in `orchestrator.rs`**
+
+In `src/orchestrator.rs`:
+- Add a field to `VcfListDroppedProxy`: `ref_excluded_out: Arc<AtomicU64>,` (next to `dropped_out`).
+- In its `read_next_chunk` (or wherever the EOF `store` happens, ~line 110-113), mirror the dropped store on the EOF transition:
+
+```rust
+        if rec.is_none() {
+            self.dropped_out.store(self.inner.dropped_out_of_scope(), Ordering::Relaxed);
+            self.ref_excluded_out.store(self.inner.ref_excluded(), Ordering::Relaxed);
+        }
+```
+
+- Add `check_ref: crate::normalize::CheckRef,` to `process_chromosome`'s params — **already added in Task 2**; no change here.
+- In the `SourceSpec::VcfList` arm of the reader thread (~256-278): create a second atomic alongside `vcf_list_dropped`:
+
+```rust
+                let vcf_list_dropped = Arc::new(AtomicU64::new(0));
+                let vcf_list_ref_excluded = Arc::new(AtomicU64::new(0));
+```
+
+  Pass `check_ref` to `VcfListRecordSource::new` (after `skip_out_of_scope,`), and set `ref_excluded_out: Arc::clone(&vcf_list_ref_excluded),` in the `VcfListDroppedProxy { ... }` literal.
+
+- Extend the per-contig log (added in Task 2 at ~line 321) so it also reports the vcf_list count. Replace that block with:
+
+```rust
+                let ref_excluded = reader.ref_excluded() + vcf_list_ref_excluded.load(Ordering::Relaxed);
+                if ref_excluded > 0 {
+                    println!(
+                        "[{chr}] check_ref=x: excluded {ref_excluded} record(s) whose REF \
+                         disagreed with the reference FASTA."
+                    );
+                }
+                Ok(reader.dropped_out_of_scope() + vcf_list_dropped.load(Ordering::Relaxed))
+```
+
+- In `run_vcf_list` (~576-590): add `check_ref: crate::normalize::CheckRef,` after `skip_out_of_scope: bool,`, and replace the placeholder `crate::normalize::CheckRef::Error` in its `process_chromosome` call (Task 2 Step 4) with `check_ref`.
+
+- [ ] **Step 6: Wire the pyo3 fn**
+
+In `src/lib.rs`, `run_vcf_list_conversion_pipeline`:
+- Append `check_ref="e".to_string()` to the `#[pyo3(signature = (...))]`.
+- Add `check_ref: String,` as the last fn arg.
+- Parse it (before the `py.detach`): `let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;`
+- Pass `check_ref` into the `orchestrator::run_vcf_list(...)` call, after `skip_out_of_scope,`.
+
+- [ ] **Step 7: Run the Rust e2e test**
+
+Run: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target && pixi run bash -lc 'cargo test --no-default-features --features conversion --test test_check_ref_e2e'`
+Expected: PASS (3 tests total). Also run the existing merge test to confirm no regression: `pixi run bash -lc 'cargo test --no-default-features --features conversion --test test_vcf_list_e2e'` → PASS.
+
+- [ ] **Step 8: Add the Python kwarg + test**
+
+In `python/genoray/_svar2.py`, add `check_ref: Literal["e", "x"] = "e"` to `from_vcf_list` (last kwarg), the same docstring paragraph, `_validate_check_ref(check_ref)` before the `_core` call, and append `check_ref` as the last positional arg to `_core.run_vcf_list_conversion_pipeline(...)` (after `format_,`, ~line 837).
+
+Rebuild: `pixi run bash -lc 'maturin develop --features conversion'` (foreground).
+
+`tests/test_svar2_from_vcf_list.py` already defines `_write_ref(d)` (same `_REF`, pos 10 = `G`) and `_ss(d, name, sample, rows)` (writes one bgzipped+indexed single-sample VCF). Append:
+
+```python
+def test_from_vcf_list_check_ref_error_aborts(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    a = _ss(tmp_path, "a", "A", "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\n")
+    b = _ss(tmp_path, "b", "B", "chr1\t10\t.\tA\tT\t.\t.\t.\tGT\t0|1\n")  # REF=A, _REF[10]='G'
+    with pytest.raises(Exception):
+        SparseVar2.from_vcf_list(tmp_path / "s", [a, b], ref, check_ref="e", threads=1)
+
+
+def test_from_vcf_list_check_ref_exclude_continues(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    a = _ss(tmp_path, "a", "A", "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\n")
+    b = _ss(tmp_path, "b", "B", "chr1\t10\t.\tA\tT\t.\t.\t.\tGT\t0|1\n")
+    out = tmp_path / "store"
+    SparseVar2.from_vcf_list(out, [a, b], ref, check_ref="x", threads=1)
+    assert (out / "meta.json").exists()  # merge completed; b's bad record excluded
+    sv = SparseVar2(out)
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 1  # only a's clean pos-3 record survives
+```
+
+- [ ] **Step 9: Run the Python test**
+
+Run: `pixi run pytest tests/test_svar2_from_vcf_list.py -k check_ref -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 10: Commit**
+
+```bash
+export CARGO_TARGET_DIR=/tmp/genoray-checkref-target
+git add src/vcf_list_reader.rs src/orchestrator.rs src/lib.rs python/genoray/_svar2.py tests/test_check_ref_e2e.rs tests/test_svar2_from_vcf_list.py
+git commit -m "feat: check_ref option for from_vcf_list (k-way merge)"
+```
+
+---
+
+## Task 5: CLI `--check-ref` flag
+
+**Files:**
+- Modify: `python/genoray/_cli/__main__.py` (`write_svar2` ~54-142)
+
+**Interfaces:**
+- Consumes: `SparseVar2.from_vcf` / `from_pgen` `check_ref` kwarg (Tasks 2-3).
+- Produces: `genoray write ... --check-ref {e,x}` (default `e`).
+
+- [ ] **Step 1: Add the `--check-ref` parameter**
+
+In `write_svar2`, add after `skip_symbolics_and_breakends` (keep it keyword-only, in the existing `*,` block):
+
+```python
+    check_ref: Annotated[
+        Literal["e", "x"], Parameter(name="--check-ref")
+    ] = "e",
+```
+
+Ensure `Literal` is imported at the top of the file.
+
+Add to the docstring's Parameters:
+
+```
+    check_ref
+        REF-vs-reference policy (ignored with ``--no-reference``). ``e``
+        (default) aborts on the first REF/FASTA disagreement; ``x`` drops the
+        offending record and continues. Mirrors ``bcftools norm --check-ref``.
+```
+
+- [ ] **Step 2: Pass it through both branches**
+
+Add `check_ref=check_ref,` to both the `SparseVar2.from_pgen(...)` call (~line 117) and the `SparseVar2.from_vcf(...)` call (~line 129).
+
+- [ ] **Step 3: Verify the CLI wires through**
+
+Run: `pixi run bash -lc 'genoray write --help'` → shows `--check-ref`.
+Run a smoke conversion on an existing test fixture with `--check-ref x` and confirm it exits 0 (use any VCF+FASTA fixture already under `tests/data/`):
+
+```bash
+pixi run bash -lc 'genoray write <fixture>.vcf.gz /tmp/cli_checkref_store --reference <fixture>.fa --check-ref x --overwrite && echo OK'
+```
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add python/genoray/_cli/__main__.py
+git commit -m "feat: --check-ref flag on genoray write"
+```
+
+---
+
+## Task 6: Update `skills/genoray-api/SKILL.md`
+
+**Files:**
+- Modify: `skills/genoray-api/SKILL.md`
+
+**Interfaces:**
+- Consumes: the finished public API (Tasks 2-5).
+
+- [ ] **Step 1: Find where the conversion methods are documented**
+
+Run: `grep -n "from_vcf\|from_pgen\|from_svar1\|from_vcf_list\|skip_out_of_scope\|no_reference" skills/genoray-api/SKILL.md`
+
+- [ ] **Step 2: Document `check_ref`**
+
+For each of the four `from_*` methods documented in `SKILL.md`, add the `check_ref` keyword alongside the existing `no_reference` / `skip_out_of_scope` documentation, with this wording (adapt to the file's format):
+
+```
+- `check_ref` (`"e"` | `"x"`, default `"e"`): policy when a record's REF
+  disagrees with the reference FASTA (ignored with `no_reference=True`).
+  `"e"` raises and aborts (like `bcftools norm --check-ref e`); `"x"` drops the
+  offending record — including a REF running past the contig end — and
+  continues. Case-insensitive, so soft-masked reference bases match.
+```
+
+If `SKILL.md` documents these methods with a shared "reference handling" note rather than per-method, add the `check_ref` note once in that shared section and reference it from each method.
+
+- [ ] **Step 3: Verify no stale claims**
+
+Re-read the edited sections; confirm the return-value description still says the methods return the out-of-scope drop count (unchanged) and that nothing claims REF mismatches always abort.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/genoray-api/SKILL.md
+git commit -m "docs: document check_ref in genoray-api skill"
+```
+
+---
+
+## Task 7: Full-suite verification
+
+- [ ] **Step 1: Run the full Rust test suite**
+
+Run: `export CARGO_TARGET_DIR=/tmp/genoray-checkref-target && pixi run bash -lc 'cargo test --no-default-features --features conversion'`
+Expected: all pass (including the pre-existing `test_convert_skip_e2e`, `test_vcf_list_e2e`, `test_left_align_e2e`, and `normalize` unit tests).
+
+- [ ] **Step 2: Confirm the no-conversion query-core build still compiles**
+
+Run: `pixi run bash -lc 'cargo check --no-default-features'`
+Expected: clean (the `check_ref` additions live behind `#[cfg(feature = "conversion")]` in `lib.rs`; `normalize.rs` additions must not reference conversion-only symbols).
+
+- [ ] **Step 3: Rebuild and run the full Python suite**
+
+Run: `pixi run bash -lc 'maturin develop --features conversion'` (foreground) then `pixi run test`.
+Expected: all pass. Confirm the default path is unchanged by spot-checking that existing from_vcf/from_pgen/from_vcf_list/from_svar1 tests (without `check_ref`) still pass.
+
+- [ ] **Step 4: Lint**
+
+Run: `pixi run bash -lc 'ruff check genoray tests && ruff format --check genoray tests'` and confirm prek hooks pass on a dry run: `pixi run bash -lc 'prek run --all-files'`.
+Expected: clean.
+
+- [ ] **Step 5: Push and open the draft PR**
+
+```bash
+git push -u origin worktree-check-ref-svar2
+gh pr create --draft --title "feat: check_ref (e/x) for all SVAR2 conversion methods (#116)" --body "$(cat <<'EOF'
+Closes #116.
+
+Adds a `check_ref` policy to `from_vcf`, `from_pgen`, `from_svar1`, and
+`from_vcf_list` (plus `genoray write --check-ref`):
+
+- `"e"` (default) — abort on a REF/FASTA disagreement (current behavior).
+- `"x"` — drop the offending record and continue, logging a per-contig count
+  and the first offending locus.
+
+One shared `apply_check_ref` helper in `normalize.rs` replaces the two
+`validate_ref(...)?` call sites. Return types and default behavior are
+unchanged (non-breaking). `skills/genoray-api/SKILL.md` updated.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** `CheckRef`/`apply_check_ref` (Task 1) ↔ spec "Architecture"; chunk_assembler + vcf_list_reader call-site replacement (Tasks 2, 4) ↔ spec "one shared decision point"; threading through 4 pyo3 fns + Python kwargs (Tasks 2-4) ↔ spec "Threading" + "Python surface"; CLI (Task 5) + SKILL.md (Task 6) ↔ spec "Python / CLI / docs surface"; per-contig count + first-locus logging (Tasks 2, 4) ↔ spec "Reporting" (grand total explicitly dropped, spec updated); `RefOutOfContig` handled under `x` (Task 1 tests + apply_check_ref) ↔ spec note; `w`/`s` absent ↔ spec "Out of scope".
+- **Type consistency:** `check_ref` param is inserted **after `skip_out_of_scope`** in every Rust fn (`ChunkAssembler::new`, `process_chromosome`, `run_vcf_list`, `FileCursor::advance`, `VcfListRecordSource::new`) and **before `fields`** where a `fields`/`format_specs` trailing arg exists; the pyo3 boundary always takes `check_ref: String` as the **trailing** param and parses via `FromStr`. Getters are `ref_excluded()` on both `ChunkAssembler` and `VcfListRecordSource`. Python kwarg is `check_ref: Literal["e","x"] = "e"` on all four methods, validated by `_validate_check_ref`.
+- **Non-breaking:** every new Rust param has a placeholder (`CheckRef::Error`) until its surface is wired; pyo3 signatures default `check_ref="e"`; Python kwargs default `"e"`. Existing tests pass unchanged (verified in Task 7).

--- a/docs/superpowers/specs/2026-07-15-check-ref-svar2-conversion-design.md
+++ b/docs/superpowers/specs/2026-07-15-check-ref-svar2-conversion-design.md
@@ -1,0 +1,188 @@
+# Design: `check_ref` for all SVAR2 conversion methods (issue #116)
+
+Date: 2026-07-15
+
+## Problem
+
+Every SVAR2 conversion validates each record's REF against the reference FASTA
+and **hard-aborts the entire build** on the first disagreement:
+
+```
+ValueError: REF 'G' at pos 46405660 disagrees with reference FASTA ('T')
+```
+
+For a large k-way merge (e.g. ~7,000 single-sample somatic VCFs), a single
+malformed record — SAGE/PURPLE occasionally emits a REF that disagrees with the
+genome in low-complexity/repeat regions — kills the whole build and leaves a
+partial, unusable store. The cost of one bad record is the entire cohort merge.
+
+The check lives in `src/normalize.rs::validate_ref` and is invoked at two sites:
+
+- `chunk_assembler.rs:320` — shared by `from_vcf`, `from_pgen`, `from_svar1`
+  (single-source spine: atomize with the record's REF, then left-align).
+- `vcf_list_reader.rs:115` — `from_vcf_list` (k-way merge; `atomize_to_vcf_biallelic`
+  reconstructs REF bytes from the FASTA).
+
+Both propagate the error → hard abort. Validation runs only when a reference is
+supplied (`no_reference` skips it entirely).
+
+## Goal
+
+Add a `check_ref` policy mirroring a subset of `bcftools norm --check-ref` to
+**all four** conversion entry points:
+
+- `"e"` (error) — current behavior; abort on disagreement. **Default** (non-breaking).
+- `"x"` (exclude) — drop the offending record and continue.
+
+`"w"` (warn/keep) and `"s"` (set REF from FASTA) are **out of scope** (see below).
+
+REF comparison is already ASCII-case-insensitive in `validate_ref`, so
+soft-masked (lowercase) reference bases match uppercase VCF REF — no change
+needed there.
+
+## Architecture — one shared decision point (DRY)
+
+Both call sites currently do `validate_ref(...)?`. Replace both with a single
+shared helper in `src/normalize.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckRef {
+    /// Abort on REF/FASTA disagreement (current behavior).
+    Error,
+    /// Drop the offending record and continue.
+    Exclude,
+}
+
+/// Per-record outcome of applying a `CheckRef` policy.
+pub enum RefDecision {
+    /// REF matches — process the record normally.
+    Keep,
+    /// REF disagrees under `Exclude` — skip this whole record.
+    Exclude,
+}
+
+/// Apply the `CheckRef` policy to one record. Returns `Err` only under
+/// `CheckRef::Error` (propagating `RefMismatch` / `RefOutOfContig`); under
+/// `CheckRef::Exclude` a disagreement becomes `Ok(RefDecision::Exclude)`.
+pub fn apply_check_ref(
+    mode: CheckRef,
+    pos: u32,
+    ref_allele: &[u8],
+    ref_seq: &[u8],
+) -> Result<RefDecision, NormalizeError> {
+    match validate_ref(pos, ref_allele, ref_seq) {
+        Ok(()) => Ok(RefDecision::Keep),
+        Err(e) => match mode {
+            CheckRef::Error => Err(e),
+            CheckRef::Exclude => Ok(RefDecision::Exclude),
+        },
+    }
+}
+```
+
+Behavior:
+
+- Under `Error`, the `?` propagates exactly today's `RefMismatch` /
+  `RefOutOfContig` → byte-identical to current behavior.
+- Under `Exclude`, both a base mismatch **and** `RefOutOfContig` (REF runs past
+  the contig end) drop the record and continue — both are cases of "this record
+  disagrees with this reference," which is precisely what a robust cohort merge
+  wants to skip.
+
+Each call site becomes:
+
+```rust
+match apply_check_ref(mode, pos, &rec.reference, ref_seq)? {
+    RefDecision::Keep => { /* proceed: atomize + left-align as today */ }
+    RefDecision::Exclude => { self.ref_excluded += 1; /* skip record */ }
+}
+```
+
+- `chunk_assembler::decompose_record`: on `Exclude`, increment the counter and
+  `return Ok(())` before atomizing — the record contributes no atoms.
+- `vcf_list_reader::FileCursor::advance`: on `Exclude`, increment the counter and
+  skip the atomize/buffer-fill block, falling through to the existing
+  `Ok(self.buf.pop_front())`. That returns `None` while `!eof`, and the caller
+  re-advances — the exact path already used when a record atomizes to zero atoms
+  (all-`*`/dropped ALTs). No new control flow in the merge loop.
+
+## Threading
+
+`check_ref` flows top-down:
+
+1. 4 pyo3 functions in `src/lib.rs`
+   (`run_conversion_pipeline`, `run_pgen_conversion_pipeline`,
+   `run_vcf_list_conversion_pipeline`, `run_svar1_conversion_pipeline`)
+   gain a `check_ref: &str` parameter in their `#[pyo3(signature = ...)]`.
+2. → the orchestrator / pipeline bodies → `process_chromosome`.
+3. → `ChunkAssembler::new` and `VcfListRecordSource::new` (stored as a
+   `CheckRef` field), and to `FileCursor::advance`.
+
+Python passes the string `"e"` / `"x"`; Rust parses it into `CheckRef` (via
+`TryFrom<&str>` / `FromStr`), erroring on an unknown value. The enum is the
+single source of truth for the mapping; the Python `Literal` is the typed
+surface. Extending to `"w"`/`"s"` later requires no signature change.
+
+`check_ref` is only consulted when a reference is present; `no_reference` builds
+are unaffected (validation never runs).
+
+## Reporting
+
+The excluded-record count is surfaced via the existing `println!("Notice: ...")`
+pattern used throughout the pipeline:
+
+- a per-contig count,
+- a grand total at the end of the run,
+- the **first** offending locus (`chrom:pos REF vs FASTA`) for debuggability.
+
+Bounded output — never one line per excluded record.
+
+**Return type is unchanged:** each `from_*` still returns `int` = out-of-scope
+(symbolic/breakend) ALTs dropped. Rationale: a second count cannot be added
+without a breaking change to the return type, and stdout logging matches how the
+pipeline already reports progress and the `skip_out_of_scope` behavior. If
+programmatic access to the exclusion count is wanted later, a small stats object
+is a future (breaking) release.
+
+## Python / CLI / docs surface
+
+- Add `check_ref: Literal["e", "x"] = "e"` (keyword-only) to `from_vcf`,
+  `from_pgen`, `from_vcf_list`, `from_svar1`. Validate the literal, pass through.
+  Docstrings updated to explain that `"x"` drops REF/FASTA disagreements
+  (including out-of-contig) and continues.
+- CLI `genoray write` (the svar2 default command, which covers VCF + PGEN): add
+  `--check-ref {e,x}` (default `e`) and a closing "Notice" line, mirroring the
+  existing `--skip-symbolics-and-breakends` treatment. (`from_vcf_list` and
+  `from_svar1` have no CLI entry point today; no CLI change for them.)
+- **`skills/genoray-api/SKILL.md` updated** — required by CLAUDE.md, since a
+  public keyword is added to four public methods.
+
+## Testing
+
+- **Rust unit** (`src/normalize.rs`): `apply_check_ref` — `Error` propagates both
+  `RefMismatch` and `RefOutOfContig`; `Exclude` returns `RefDecision::Exclude`
+  for mismatch and out-of-contig, `RefDecision::Keep` on match.
+- **Rust e2e** (new `tests/test_check_ref_e2e.rs`, mirroring
+  `tests/test_convert_skip_e2e.rs`): a tiny VCF with one bad-REF record plus a
+  tiny FASTA → `check_ref="e"` errors; `check_ref="x"` produces a store missing
+  exactly that variant and retaining the rest. Covers the shared
+  chunk_assembler path; a `from_vcf_list` variant covers the merge path.
+- **Python** (extend `tests/test_svar2_from_vcf.py`, `_from_pgen`,
+  `_from_vcf_list`, `_from_svar1`): reproduce issue #116's `REF=G`-where-FASTA-is-
+  `T` record (a T-homopolymer insertion); assert `check_ref="e"` raises and
+  `check_ref="x"` succeeds, excluding only the offending record while keeping a
+  legitimate adjacent variant.
+
+## Out of scope
+
+- `"w"` (warn/keep): in genoray a kept record can't be trusted for left-alignment
+  against a FASTA it disagrees with, so "keep as-is" would mean processing it in
+  no-reference mode — muddy semantics for little benefit over `"x"` in the
+  cohort-merge use case.
+- `"s"` (set REF from FASTA): a footgun for indels (rewriting REF changes the
+  variant; bcftools itself only reliably fixes SNVs and may silently drop
+  indels), and the REF-reconstruction differs between the two call sites.
+
+Both can be added later without changing the signature (the `check_ref` string
+surface and the `CheckRef` enum are already extensible).

--- a/docs/superpowers/specs/2026-07-15-check-ref-svar2-conversion-design.md
+++ b/docs/superpowers/specs/2026-07-15-check-ref-svar2-conversion-design.md
@@ -132,11 +132,15 @@ are unaffected (validation never runs).
 The excluded-record count is surfaced via the existing `println!("Notice: ...")`
 pattern used throughout the pipeline:
 
-- a per-contig count,
-- a grand total at the end of the run,
-- the **first** offending locus (`chrom:pos REF vs FASTA`) for debuggability.
+- a per-contig count, logged as the pipeline finishes each contig,
+- the **first** offending locus (`pos REF vs FASTA`, from the carried
+  `NormalizeError`) logged once per source when the first exclusion occurs.
 
-Bounded output — never one line per excluded record.
+Bounded output — never one line per excluded record. A cross-contig grand total
+is intentionally **not** emitted: it would require changing `process_chromosome`'s
+internal return type (rippling through all four pipeline callers and the
+thread-join plumbing) for marginal value over the per-contig lines, which the
+user can trivially sum.
 
 **Return type is unchanged:** each `from_*` still returns `int` = out-of-scope
 (symbolic/breakend) ALTs dropped. Rationale: a second count cannot be added

--- a/python/genoray/_cli/__main__.py
+++ b/python/genoray/_cli/__main__.py
@@ -68,6 +68,7 @@ def write_svar2(
     skip_symbolics_and_breakends: Annotated[
         bool, Parameter(name="--skip-symbolics-and-breakends", negative="")
     ] = False,
+    check_ref: Annotated[Literal["e", "x"], Parameter(name="--check-ref")] = "e",
 ) -> None:
     """
     Convert a bgzipped VCF, BCF, or PLINK2 PGEN to an SVAR2 store (the default, better-across-the-board format).
@@ -105,6 +106,10 @@ def write_svar2(
         class into nucleotides, so they are dropped together. (On
         ``genoray write svar1`` the two classes are filtered independently
         via ``--no-symbolic`` / ``--no-breakend``.)
+    check_ref
+        REF-vs-reference policy (ignored with ``--no-reference``). ``e``
+        (default) aborts on the first REF/FASTA disagreement; ``x`` drops the
+        offending record and continues. Mirrors ``bcftools norm --check-ref``.
     """
     from genoray import SparseVar2
 
@@ -124,6 +129,7 @@ def write_svar2(
             threads=threads,
             overwrite=overwrite,
             long_allele_capacity=long_allele_capacity,
+            check_ref=check_ref,
         )
     else:
         dropped = SparseVar2.from_vcf(
@@ -137,6 +143,7 @@ def write_svar2(
             threads=threads,
             overwrite=overwrite,
             long_allele_capacity=long_allele_capacity,
+            check_ref=check_ref,
         )
     if skip_out_of_scope:
         print(f"Dropped {dropped} out-of-scope (symbolic/breakend) ALT alleles.")

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -590,6 +590,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         overwrite: bool = False,
         long_allele_capacity: int = 8 * 1024 * 1024,
         signatures: bool = False,
+        check_ref: Literal["e", "x"] = "e",
     ) -> int:
         """Convert a PLINK2 PGEN to an SVAR2 store.
 
@@ -620,6 +621,13 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         Haplotype resolution for *unphased* heterozygotes follows the allele-code
         order ``pgenlib`` returns — the same caveat :meth:`from_vcf` carries for
         unphased ``GT``.
+
+        check_ref: policy for a record whose REF disagrees with the reference
+        FASTA (ignored when `no_reference=True`). `"e"` (default) raises and
+        aborts the build — matching `bcftools norm --check-ref e`. `"x"` drops
+        the offending record (including a REF that runs past the contig end)
+        and continues, logging a per-contig count. Comparison is
+        case-insensitive, so soft-masked (lowercase) reference bases match.
         """
         from genoray._pgen import _read_psam
 
@@ -673,6 +681,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             for _ in contigs
         ]
 
+        _validate_check_ref(check_ref)
         return _core.run_pgen_conversion_pipeline(
             str(source),
             str(pvar),
@@ -687,6 +696,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             skip_out_of_scope,
             signatures,
             readers,
+            check_ref,
         )
 
     @classmethod
@@ -870,6 +880,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         overwrite: bool = False,
         long_allele_capacity: int = 8 * 1024 * 1024,
         signatures: bool = False,
+        check_ref: Literal["e", "x"] = "e",
     ) -> int:
         """Convert a SVAR1 (``SparseVar``) store to an SVAR2 store natively.
 
@@ -888,6 +899,13 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         values, a dense-routed variant's non-carrier cells are filled with the
         field's default/missing sentinel — field output is byte-identical to
         :meth:`from_vcf` only for var_key (carrier-only) routing.
+
+        check_ref: policy for a record whose REF disagrees with the reference
+        FASTA (ignored when `no_reference=True`). `"e"` (default) raises and
+        aborts the build — matching `bcftools norm --check-ref e`. `"x"` drops
+        the offending record (including a REF that runs past the contig end)
+        and continues, logging a per-contig count. Comparison is
+        case-insensitive, so soft-masked (lowercase) reference bases match.
         """
         from genoray._svar import SparseVar
 
@@ -934,6 +952,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             chunk_size = _auto_chunk_size(n_samples, ploidy)
 
         out.parent.mkdir(parents=True, exist_ok=True)
+        _validate_check_ref(check_ref)
         return _core.run_svar1_conversion_pipeline(
             str(source),
             None if no_reference else str(reference),
@@ -955,6 +974,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             alt_off_pc,
             format_tuples,
             src_dtypes,
+            check_ref,
         )
 
 

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -208,6 +208,15 @@ def _check_fd_budget(n_files: int) -> None:
     )
 
 
+def _validate_check_ref(check_ref: str) -> str:
+    """Validate a `check_ref` mode string. Returns it unchanged on success."""
+    if check_ref not in ("e", "x"):
+        raise ValueError(
+            f'check_ref must be "e" (error) or "x" (exclude), got {check_ref!r}'
+        )
+    return check_ref
+
+
 class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
     """Reader for a finished SVAR2 store (M6a skeleton).
 
@@ -487,6 +496,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         signatures: bool = False,
         info_fields: Sequence[str | InfoField] | None = None,
         format_fields: Sequence[str | FormatField] | None = None,
+        check_ref: Literal["e", "x"] = "e",
     ) -> int:
         """Convert a bgzipped VCF or BCF to an SVAR2 store.
 
@@ -509,6 +519,13 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         otherwise a reserved sentinel/NaN is written. FORMAT fields are
         genotype-aligned: non-carrier values are dropped for var_key-routed
         variants.
+
+        check_ref: policy for a record whose REF disagrees with the reference
+        FASTA (ignored when `no_reference=True`). `"e"` (default) raises and
+        aborts the build — matching `bcftools norm --check-ref e`. `"x"` drops
+        the offending record (including a REF that runs past the contig end)
+        and continues, logging a per-contig count. Comparison is
+        case-insensitive, so soft-masked (lowercase) reference bases match.
         """
         from cyvcf2 import VCF as _CyVCF
 
@@ -541,6 +558,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         flds = _resolve_fields(str(source), info_fields, format_fields)
         info = [t for t in flds if t[1] == "info"]
         format_ = [t for t in flds if t[1] == "format"]
+        _validate_check_ref(check_ref)
         return _core.run_conversion_pipeline(
             str(source),
             reference_path,
@@ -555,6 +573,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             signatures,
             info,
             format_,
+            check_ref,
         )
 
     @classmethod

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -716,6 +716,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         signatures: bool = False,
         info_fields: "Sequence[str | InfoField] | None" = None,
         format_fields: "Sequence[str | FormatField] | None" = None,
+        check_ref: Literal["e", "x"] = "e",
     ) -> int:
         """Build one SVAR2 store from many **single-sample** VCFs/BCFs via a
         native k-way merge (no `bcftools merge`, no intermediate multi-sample
@@ -795,6 +796,13 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
 
         Returns the number of out-of-scope (symbolic/breakend) ALTs dropped
         (0 unless `skip_out_of_scope`).
+
+        check_ref: policy for a record whose REF disagrees with the reference
+        FASTA (ignored when `no_reference=True`). `"e"` (default) raises and
+        aborts the build — matching `bcftools norm --check-ref e`. `"x"` drops
+        the offending record (including a REF that runs past the contig end)
+        and continues, logging a per-contig count. Comparison is
+        case-insensitive, so soft-masked (lowercase) reference bases match.
         """
         from cyvcf2 import VCF as _CyVCF
 
@@ -850,6 +858,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         info = [t for t in flds if t[1] == "info"]
         format_ = [t for t in flds if t[1] == "format"]
 
+        _validate_check_ref(check_ref)
         return _core.run_vcf_list_conversion_pipeline(
             [str(p) for p in paths],
             None if no_reference else str(reference),
@@ -864,6 +873,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             signatures,
             info,
             format_,
+            check_ref,
         )
 
     @classmethod

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -371,7 +371,7 @@ dropped = SparseVar2.from_vcf_list("out.svar2", "vcfs/", "ref.fa")
 dropped = SparseVar2.from_vcf_list("out.svar2", "manifest.txt", "ref.fa")
 ```
 
-Signature: `from_vcf_list(out, sources, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None) -> int`
+Signature: `from_vcf_list(out, sources, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None, check_ref="e") -> int`
 
 Builds **one** SVAR2 store from **N single-sample** VCFs/BCFs with different
 site lists, via a native k-way merge — no `bcftools merge`, no intermediate
@@ -448,8 +448,12 @@ multi-sample VCF.
     gets the field's default (reserved sentinel/NaN, or an explicit
     `default=`).
 - `ploidy`, `skip_out_of_scope`, `chunk_size`, `threads`, `overwrite`,
-  `long_allele_capacity`, `signatures` all mean the same as `from_vcf`, and
-  the return value is the same `int` (dropped out-of-scope ALTs).
+  `long_allele_capacity`, `signatures`, `check_ref` all mean the same as
+  `from_vcf`, and the return value is the same `int` (dropped out-of-scope
+  ALTs). `check_ref` is applied per input file during the merge (ignored
+  when `no_reference=True`): under `"x"`, a bad record is excluded from its
+  own file only (not the whole merged site), and the per-contig log reports
+  the total excluded across every input file.
 
 ### Conversion from SVAR1
 

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -246,7 +246,7 @@ dropped = SparseVar2.from_vcf(
 dropped = SparseVar2.from_vcf("out.svar2", "file.vcf.gz", no_reference=True)
 ```
 
-Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None) -> int`
+Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=25_000, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None, check_ref="e") -> int`
 
 - `source` — a bgzipped VCF (`.vcf.gz`) or BCF (`.bcf`). Auto-indexes (`.csi`) if
   no `.csi`/`.tbi` is found. For a PLINK2 PGEN source, use `from_pgen` instead
@@ -261,6 +261,13 @@ Signature: `from_vcf(out, source, reference=None, *, no_reference=False, skip_ou
   layer — there's no separate "symbolic only" vs. "breakend only" toggle.
 - Returns the number of dropped out-of-scope ALTs as an `int` (always `0`
   unless `skip_out_of_scope=True`).
+- `check_ref: Literal["e", "x"] = "e"` — policy for a record whose REF
+  disagrees with the reference FASTA (ignored when `no_reference=True`).
+  `"e"` (default) raises and aborts the build, matching `bcftools norm
+  --check-ref e`. `"x"` drops the offending record (including a REF that
+  runs past the contig end) and continues, logging a per-contig count.
+  Comparison is case-insensitive (soft-masked lowercase reference bases
+  match). Any other value raises `ValueError` before conversion starts.
 - No dosages, no `haploid=` OR-collapse, no `max_mem`-based chunking (use
   `chunk_size` instead) — these remain `SparseVar` (SVAR 1.0)-only for now.
 - `signatures=False` — when `True`, classifies every SNP/indel into its

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -747,6 +747,10 @@ genoray write svar1 file.vcf.gz out.svar --max-mem 4g --haploid
   together; prints a `Dropped {n} out-of-scope (symbolic/breakend) ALT
   alleles.` line when set. `--ploidy` (default 2) is VCF/BCF only — PGEN is
   diploid, and passing a non-default `--ploidy` with a `.pgen` source raises.
+  `--check-ref {e,x}` (default `e`, maps to `check_ref=`): REF-vs-reference
+  policy, ignored with `--no-reference`. `e` aborts on the first REF/FASTA
+  disagreement; `x` drops the offending record and continues. Mirrors
+  `bcftools norm --check-ref`.
 - `genoray write svar1`: unchanged SVAR 1.0 behavior — VCF or PGEN source,
   `--dosages`, `--max-mem`, `--haploid`, `--no-symbolic`/`--no-breakend`
   (independent flags here, unlike SVAR2).

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -334,13 +334,14 @@ dropped = SparseVar2.from_pgen(
 )
 ```
 
-Signature: `from_pgen(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, chunk_size=None, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False) -> int`
+Signature: `from_pgen(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, chunk_size=None, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, check_ref="e") -> int`
 
 - `source` — a `.pgen` file. Variant metadata is read from the sibling
   `.pvar`/`.pvar.zst`, sample names from the sibling `.psam` (all samples are
   converted — no subsetting). `reference`/`no_reference`, `skip_out_of_scope`,
-  `overwrite`, `long_allele_capacity`, and `signatures` all mean the same as
-  `from_vcf` (above), and return the same `int` (dropped out-of-scope ALTs).
+  `overwrite`, `long_allele_capacity`, `signatures`, and `check_ref` all mean
+  the same as `from_vcf` (above), and return the same `int` (dropped
+  out-of-scope ALTs).
 - **Diploid only** — no `ploidy=` kwarg (`from_vcf`'s default `ploidy=2` is
   implicit and fixed here).
 - `chunk_size=None` — unlike `from_vcf`'s fixed `25_000` default, `None` here
@@ -461,16 +462,16 @@ dropped = SparseVar2.from_svar1(
 )
 ```
 
-Signature: `from_svar1(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, chunk_size=None, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False) -> int`
+Signature: `from_svar1(out, source, reference=None, *, no_reference=False, skip_out_of_scope=False, chunk_size=None, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, check_ref="e") -> int`
 
 Migrates an existing SVAR 1.0 (`SparseVar`) store to SVAR2 natively — reads no
 VCF and no htslib; SVAR1 is already sparse, so this reconstructs variant
 records from SVAR1's arrays and reuses the same conversion spine as `from_vcf`.
 
 - `source` — a `SparseVar` store directory (SVAR1). `reference`/`no_reference`,
-  `skip_out_of_scope`, `overwrite`, `long_allele_capacity`, and `signatures` all
-  mean the same as `from_vcf` (above), and return the same `int` (dropped
-  out-of-scope ALTs).
+  `skip_out_of_scope`, `overwrite`, `long_allele_capacity`, `signatures`, and
+  `check_ref` all mean the same as `from_vcf` (above), and return the same
+  `int` (dropped out-of-scope ALTs).
 - `ploidy` is read from SVAR1's metadata — no `ploidy=` kwarg.
 - **Biallelic SVAR1 only** — raises `ValueError` if the source store has
   multiallelic variants (SVAR1's `geno==1` model); re-create the SVAR1 store

--- a/src/chunk_assembler.rs
+++ b/src/chunk_assembler.rs
@@ -254,6 +254,8 @@ pub struct ChunkAssembler {
     ref_seq: Vec<u8>,
     has_reference: bool,
     skip_out_of_scope: bool,
+    check_ref: crate::normalize::CheckRef,
+    ref_excluded: u64,
     dropped_out_of_scope: u64,
     info_fields: Vec<FieldSpec>,
     format_fields: Vec<FieldSpec>,
@@ -264,6 +266,7 @@ pub struct ChunkAssembler {
 }
 
 impl ChunkAssembler {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         source: Box<dyn RecordSource + Send>,
         num_samples: usize,
@@ -271,6 +274,7 @@ impl ChunkAssembler {
         fasta_path: Option<&str>,
         chrom: &str,
         skip_out_of_scope: bool,
+        check_ref: crate::normalize::CheckRef,
         fields: &[FieldSpec],
     ) -> Result<Self, ConversionError> {
         let (ref_seq, has_reference) = match fasta_path {
@@ -284,6 +288,8 @@ impl ChunkAssembler {
             ref_seq,
             has_reference,
             skip_out_of_scope,
+            check_ref,
+            ref_excluded: 0,
             dropped_out_of_scope: 0,
             info_fields: fields
                 .iter()
@@ -308,6 +314,12 @@ impl ChunkAssembler {
         self.dropped_out_of_scope
     }
 
+    /// Records excluded because their REF disagreed with the reference under
+    /// `CheckRef::Exclude`. Valid after the read loop drains.
+    pub fn ref_excluded(&self) -> u64 {
+        self.ref_excluded
+    }
+
     // Decompose one record into atoms and push them onto the reorder heap, sharing
     // one decoded genotype vector across all atoms of the record.
     fn decompose_record(&mut self, rec: RawRecord) -> Result<(), ConversionError> {
@@ -317,7 +329,25 @@ impl ChunkAssembler {
         // Fail fast only when a reference is available; without one we trust the
         // input is already normalized/left-aligned.
         if self.has_reference {
-            crate::normalize::validate_ref(pos, &rec.reference, &self.ref_seq)?;
+            match crate::normalize::apply_check_ref(
+                self.check_ref,
+                pos,
+                &rec.reference,
+                &self.ref_seq,
+            )? {
+                crate::normalize::RefDecision::Keep => {}
+                crate::normalize::RefDecision::Exclude(e) => {
+                    self.ref_excluded += 1;
+                    if self.ref_excluded == 1 {
+                        println!(
+                            "Notice: check_ref=x excluding record(s) whose REF disagrees \
+                             with the reference (first: {e}); further exclusions on this \
+                             contig are counted, not printed."
+                        );
+                    }
+                    return Ok(());
+                }
+            }
         }
 
         let alt_refs: Vec<&[u8]> = rec.alts.iter().map(|a| a.as_slice()).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,7 +791,7 @@ fn svar2_variant_stats<'py>(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-#[pyo3(signature = (vcf_paths, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new()))]
+#[pyo3(signature = (vcf_paths, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string()))]
 fn run_vcf_list_conversion_pipeline(
     py: Python,
     vcf_paths: Vec<String>,
@@ -807,7 +807,9 @@ fn run_vcf_list_conversion_pipeline(
     signatures: bool,
     info_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
+    check_ref: String,
 ) -> PyResult<usize> {
+    let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;
     let dropped: u64 = py.detach(|| {
         orchestrator::run_vcf_list(
             &vcf_paths,
@@ -820,6 +822,7 @@ fn run_vcf_list_conversion_pipeline(
             max_threads,
             long_allele_capacity,
             skip_out_of_scope,
+            check_ref,
             signatures,
             info_fields,
             format_fields,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ fn run_conversion_pipeline(
 #[cfg(feature = "conversion")]
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (pgen_path, pvar_path, reference_path, chroms, contig_ranges, output_dir, samples, chunk_size, max_threads, long_allele_capacity, skip_out_of_scope, signatures, pgen_readers))]
+#[pyo3(signature = (pgen_path, pvar_path, reference_path, chroms, contig_ranges, output_dir, samples, chunk_size, max_threads, long_allele_capacity, skip_out_of_scope, signatures, pgen_readers, check_ref))]
 fn run_pgen_conversion_pipeline(
     py: Python,
     pgen_path: String,
@@ -277,12 +277,14 @@ fn run_pgen_conversion_pipeline(
     skip_out_of_scope: bool,
     signatures: bool,
     pgen_readers: Vec<Py<PyAny>>,
+    check_ref: String,
 ) -> PyResult<usize> {
     if chroms.len() != contig_ranges.len() || chroms.len() != pgen_readers.len() {
         return Err(PyValueError::new_err(
             "chroms, contig_ranges, and pgen_readers must be the same length",
         ));
     }
+    let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;
     let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
     // PGEN is diploid-only.
     let ploidy = 2usize;
@@ -337,7 +339,7 @@ fn run_pgen_conversion_pipeline(
                         ploidy,
                         long_allele_capacity,
                         skip_out_of_scope,
-                        crate::normalize::CheckRef::Error,
+                        check_ref,
                         processing_threads,
                         signatures,
                         &fields,
@@ -838,7 +840,7 @@ fn run_vcf_list_conversion_pipeline(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-#[pyo3(signature = (svar1_dir, reference_path, chroms, contig_starts, contig_lens, output_dir, samples, ploidy, chunk_size, max_threads, long_allele_capacity, skip_out_of_scope, signatures, pos_per_contig, ref_bytes_per_contig, ref_offsets_per_contig, alt_bytes_per_contig, alt_offsets_per_contig, format_fields, format_src_dtypes))]
+#[pyo3(signature = (svar1_dir, reference_path, chroms, contig_starts, contig_lens, output_dir, samples, ploidy, chunk_size, max_threads, long_allele_capacity, skip_out_of_scope, signatures, pos_per_contig, ref_bytes_per_contig, ref_offsets_per_contig, alt_bytes_per_contig, alt_offsets_per_contig, format_fields, format_src_dtypes, check_ref))]
 fn run_svar1_conversion_pipeline(
     py: Python,
     svar1_dir: String,
@@ -861,6 +863,7 @@ fn run_svar1_conversion_pipeline(
     alt_offsets_per_contig: Vec<Vec<i64>>,
     format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     format_src_dtypes: Vec<String>,
+    check_ref: String,
 ) -> PyResult<usize> {
     let n = chroms.len();
     if [
@@ -882,6 +885,7 @@ fn run_svar1_conversion_pipeline(
     let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
     let fields = crate::field::parse_manifest(format_fields)
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;
 
     // Move per-contig owned data into jobs before detaching.
     let mut jobs: Vec<_> = Vec::with_capacity(n);
@@ -940,7 +944,7 @@ fn run_svar1_conversion_pipeline(
                         ploidy,
                         long_allele_capacity,
                         skip_out_of_scope,
-                        crate::normalize::CheckRef::Error,
+                        check_ref,
                         processing_threads,
                         signatures,
                         &fields,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // src/lib.rs
+#[cfg(feature = "conversion")]
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 #[cfg(feature = "conversion")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ fn index_vcf(path: String) -> PyResult<()> {
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new()))]
+#[pyo3(signature = (vcf_path, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string()))]
 fn run_conversion_pipeline(
     py: Python,
     vcf_path: String,
@@ -136,6 +136,7 @@ fn run_conversion_pipeline(
     signatures: bool,
     info_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
+    check_ref: String,
 ) -> PyResult<usize> {
     let sample_refs: Vec<&str> = samples.iter().map(|s| s.as_str()).collect();
 
@@ -143,6 +144,8 @@ fn run_conversion_pipeline(
     raw.extend(format_fields);
     let fields =
         crate::field::parse_manifest(raw).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;
 
     let results: Vec<Result<u64, crate::error::ConversionError>> = py.detach(|| {
         // Step 1 -> HW discovery/override and budgeting
@@ -209,6 +212,7 @@ fn run_conversion_pipeline(
                         ploidy,
                         long_allele_capacity,
                         skip_out_of_scope,
+                        check_ref,
                         processing_threads,
                         signatures,
                         &fields,
@@ -333,6 +337,7 @@ fn run_pgen_conversion_pipeline(
                         ploidy,
                         long_allele_capacity,
                         skip_out_of_scope,
+                        crate::normalize::CheckRef::Error,
                         processing_threads,
                         signatures,
                         &fields,
@@ -935,6 +940,7 @@ fn run_svar1_conversion_pipeline(
                         ploidy,
                         long_allele_capacity,
                         skip_out_of_scope,
+                        crate::normalize::CheckRef::Error,
                         processing_threads,
                         signatures,
                         &fields,

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -102,6 +102,59 @@ pub fn validate_ref(pos: u32, ref_allele: &[u8], ref_seq: &[u8]) -> Result<(), N
     Ok(())
 }
 
+/// Policy for how a REF/FASTA disagreement is handled during conversion,
+/// mirroring the `e`/`x` subset of `bcftools norm --check-ref`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckRef {
+    /// Abort the build on the first disagreement (the historical behavior).
+    Error,
+    /// Drop the offending record and continue.
+    Exclude,
+}
+
+impl std::str::FromStr for CheckRef {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "e" => Ok(CheckRef::Error),
+            "x" => Ok(CheckRef::Exclude),
+            other => Err(format!(
+                "invalid check_ref {other:?}; expected \"e\" (error) or \"x\" (exclude)"
+            )),
+        }
+    }
+}
+
+/// Per-record outcome of applying a [`CheckRef`] policy. `Exclude` carries the
+/// originating [`NormalizeError`] so the caller can log the first offending
+/// locus without re-running validation.
+#[derive(Debug)]
+pub enum RefDecision {
+    /// REF matches the reference — process the record normally.
+    Keep,
+    /// REF disagrees under [`CheckRef::Exclude`] — skip this whole record.
+    Exclude(NormalizeError),
+}
+
+/// Apply the [`CheckRef`] policy to one record's REF. Returns `Err` only under
+/// [`CheckRef::Error`] (propagating `RefMismatch` / `RefOutOfContig`); under
+/// [`CheckRef::Exclude`] a disagreement (either kind) becomes
+/// `Ok(RefDecision::Exclude(_))`. A matching REF is always `Ok(RefDecision::Keep)`.
+pub fn apply_check_ref(
+    mode: CheckRef,
+    pos: u32,
+    ref_allele: &[u8],
+    ref_seq: &[u8],
+) -> Result<RefDecision, NormalizeError> {
+    match validate_ref(pos, ref_allele, ref_seq) {
+        Ok(()) => Ok(RefDecision::Keep),
+        Err(e) => match mode {
+            CheckRef::Error => Err(e),
+            CheckRef::Exclude => Ok(RefDecision::Exclude(e)),
+        },
+    }
+}
+
 /// Shift an anchored indel atom to its leftmost reference-equivalent position (classic VCF
 /// left-alignment / repeat roll), capped at `l_max` leftward bases. SNP atoms and
 /// substituted-anchor insertions never move. `ref_seq` is the full 0-based contig
@@ -469,6 +522,65 @@ mod tests {
                 contig_len: 4
             })
         ));
+    }
+
+    #[test]
+    fn apply_check_ref_error_mode_propagates_mismatch() {
+        let ref_seq = b"ACGTAC";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Error, 2, b"AA", ref_seq),
+            Err(NormalizeError::RefMismatch { pos: 2, .. })
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_error_mode_propagates_out_of_contig() {
+        let ref_seq = b"ACGT";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Error, 3, b"TAC", ref_seq),
+            Err(NormalizeError::RefOutOfContig { .. })
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_exclude_mode_excludes_mismatch() {
+        let ref_seq = b"ACGTAC";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Exclude, 2, b"AA", ref_seq),
+            Ok(RefDecision::Exclude(NormalizeError::RefMismatch {
+                pos: 2,
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_exclude_mode_excludes_out_of_contig() {
+        let ref_seq = b"ACGT";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Exclude, 3, b"TAC", ref_seq),
+            Ok(RefDecision::Exclude(NormalizeError::RefOutOfContig { .. }))
+        ));
+    }
+
+    #[test]
+    fn apply_check_ref_keeps_matching_ref_in_both_modes() {
+        let ref_seq = b"ACGTAC";
+        assert!(matches!(
+            apply_check_ref(CheckRef::Error, 2, b"GT", ref_seq),
+            Ok(RefDecision::Keep)
+        ));
+        assert!(matches!(
+            apply_check_ref(CheckRef::Exclude, 2, b"GT", ref_seq),
+            Ok(RefDecision::Keep)
+        ));
+    }
+
+    #[test]
+    fn check_ref_from_str_parses_e_and_x() {
+        assert_eq!("e".parse::<CheckRef>(), Ok(CheckRef::Error));
+        assert_eq!("x".parse::<CheckRef>(), Ok(CheckRef::Exclude));
+        assert!("z".parse::<CheckRef>().is_err());
     }
 
     // Reference used across left_align tests (0-based indices):

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -127,6 +127,7 @@ pub fn process_chromosome(
     ploidy: usize,
     long_allele_capacity: usize,
     skip_out_of_scope: bool,
+    check_ref: crate::normalize::CheckRef,
     processing_threads: usize,
     signatures: bool,
     fields: &[crate::field::FieldSpec],
@@ -309,6 +310,7 @@ pub fn process_chromosome(
                     fasta.as_deref(),
                     &chr,
                     skip_out_of_scope,
+                    check_ref,
                     &fields_owned,
                 )?;
                 let mut chunk_id = 0;
@@ -317,6 +319,13 @@ pub fn process_chromosome(
                 {
                     tx_dense.send(dense_chunk).unwrap();
                     chunk_id += 1;
+                }
+                let ref_excluded = reader.ref_excluded();
+                if ref_excluded > 0 {
+                    println!(
+                        "[{chr}] check_ref=x: excluded {ref_excluded} record(s) whose REF \
+                         disagreed with the reference FASTA."
+                    );
                 }
                 Ok(reader.dropped_out_of_scope() + vcf_list_dropped.load(Ordering::Relaxed))
             }
@@ -643,6 +652,7 @@ pub fn run_vcf_list(
             ploidy,
             long_allele_capacity,
             skip_out_of_scope,
+            crate::normalize::CheckRef::Error,
             processing_threads,
             signatures,
             &fields,

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -91,6 +91,7 @@ pub enum SourceSpec {
 struct VcfListDroppedProxy {
     inner: crate::vcf_list_reader::VcfListRecordSource,
     dropped_out: Arc<AtomicU64>,
+    ref_excluded_out: Arc<AtomicU64>,
 }
 
 impl crate::record_source::RecordSource for VcfListDroppedProxy {
@@ -110,6 +111,8 @@ impl crate::record_source::RecordSource for VcfListDroppedProxy {
         if rec.is_none() {
             self.dropped_out
                 .store(self.inner.dropped_out_of_scope(), Ordering::Relaxed);
+            self.ref_excluded_out
+                .store(self.inner.ref_excluded(), Ordering::Relaxed);
         }
         Ok(rec)
     }
@@ -228,6 +231,7 @@ pub fn process_chromosome(
                 // Only populated (and only meaningful) for `SourceSpec::VcfList`;
                 // stays 0 for the other variants.
                 let vcf_list_dropped = Arc::new(AtomicU64::new(0));
+                let vcf_list_ref_excluded = Arc::new(AtomicU64::new(0));
                 let src: Box<dyn crate::record_source::RecordSource + Send> = match source {
                     SourceSpec::Vcf {
                         vcf_path,
@@ -270,11 +274,13 @@ pub fn process_chromosome(
                             ploidy,
                             htslib_threads,
                             skip_out_of_scope,
+                            check_ref,
                             &fields_owned,
                         )?;
                         Box::new(VcfListDroppedProxy {
                             inner: vcf_list,
                             dropped_out: Arc::clone(&vcf_list_dropped),
+                            ref_excluded_out: Arc::clone(&vcf_list_ref_excluded),
                         })
                     }
                     SourceSpec::Svar1 {
@@ -320,7 +326,8 @@ pub fn process_chromosome(
                     tx_dense.send(dense_chunk).unwrap();
                     chunk_id += 1;
                 }
-                let ref_excluded = reader.ref_excluded();
+                let ref_excluded =
+                    reader.ref_excluded() + vcf_list_ref_excluded.load(Ordering::Relaxed);
                 if ref_excluded > 0 {
                     println!(
                         "[{chr}] check_ref=x: excluded {ref_excluded} record(s) whose REF \
@@ -593,6 +600,7 @@ pub fn run_vcf_list(
     max_threads: Option<usize>,
     long_allele_capacity: usize,
     skip_out_of_scope: bool,
+    check_ref: crate::normalize::CheckRef,
     signatures: bool,
     info_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
@@ -652,7 +660,7 @@ pub fn run_vcf_list(
             ploidy,
             long_allele_capacity,
             skip_out_of_scope,
-            crate::normalize::CheckRef::Error,
+            check_ref,
             processing_threads,
             signatures,
             &fields,

--- a/src/vcf_list_reader.rs
+++ b/src/vcf_list_reader.rs
@@ -16,7 +16,7 @@
 use crate::chunk_assembler::resolve_scalar;
 use crate::error::ConversionError;
 use crate::field::{FieldCategory, FieldSpec};
-use crate::normalize::{L_MAX, atomize_to_vcf_biallelic, validate_ref};
+use crate::normalize::{L_MAX, atomize_to_vcf_biallelic};
 use crate::record_source::{RawRecord, RecordSource};
 use crate::vcf_reader::VcfRecordSource;
 use std::cmp::Reverse;
@@ -72,6 +72,9 @@ struct FileCursor {
     eof: bool,
     col: usize,
     dropped: u64,
+    /// Records excluded because their REF disagreed with the reference under
+    /// `CheckRef::Exclude`.
+    ref_excluded: u64,
     /// This file's own path, kept only for error messages (unsorted-input
     /// detection, cross-file REF disagreement) that need to name the
     /// offending file.
@@ -90,6 +93,7 @@ impl FileCursor {
         ref_seq: Option<&[u8]>,
         ploidy: usize,
         skip_out_of_scope: bool,
+        check_ref: crate::normalize::CheckRef,
         info_specs: &[FieldSpec],
         format_specs: &[FieldSpec],
     ) -> Result<Option<NormAtom>, ConversionError> {
@@ -112,7 +116,28 @@ impl FileCursor {
                     check_position_sorted(&self.path, self.frontier, rec.pos)?;
                     self.frontier = Some(rec.pos);
                     if let Some(rs) = ref_seq {
-                        validate_ref(rec.pos, &rec.reference, rs)?;
+                        match crate::normalize::apply_check_ref(
+                            check_ref,
+                            rec.pos,
+                            &rec.reference,
+                            rs,
+                        )? {
+                            crate::normalize::RefDecision::Keep => {}
+                            crate::normalize::RefDecision::Exclude(e) => {
+                                self.ref_excluded += 1;
+                                if self.ref_excluded == 1 {
+                                    println!(
+                                        "Notice: check_ref=x excluding record(s) in {} \
+                                         whose REF disagrees with the reference (first: {e}).",
+                                        self.path
+                                    );
+                                }
+                                // This record contributes no atoms; fall through to
+                                // the buffer pop, exactly like an all-`*`/dropped ALT
+                                // record — the caller re-advances.
+                                return Ok(self.buf.pop_front());
+                            }
+                        }
                     }
                     let alt_refs: Vec<&[u8]> = rec.alts.iter().map(|a| a.as_slice()).collect();
                     let (records, dropped) = atomize_to_vcf_biallelic(
@@ -231,6 +256,7 @@ pub struct VcfListRecordSource {
     ref_seq: Option<Vec<u8>>,
     ploidy: usize,
     skip_out_of_scope: bool,
+    check_ref: crate::normalize::CheckRef,
     num_samples: usize,
     info_specs: Vec<FieldSpec>,
     format_specs: Vec<FieldSpec>,
@@ -250,6 +276,7 @@ impl VcfListRecordSource {
         ploidy: usize,
         htslib_threads: usize,
         skip_out_of_scope: bool,
+        check_ref: crate::normalize::CheckRef,
         fields: &[FieldSpec],
     ) -> Result<Self, ConversionError> {
         if vcf_paths.len() != samples.len() {
@@ -272,6 +299,7 @@ impl VcfListRecordSource {
                     eof: false,
                     col,
                     dropped: 0,
+                    ref_excluded: 0,
                     path: path.clone(),
                 }),
                 // This file's header simply doesn't declare `chrom` at all --
@@ -287,6 +315,7 @@ impl VcfListRecordSource {
                         eof: true,
                         col,
                         dropped: 0,
+                        ref_excluded: 0,
                         path: path.clone(),
                     });
                 }
@@ -309,6 +338,7 @@ impl VcfListRecordSource {
             ref_seq: ref_seq.map(|s| s.to_vec()),
             ploidy,
             skip_out_of_scope,
+            check_ref,
             num_samples: vcf_paths.len(),
             info_specs,
             format_specs,
@@ -319,6 +349,12 @@ impl VcfListRecordSource {
     /// far. Valid after the read loop drains.
     pub fn dropped_out_of_scope(&self) -> u64 {
         self.cursors.iter().map(|c| c.dropped).sum()
+    }
+
+    /// Total REF-mismatch records excluded across every file so far
+    /// (`CheckRef::Exclude`). Valid after the read loop drains.
+    pub fn ref_excluded(&self) -> u64 {
+        self.cursors.iter().map(|c| c.ref_excluded).sum()
     }
 
     /// Number of atoms currently buffered in the merge heap. Test-only: used to
@@ -509,6 +545,7 @@ impl RecordSource for VcfListRecordSource {
                         ref_seq,
                         self.ploidy,
                         self.skip_out_of_scope,
+                        self.check_ref,
                         &self.info_specs,
                         &self.format_specs,
                     )? {
@@ -529,6 +566,7 @@ impl RecordSource for VcfListRecordSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::normalize::CheckRef;
     use rust_htslib::bcf::record::GenotypeAllele;
     use rust_htslib::bcf::{Format, Header, Writer};
     use std::path::{Path, PathBuf};
@@ -648,9 +686,18 @@ mod tests {
             b.to_str().unwrap().to_string(),
         ];
         let samples = vec!["SA", "SB"];
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", Some(&ref_seq), 2, 1, false, &[])
-                .unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         let r1 = src.next_record().unwrap().unwrap();
         assert_eq!(r1.pos, 2);
@@ -701,9 +748,18 @@ mod tests {
             b.to_str().unwrap().to_string(),
         ];
         let samples = vec!["SA", "SB"];
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", Some(&ref_seq), 2, 1, false, &[])
-                .unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         let r1 = src.next_record().unwrap().unwrap();
         assert_eq!(r1.pos, 2);
@@ -733,9 +789,18 @@ mod tests {
 
         let paths = vec![a.to_str().unwrap().to_string()];
         let samples = vec!["SA"];
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", Some(&ref_seq), 2, 1, false, &[])
-                .unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         let r1 = src.next_record().unwrap().unwrap();
         assert_eq!(r1.pos, 2);
@@ -771,9 +836,18 @@ mod tests {
 
         let paths = vec![a.to_str().unwrap().to_string()];
         let samples = vec!["SA"];
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", Some(&ref_seq), 2, 1, false, &[])
-                .unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         let r1 = src.next_record().unwrap().unwrap();
         assert_eq!(r1.pos, 2);
@@ -826,9 +900,18 @@ mod tests {
             b_path.to_str().unwrap().to_string(),
         ];
         let samples = vec!["SA", "SB"];
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", Some(&ref_seq), 2, 1, false, &[])
-                .unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         let r1 = src.next_record().unwrap().unwrap();
         assert_eq!(r1.pos, 2);
@@ -928,9 +1011,18 @@ mod tests {
             c.to_str().unwrap().to_string(),
         ];
         let samples = vec!["SA", "SB", "SC"];
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", Some(&ref_seq), 2, 1, false, &[])
-                .unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         // Record 1: pos 10 — SA + SC carry, SB filled hom-ref.
         let r1 = src.next_record().unwrap().unwrap();
@@ -1110,6 +1202,7 @@ mod tests {
             2,
             1,
             false,
+            CheckRef::Error,
             &fields,
         )
         .unwrap();
@@ -1230,8 +1323,18 @@ mod tests {
         let samples = vec!["SA", "SB"];
         // ref_seq: None -- no_reference mode, exercising the branch validate_ref
         // never guards.
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", None, 2, 1, false, &[]).unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            None,
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         // `RawRecord` isn't `Debug` (see `record_source.rs`), so `unwrap_err`
         // isn't available on `Result<Option<RawRecord>, ConversionError>` --
@@ -1298,9 +1401,18 @@ mod tests {
             b_path.to_str().unwrap().to_string(),
         ];
         let samples = vec!["SA", "SB"];
-        let mut src =
-            VcfListRecordSource::new(&paths, &samples, "chr1", Some(&ref_seq), 2, 1, false, &[])
-                .unwrap();
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr1",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+        )
+        .unwrap();
 
         let r1 = src.next_record().unwrap().unwrap();
         assert_eq!(r1.pos, 2);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -186,6 +186,7 @@ pub fn build_contig(
         ploidy,
         4096, // long_allele_capacity
         false,
+        genoray_core::normalize::CheckRef::Error,
         1,     // processing_threads
         false, // signatures
         &[],   // fields

--- a/tests/test_atomize_e2e.rs
+++ b/tests/test_atomize_e2e.rs
@@ -29,6 +29,7 @@ fn drain_reader(
         Some(fasta_path.to_str().unwrap()),
         chrom,
         false,
+        genoray_core::normalize::CheckRef::Error,
         &[],
     )
     .unwrap();

--- a/tests/test_check_ref_e2e.rs
+++ b/tests/test_check_ref_e2e.rs
@@ -1,0 +1,108 @@
+mod common;
+
+use common::{SynthRecord, build_bcf_with_index, build_fasta_with_index};
+use genoray_core::normalize::CheckRef;
+use genoray_core::orchestrator::{SourceSpec, process_chromosome};
+use tempfile::TempDir;
+
+// Three records; the middle one's REF ("G") will disagree with the FASTA
+// (which carries "T" at that position), reproducing issue #116.
+fn bcf_records() -> Vec<SynthRecord<'static>> {
+    vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"G",
+            alts: vec![&b"GTTT"[..]],
+            gt: vec![1, 1, 0, 0],
+        },
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"T",
+            alts: vec![&b"A"[..]],
+            gt: vec![0, 0, 1, 0],
+        },
+    ]
+}
+
+// Same loci, but the FASTA truth at pos 200 is "T" (not the record's "G").
+fn fasta_records() -> Vec<SynthRecord<'static>> {
+    vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![],
+            gt: vec![],
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"T",
+            alts: vec![],
+            gt: vec![],
+        },
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"T",
+            alts: vec![],
+            gt: vec![],
+        },
+    ]
+}
+
+fn convert(
+    out: &std::path::Path,
+    check_ref: CheckRef,
+) -> Result<u64, genoray_core::error::ConversionError> {
+    let tmp = out.parent().unwrap();
+    let bcf = tmp.join("in.bcf");
+    let fasta = tmp.join("in.fa");
+    let samples = ["S0", "S1"];
+    build_bcf_with_index(&bcf, "chr1", 1000, &samples, &bcf_records());
+    build_fasta_with_index(&fasta, "chr1", 1000, &fasta_records());
+    let sample_refs: Vec<&str> = samples.to_vec();
+    process_chromosome(
+        SourceSpec::Vcf {
+            vcf_path: bcf.to_str().unwrap().to_string(),
+            htslib_threads: 1,
+        },
+        Some(fasta.to_str().unwrap()),
+        "chr1",
+        out.to_str().unwrap(),
+        &sample_refs,
+        25_000,
+        2,
+        8 * 1024 * 1024,
+        false,     // skip_out_of_scope
+        check_ref, // NEW
+        1,         // processing_threads
+        false,     // signatures
+        &[],       // fields
+    )
+}
+
+#[test]
+fn ref_mismatch_errors_under_e() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("store");
+    assert!(
+        convert(&out, CheckRef::Error).is_err(),
+        "check_ref=e must abort on a REF mismatch"
+    );
+}
+
+#[test]
+fn ref_mismatch_excluded_under_x() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("store");
+    // Succeeds; the two clean SNPs (pos 100, 300) are still written.
+    convert(&out, CheckRef::Exclude).unwrap();
+    assert!(
+        out.join("chr1/var_key/snp/positions.bin").exists(),
+        "clean SNPs still converted"
+    );
+}

--- a/tests/test_check_ref_e2e.rs
+++ b/tests/test_check_ref_e2e.rs
@@ -106,3 +106,72 @@ fn ref_mismatch_excluded_under_x() {
         "clean SNPs still converted"
     );
 }
+
+use common::build_bcf_with_index as build_single;
+
+// Two single-sample files; file B carries a REF at pos 200 that disagrees with
+// the FASTA (which says "T"). Under x, B's bad record is dropped; the merge
+// still produces a store.
+#[test]
+fn vcf_list_ref_mismatch_excluded_under_x() {
+    let tmp = TempDir::new().unwrap();
+    let out = tmp.path().join("store");
+    let fasta = tmp.path().join("in.fa");
+    build_fasta_with_index(&fasta, "chr1", 1000, &fasta_records());
+
+    let a = tmp.path().join("a.bcf");
+    let b = tmp.path().join("b.bcf");
+    build_single(
+        &a,
+        "chr1",
+        1000,
+        &["A"],
+        &[SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0],
+        }],
+    );
+    build_single(
+        &b,
+        "chr1",
+        1000,
+        &["B"],
+        &[SynthRecord {
+            pos: 200,
+            ref_allele: b"G",
+            alts: vec![&b"GTTT"[..]],
+            gt: vec![1, 0],
+        }],
+    );
+
+    let dropped = genoray_core::orchestrator::run_vcf_list(
+        &[
+            a.to_str().unwrap().to_string(),
+            b.to_str().unwrap().to_string(),
+        ],
+        Some(fasta.to_str().unwrap()),
+        &["chr1".to_string()],
+        out.to_str().unwrap(),
+        &["A".to_string(), "B".to_string()],
+        25_000,
+        2,
+        Some(1),
+        8 * 1024 * 1024,
+        false,             // skip_out_of_scope
+        CheckRef::Exclude, // NEW
+        false,             // signatures
+        Vec::new(),        // info_fields
+        Vec::new(),        // format_fields
+    )
+    .unwrap();
+    assert_eq!(
+        dropped, 0,
+        "no out-of-scope ALTs; the REF-mismatch is excluded, not counted here"
+    );
+    assert!(
+        out.join("meta.json").exists(),
+        "merge completed despite the bad record"
+    );
+}

--- a/tests/test_convert_skip_e2e.rs
+++ b/tests/test_convert_skip_e2e.rs
@@ -53,6 +53,7 @@ fn convert(
         2,
         8 * 1024 * 1024,
         skip,
+        genoray_core::normalize::CheckRef::Error,
         1,     // processing_threads
         false, // signatures
         &[],   // fields

--- a/tests/test_e2e.rs
+++ b/tests/test_e2e.rs
@@ -101,6 +101,7 @@ fn test_e2e_normalized_bcf_pipeline() {
         2,    // ploidy
         4096, // long_allele_capacity
         false,
+        genoray_core::normalize::CheckRef::Error,
         1,     // processing_threads
         false, // signatures
         &[],   // fields
@@ -194,6 +195,7 @@ fn test_e2e_max_del_postpass() {
         2,
         4096,
         false,
+        genoray_core::normalize::CheckRef::Error,
         1,     // processing_threads
         false, // signatures
         &[],   // fields
@@ -271,6 +273,7 @@ fn test_e2e_dense_snp_roundtrip() {
         2,
         4096,
         false,
+        genoray_core::normalize::CheckRef::Error,
         1,     // processing_threads
         false, // signatures
         &[],   // fields
@@ -347,6 +350,7 @@ fn test_e2e_mutation_conservation() {
         2,
         4096,
         false,
+        genoray_core::normalize::CheckRef::Error,
         1,     // processing_threads
         false, // signatures
         &[],   // fields
@@ -477,6 +481,7 @@ fn test_reader_extracts_info_format_fields() {
         None,
         "chr1",
         false,
+        genoray_core::normalize::CheckRef::Error,
         &all,
     )
     .unwrap();
@@ -634,6 +639,7 @@ fn test_reader_extracts_multiallelic_number_a_fields() {
         None,
         "chr1",
         false,
+        genoray_core::normalize::CheckRef::Error,
         &all,
     )
     .unwrap();
@@ -739,6 +745,7 @@ fn test_reader_accepts_pure_del() {
         Some(bcf_path.with_extension("fa").to_str().unwrap()),
         "chr1",
         false,
+        genoray_core::normalize::CheckRef::Error,
         &[],
     )
     .unwrap();
@@ -787,6 +794,7 @@ fn test_missing_chrom_returns_err() {
         2,
         1 << 20,
         false,
+        genoray_core::normalize::CheckRef::Error,
         1,     // processing_threads
         false, // signatures
         &[],   // fields

--- a/tests/test_left_align_e2e.rs
+++ b/tests/test_left_align_e2e.rs
@@ -33,6 +33,7 @@ fn drain(bcf: &Path, fasta: &Path, chrom: &str, samples: &[&str]) -> Vec<(u32, i
         Some(fasta.to_str().unwrap()),
         chrom,
         false,
+        genoray_core::normalize::CheckRef::Error,
         &[],
     )
     .unwrap();
@@ -243,6 +244,7 @@ fn left_shifts_stay_sorted_across_chunk_boundaries() {
         Some(fasta.to_str().unwrap()),
         "chr1",
         false,
+        genoray_core::normalize::CheckRef::Error,
         &[],
     )
     .unwrap();
@@ -311,6 +313,7 @@ proptest! {
             Some(fasta.to_str().unwrap()),
             "chr1",
             false,
+            genoray_core::normalize::CheckRef::Error,
             &[],
         )
         .unwrap();

--- a/tests/test_svar2_from_pgen.py
+++ b/tests/test_svar2_from_pgen.py
@@ -279,3 +279,16 @@ def test_from_pgen_missing_pvar_is_a_clear_error(sources, tmp_path):
     lonely.write_bytes(pgen.read_bytes())
     with pytest.raises(FileNotFoundError, match="No .pvar or .pvar.zst"):
         SparseVar2.from_pgen(tmp_path / "x.svar2", lonely, no_reference=True)
+
+
+def test_from_pgen_check_ref_accepts_x(sources, tmp_path):
+    ref, _, pgen = sources
+    out = tmp_path / "check_ref_x.svar2"
+    SparseVar2.from_pgen(out, pgen, ref, check_ref="x")
+    assert (out / "meta.json").exists()
+
+
+def test_from_pgen_check_ref_invalid_raises(sources, tmp_path):
+    ref, _, pgen = sources
+    with pytest.raises(ValueError, match="check_ref"):
+        SparseVar2.from_pgen(tmp_path / "bad.svar2", pgen, ref, check_ref="z")

--- a/tests/test_svar2_from_svar1.py
+++ b/tests/test_svar2_from_svar1.py
@@ -266,3 +266,18 @@ def test_from_svar1_rejects_multiallelic(tmp_path: Path):
 
     with pytest.raises(ValueError, match="biallelic"):
         SparseVar2.from_svar1(tmp_path / "out", v1_out, ref, threads=1)
+
+
+def test_from_svar1_check_ref_accepts_x(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    src = _build_svar1(tmp_path)
+    out = tmp_path / "check_ref_x"
+    SparseVar2.from_svar1(out, src, ref, threads=1, check_ref="x")
+    assert (out / "meta.json").exists()
+
+
+def test_from_svar1_check_ref_invalid_raises(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    src = _build_svar1(tmp_path)
+    with pytest.raises(ValueError, match="check_ref"):
+        SparseVar2.from_svar1(tmp_path / "out", src, ref, threads=1, check_ref="z")

--- a/tests/test_svar2_from_vcf.py
+++ b/tests/test_svar2_from_vcf.py
@@ -108,3 +108,54 @@ def test_from_vcf_plain_vcf_rejected(tmp_path: Path):
     )
     with pytest.raises(ValueError, match="bgzip"):
         SparseVar2.from_vcf(tmp_path / "s3", plain, ref, threads=1)
+
+
+def _write_vcf_bad_ref(d: Path) -> Path:
+    # Clean records at pos 3 (REF=A) and 7 (REF=C) match _REF; the record at
+    # pos 10 declares REF=A but _REF[10] is 'G' — a REF/FASTA disagreement
+    # (issue #116). Rows stay position-sorted for `bcftools index`.
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=chr1,length=40>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS0\tS1\n"
+        "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\t0|0\n"
+        "chr1\t7\t.\tC\tCAT\t.\t.\t.\tGT\t0|1\t1|1\n"
+        "chr1\t10\t.\tA\tT\t.\t.\t.\tGT\t0|1\t0|0\n"  # REF=A, but _REF[10]='G'
+    )
+    plain = d / "bad.vcf"
+    plain.write_text(body)
+    gz = d / "bad.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+    return gz
+
+
+def test_from_vcf_check_ref_error_aborts(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf_bad_ref(tmp_path)
+    with pytest.raises(Exception):
+        SparseVar2.from_vcf(tmp_path / "store", vcf, ref, check_ref="e", threads=1)
+
+
+def test_from_vcf_check_ref_exclude_continues(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf_bad_ref(tmp_path)
+    out = tmp_path / "store"
+    SparseVar2.from_vcf(out, vcf, ref, check_ref="x", threads=1)
+    assert (out / "meta.json").exists()  # completed despite the bad record
+    sv = SparseVar2(out)
+    # The two clean records survive; the pos-10 mismatch is excluded.
+    # `region_counts` is a per-hap carrier count (see `SparseVar2.region_counts`),
+    # not a distinct-variant count: pos 3 contributes 1 carrier hap (S0 "1|0"),
+    # pos 7 contributes 3 (S0 "0|1", S1 hom-alt "1|1") -> 4 total.
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 4
+
+
+def test_from_vcf_check_ref_invalid_value_raises(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    vcf = _write_vcf_bad_ref(tmp_path)
+    with pytest.raises(ValueError, match="check_ref"):
+        SparseVar2.from_vcf(tmp_path / "s", vcf, ref, check_ref="z", threads=1)  # type: ignore[arg-type]

--- a/tests/test_svar2_from_vcf_list.py
+++ b/tests/test_svar2_from_vcf_list.py
@@ -575,3 +575,25 @@ def test_check_fd_budget_raises_soft_limit_when_hard_limit_allows(monkeypatch):
 
     _check_fd_budget(1000)  # must not raise
     assert raised["limits"][0] >= 1000 * 2 + 64
+
+
+def test_from_vcf_list_check_ref_error_aborts(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    a = _ss(tmp_path, "a", "A", "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\n")
+    b = _ss(
+        tmp_path, "b", "B", "chr1\t10\t.\tA\tT\t.\t.\t.\tGT\t0|1\n"
+    )  # REF=A, _REF[10]='G'
+    with pytest.raises(Exception):
+        SparseVar2.from_vcf_list(tmp_path / "s", [a, b], ref, check_ref="e", threads=1)
+
+
+def test_from_vcf_list_check_ref_exclude_continues(tmp_path: Path):
+    ref = _write_ref(tmp_path)
+    a = _ss(tmp_path, "a", "A", "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\n")
+    b = _ss(tmp_path, "b", "B", "chr1\t10\t.\tA\tT\t.\t.\t.\tGT\t0|1\n")
+    out = tmp_path / "store"
+    SparseVar2.from_vcf_list(out, [a, b], ref, check_ref="x", threads=1)
+    assert (out / "meta.json").exists()  # merge completed; b's bad record excluded
+    sv = SparseVar2(out)
+    counts = sv.region_counts("chr1", [(0, 40)])
+    assert int(counts.sum()) == 1  # only a's clean pos-3 record survives

--- a/tests/test_vcf_list_e2e.rs
+++ b/tests/test_vcf_list_e2e.rs
@@ -6,6 +6,7 @@
 mod common;
 
 use common::{SynthRecord, build_bcf_with_index, build_fasta_with_index, read_u32_bin};
+use genoray_core::normalize::CheckRef;
 use genoray_core::orchestrator::run_vcf_list;
 use genoray_core::rvk::{DecodedKey, decode_key, decode_snp_2bit, unpack_snp_keys};
 
@@ -65,6 +66,7 @@ fn vcf_list_e2e_two_samples_one_store() {
         Some(1),
         8_388_608,
         false,
+        CheckRef::Error,
         false,
         Vec::new(),
         Vec::new(),


### PR DESCRIPTION
Closes #116.

Adds a `check_ref` policy to `from_vcf`, `from_pgen`, `from_svar1`, and
`from_vcf_list` (plus `genoray write --check-ref`):

- `"e"` (default) — abort on a REF/FASTA disagreement (current behavior).
- `"x"` — drop the offending record and continue, logging a per-contig count
  and the first offending locus.

## Design

One shared `apply_check_ref` helper in `src/normalize.rs` replaces the two
unconditional `validate_ref(...)?` call sites (`chunk_assembler.rs` for the
single-source engine; `vcf_list_reader.rs` for the k-way merge). A `CheckRef`
mode is threaded from the four pyo3 pipeline functions →
`process_chromosome`/`run_vcf_list` → the assemblers/cursors.

## Behavior & scope

- Return types are **unchanged** (`int` = out-of-scope drop count); `x`-exclusions
  are logged, not folded into the returned count.
- Default `"e"` preserves byte-identical behavior for existing callers (non-breaking).
- REF comparison stays case-insensitive (soft-masked bases match).
- `RefOutOfContig` (REF running past the contig end) is excluded under `"x"`, same
  as `RefMismatch`.
- `skills/genoray-api/SKILL.md` updated for all four methods + the CLI flag.

## Verification

- Rust: full suite (245 lib + all integration tests) green under
  `--no-default-features --features conversion`.
- Query-core build (`cargo check --no-default-features`) clean, 0 warnings
  (also gated a pre-existing unused `PyValueError` import behind the conversion
  feature as a Boy-Scout fix).
- Python: 52 SVAR2 conversion tests pass; new tests prove abort-under-`e` and
  exclude-under-`x` for both the single-source and vcf_list paths.
- Lint: `prek run --all-files` (ruff, cargo fmt/check/clippy -D warnings, pyrefly) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)