### PR TITLE
feat(svar2): ingest position-sharded cohort VCFs

### DIFF
--- a/docs/source/svar.md
+++ b/docs/source/svar.md
@@ -18,7 +18,9 @@ svar = SparseVar("out.svar")
 ### Region/sample-restricted SVAR2 conversion
 
 `SparseVar2.from_vcf`, `from_pgen`, and `from_svar1` can all convert directly
-into a subset of regions and samples. `from_vcf_list` supports the same
+into a subset of regions and samples. `from_vcf_shards` does the same for
+position-partitioned multi-sample cohort VCFs (with POS overlap semantics).
+`from_vcf_list` supports the same
 `regions=`/`merge_overlapping=`/`regions_overlap=` but has **no `samples=`**
 — each input file is single-sample, so the cohort is defined by the file set
 itself:
@@ -34,6 +36,20 @@ SparseVar2.from_vcf(
     samples=["HG00096", "HG00097"],
     merge_overlapping=True,
     threads=8,
+)
+
+# Native position partitions of the same multi-sample cohort. Each ownership
+# input is 0-based, half-open and may also be a BED/frame/region list.
+SparseVar2.from_vcf_shards(
+    "subset.svar2",
+    [
+        ("part-000.vcf.gz", [("chr22", 0, 10_000_000)]),
+        ("part-001.vcf.gz", [("chr22", 10_000_000, 20_000_000)]),
+    ],
+    "reference.fa",
+    regions="chr22",
+    samples=["HG00096", "HG00097"],
+    threads=16,
 )
 ```
 
@@ -100,6 +116,20 @@ The two backends behave differently:
 
 `SparseVar2.from_vcf_list` (merging N single-sample VCFs) does not shard within
 a contig — it already opens one file descriptor per input file per contig.
+
+`SparseVar2.from_vcf_shards` is a different multi-file shape: every file has
+the identical multi-sample header and owns disjoint raw-POS intervals. It uses
+a fixed pool of indexed readers over padded native source runs. Reads and
+normalization execute concurrently, while normalized-POS ownership
+deduplicates records crossing worker/file boundaries and preserves global
+order. Consequently an indel can left-align across a physical file boundary
+without being lost or written out of order. Output is byte-identical to
+converting the same raw records from one VCF; no concatenated VCF is
+materialized. Source ownership must be explicit and non-overlapping. The
+default memory-bounded chunk size targets a 256 MiB packed dense chunk, rather
+than applying a fixed variant count to very large cohorts. The current
+implementation supports `regions_overlap="pos"` only and raises for
+`record`/`variant` rather than silently approximating their extent semantics.
 
 See `docs/roadmap/svar2-conversion-baseline-2026-07-15.md` for the full scaling
 results.

--- a/python/genoray/_cli/__main__.py
+++ b/python/genoray/_cli/__main__.py
@@ -95,14 +95,14 @@ def write_svar2(
     Parameters
     ----------
     source
-        Path to a bgzipped VCF (``.vcf.gz``), BCF (``.bcf``), PLINK2 PGEN
-        (``.pgen``, with its ``.pvar``/``.pvar.zst`` and ``.psam`` siblings),
-        or SVAR1 store (a ``*.svar`` directory). VCF/BCF inputs are
-        auto-indexed (``.csi``) if no index is present. A directory (other
-        than a ``.svar`` store) or any other file is treated as the
+        Path to a bgzipped VCF (``.vcf.gz`` or ``.vcf.bgz``), BCF (``.bcf``),
+        PLINK2 PGEN (``.pgen``, with its ``.pvar``/``.pvar.zst`` and ``.psam``
+        siblings), or SVAR1 store (a ``*.svar`` directory). VCF/BCF inputs
+        are auto-indexed (``.csi``) if no index is present. A directory
+        (other than a ``.svar`` store) or any other file is treated as the
         multi-file (vcf-list) form: a directory of single-sample
-        ``*.vcf.gz``/``*.bcf`` files, or a manifest listing them one per
-        line; see :meth:`SparseVar2.from_vcf_list`.
+        ``*.vcf.gz``/``*.vcf.bgz``/``*.bcf`` files, or a manifest listing
+        them one per line; see :meth:`SparseVar2.from_vcf_list`.
     out
         Path to the output SVAR2 directory.
     reference
@@ -160,6 +160,7 @@ def write_svar2(
         offending record and continues. Mirrors ``bcftools norm --check-ref``.
     """
     from genoray import SparseVar2
+    from genoray._svar2 import _is_bgzipped_vcf
 
     from ._view_helpers import parse_regions_arg
 
@@ -184,7 +185,7 @@ def write_svar2(
 
     skip_out_of_scope = skip_symbolics_and_breakends
     is_single_vcf = source.is_file() and (
-        source.name.endswith(".vcf.gz") or source.suffix == ".bcf"
+        _is_bgzipped_vcf(source) or source.suffix == ".bcf"
     )
     if source.suffix == ".pgen":
         if ploidy != 2:

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -764,6 +764,208 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         )
 
     @classmethod
+    def from_vcf_shards(
+        cls,
+        out: str | Path,
+        sources: "Sequence[tuple[str | Path, object]]",
+        reference: str | Path | None = None,
+        *,
+        regions: "str | tuple[str, int, int] | PathLike | object | None" = None,
+        samples: "str | Sequence[str] | PathLike | None" = None,
+        merge_overlapping: bool = False,
+        regions_overlap: "Literal['pos', 'record', 'variant']" = "pos",
+        no_reference: bool = False,
+        skip_out_of_scope: bool = False,
+        ploidy: int = 2,
+        chunk_size: int | None = None,
+        threads: int | None = None,
+        overwrite: bool = False,
+        long_allele_capacity: int = 8 * 1024 * 1024,
+        signatures: bool = False,
+        info_fields: Sequence[str | InfoField] | None = None,
+        format_fields: Sequence[str | FormatField] | None = None,
+        check_ref: Literal["e", "x"] = "e",
+    ) -> int:
+        """Convert position-sharded multi-sample VCFs into one SVAR2 store.
+
+        ``sources`` is an ordered sequence of ``(path, ownership_regions)``
+        pairs. Every path must be an indexed VCF/BCF for the same cohort: the
+        sample names and their order must be identical. Ownership regions use
+        the normal Genoray region inputs and are 0-based half-open for tuple,
+        BED, or frame inputs. Across all sources they must be disjoint; gaps
+        and empty owned intervals are allowed.
+
+        Indexed readers consume and normalize padded native source intervals
+        concurrently under ``threads=``. Normalized-POS ownership keeps each
+        atom exactly once when it crosses a physical source-file boundary. No
+        concatenated VCF is materialized.
+
+        ``chunk_size=None`` chooses a cohort-size-aware value targeting a
+        256 MiB packed dense chunk, avoiding multi-gigabyte chunks for very
+        large cohorts.
+
+        The other conversion options match :meth:`from_vcf`. This first public
+        version supports ``regions_overlap='pos'``; record/variant-extent
+        selection requires a second predicate in addition to source ownership
+        and is rejected rather than approximated.
+        """
+        from cyvcf2 import VCF as _CyVCF
+        from genoray._svar._regions import _normalize_samples
+
+        if regions_overlap != "pos":
+            raise ValueError(
+                "from_vcf_shards currently supports only regions_overlap='pos'; "
+                "source ownership is POS-based"
+            )
+        if not isinstance(sources, AbcSequence) or isinstance(
+            sources, (str, bytes, PathLike)
+        ):
+            raise TypeError(
+                "sources must be a sequence of (path, ownership_regions) pairs"
+            )
+        if not sources:
+            raise ValueError("from_vcf_shards requires at least one source")
+
+        out = Path(out)
+        if (reference is None) == (not no_reference):
+            raise ValueError(
+                "provide exactly one of `reference` (a FASTA path) or "
+                "`no_reference=True`"
+            )
+        if signatures and no_reference:
+            raise ValueError("signatures=True requires a reference (not no_reference).")
+        if out.exists() and not overwrite:
+            raise FileExistsError(
+                f"Output path {out} already exists. Use overwrite=True to overwrite."
+            )
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+        paths: list[Path] = []
+        vcfs: list[Any] = []
+        ownership: list[tuple[int, str, int, int]] = []
+        per_file_contigs: list[tuple[Path, set[str]]] = []
+        cohort_samples: list[str] | None = None
+        try:
+            for path_index, entry in enumerate(sources):
+                if not isinstance(entry, tuple) or len(entry) != 2:
+                    raise TypeError(
+                        "each source must be a (path, ownership_regions) pair"
+                    )
+                path = Path(entry[0])
+                owned_input = entry[1]
+                _ensure_bgzipped(path)
+                _ensure_index(path)
+                vcf = _CyVCF(str(path))
+                paths.append(path)
+                vcfs.append(vcf)
+
+                file_samples = list(vcf.samples)
+                if cohort_samples is None:
+                    cohort_samples = file_samples
+                elif file_samples != cohort_samples:
+                    raise ValueError(
+                        f"VCF shard {path} does not have the identical sample order "
+                        "required by the first source"
+                    )
+
+                file_contigs = set(vcf.seqnames)
+                per_file_contigs.append((path, file_contigs))
+                owned = _normalize_svar2_regions(
+                    owned_input,
+                    list(vcf.seqnames),
+                    merge_overlapping=True,
+                )
+                for chrom, start, end in owned:
+                    ownership.append((path_index, chrom, start, end))
+
+            assert cohort_samples is not None
+            if not cohort_samples:
+                raise ValueError("from_vcf_shards requires at least one sample")
+            _check_consistent_contig_naming(per_file_contigs)
+
+            # Validate physical ownership BEFORE applying the caller's optional
+            # query subset. An overlap is a malformed shard map even if the
+            # requested region happens not to touch it.
+            ownership.sort(key=lambda x: (x[1], x[2], x[3], x[0]))
+            for left, right in zip(ownership, ownership[1:]):
+                if left[1] == right[1] and right[2] < left[3]:
+                    raise ValueError(
+                        "VCF shard ownership intervals overlap: "
+                        f"{left[1]}:{left[2]}-{left[3]} and "
+                        f"{right[1]}:{right[2]}-{right[3]}"
+                    )
+
+            all_contigs = natsorted({chrom for _i, chrom, _s, _e in ownership})
+            if not all_contigs:
+                raise ValueError("from_vcf_shards resolved no ownership intervals")
+            requested = _normalize_svar2_regions(
+                regions,
+                all_contigs,
+                merge_overlapping=merge_overlapping,
+            )
+
+            if requested:
+                requested_by_contig: dict[str, list[tuple[int, int]]] = {}
+                for chrom, start, end in requested:
+                    requested_by_contig.setdefault(chrom, []).append((start, end))
+                selected_ownership: list[tuple[int, str, int, int]] = []
+                for path_index, chrom, own_start, own_end in ownership:
+                    for query_start, query_end in requested_by_contig.get(chrom, []):
+                        start = max(own_start, query_start)
+                        end = min(own_end, query_end)
+                        if start < end:
+                            selected_ownership.append((path_index, chrom, start, end))
+            else:
+                selected_ownership = ownership
+
+            if not selected_ownership:
+                raise ValueError("No requested regions match VCF shard ownership.")
+            contigs = natsorted({chrom for _i, chrom, _s, _e in selected_ownership})
+            selected_samples = (
+                cohort_samples
+                if samples is None
+                else _normalize_samples(samples, cohort_samples)
+            )
+            if not selected_samples:
+                raise ValueError("from_vcf_shards requires at least one sample")
+
+            if chunk_size is None:
+                chunk_size = _auto_chunk_size(len(selected_samples), ploidy)
+
+            flds = _resolve_fields(str(paths[0]), info_fields, format_fields)
+            for path in paths[1:]:
+                other = _resolve_fields(str(path), info_fields, format_fields)
+                if other != flds:
+                    raise ValueError(
+                        f"VCF shard {path} has incompatible requested INFO/FORMAT headers"
+                    )
+        finally:
+            for vcf in vcfs:
+                vcf.close()
+
+        info = [field for field in flds if field[1] == "info"]
+        format_ = [field for field in flds if field[1] == "format"]
+        assert chunk_size is not None
+        _validate_check_ref(check_ref)
+        return _core.run_vcf_shards_conversion_pipeline(
+            [str(path) for path in paths],
+            selected_ownership,
+            None if no_reference else str(reference),
+            contigs,
+            str(out),
+            selected_samples,
+            chunk_size,
+            ploidy,
+            threads,
+            long_allele_capacity,
+            skip_out_of_scope,
+            signatures,
+            info,
+            format_,
+            check_ref,
+        )
+
+    @classmethod
     def from_pgen(
         cls,
         out: str | Path,

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -867,8 +867,15 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
                 vcf = _CyVCF(str(path))
                 paths.append(path)
                 vcfs.append(vcf)
-
-                file_samples = list(vcf.samples)
+                try:
+                    file_samples = list(vcf.samples)
+                    file_seqnames = list(vcf.seqnames)
+                finally:
+                    # Cohort headers can contain hundreds of thousands of sample
+                    # names. Keep at most one cyvcf2 header resident during
+                    # preflight instead of retaining one per physical source.
+                    vcf.close()
+                    vcfs.pop()
                 if cohort_samples is None:
                     cohort_samples = file_samples
                 elif file_samples != cohort_samples:
@@ -877,11 +884,11 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
                         "required by the first source"
                     )
 
-                file_contigs = set(vcf.seqnames)
+                file_contigs = set(file_seqnames)
                 per_file_contigs.append((path, file_contigs))
                 owned = _normalize_svar2_regions(
                     owned_input,
-                    list(vcf.seqnames),
+                    file_seqnames,
                     merge_overlapping=True,
                 )
                 for chrom, start, end in owned:

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -41,9 +41,11 @@ def _resolve_vcf_sources(sources: "str | Path | Sequence[str | Path]") -> list[P
 
     - a `Sequence` (list/tuple, not `str`/`Path`) of file paths, taken as-is
       and in the given order.
-    - a single directory `Path`: every `*.vcf.gz` then every `*.bcf` directly
-      inside it (non-recursive), each group name-sorted (`natsort`).
-    - a single file `Path` ending in `.vcf.gz` or `.bcf`: that one file.
+    - a single directory `Path`: every `*.vcf.gz`/`*.vcf.bgz` then every
+      `*.bcf` directly inside it (non-recursive), each group name-sorted
+      (`natsort`).
+    - a single file `Path` ending in `.vcf.gz`, `.vcf.bgz`, or `.bcf`: that
+      one file.
     - any other single file `Path`: treated as a manifest -- one path per
       line, blank lines and `#`-prefixed comment lines skipped, relative
       entries resolved against the manifest's parent directory.
