### PR TITLE
fix(svar2): thread per-file contig membership into from_vcf_list merge

### DIFF
--- a/python/genoray/_svar2.py
+++ b/python/genoray/_svar2.py
@@ -1242,12 +1242,29 @@ class SparseVar2(_BatchQueryMixin, _DecodeMixin, _MutcatMixin):
                 n_format_fields=len(format_),
                 max_mem=None if max_mem is None else parse_memory(max_mem),
             )
+
+        # Per-contig, per-file membership: `contig_membership[c][i]` is True iff
+        # paths[i] has records on contigs[c]. Built from the SAME cyvcf2 probe
+        # (`per_file_contigs`) that produced the contig union above, so Rust
+        # never opens/seeks a file for a contig it has no records on. This is
+        # what fixes issue #122: a cohort-shared header declares every contig in
+        # every file, but a file with no records on a contig (e.g. a female
+        # sample has no somatic chrY) makes rust-htslib's seek raise -- while
+        # cyvcf2 (hence this probe) just returns empty. `per_file_contigs` is
+        # parallel to `paths` (built in the same order above), so the inner
+        # list is parallel to the paths list passed to Rust.
+        contig_membership = [
+            [contig in file_contigs for _p, file_contigs in per_file_contigs]
+            for contig in contigs
+        ]
+
         return _core.run_vcf_list_conversion_pipeline(
             [str(p) for p in paths],
             None if no_reference else str(reference),
             contigs,
             str(out),
             samples,
+            contig_membership,
             chunk_size,
             ploidy,
             threads,

--- a/src/bin/bench_from_vcf_list.rs
+++ b/src/bin/bench_from_vcf_list.rs
@@ -8,7 +8,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 use genoray_core::normalize::CheckRef;
 use genoray_core::orchestrator::run_vcf_list;
 use genoray_core::svar2_view::OverlapMode;
-use rust_htslib::bcf::{Read, Reader};
+use rust_htslib::bcf::{IndexedReader, Read, Reader};
 use std::fs;
 use std::time::Instant;
 
@@ -21,6 +21,27 @@ fn sample_of(path: &str) -> String {
     let r = Reader::from_path(path).expect("open vcf");
     let s = r.header().samples();
     String::from_utf8_lossy(s[0]).into_owned()
+}
+
+/// Does `path` actually carry at least one record on `chrom`? Mirrors the
+/// cyvcf2 probe `run_vcf_list_conversion_pipeline` runs Python-side: a shared
+/// pipeline header can declare a contig every file lacks records on (e.g. a
+/// female sample has no somatic chrY), so a fetch either seek-raises (VCF.gz +
+/// tabix/CSI) or returns empty (BCF + CSI) -- both mean "not a member". Real
+/// cohorts (issue #120) hit this, so the bench must compute membership rather
+/// than assume every file carries every contig (which would reproduce #122).
+fn file_has_contig(path: &str, chrom: &str) -> bool {
+    let Ok(mut reader) = IndexedReader::from_path(path) else {
+        return false;
+    };
+    let Ok(rid) = reader.header().name2rid(chrom.as_bytes()) else {
+        return false; // contig absent from header entirely
+    };
+    if reader.fetch(rid, 0, None).is_err() {
+        return false; // seek raised => no index entry for this contig
+    }
+    let mut rec = reader.empty_record();
+    matches!(reader.read(&mut rec), Some(Ok(())))
 }
 
 fn main() {
@@ -90,6 +111,14 @@ fn main() {
         reference.unwrap_or("<none>"),
     );
 
+    // Per-contig membership, computed exactly as the Python entrypoint does
+    // (probe each file for records on each contig) so the bench runs on real
+    // cohorts whose shared header declares contigs some files lack (issue #122).
+    let contig_membership: Vec<Vec<bool>> = chroms
+        .iter()
+        .map(|c| vcf_paths.iter().map(|p| file_has_contig(p, c)).collect())
+        .collect();
+
     let t = Instant::now();
     let dropped = run_vcf_list(
         &vcf_paths,
@@ -108,6 +137,7 @@ fn main() {
         format_fields,
         Vec::new(),       // region_ranges: empty => whole contig, as the bench intends
         OverlapMode::Pos, // overlap (inert with no regions; mirrors the default)
+        contig_membership,
     )
     .expect("run_vcf_list");
     eprintln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -839,7 +839,7 @@ fn svar2_variant_stats<'py>(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-#[pyo3(signature = (vcf_paths, reference_path, chroms, output_dir, samples, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string(), region_ranges=Vec::new(), regions_overlap="pos".to_string()))]
+#[pyo3(signature = (vcf_paths, reference_path, chroms, output_dir, samples, contig_membership, chunk_size=25_000, ploidy=2, max_threads=None, long_allele_capacity=8_388_608, skip_out_of_scope=false, signatures=false, info_fields=Vec::new(), format_fields=Vec::new(), check_ref="e".to_string(), region_ranges=Vec::new(), regions_overlap="pos".to_string()))]
 fn run_vcf_list_conversion_pipeline(
     py: Python,
     vcf_paths: Vec<String>,
@@ -847,6 +847,12 @@ fn run_vcf_list_conversion_pipeline(
     chroms: Vec<String>,
     output_dir: String,
     samples: Vec<String>,
+    // `contig_membership[c][i]` == whether `vcf_paths[i]` has records on
+    // `chroms[c]` (computed Python-side via the same cyvcf2 probe that builds
+    // the contig union). Parallel: outer to `chroms`, inner to `vcf_paths`.
+    // Threaded down so a file with no records on a contig is never opened/seeked
+    // for it (issue #122).
+    contig_membership: Vec<Vec<bool>>,
     chunk_size: usize,
     ploidy: usize,
     max_threads: Option<usize>,
@@ -882,6 +888,7 @@ fn run_vcf_list_conversion_pipeline(
             format_fields,
             region_ranges,
             overlap_mode,
+            contig_membership,
         )
     })?;
     Ok(dropped as usize)

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -96,6 +96,12 @@ pub enum SourceSpec {
         htslib_threads: usize,
         regions: Vec<(u32, u32)>,
         overlap: crate::svar2_view::OverlapMode,
+        /// `members[i]` is `false` when `vcf_paths[i]` has no records on THIS
+        /// contig (Python's per-file cyvcf2 probe). Non-members are never opened
+        /// -- their column is hom-ref filled. This is per-contig, so a fresh
+        /// `Vec` is built for each `process_chromosome` call (see
+        /// `run_vcf_list`). See `VcfListRecordSource::new`.
+        members: Vec<bool>,
     },
     Svar1 {
         svar1_dir: String,
@@ -610,6 +616,7 @@ pub fn process_chromosome(
                         htslib_threads,
                         regions,
                         overlap,
+                        members,
                     } => {
                         let ref_seq_opt: Option<Vec<u8>> = match fasta.as_deref() {
                             Some(f) => Some(crate::vcf_reader::load_contig_seq(f, &chr)?),
@@ -627,6 +634,7 @@ pub fn process_chromosome(
                             &fields_owned,
                             regions,
                             overlap,
+                            &members,
                         )?;
                         Box::new(VcfListDroppedProxy {
                             inner: vcf_list,
@@ -971,7 +979,21 @@ pub fn run_vcf_list(
     format_fields: Vec<(String, String, String, Option<String>, Option<f64>)>,
     region_ranges: Vec<(String, u32, u32)>,
     overlap: crate::svar2_view::OverlapMode,
+    // `contig_membership[c][i]` is `true` when `vcf_paths[i]` has records on
+    // `chroms[c]` (Python's per-file cyvcf2 probe). Outer parallel to `chroms`,
+    // inner parallel to `vcf_paths`. Threaded into each contig's
+    // `SourceSpec::VcfList` so non-member files are never opened for that contig
+    // (issue #122).
+    contig_membership: Vec<Vec<bool>>,
 ) -> Result<u64, ConversionError> {
+    if contig_membership.len() != chroms.len() {
+        return Err(ConversionError::Input(format!(
+            "contig_membership must be parallel to chroms (one row per contig): \
+             got {} rows and {} contigs",
+            contig_membership.len(),
+            chroms.len()
+        )));
+    }
     // `from_vcf_list` holds every input open at once, per contig, so a per-file decode
     // thread is N threads per contig -- 7,089 on the #120 cohort, recreated 24 times.
     // Each wave takes fresh glibc arenas whose 64 MB heaps are never unmapped. They buy
@@ -1019,7 +1041,7 @@ pub fn run_vcf_list(
 
     let fasta_ref = reference_path;
     let mut total_dropped: u64 = 0;
-    for chrom in chroms {
+    for (chrom, members) in chroms.iter().zip(contig_membership) {
         println!("==> Processing {}", chrom);
         let dropped = process_chromosome(
             SourceSpec::VcfList {
@@ -1027,6 +1049,7 @@ pub fn run_vcf_list(
                 htslib_threads: VCF_LIST_HTSLIB_THREADS,
                 regions: ranges_by_chrom.get(chrom).cloned().unwrap_or_default(),
                 overlap,
+                members,
             },
             fasta_ref,
             chrom,

--- a/src/vcf_list_reader.rs
+++ b/src/vcf_list_reader.rs
@@ -290,8 +290,18 @@ pub struct VcfListRecordSource {
 impl VcfListRecordSource {
     /// `vcf_paths[i]` is a single-sample file whose sample is `samples[i]` and
     /// whose merged column is `i`. `ref_seq` is the contig sequence (`None` ⇒
-    /// no-reference mode). Files without `chrom` in their header are skipped
-    /// (their column is filled hom-ref for every merged record).
+    /// no-reference mode).
+    ///
+    /// `members[i]` is `false` when file `i` has NO records on `chrom` (as
+    /// determined Python-side by the same cyvcf2 probe that builds the contig
+    /// union). Non-member files are never opened for this contig — their column
+    /// is filled hom-ref for every merged record. This is essential, not just an
+    /// optimization: a file whose shared pipeline header declares `chrom` but
+    /// whose index has no entry for it makes rust-htslib's seek RAISE (issue
+    /// #122 — cyvcf2 instead warns and returns empty, which is why the probe
+    /// drops it and the union still carries the contig via other files). Files
+    /// whose header omits `chrom` entirely (`name2rid` fails) are ALSO skipped,
+    /// as a defensive fallback for any residual header/probe disagreement.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         vcf_paths: &[String],
@@ -305,6 +315,7 @@ impl VcfListRecordSource {
         fields: &[FieldSpec],
         regions: Vec<(u32, u32)>,
         overlap: crate::svar2_view::OverlapMode,
+        members: &[bool],
     ) -> Result<Self, ConversionError> {
         if vcf_paths.len() != samples.len() {
             return Err(ConversionError::Input(format!(
@@ -314,8 +325,36 @@ impl VcfListRecordSource {
                 samples.len()
             )));
         }
+        if members.len() != vcf_paths.len() {
+            return Err(ConversionError::Input(format!(
+                "members must be parallel to vcf_paths (one membership flag per \
+                 file): got {} flags and {} paths",
+                members.len(),
+                vcf_paths.len()
+            )));
+        }
+        // A hom-ref-filled, never-opened cursor for a file that has no records
+        // on this contig.
+        let absent_cursor = |col: usize, path: &str| FileCursor {
+            vcf: None,
+            buf: VecDeque::new(),
+            frontier: None,
+            eof: true,
+            col,
+            dropped: 0,
+            ref_excluded: 0,
+            path: path.to_string(),
+        };
         let mut cursors = Vec::with_capacity(vcf_paths.len());
         for (col, (path, &sample)) in vcf_paths.iter().zip(samples.iter()).enumerate() {
+            // File has no records on this contig (per Python's cyvcf2 probe):
+            // never open/seek it -- fill its column hom-ref. Skipping the open
+            // is what avoids the issue #122 seek-raise on a header-declared but
+            // index-absent contig.
+            if !members[col] {
+                cursors.push(absent_cursor(col, path));
+                continue;
+            }
             let single_sample = [sample];
             match VcfRecordSource::new(
                 path,
@@ -341,20 +380,22 @@ impl VcfListRecordSource {
                 // matched on the typed variant (not a message substring, which
                 // would silently stop matching if `vcf_reader.rs`'s wording
                 // ever changed) -- skip it, filling its column hom-ref for
-                // every merged record on this contig.
+                // every merged record on this contig. (With correct `members`
+                // this is unreachable, but keep it as a defensive fallback.)
                 Err(ConversionError::ContigNotInHeader { .. }) => {
-                    cursors.push(FileCursor {
-                        vcf: None,
-                        buf: VecDeque::new(),
-                        frontier: None,
-                        eof: true,
-                        col,
-                        dropped: 0,
-                        ref_excluded: 0,
-                        path: path.clone(),
-                    });
+                    cursors.push(absent_cursor(col, path));
                 }
-                Err(e) => return Err(e),
+                // Any other open/seek failure on a file that IS supposed to
+                // carry this contig is a genuine error (corrupt index, NFS
+                // transient, ...). Surface it WITH the file path -- the seek
+                // site in `vcf_reader.rs` only has the contig string, so
+                // without this the error names the contig but not which of N
+                // files failed (issue #122's secondary ask).
+                Err(e) => {
+                    return Err(ConversionError::Input(format!(
+                        "{path}: failed to open/seek contig {chrom:?}: {e}"
+                    )));
+                }
             }
         }
         let info_specs: Vec<FieldSpec> = fields
@@ -834,6 +875,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -898,6 +940,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -941,6 +984,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1003,6 +1047,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1060,6 +1105,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1126,6 +1172,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1239,6 +1286,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1459,6 +1507,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1548,6 +1597,7 @@ mod tests {
             &fields,
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1684,6 +1734,7 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
@@ -1764,12 +1815,170 @@ mod tests {
             &[],
             Vec::new(),
             crate::svar2_view::OverlapMode::Pos,
+            &vec![true; samples.len()],
         )
         .unwrap();
 
         let r1 = src.next_record().unwrap().unwrap();
         assert_eq!(r1.pos, 2);
         assert_eq!(r1.calls, sparse(&[/* SA hap0 */ (0, 1)]));
+        assert!(src.next_record().unwrap().is_none());
+        assert_eq!(src.dropped_out_of_scope(), 0);
+    }
+
+    // Write a single-sample, CSI-indexed BCF declaring EVERY `header_contigs`
+    // entry in its header, but carrying records only on the contigs named in
+    // `records` (a map from contig to that contig's `SsRec`s). This is the
+    // shape a real cohort-shared pipeline header produces: every file declares
+    // every contig, yet a given sample has zero calls on some of them (e.g. a
+    // female sample has no somatic chrY records). `rid` is assigned by header
+    // declaration order, so `records` keys must appear in `header_contigs`.
+    fn write_multi_contig_ss_vcf(
+        dir: &Path,
+        name: &str,
+        header_contigs: &[(&str, u64)],
+        sample: &str,
+        records: &[(&str, &[SsRec])],
+    ) -> PathBuf {
+        // A bgzipped VCF (not BCF): htslib's seek to a header-declared contig
+        // that has no index entry RAISES for a bgzf-VCF+CSI/tabix index (the
+        // issue #122 shape), whereas the same seek over a BCF+CSI returns an
+        // empty iterator -- so the reproduction only holds for the VCF form.
+        let path = dir.join(format!("{name}.vcf.gz"));
+        let mut header = Header::new();
+        for (chrom, len) in header_contigs {
+            header.push_record(format!("##contig=<ID={chrom},length={len}>").as_bytes());
+        }
+        header.push_record(b"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+        header.push_sample(sample.as_bytes());
+        let rid_of = |chrom: &str| {
+            header_contigs
+                .iter()
+                .position(|(c, _)| *c == chrom)
+                .expect("record contig must be declared in header") as u32
+        };
+        {
+            let mut writer =
+                Writer::from_path(&path, &header, false, Format::Vcf).expect("open VCF writer");
+            for (chrom, recs) in records {
+                for rec in recs.iter() {
+                    let mut record = writer.empty_record();
+                    record.set_rid(Some(rid_of(chrom)));
+                    record.set_pos(rec.pos);
+                    let mut alleles: Vec<&[u8]> = Vec::with_capacity(1 + rec.alts.len());
+                    alleles.push(rec.r);
+                    alleles.extend(rec.alts.iter().copied());
+                    record.set_alleles(&alleles).expect("set alleles");
+                    let gt_alleles: Vec<GenotypeAllele> = rec
+                        .gt
+                        .iter()
+                        .map(|&g| {
+                            if g < 0 {
+                                GenotypeAllele::PhasedMissing
+                            } else {
+                                GenotypeAllele::Phased(g)
+                            }
+                        })
+                        .collect();
+                    record.push_genotypes(&gt_alleles).expect("push genotypes");
+                    writer.write(&record).expect("write record");
+                }
+            }
+        }
+        rust_htslib::bcf::index::build(&path, None, 0, rust_htslib::bcf::index::Type::Csi(14))
+            .expect("build BCF index");
+        path
+    }
+
+    // Issue #122: a file that declares the queried contig in its header but has
+    // records on a DIFFERENT contig (and none on the queried one) is the real
+    // crash shape -- distinct from `contig_in_header_but_no_records_...` above,
+    // where the file has ZERO records total and htslib's `fetch` happens to
+    // succeed (empty). Here `name2rid` succeeds but the index has no entry for
+    // the queried contig, so rust-htslib's `fetch`/seek RAISES (cyvcf2 instead
+    // warns + returns empty, which is why Python's per-file contig probe drops
+    // it and the union still carries the contig via the other file). The merge
+    // must treat this column as a non-member (hom-ref fill), not crash.
+    #[test]
+    fn contig_absent_from_index_but_in_header_is_filled_hom_ref() {
+        let tmp = tempdir().unwrap();
+        // file A: declares chr1 & chr2, has records on BOTH.
+        let a = write_multi_contig_ss_vcf(
+            tmp.path(),
+            "a",
+            &[("chr1", 100), ("chr2", 100)],
+            "SA",
+            &[
+                (
+                    "chr1",
+                    &[SsRec {
+                        pos: 2,
+                        r: b"A",
+                        alts: vec![b"G"],
+                        gt: vec![1, 0],
+                    }],
+                ),
+                (
+                    "chr2",
+                    &[SsRec {
+                        pos: 5,
+                        r: b"A",
+                        alts: vec![b"G"],
+                        gt: vec![1, 1],
+                    }],
+                ),
+            ],
+        );
+        // file B: declares chr1 & chr2 (shared pipeline header) but has records
+        // ONLY on chr1 -- its index has no chr2 entry, so fetching chr2 raises.
+        let b = write_multi_contig_ss_vcf(
+            tmp.path(),
+            "b",
+            &[("chr1", 100), ("chr2", 100)],
+            "SB",
+            &[(
+                "chr1",
+                &[SsRec {
+                    pos: 2,
+                    r: b"A",
+                    alts: vec![b"G"],
+                    gt: vec![0, 1],
+                }],
+            )],
+        );
+        let ref_seq = make_ref(tmp.path(), "chr2", 100, &[(5, b"A")]);
+
+        let paths = vec![
+            a.to_str().unwrap().to_string(),
+            b.to_str().unwrap().to_string(),
+        ];
+        let samples = vec!["SA", "SB"];
+        // Membership on chr2: A carries records (true), B does not (false) --
+        // exactly what Python's per-file cyvcf2 probe computes.
+        let members = vec![true, false];
+        let mut src = VcfListRecordSource::new(
+            &paths,
+            &samples,
+            "chr2",
+            Some(&ref_seq),
+            2,
+            1,
+            false,
+            CheckRef::Error,
+            &[],
+            Vec::new(),
+            crate::svar2_view::OverlapMode::Pos,
+            &members,
+        )
+        .unwrap();
+
+        // Only A's chr2 record; B's column is hom-ref filled (no crash).
+        let r1 = src.next_record().unwrap().unwrap();
+        assert_eq!(r1.pos, 5);
+        assert_eq!(
+            r1.calls,
+            sparse(&[/* SA hap0 */ (0, 1), /* SA hap1 */ (1, 1)])
+        );
         assert!(src.next_record().unwrap().is_none());
         assert_eq!(src.dropped_out_of_scope(), 0);
     }

--- a/tests/test_check_ref_e2e.rs
+++ b/tests/test_check_ref_e2e.rs
@@ -168,6 +168,7 @@ fn vcf_list_ref_mismatch_excluded_under_x() {
         Vec::new(),                                 // format_fields
         Vec::new(),                                 // region_ranges
         genoray_core::svar2_view::OverlapMode::Pos, // overlap
+        vec![vec![true; 2]; 1],                     // contig_membership: both files carry chr1
     )
     .unwrap();
     assert_eq!(

--- a/tests/test_svar2_from_vcf_list.py
+++ b/tests/test_svar2_from_vcf_list.py
@@ -90,6 +90,65 @@ def test_from_vcf_list_disjoint_sites_hom_ref_fill(tmp_path: Path):
     assert counts.tolist() == [1, 0, 0, 1]
 
 
+def test_from_vcf_list_contig_missing_from_some_files_is_hom_ref_filled(
+    tmp_path: Path,
+):
+    """Issue #122: a cohort-shared pipeline header declares every contig in
+    every file, yet a file may have zero records on a given contig (e.g. a
+    female sample has no somatic chrY). rust-htslib's seek RAISES on such a
+    header-declared-but-index-absent contig (cyvcf2 instead returns empty),
+    which used to abort the whole `from_vcf_list` run with an opaque OSError
+    (`error seeking to "<contig>":0 in indexed file`). The conversion must
+    instead skip that file for the contig and hom-ref-fill its column.
+
+    Uses tabix (`.tbi`) indexes to match real PURPLE `*.somatic.vcf.gz` inputs
+    (both `.tbi` and `bcftools index` `.csi` reproduced the crash pre-fix).
+    """
+    ref = tmp_path / "ref.fa"
+    ref.write_text(">chr1\n" + "A" * 40 + "\n>chr2\n" + "A" * 40 + "\n")
+    subprocess.run(["samtools", "faidx", str(ref)], check=True)
+
+    header = (
+        "##fileformat=VCFv4.2\n"
+        "##contig=<ID=chr1,length=40>\n"
+        "##contig=<ID=chr2,length=40>\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="GT">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t{s}\n"
+    )
+
+    def ss(name: str, sample: str, rows: str) -> Path:
+        plain = tmp_path / f"{name}.vcf"
+        plain.write_text(header.format(s=sample) + rows)
+        gz = tmp_path / f"{name}.vcf.gz"
+        with open(gz, "wb") as fh:
+            subprocess.run(["bgzip", "-c", str(plain)], check=True, stdout=fh)
+        subprocess.run(["tabix", "-p", "vcf", str(gz)], check=True)
+        return gz
+
+    # file A carries records on BOTH contigs; file B ONLY on chr1 -- its index
+    # has no chr2 entry, so seeking chr2 is exactly the failing operation.
+    a = ss(
+        "a",
+        "SA",
+        "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t1|0\nchr2\t6\t.\tA\tG\t.\t.\t.\tGT\t1|1\n",
+    )
+    b = ss("b", "SB", "chr1\t3\t.\tA\tG\t.\t.\t.\tGT\t0|1\n")
+
+    out = tmp_path / "store"
+    dropped = SparseVar2.from_vcf_list(out, [a, b], ref, threads=1)
+    assert dropped == 0
+    sv = SparseVar2(out)
+    assert sv.available_samples == ["SA", "SB"]
+
+    # chr2: only SA carries (hom-alt, both haps); SB is hom-ref filled, NOT a
+    # crash. (R,S,P) -> [SA_h0, SA_h1, SB_h0, SB_h1].
+    counts_chr2 = sv.region_counts("chr2", [(0, 40)]).reshape(-1)
+    assert counts_chr2.tolist() == [1, 1, 0, 0]
+    # chr1 is unaffected: both files carry one hap each.
+    counts_chr1 = sv.region_counts("chr1", [(0, 40)]).reshape(-1)
+    assert counts_chr1.tolist() == [1, 0, 0, 1]
+
+
 def test_from_vcf_list_regions_restricts(tmp_path: Path):
     """`regions` restricts the k-way merge to the requested interval, exactly
     as it restricts `from_vcf` -- exercised here through `from_vcf_list`'s
@@ -762,9 +821,11 @@ def test_from_vcf_list_auto_chunk_size(tmp_path, monkeypatch):
     seen = {}
     real_pipeline = sv2._core.run_vcf_list_conversion_pipeline
 
-    def spy(paths, ref, contigs, out, samples, chunk_size, *rest):
+    def spy(paths, ref, contigs, out, samples, contig_membership, chunk_size, *rest):
         seen["chunk_size"] = chunk_size
-        return real_pipeline(paths, ref, contigs, out, samples, chunk_size, *rest)
+        return real_pipeline(
+            paths, ref, contigs, out, samples, contig_membership, chunk_size, *rest
+        )
 
     monkeypatch.setattr(sv2._core, "run_vcf_list_conversion_pipeline", spy)
     monkeypatch.setattr(

--- a/tests/test_vcf_list_e2e.rs
+++ b/tests/test_vcf_list_e2e.rs
@@ -72,6 +72,8 @@ fn vcf_list_e2e_two_samples_one_store() {
         Vec::new(),
         Vec::new(),
         genoray_core::svar2_view::OverlapMode::Pos,
+        // Every file declares chr1 and has records on it -> all members.
+        vec![vec![true; vcf_paths.len()]; chroms.len()],
     )
     .expect("run_vcf_list should succeed");
 
@@ -274,6 +276,8 @@ fn vcf_list_e2e_regions_restricts_merge() {
         Vec::new(),
         vec![("chr1".to_string(), 0u32, 5u32)],
         genoray_core::svar2_view::OverlapMode::Pos,
+        // Every file declares chr1 and has records on it -> all members.
+        vec![vec![true; vcf_paths.len()]; chroms.len()],
     )
     .expect("run_vcf_list should succeed");
 


### PR DESCRIPTION
## Summary

Fixes #122. `SparseVar2.from_vcf_list` crashed with an opaque `OSError` (`I/O error at fetching region for chromosome '<contig>': error seeking to "<contig>":0 in indexed file`) whenever **any input VCF lacked records on a contig that another input carried**.

### Mechanism

A cohort-shared pipeline header declares *every* contig in *every* file, so htslib's `name2rid` succeeds and only the fetch/seek fails. rust-htslib **raises** on a header-declared but index-absent contig, whereas cyvcf2 (the Python-side probe) just warns and returns empty. The contig union still carried the contig via the files that *do* have it, so every other file's k-way-merge cursor then seek-crashed.

This is **guaranteed** on real somatic cohorts: e.g. female samples have no somatic chrY calls, so their `*.somatic.vcf.gz` index has no chrY entry while the header still declares it — killing the whole run on the last (natsort) contig after all the real work is done.

### Fix

Thread the already-computed per-file contig membership (`per_file_contigs` — the *same* cyvcf2 probe that builds the contig union) down to Rust as a per-contig `Vec<Vec<bool>>`. `VcfListRecordSource::new` now **skips** (never opens/seeks) any file with no records on the contig, filling its column hom-ref — the exact mechanism already used for a file whose header omits the contig entirely.

This *removes* the crash rather than masking a seek error (the "lighter alternative" of swallowing seek failures would silently drop data on a genuine NFS/index fault). A residual open/seek failure on a file that **is** supposed to carry the contig now surfaces **with the offending file path** (the seek site previously had only the contig string).

Bonus: on wide cohorts this also avoids pointlessly opening + seeking hundreds of files that have no records for a contig.

- Public `SparseVar2.from_vcf_list` signature is **unchanged** (membership is computed internally); no SKILL.md change needed.
- The bench binary (`bench_from_vcf_list`) computes membership via its own rust-htslib probe so it runs on real cohorts.

## Testing

- **New Rust unit test** `contig_absent_from_index_but_in_header_is_filled_hom_ref` — uses a **bgzipped VCF** (the form whose seek raises; a BCF+CSI fixture does *not* reproduce it, which is why the pre-existing zero-record test never caught this).
- **New Python e2e test** `test_from_vcf_list_contig_missing_from_some_files_is_hom_ref_filled` — tabix-indexed, matching real PURPLE inputs; verifies correct hom-ref fill, not just no-crash.
- Confirmed RED→GREEN: the exact issue error reproduced pre-fix; both index types (`.tbi` and `bcftools index` `.csi`) reproduced at the Python level.
- Full suites green: Rust lib (298) + integration tests, Python non-network suite (747 passed, 0 failed), ruff / cargo fmt / clippy / pyrefly / query-core `cargo check --no-default-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)