@@ -51,8 +53,10 @@ def _resolve_vcf_sources(sources: "str | Path | Sequence[str | Path]") -> list[P
     if isinstance(sources, (str, Path)):
         path = Path(sources)
         if path.is_dir():
-            paths = natsorted(path.glob("*.vcf.gz")) + natsorted(path.glob("*.bcf"))
-        elif path.name.endswith(".vcf.gz") or path.suffix == ".bcf":
+            paths = natsorted(
+                [*path.glob("*.vcf.gz"), *path.glob("*.vcf.bgz")]
+            ) + natsorted(path.glob("*.bcf"))
+        elif _is_bgzipped_vcf(path) or path.suffix == ".bcf":
             paths = [path]
         elif path.suffix == ".vcf":
             # Without this, a bare `.vcf` single-path `sources` falls into the
@@ -61,8 +65,9 @@ def _resolve_vcf_sources(sources: "str | Path | Sequence[str | Path]") -> list[P
             # *path* -- producing a bewildering downstream error far from the
             # real problem. `_ensure_bgzipped` always raises here (this
             # branch is reached only when the suffix is exactly `.vcf`, which
-            # is neither `.bcf` nor `.vcf.gz`); the `paths = []` afterward is
-            # unreachable but keeps this branch's static type honest.
+            # is neither `.bcf` nor a recognized bgzipped VCF suffix); the
+            # `paths = []` afterward is unreachable but keeps this branch's
+            # static type honest.
             _ensure_bgzipped(path)
             paths = cast("list[Path]", [])
         else:
@@ -83,13 +88,17 @@ def _resolve_vcf_sources(sources: "str | Path | Sequence[str | Path]") -> list[P
     return paths
 
 
+def _is_bgzipped_vcf(source: Path) -> bool:
+    return source.name.endswith((".vcf.gz", ".vcf.bgz"))
+
+
 def _ensure_bgzipped(source: Path) -> None:
     """Reject a plain (uncompressed) VCF — it can't be tabix/csi-indexed."""
     is_bcf = source.suffix == ".bcf"
-    is_vcfgz = source.name.endswith(".vcf.gz")
-    if not (is_bcf or is_vcfgz):
+    if not (is_bcf or _is_bgzipped_vcf(source)):
         raise ValueError(
-            f"{source} must be a BCF (.bcf) or bgzipped VCF (.vcf.gz); bgzip it first."
+            f"{source} must be a BCF (.bcf) or bgzipped VCF "
+            "(.vcf.gz/.vcf.bgz); bgzip it first."
         )
 
 
@@ -1240,12 +1249,12 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
         `_resolve_vcf_sources`):
 
         - a `Sequence` of paths -- explicit, in the given order.
-        - a single directory `Path` -- every `*.vcf.gz` then every `*.bcf`
-          directly inside it (non-recursive), each group name-sorted.
-        - a single file `Path` -- if it ends in `.vcf.gz`/`.bcf`, that one
-          file; otherwise treated as a manifest (one path per line, blank
-          and `#`-comment lines skipped, relative entries resolved against
-          the manifest's directory).
+        - a single directory `Path` -- every `*.vcf.gz`/`*.vcf.bgz` then every
+          `*.bcf` directly inside it (non-recursive), each group name-sorted.
+        - a single file `Path` -- if it ends in
+          `.vcf.gz`/`.vcf.bgz`/`.bcf`, that one file; otherwise treated as a
+          manifest (one path per line, blank and `#`-comment lines skipped,
+          relative entries resolved against the manifest's directory).
 
         As with :meth:`from_vcf`, each input VCF's records must already be
         position-sorted per contig; an unsorted file raises `ValueError`

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -948,13 +948,20 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             if chunk_size is None:
                 chunk_size = _auto_chunk_size(len(selected_samples), ploidy)
 
-            flds = _resolve_fields(str(paths[0]), info_fields, format_fields)
-            for path in paths[1:]:
-                other = _resolve_fields(str(path), info_fields, format_fields)
-                if other != flds:
-                    raise ValueError(
-                        f"VCF shard {path} has incompatible requested INFO/FORMAT headers"
-                    )
+            if not info_fields and not format_fields:
+                # Resolving an empty field manifest still opens and parses the
+                # VCF header. Avoid a redundant second pass over every native
+                # cohort source when the caller only needs genotypes.
+                flds = []
+            else:
+                flds = _resolve_fields(str(paths[0]), info_fields, format_fields)
+                for path in paths[1:]:
+                    other = _resolve_fields(str(path), info_fields, format_fields)
+                    if other != flds:
+                        raise ValueError(
+                            f"VCF shard {path} has incompatible requested "
+                            "INFO/FORMAT headers"
+                        )
         finally:
             for vcf in vcfs:
                 vcf.close()

--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -948,6 +948,7 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
             if chunk_size is None:
                 chunk_size = _auto_chunk_size(len(selected_samples), ploidy)
 
+            flds: list[tuple[str, str, str, str | None, float | None]]
             if not info_fields and not format_fields:
                 # Resolving an empty field manifest still opens and parses the
                 # VCF header. Avoid a redundant second pass over every native

--- a/skills/genoray-api/SKILL.md
+++ b/skills/genoray-api/SKILL.md
@@ -17,7 +17,7 @@ description: Use when writing or modifying Python code that imports `genoray` to
 - `genoray.VCF` — VCF/BCF reader
 - `genoray.Filter` — VCF filter value object bundling a cyvcf2 record predicate (`record`) with its matching `.gvi` polars expression (`expr`)
 - `genoray.SparseVar` — sparse `.svar` reader/writer
-- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf` (supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=`), PLINK2 PGEN → SVAR2 conversion via `from_pgen`, N single-sample VCFs/BCFs → one SVAR2 store via a native k-way merge in `from_vcf_list` (`reference`/`no_reference` supported like `from_vcf`, absent sites fill hom-ref; supports `regions=`/`merge_overlapping=`/`regions_overlap=` but **no `samples=`** — the cohort is the file set), SVAR1 (`SparseVar`) → SVAR2 native migration via `from_svar1` (reads no VCF/htslib; biallelic SVAR1 only; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`/`from_pgen`); range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`/`from_pgen(signatures=True)`/`from_svar1(signatures=True)`; scalar-numeric INFO/FORMAT field extraction during the write via `from_vcf(info_fields=, format_fields=)`/`from_vcf_list(info_fields=, format_fields=)` (`from_vcf_list` merges INFO first-carrier-wins, FORMAT per-sample) — not supported by `from_pgen`/`from_svar1` (which carries through all of SVAR1's existing fields automatically) — read back opt-in via `fields=`/`with_fields`/`available_fields` and attached to `decode`'s result)
+- `genoray.SparseVar2` — next-gen sparse variant store (VCF/BCF → SVAR2 conversion via `from_vcf` (supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=`); N position-sharded multi-sample VCFs for the same cohort → one SVAR2 via `from_vcf_shards` (explicit disjoint ownership intervals, identical sample order, native parallel indexed reads, global cross-file normalization, POS overlap mode); PLINK2 PGEN → SVAR2 conversion via `from_pgen`; N single-sample VCFs/BCFs → one SVAR2 store via a native k-way merge in `from_vcf_list` (`reference`/`no_reference` supported like `from_vcf`, absent sites fill hom-ref; supports `regions=`/`merge_overlapping=`/`regions_overlap=` but **no `samples=`** — the cohort is the file set); SVAR1 (`SparseVar`) → SVAR2 native migration via `from_svar1` (reads no VCF/htslib; biallelic SVAR1 only; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`/`from_pgen`); range queries via `decode`/`region_counts`/`read_ranges`; mutational-signature support (SBS96/DBS78/ID83) via `annotate_mutations`/`mutation_matrix`/`assign_signatures`, or classify during the write with `from_vcf(signatures=True)`/`from_pgen(signatures=True)`/`from_svar1(signatures=True)`; scalar-numeric INFO/FORMAT field extraction during the write via `from_vcf(info_fields=, format_fields=)`/`from_vcf_shards(info_fields=, format_fields=)`/`from_vcf_list(info_fields=, format_fields=)` (`from_vcf_list` merges INFO first-carrier-wins, FORMAT per-sample) — not supported by `from_pgen`/`from_svar1` (which carries through all of SVAR1's existing fields automatically) — read back opt-in via `fields=`/`with_fields`/`available_fields` and attached to `decode`'s result)
 - `genoray.InfoField` / `genoray.FormatField` — frozen dataclasses (`name`, `dtype=None`, `default=None`) configuring a single INFO/FORMAT field for `SparseVar2.from_vcf`; a bare `str` name uses inferred defaults instead
 - `genoray.exprs` — polars filter expressions for `.gvi` indexes
 - `genoray.cosmic_signatures` — fetch/cache COSMIC reference signatures
@@ -36,7 +36,7 @@ Prefer reading these over guessing:
 - `genoray/_vcf.py` — `VCF` class: constructor, `read`, `chunk`, mode constants near the top of the class; `get_record_info(contig=None, start=None, end=None, fields=None, info=None, lazy=False)` — non-FORMAT record-level fields (including INFO) for a range or the whole file, returns `pl.DataFrame` (or `pl.LazyFrame` when `lazy=True`)
 - `genoray/_pgen.py` — `PGEN` class: constructor, `read`, `chunk`, `read_ranges`, `chunk_ranges`, mode constants near the top of the class
 - `genoray/_svar.py` — `SparseVar`: `__init__`, `from_vcf`, `from_pgen`, `read_ranges`, `read_ranges_with_length(contig, starts=0, ends=POS_MAX, samples=None)` (length-guaranteed range read; returns the same type as `read_ranges` — a `Ragged` or fields-augmented record), `with_fields`, `annotate_mutations`, `mutation_matrix`, `assign_signatures`, `annotate_with_gtf(gtf, level_filter=1, write_back=True, *, strand_encoding=None, codon_null_token=None)` (GTF CDS annotation entry point, returns `pl.DataFrame` with `varID`/`gene_id`/`strand`/`codon_pos`), `cache_afs()` (computes and persists an `AF` column to the `.gvi` index; returns `None`)
-- `genoray/_svar2.py` — `SparseVar2`: `__init__(path, *, fields=None)`, `with_fields(fields)` (new reader over the same store with those fields selected), `available_fields` (`dict[str, StoredField]`, set in `__init__`), `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write, `info_fields=`/`format_fields=` extract scalar-numeric fields during the write; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=`), `from_pgen` (PLINK2 PGEN → SVAR2 conversion entry point; diploid-only, no `ploidy=`/`info_fields=`/`format_fields=`; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`), `from_vcf_list` (N single-sample VCFs/BCFs → one SVAR2 store via a native k-way merge; `sources` accepts a `Sequence`/directory/manifest, resolved by module-level `_resolve_vcf_sources`; `reference`/`no_reference` supported (no_reference skips left-alignment, so cross-file joins require pre-normalized inputs); `info_fields=`/`format_fields=` supported — INFO merges first-carrier-wins, FORMAT stays per-sample; supports `regions=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`, but **no `samples=`** — the cohort is the file set), `from_svar1` (SVAR1 (`SparseVar`) → SVAR2 native migration entry point; reads no VCF/htslib, `ploidy` from SVAR1 metadata, biallelic SVAR1 only, no `info_fields=`/`format_fields=` — every SVAR1 FORMAT field carries through automatically, `mutcat` dropped; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`/`from_pgen`, though regions filter per-record rather than narrowing a covering range up front); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode` — attaches one `Ragged` per selected field, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
+- `genoray/_svar2.py` — `SparseVar2`: `__init__(path, *, fields=None)`, `with_fields(fields)` (new reader over the same store with those fields selected), `available_fields` (`dict[str, StoredField]`, set in `__init__`), `from_vcf` (VCF/BCF → SVAR2 conversion entry point, `signatures=` classifies during the write, `info_fields=`/`format_fields=` extract scalar-numeric fields during the write; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=`), `from_vcf_shards` (N position-sharded multi-sample VCFs for one cohort → one SVAR2; `sources` is a sequence of `(path, ownership_regions)` pairs, sample headers/order must match, ownership must be disjoint; supports `regions=`/`samples=` and POS overlap semantics; raw reads are parallel but normalization is global across files), `from_pgen` (PLINK2 PGEN → SVAR2 conversion entry point; diploid-only, no `ploidy=`/`info_fields=`/`format_fields=`; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`), `from_vcf_list` (N single-sample VCFs/BCFs → one SVAR2 store via a native k-way merge; `sources` accepts a `Sequence`/directory/manifest, resolved by module-level `_resolve_vcf_sources`; `reference`/`no_reference` supported (no_reference skips left-alignment, so cross-file joins require pre-normalized inputs); `info_fields=`/`format_fields=` supported — INFO merges first-carrier-wins, FORMAT stays per-sample; supports `regions=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`, but **no `samples=`** — the cohort is the file set), `from_svar1` (SVAR1 (`SparseVar`) → SVAR2 native migration entry point; reads no VCF/htslib, `ploidy` from SVAR1 metadata, biallelic SVAR1 only, no `info_fields=`/`format_fields=` — every SVAR1 FORMAT field carries through automatically, `mutcat` dropped; supports `regions=`/`samples=`/`merge_overlapping=`/`regions_overlap=` like `from_vcf`/`from_pgen`, though regions filter per-record rather than narrowing a covering range up front); `n_samples`/`available_samples`/`contigs`/`ploidy` metadata. Read/query methods live in the mixins: `genoray/_svar2_decode.py` (`decode` — attaches one `Ragged` per selected field, `region_counts`), `genoray/_svar2_batch.py` (public `read_ranges`; internal gvl-only `_overlap_batch`/`_find_ranges`/`_gather_ranges`), and `genoray/_svar2_mutcat.py` (`annotate_mutations`, `mutation_matrix`, `assign_signatures` — COSMIC mutational-signature workflow, mirroring `SparseVar`'s but backed by a per-contig Rust sidecar instead of a `.gvi`-attached field)
 - `genoray/_svar2_fields.py` — `InfoField`/`FormatField` dataclasses + `FieldDtype` and the header/dtype validation used by `from_vcf(info_fields=, format_fields=)`; `StoredField` (frozen dataclass: `name`, `category`, `dtype`, `default`, `key`) is the read-side manifest entry type returned by `SparseVar2.available_fields` — not exported at top-level `genoray`, only reached via that dict
 - `genoray/_cli/__main__.py` — the `genoray` CLI (`index`, `write` / `write svar1`, `view` / `view svar1`, `concat`, `split`)
 - `genoray/_signatures.py` — `cosmic_signatures`, `fit_signatures`
@@ -347,6 +347,48 @@ Signature: `from_vcf(out, source, reference=None, *, regions=None, samples=None,
   - **Read path:** see "Reading INFO/FORMAT fields (SVAR2)" below —
     `SparseVar2(path, fields=…)` / `.with_fields(…)` / `.available_fields`
     opt into decoding these back out via `decode()`.
+
+### Conversion from position-sharded cohort VCFs
+
+Use `from_vcf_shards` when physical VCFs partition genomic positions but each
+file contains the same multi-sample cohort in the same header order. This is
+not `from_vcf_list` (which requires one sample per file and unions samples).
+
+```python
+dropped = SparseVar2.from_vcf_shards(
+    "out.svar2",
+    [
+        ("part-000.vcf.gz", [("chr22", 0, 10_000_000)]),
+        ("part-001.vcf.gz", [("chr22", 10_000_000, 20_000_000)]),
+    ],
+    "ref.fa",
+    regions=("chr22", 0, 20_000_000),
+    samples=["S1", "S2"],
+    threads=16,
+)
+```
+
+Signature: `from_vcf_shards(out, sources, reference=None, *, regions=None, samples=None, merge_overlapping=False, regions_overlap="pos", no_reference=False, skip_out_of_scope=False, ploidy=2, chunk_size=None, threads=None, overwrite=False, long_allele_capacity=8*1024*1024, signatures=False, info_fields=None, format_fields=None, check_ref="e") -> int`
+
+- `sources` is a sequence of `(path, ownership_regions)` pairs. Ownership uses
+  the standard Genoray inputs: tuple/list/BED/frame coordinates are 0-based
+  half-open. Regions may be disjoint and gaps are fine, but ownership must not
+  overlap anywhere across sources.
+- Every VCF/BCF must have identical sample names in identical order. A mismatch
+  raises before conversion. `samples=` may then select/reorder the shared cohort
+  exactly as in `from_vcf`.
+- Padded source runs are decoded and normalized concurrently under `threads=`.
+  Normalized-POS ownership deduplicates boundary records and keeps their global
+  order, so an indel can left-align across a physical file boundary without
+  loss or reordering. No concatenated VCF is written.
+- `regions=` intersects the source ownership map before reads. This version
+  supports only `regions_overlap="pos"`; `record` and `variant` raise instead
+  of approximating their extent semantics.
+- `chunk_size=None` derives a memory-bounded value from cohort size, targeting
+  a 256 MiB packed dense chunk; this matters for 500k-sample cohorts.
+- `reference`/`no_reference`, `skip_out_of_scope`, `ploidy`, `chunk_size`,
+  `overwrite`, `signatures`, INFO/FORMAT fields, `check_ref`, and the return
+  value have the same meaning as `from_vcf`.
 
 ### Conversion from PGEN
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,8 @@ pub mod vcf_list_reader;
 #[cfg(feature = "conversion")]
 pub mod vcf_reader;
 #[cfg(feature = "conversion")]
+pub mod vcf_shard_reader;
+#[cfg(feature = "conversion")]
 pub mod writer;
 
 #[cfg(feature = "conversion")]
@@ -273,6 +275,174 @@ fn run_conversion_pipeline(
     )
     .map_err(|e| pyo3::exceptions::PyOSError::new_err(format!("failed to write meta.json: {e}")))?;
 
+    Ok(total_dropped as usize)
+}
+
+/// Convert position-sharded, multi-sample VCFs into one SVAR2 store.
+///
+/// `shard_ranges` entries are `(path_index, chrom, start, end)` raw-POS
+/// ownership intervals. Python validates identical cohort headers and
+/// non-overlap; this boundary repeats the structural checks before any worker
+/// is launched. Padded workers decode and normalize source runs concurrently;
+/// normalized-POS ownership preserves correctness across physical boundaries.
+#[cfg(feature = "conversion")]
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+#[pyo3(signature = (vcf_paths, shard_ranges, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string()))]
+fn run_vcf_shards_conversion_pipeline(
+    py: Python,
+    vcf_paths: Vec<String>,
+    shard_ranges: Vec<(usize, String, u32, u32)>,
+    reference_path: Option<String>,
+    chroms: Vec<String>,
+    output_dir: String,
+    samples: Vec<String>,
+    chunk_size: usize,
+    ploidy: usize,
+    max_threads: Option<usize>,
+    long_allele_capacity: usize,
+    skip_out_of_scope: bool,
+    signatures: bool,
+    info_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
+    format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
+    check_ref: String,
+) -> PyResult<usize> {
+    let check_ref: crate::normalize::CheckRef = check_ref.parse().map_err(PyValueError::new_err)?;
+    let mut raw = info_fields;
+    raw.extend(format_fields);
+    let fields =
+        crate::field::parse_manifest(raw).map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let mut ranges_by_chrom: std::collections::HashMap<String, Vec<(usize, u32, u32)>> =
+        std::collections::HashMap::new();
+    for (path_index, chrom, start, end) in shard_ranges {
+        if path_index >= vcf_paths.len() {
+            return Err(PyValueError::new_err(format!(
+                "VCF shard range references path index {path_index}, but only {} paths were provided",
+                vcf_paths.len()
+            )));
+        }
+        if end <= start {
+            return Err(PyValueError::new_err(format!(
+                "invalid VCF shard ownership interval {chrom}:{start}-{end}"
+            )));
+        }
+        ranges_by_chrom
+            .entry(chrom)
+            .or_default()
+            .push((path_index, start, end));
+    }
+
+    for chrom in &chroms {
+        let ranges = ranges_by_chrom.get_mut(chrom).ok_or_else(|| {
+            PyValueError::new_err(format!("no VCF shard ownership intervals for {chrom}"))
+        })?;
+        ranges.sort_unstable_by_key(|&(path_index, start, end)| (start, end, path_index));
+        for pair in ranges.windows(2) {
+            if pair[1].1 < pair[0].2 {
+                return Err(PyValueError::new_err(format!(
+                    "VCF shard ownership intervals overlap on {chrom}: {}-{} and {}-{}",
+                    pair[0].1, pair[0].2, pair[1].1, pair[1].2
+                )));
+            }
+        }
+    }
+
+    let sample_refs: Vec<&str> = samples.iter().map(String::as_str).collect();
+    let results: Vec<Result<u64, crate::error::ConversionError>> = py.detach(|| {
+        let available_cores = match max_threads {
+            Some(t) if t > 0 => {
+                println!("Notice: Using user-provided thread limit: {t}");
+                t
+            }
+            _ => {
+                let detected = std::thread::available_parallelism().unwrap().get();
+                println!("Notice: No thread limit provided. Hardware Detected: {detected} cores.");
+                detected
+            }
+        };
+        let plan = crate::budget::plan_thread_budget(available_cores, chroms.len());
+        let concurrent_chroms = plan.concurrent_chroms;
+        // Cohort-shard input needs no per-reader HTSlib background pool: the
+        // independent indexed readers ARE the useful decode parallelism. Reuse
+        // the cores the ordinary single-file plan reserves for HTSlib, plus
+        // this chromosome's share of the leftover processing budget.
+        let reader_workers = (plan.htslib_threads
+            + plan.processing_threads / concurrent_chroms)
+            .max(1);
+        println!("Using: {available_cores} cores.");
+        println!(
+            "Pipeline Config (VCF cohort shards): {} concurrent chromosomes | {} indexed-reader workers per chromosome.",
+            concurrent_chroms, reader_workers
+        );
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(concurrent_chroms)
+            .thread_name(|i| format!("rayon-{i}"))
+            .build()
+            .unwrap();
+        let fasta_ref = reference_path.as_deref();
+        pool.install(|| {
+            chroms
+                .par_iter()
+                .map(|chrom| {
+                    println!("==> Processing {chrom}");
+                    let units = ranges_by_chrom[chrom]
+                        .iter()
+                        .enumerate()
+                        .map(
+                            |(ordinal, &(path_index, start, end))| {
+                                crate::vcf_shard_reader::VcfCohortShardUnit {
+                                    path_index,
+                                    start,
+                                    end,
+                                    ordinal,
+                                }
+                            },
+                        )
+                        .collect();
+                    orchestrator::process_chromosome(
+                        orchestrator::SourceSpec::VcfShards {
+                            vcf_paths: vcf_paths.clone(),
+                            units,
+                        },
+                        fasta_ref,
+                        chrom,
+                        &output_dir,
+                        &sample_refs,
+                        chunk_size,
+                        ploidy,
+                        long_allele_capacity,
+                        skip_out_of_scope,
+                        check_ref,
+                        reader_workers,
+                        signatures,
+                        &fields,
+                    )
+                })
+                .collect()
+        })
+    });
+
+    let mut total_dropped = 0u64;
+    for result in results {
+        total_dropped += result?;
+    }
+    let resolved_fields = crate::field_finalize::finalize_fields(
+        std::path::Path::new(&output_dir),
+        &chroms,
+        &fields,
+    )?;
+    crate::meta::write_meta(
+        std::path::Path::new(&output_dir),
+        crate::meta::FORMAT_VERSION,
+        &samples,
+        &chroms,
+        ploidy,
+        &resolved_fields,
+    )
+    .map_err(|e| pyo3::exceptions::PyOSError::new_err(format!("failed to write meta.json: {e}")))?;
     Ok(total_dropped as usize)
 }
 
@@ -1067,6 +1237,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(svar2_variant_stats, m)?)?;
     #[cfg(feature = "conversion")]
     m.add_function(wrap_pyfunction!(run_vcf_list_conversion_pipeline, m)?)?;
+    #[cfg(feature = "conversion")]
+    m.add_function(wrap_pyfunction!(run_vcf_shards_conversion_pipeline, m)?)?;
     #[cfg(feature = "conversion")]
     m.add_function(wrap_pyfunction!(run_svar1_conversion_pipeline, m)?)?;
     #[cfg(feature = "conversion")]

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -97,6 +97,15 @@ pub enum SourceSpec {
         regions: Vec<(u32, u32)>,
         overlap: crate::svar2_view::OverlapMode,
     },
+    /// N multi-sample VCFs representing disjoint genomic intervals of ONE
+    /// cohort. Every file has the same sample columns/order. `units` are
+    /// globally sorted, non-overlapping raw-POS ownership intervals for this
+    /// contig. Padded source-run workers normalize concurrently and retain
+    /// atoms by normalized-POS ownership, including across file boundaries.
+    VcfShards {
+        vcf_paths: Vec<String>,
+        units: Vec<crate::vcf_shard_reader::VcfCohortShardUnit>,
+    },
     Svar1 {
         svar1_dir: String,
         contig_start: usize,
@@ -634,6 +643,63 @@ pub fn process_chromosome(
                             ref_excluded_out: Arc::clone(&vcf_list_ref_excluded),
                         })
                     }
+                    SourceSpec::VcfShards { vcf_paths, units } => {
+                        let work_units = crate::vcf_shard_reader::plan_work_units(
+                            &units,
+                            crate::normalize::L_MAX,
+                        )?;
+                        let owned = Arc::new(units);
+                        let paths = Arc::new(vcf_paths);
+                        let (ref_seq, has_reference) = match fasta.as_deref() {
+                            Some(path) => (
+                                Arc::new(crate::vcf_reader::load_contig_seq(path, &chr)?),
+                                true,
+                            ),
+                            None => (Arc::new(Vec::new()), false),
+                        };
+                        let totals = crate::shard_exec::run(
+                            work_units,
+                            processing_threads,
+                            |unit| {
+                                let slices = crate::vcf_shard_reader::slices_for_fetch(
+                                    owned.as_ref(),
+                                    unit.fetch_start,
+                                    unit.fetch_end,
+                                );
+                                let source =
+                                    crate::vcf_shard_reader::VcfCohortSliceRecordSource::new(
+                                        paths.as_ref(),
+                                        slices,
+                                        &chr,
+                                        &s_refs,
+                                        ploidy,
+                                        &fields_owned,
+                                    )?;
+                                Ok(crate::chunk_assembler::ChunkAssembler::with_reference(
+                                    Box::new(source),
+                                    s_refs.len(),
+                                    ploidy,
+                                    Arc::clone(&ref_seq),
+                                    has_reference,
+                                    skip_out_of_scope,
+                                    check_ref,
+                                    &fields_owned,
+                                    Some((unit.own_start, unit.own_end)),
+                                ))
+                            },
+                            |e, unit| {
+                                with_vcf_shard_context(
+                                    e,
+                                    &chr,
+                                    crate::vcf_reader::VcfShard::from(*unit),
+                                )
+                            },
+                            chunk_size,
+                            &tx_dense,
+                        )?;
+                        report_ref_excluded(&chr, totals.ref_excluded);
+                        return Ok(totals.dropped_out_of_scope);
+                    }
                     SourceSpec::Svar1 {
                         svar1_dir,
                         contig_start,
@@ -668,10 +734,8 @@ pub fn process_chromosome(
                 };
 
                 // Dedicated rayon pool for reader-side CPU work: bounded per-record
-                // normalization batches plus intra-chunk presence packing. The
-                // sharded VCF branch above returns before this point because its
-                // independent indexed readers consume the same `processing_threads`
-                // budget directly; building both would double-reserve cores.
+                // normalization batches plus intra-chunk presence packing. Sharded
+                // sources return above after using the same thread budget directly.
                 let pool = rayon::ThreadPoolBuilder::new()
                     .num_threads(processing_threads.max(1))
                     .thread_name(|i| format!("pack-{}", i))

--- a/src/vcf_shard_reader.rs
+++ b/src/vcf_shard_reader.rs
@@ -1,0 +1,286 @@
+//! Reader pieces for position-sharded, multi-sample VCF cohorts.
+//!
+//! `vcf_list_reader` is sample-sharded (one sample per file). This module is
+//! the orthogonal shape: every file has the SAME cohort columns and owns
+//! disjoint raw-POS intervals. The orchestrator plans padded normalized-POS
+//! work units; each unit uses this source to concatenate only the source-owned
+//! raw slices intersecting its padded fetch window. A local `ChunkAssembler`
+//! then normalizes those records and keeps atoms in the unit's owned range,
+//! exactly like single-file VCF sub-contig sharding.
+
+use std::collections::VecDeque;
+
+use crate::error::ConversionError;
+use crate::field::FieldSpec;
+use crate::record_source::{RawRecord, RecordSource};
+use crate::shard::WorkUnit;
+use crate::svar2_view::OverlapMode;
+use crate::vcf_reader::VcfRecordSource;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VcfCohortShardUnit {
+    pub path_index: usize,
+    /// Raw-POS source ownership, 0-based half-open.
+    pub start: u32,
+    pub end: u32,
+    pub ordinal: usize,
+}
+
+/// Turn source-owned intervals into normalized-POS work units.
+///
+/// Consecutive intervals from one physical source are one run. The boundary
+/// between runs is the next run's first raw position; gaps therefore belong
+/// to the run on their left. Padding lets both neighboring workers see raw
+/// records that normalize across that boundary, while `owned_range` keeps
+/// each normalized atom in exactly one output unit.
+pub fn plan_work_units(
+    owned: &[VcfCohortShardUnit],
+    pad: u32,
+) -> Result<Vec<WorkUnit>, ConversionError> {
+    if owned.is_empty() {
+        return Err(ConversionError::Input(
+            "position-sharded VCF conversion has no owned intervals".to_string(),
+        ));
+    }
+    for (expected, unit) in owned.iter().enumerate() {
+        if unit.ordinal != expected {
+            return Err(ConversionError::Input(format!(
+                "position-sharded VCF intervals must have dense ordinals; expected {expected}, got {}",
+                unit.ordinal
+            )));
+        }
+        if unit.start >= unit.end {
+            return Err(ConversionError::Input(format!(
+                "invalid position-sharded VCF ownership interval {}-{}",
+                unit.start, unit.end
+            )));
+        }
+        if let Some(previous) = expected.checked_sub(1).map(|i| owned[i])
+            && unit.start < previous.end
+        {
+            return Err(ConversionError::Input(format!(
+                "position-sharded VCF ownership intervals overlap: {}-{} and {}-{}",
+                previous.start, previous.end, unit.start, unit.end
+            )));
+        }
+    }
+
+    let mut run_starts = vec![owned[0].start];
+    for pair in owned.windows(2) {
+        if pair[0].path_index != pair[1].path_index {
+            run_starts.push(pair[1].start);
+        }
+    }
+
+    Ok(run_starts
+        .iter()
+        .enumerate()
+        .map(|(ordinal, &run_start)| {
+            let own_start = if ordinal == 0 { 0 } else { run_start };
+            let own_end = run_starts.get(ordinal + 1).copied().unwrap_or(u32::MAX);
+            WorkUnit {
+                own_start,
+                own_end,
+                fetch_start: own_start.saturating_sub(pad),
+                fetch_end: own_end.saturating_add(pad),
+                ordinal,
+            }
+        })
+        .collect())
+}
+
+/// Consecutive source slices for one padded work-unit fetch window. Adjacent
+/// intervals owned by the same physical file are grouped so one indexed reader
+/// can seek through all of them without reparsing the large cohort header.
+pub fn slices_for_fetch(
+    owned: &[VcfCohortShardUnit],
+    fetch_start: u32,
+    fetch_end: u32,
+) -> Vec<(usize, Vec<(u32, u32)>)> {
+    let mut groups: Vec<(usize, Vec<(u32, u32)>)> = Vec::new();
+    for shard in owned {
+        let start = shard.start.max(fetch_start);
+        let end = shard.end.min(fetch_end);
+        if start >= end {
+            continue;
+        }
+        if let Some((path_index, regions)) = groups.last_mut()
+            && *path_index == shard.path_index
+        {
+            regions.push((start, end));
+        } else {
+            groups.push((shard.path_index, vec![(start, end)]));
+        }
+    }
+    groups
+}
+
+/// Concatenates globally ordered source-owned VCF slices. Readers for the
+/// small number of physical sources touched by one padded work unit are opened
+/// up front; only one is consumed at a time. Parallelism comes from
+/// `shard_exec` running independent padded work units concurrently.
+pub struct VcfCohortSliceRecordSource {
+    readers: VecDeque<VcfRecordSource>,
+    current: Option<VcfRecordSource>,
+}
+
+impl VcfCohortSliceRecordSource {
+    pub fn new(
+        vcf_paths: &[String],
+        slices: Vec<(usize, Vec<(u32, u32)>)>,
+        chrom: &str,
+        samples: &[&str],
+        ploidy: usize,
+        fields: &[FieldSpec],
+    ) -> Result<Self, ConversionError> {
+        if slices.is_empty() {
+            return Err(ConversionError::Input(format!(
+                "position-sharded VCF fetch has no source-owned slices for {chrom}"
+            )));
+        }
+        if let Some((path_index, _)) = slices
+            .iter()
+            .find(|(path_index, _)| *path_index >= vcf_paths.len())
+        {
+            return Err(ConversionError::Input(format!(
+                "position-sharded VCF slice references missing path index {path_index}"
+            )));
+        }
+        let readers = slices
+            .into_iter()
+            .map(|(path_index, regions)| {
+                VcfRecordSource::new(
+                    &vcf_paths[path_index],
+                    chrom,
+                    samples,
+                    1,
+                    ploidy,
+                    fields,
+                    regions,
+                    OverlapMode::Pos,
+                )
+            })
+            .collect::<Result<VecDeque<_>, _>>()?;
+        Ok(Self {
+            readers,
+            current: None,
+        })
+    }
+}
+
+impl RecordSource for VcfCohortSliceRecordSource {
+    fn next_record(&mut self) -> Result<Option<RawRecord>, ConversionError> {
+        loop {
+            if self.current.is_none() {
+                self.current = self.readers.pop_front();
+                if self.current.is_none() {
+                    return Ok(None);
+                }
+            }
+            match self
+                .current
+                .as_mut()
+                .expect("current reader opened")
+                .next_record()?
+            {
+                Some(record) => return Ok(Some(record)),
+                None => self.current = None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_slices_intersect_and_group_consecutive_paths() {
+        let owned = vec![
+            VcfCohortShardUnit {
+                path_index: 0,
+                start: 0,
+                end: 10,
+                ordinal: 0,
+            },
+            VcfCohortShardUnit {
+                path_index: 0,
+                start: 20,
+                end: 30,
+                ordinal: 1,
+            },
+            VcfCohortShardUnit {
+                path_index: 1,
+                start: 40,
+                end: 50,
+                ordinal: 2,
+            },
+        ];
+        assert_eq!(
+            slices_for_fetch(&owned, 5, 45),
+            vec![(0, vec![(5, 10), (20, 30)]), (1, vec![(40, 45)])]
+        );
+    }
+
+    #[test]
+    fn work_units_group_source_runs_and_assign_gaps_left() {
+        let owned = vec![
+            VcfCohortShardUnit {
+                path_index: 0,
+                start: 100,
+                end: 120,
+                ordinal: 0,
+            },
+            VcfCohortShardUnit {
+                path_index: 0,
+                start: 140,
+                end: 160,
+                ordinal: 1,
+            },
+            VcfCohortShardUnit {
+                path_index: 1,
+                start: 200,
+                end: 220,
+                ordinal: 2,
+            },
+        ];
+        assert_eq!(
+            plan_work_units(&owned, 10).unwrap(),
+            vec![
+                WorkUnit {
+                    own_start: 0,
+                    own_end: 200,
+                    fetch_start: 0,
+                    fetch_end: 210,
+                    ordinal: 0,
+                },
+                WorkUnit {
+                    own_start: 200,
+                    own_end: u32::MAX,
+                    fetch_start: 190,
+                    fetch_end: u32::MAX,
+                    ordinal: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn work_unit_planner_rejects_overlap() {
+        let owned = vec![
+            VcfCohortShardUnit {
+                path_index: 0,
+                start: 10,
+                end: 20,
+                ordinal: 0,
+            },
+            VcfCohortShardUnit {
+                path_index: 1,
+                start: 19,
+                end: 30,
+                ordinal: 1,
+            },
+        ];
+        assert!(plan_work_units(&owned, 10).is_err());
+    }
+}

--- a/tests/test_svar2_from_vcf_shards.py
+++ b/tests/test_svar2_from_vcf_shards.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from genoray import SparseVar2
+
+
+_REF = "CAAAATCAGAGT"
+
+
+def _write_ref(d: Path) -> Path:
+    ref = d / "ref.fa"
+    ref.write_text(f">chr1\n{_REF}\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+    return ref
+
+
+def _write_vcf(d: Path, name: str, rows: str, samples: tuple[str, ...]) -> Path:
+    header = (
+        "##fileformat=VCFv4.2\n"
+        f"##contig=<ID=chr1,length={len(_REF)}>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
+        + "\t".join(samples)
+        + "\n"
+    )
+    plain = d / f"{name}.vcf"
+    plain.write_text(header + rows)
+    gz = d / f"{name}.vcf.gz"
+    with open(gz, "wb") as fh:
+        subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+    subprocess.run(["bcftools", "index", str(gz)], check=True)
+    return gz
+
+
+def _assert_store_equal(a: Path, b: Path) -> None:
+    left = SparseVar2(a)
+    right = SparseVar2(b)
+    assert left.available_samples == right.available_samples
+    assert left.contigs == right.contigs
+    np.testing.assert_array_equal(
+        left.region_counts("chr1", [(0, len(_REF))]),
+        right.region_counts("chr1", [(0, len(_REF))]),
+    )
+    left_rag = left.decode("chr1", [(0, len(_REF))])
+    right_rag = right.decode("chr1", [(0, len(_REF))])
+    for field in ("pos", "ilen", "allele"):
+        np.testing.assert_array_equal(
+            np.asarray(left_rag[field].data), np.asarray(right_rag[field].data)
+        )
+        np.testing.assert_array_equal(
+            np.asarray(left_rag[field].lengths),
+            np.asarray(right_rag[field].lengths),
+        )
+
+
+def _hash_store(store: Path) -> bytes:
+    digest = hashlib.sha256()
+    for path in sorted(p for p in store.rglob("*") if p.is_file()):
+        digest.update(str(path.relative_to(store)).encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+    return digest.digest()
+
+
+def test_from_vcf_shards_matches_single_vcf_across_left_align_boundary(
+    tmp_path: Path,
+) -> None:
+    """Padded native cohort-shard workers must preserve normalized ordering.
+
+    The deletion starts in shard B at 0-based POS 8, then left-aligns to POS 6,
+    before shard A's SNP at POS 7.  Normalizing each physical file independently
+    without boundary padding and normalized-POS ownership would be out of order.
+    """
+    ref = _write_ref(tmp_path)
+    samples = ("S0", "S1")
+    row_a = "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n"
+    row_b = "chr1\t9\t.\tGAG\tG\t.\t.\t.\tGT\t1|0\t1|1\n"
+    shard_a = _write_vcf(tmp_path, "a", row_a, samples)
+    shard_b = _write_vcf(tmp_path, "b", row_b, samples)
+    oracle = _write_vcf(tmp_path, "oracle", row_a + row_b, samples)
+
+    oracle_out = tmp_path / "oracle.svar2"
+    shard_out = tmp_path / "shards.svar2"
+    SparseVar2.from_vcf(oracle_out, oracle, ref, threads=1, chunk_size=1)
+    SparseVar2.from_vcf_shards(
+        shard_out,
+        [
+            (shard_a, ("chr1", 0, 8)),
+            (shard_b, ("chr1", 8, len(_REF))),
+        ],
+        ref,
+        threads=4,
+        chunk_size=1,
+    )
+
+    _assert_store_equal(shard_out, oracle_out)
+    assert _hash_store(shard_out) == _hash_store(oracle_out)
+    rag = SparseVar2(shard_out).decode("chr1", [(0, len(_REF))])
+    assert sorted(set(np.asarray(rag["pos"].data).tolist())) == [6, 7]
+
+
+def test_from_vcf_shards_rejects_sample_order_mismatch(tmp_path: Path) -> None:
+    ref = _write_ref(tmp_path)
+    shard_a = _write_vcf(
+        tmp_path,
+        "a",
+        "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n",
+        ("S0", "S1"),
+    )
+    shard_b = _write_vcf(
+        tmp_path,
+        "b",
+        "chr1\t9\t.\tGAG\tG\t.\t.\t.\tGT\t1|0\t1|1\n",
+        ("S1", "S0"),
+    )
+
+    with pytest.raises(ValueError, match="sample.*order|identical sample"):
+        SparseVar2.from_vcf_shards(
+            tmp_path / "bad.svar2",
+            [
+                (shard_a, ("chr1", 0, 8)),
+                (shard_b, ("chr1", 8, len(_REF))),
+            ],
+            ref,
+            threads=2,
+        )
+
+
+def test_from_vcf_shards_rejects_overlapping_ownership(tmp_path: Path) -> None:
+    ref = _write_ref(tmp_path)
+    samples = ("S0", "S1")
+    shard_a = _write_vcf(
+        tmp_path,
+        "a",
+        "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n",
+        samples,
+    )
+    shard_b = _write_vcf(
+        tmp_path,
+        "b",
+        "chr1\t9\t.\tGAG\tG\t.\t.\t.\tGT\t1|0\t1|1\n",
+        samples,
+    )
+
+    with pytest.raises(ValueError, match="ownership.*overlap|overlapping.*shard"):
+        SparseVar2.from_vcf_shards(
+            tmp_path / "overlap.svar2",
+            [
+                (shard_a, ("chr1", 0, 9)),
+                (shard_b, ("chr1", 8, len(_REF))),
+            ],
+            ref,
+            threads=2,
+        )
+
+
+def test_from_vcf_shards_regions_and_samples_match_single_vcf(tmp_path: Path) -> None:
+    ref = _write_ref(tmp_path)
+    samples = ("S0", "S1")
+    row_a = "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n"
+    row_b = "chr1\t9\t.\tGAG\tG\t.\t.\t.\tGT\t1|0\t1|1\n"
+    shard_a = _write_vcf(tmp_path, "a", row_a, samples)
+    shard_b = _write_vcf(tmp_path, "b", row_b, samples)
+    oracle = _write_vcf(tmp_path, "oracle", row_a + row_b, samples)
+
+    oracle_out = tmp_path / "oracle_subset.svar2"
+    shard_out = tmp_path / "shards_subset.svar2"
+    kwargs = {"regions": ("chr1", 7, len(_REF)), "samples": ["S1"]}
+    SparseVar2.from_vcf(oracle_out, oracle, ref, threads=1, **kwargs)
+    SparseVar2.from_vcf_shards(
+        shard_out,
+        [
+            (shard_a, ("chr1", 0, 8)),
+            (shard_b, ("chr1", 8, len(_REF))),
+        ],
+        ref,
+        threads=4,
+        **kwargs,
+    )
+
+    _assert_store_equal(shard_out, oracle_out)
+    assert _hash_store(shard_out) == _hash_store(oracle_out)
+
+
+def test_from_vcf_shards_rejects_non_pos_overlap_mode(tmp_path: Path) -> None:
+    ref = _write_ref(tmp_path)
+    shard = _write_vcf(
+        tmp_path,
+        "a",
+        "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n",
+        ("S0", "S1"),
+    )
+    with pytest.raises(ValueError, match="only regions_overlap='pos'"):
+        SparseVar2.from_vcf_shards(
+            tmp_path / "unsupported.svar2",
+            [(shard, ("chr1", 0, len(_REF)))],
+            ref,
+            regions_overlap="variant",
+        )

--- a/tests/test_svar2_from_vcf_shards.py
+++ b/tests/test_svar2_from_vcf_shards.py
@@ -120,6 +120,29 @@ def test_from_vcf_shards_closes_each_header_before_opening_next(
     assert TrackingVCF.max_active == 1
 
 
+def test_from_vcf_shards_skips_field_header_scan_when_no_fields_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_if_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("field headers should not be reopened without fields")
+
+    monkeypatch.setattr("genoray._svar2._resolve_fields", fail_if_called)
+    ref = _write_ref(tmp_path)
+    source = _write_vcf(
+        tmp_path,
+        "native",
+        "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n",
+        ("S0", "S1"),
+    )
+
+    SparseVar2.from_vcf_shards(
+        tmp_path / "no-fields.svar2",
+        [(source, ("chr1", 0, len(_REF)))],
+        ref,
+        threads=2,
+    )
+
+
 def _assert_store_equal(a: Path, b: Path) -> None:
     left = SparseVar2(a)
     right = SparseVar2(b)

--- a/tests/test_svar2_from_vcf_shards.py
+++ b/tests/test_svar2_from_vcf_shards.py
@@ -66,6 +66,60 @@ def test_from_vcf_shards_accepts_vcf_bgz_suffix(tmp_path: Path) -> None:
     assert SparseVar2(out).available_samples == ["S0", "S1"]
 
 
+def test_from_vcf_shards_closes_each_header_before_opening_next(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cyvcf2 import VCF as RealVCF
+
+    class TrackingVCF:
+        active = 0
+        max_active = 0
+
+        def __init__(self, path: str) -> None:
+            self._inner = RealVCF(path)
+            self._closed = False
+            type(self).active += 1
+            type(self).max_active = max(type(self).max_active, type(self).active)
+
+        def __getattr__(self, name: str):
+            return getattr(self._inner, name)
+
+        def close(self) -> None:
+            if not self._closed:
+                self._inner.close()
+                self._closed = True
+                type(self).active -= 1
+
+    monkeypatch.setattr("cyvcf2.VCF", TrackingVCF)
+    ref = _write_ref(tmp_path)
+    samples = ("S0", "S1")
+    shard_a = _write_vcf(
+        tmp_path,
+        "a",
+        "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n",
+        samples,
+    )
+    shard_b = _write_vcf(
+        tmp_path,
+        "b",
+        "chr1\t9\t.\tGAG\tG\t.\t.\t.\tGT\t1|0\t1|1\n",
+        samples,
+    )
+
+    SparseVar2.from_vcf_shards(
+        tmp_path / "headers.svar2",
+        [
+            (shard_a, ("chr1", 0, 8)),
+            (shard_b, ("chr1", 8, len(_REF))),
+        ],
+        ref,
+        threads=2,
+    )
+
+    assert TrackingVCF.active == 0
+    assert TrackingVCF.max_active == 1
+
+
 def _assert_store_equal(a: Path, b: Path) -> None:
     left = SparseVar2(a)
     right = SparseVar2(b)

--- a/tests/test_svar2_from_vcf_shards.py
+++ b/tests/test_svar2_from_vcf_shards.py
@@ -20,7 +20,14 @@ def _write_ref(d: Path) -> Path:
     return ref
 
 
-def _write_vcf(d: Path, name: str, rows: str, samples: tuple[str, ...]) -> Path:
+def _write_vcf(
+    d: Path,
+    name: str,
+    rows: str,
+    samples: tuple[str, ...],
+    *,
+    suffix: str = ".vcf.gz",
+) -> Path:
     header = (
         "##fileformat=VCFv4.2\n"
         f"##contig=<ID=chr1,length={len(_REF)}>\n"
@@ -31,11 +38,32 @@ def _write_vcf(d: Path, name: str, rows: str, samples: tuple[str, ...]) -> Path:
     )
     plain = d / f"{name}.vcf"
     plain.write_text(header + rows)
-    gz = d / f"{name}.vcf.gz"
+    gz = d / f"{name}{suffix}"
     with open(gz, "wb") as fh:
         subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
     subprocess.run(["bcftools", "index", str(gz)], check=True)
     return gz
+
+
+def test_from_vcf_shards_accepts_vcf_bgz_suffix(tmp_path: Path) -> None:
+    ref = _write_ref(tmp_path)
+    source = _write_vcf(
+        tmp_path,
+        "native",
+        "chr1\t8\t.\tA\tT\t.\t.\t.\tGT\t1|0\t0|1\n",
+        ("S0", "S1"),
+        suffix=".vcf.bgz",
+    )
+
+    out = tmp_path / "native.svar2"
+    SparseVar2.from_vcf_shards(
+        out,
+        [(source, ("chr1", 0, len(_REF)))],
+        ref,
+        threads=2,
+    )
+
+    assert SparseVar2(out).available_samples == ["S0", "S1"]
 
 
 def _assert_store_equal(a: Path, b: Path) -> None:


### PR DESCRIPTION
Closes #125.

## Summary
- add SparseVar2.from_vcf_shards for position-sharded multi-sample cohorts with identical sample order and explicit disjoint ownership intervals
- reuse the bounded padded-region worker/reorder engine so native indexed source files are decoded and normalized in parallel without concatenating or repartitioning VCFs
- preserve cross-file left-alignment via normalized-POS ownership and auto-size dense chunks for very large cohorts
- document the distinct cohort-sharded shape versus sample-sharded from_vcf_list

## Correctness
- exact store-hash parity with one concatenated test oracle, including an indel from shard B that left-aligns ahead of a SNP in shard A
- validates sample-order equality and rejects overlapping ownership
- region and sample subset parity

## Verification
- pixi run test: 740 passed, 2 skipped, 16 xfailed
- full Rust conversion suite: 276 unit tests plus all integration tests passed
- Ruff, cargo fmt, cargo check, cargo clippy, and Pyrefly passed

The aggregate local lint wrapper only misroutes the Pyrefly hook from the lint Pixi environment; running its declared pixi run typecheck task passes with 0 errors. CI invokes prek outside that nested lint environment.