### PR TITLE
feat: per-variant global_idx on DenseChunk (PGEN populated)

### DIFF
--- a/src/chunk_assembler.rs
+++ b/src/chunk_assembler.rs
@@ -19,6 +19,7 @@ struct PendingAtom {
     source_alt_index: u16,
     calls: Arc<Calls>, // shared across the atoms decomposed from one record
     seq: u64,          // stable tiebreak for equal positions
+    global_idx: i32,   // threaded verbatim from the source record
 
     // INFO is resolved eagerly (already indexed by source_alt_index where the
     // underlying VCF field is Number=A) since it's already O(1) per atom -- one
@@ -187,6 +188,7 @@ struct AtomMeta {
     source_alt_index: u16,
     info_vals: Vec<f64>,
     format_vals: Arc<FormatVals>,
+    global_idx: i32,
     /// Columns whose allele is this atom's `source_alt_index` -- i.e. exactly the
     /// bits `pack_row` sets for this atom. `None` when the source is natively
     /// dense, where recovering carriers from the grid is correct and cheaper than
@@ -260,6 +262,7 @@ fn flush_window(
             source_alt_index: a.source_alt_index,
             info_vals: a.info_vals,
             format_vals: a.format_vals,
+            global_idx: a.global_idx,
             carriers,
         });
     }
@@ -329,7 +332,8 @@ fn decompose_raw_record(
         skip_out_of_scope,
     )?;
 
-    let mut pending = Vec::with_capacity(atoms.len());
+    let atoms_len = atoms.len();
+    let mut pending = Vec::with_capacity(atoms_len);
     for (atom_ix, atom) in atoms.into_iter().enumerate() {
         let atom = if has_reference {
             crate::normalize::left_align(atom, ref_seq, crate::normalize::L_MAX)
@@ -355,8 +359,12 @@ fn decompose_raw_record(
             seq,
             info_vals,
             format_vals: Arc::clone(&format_vals),
+            global_idx: rec.global_idx,
         });
     }
+    // No per-record atom-count invariant here: multiallelic records legitimately
+    // atomize to >1 atom (see the ALT C,G test below). `global_idx` is threaded
+    // onto every atom a record produces, not asserted to produce exactly one.
 
     Ok(DecomposedRecord {
         source_pos: pos,
@@ -615,6 +623,7 @@ impl ChunkAssembler {
 
         let num_samples = self.num_samples;
         let mut pos = Vec::with_capacity(v);
+        let mut global_idx: Vec<i32> = Vec::with_capacity(v);
         let mut ilens = Vec::with_capacity(v);
         let mut alt = Vec::with_capacity(v * 2);
         let mut alt_offsets = Vec::with_capacity(v + 1);
@@ -643,6 +652,7 @@ impl ChunkAssembler {
         let mut format_arcs: Vec<Arc<FormatVals>> = Vec::with_capacity(metas.len());
         for a in metas.iter_mut() {
             pos.push(a.pos);
+            global_idx.push(a.global_idx);
             ilens.push(a.ilen);
             alt.extend_from_slice(&a.alt);
             off += a.alt.len() as u32;
@@ -704,6 +714,7 @@ impl ChunkAssembler {
         Ok(Some(DenseChunk {
             chunk_id,
             pos,
+            global_idx,
             ilens,
             alt,
             alt_offsets,
@@ -756,6 +767,7 @@ mod tests {
             seq: 0,
             info_vals: Vec::new(),
             format_vals: Arc::new(FormatVals::Dense(Vec::new())),
+            global_idx: -1,
         }
     }
 
@@ -769,6 +781,7 @@ mod tests {
             seq: pos as u64,
             info_vals: Vec::new(),
             format_vals: Arc::new(FormatVals::Dense(Vec::new())),
+            global_idx: -1,
         }
     }
 
@@ -791,6 +804,7 @@ mod tests {
             seq: 0,
             info_vals: Vec::new(),
             format_vals: Arc::new(FormatVals::Dense(Vec::new())),
+            global_idx: -1,
         }
     }
 
@@ -848,6 +862,7 @@ mod tests {
             calls: Calls::Dense(vec![1, 2]), // irrelevant to FORMAT resolution
             info_raw: Vec::new(),
             format_vals: FormatVals::Dense(vec![Some(vec![vec![10.0, 20.0]])]),
+            global_idx: -1,
         };
         let decomposed = decompose_raw_record(
             rec,
@@ -886,6 +901,37 @@ mod tests {
     }
 
     #[test]
+    fn decompose_threads_record_global_idx_onto_each_atom() {
+        // A single biallelic SNP record tagged global id 7 must yield exactly one
+        // atom whose global_idx == 7 (the 1:1 record<->atom contract).
+        let rec = RawRecord {
+            pos: 0,
+            reference: b"A".to_vec(),
+            alts: vec![b"C".to_vec()], // biallelic SNP -> 1 atom
+            calls: Calls::Dense(vec![1]),
+            info_raw: Vec::new(),
+            format_vals: FormatVals::Dense(vec![Some(vec![vec![10.0]])]),
+            global_idx: 7,
+        };
+        let decomposed = decompose_raw_record(
+            rec,
+            0,
+            &[],
+            false,
+            false,
+            crate::normalize::CheckRef::Error,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            decomposed.atoms.len(),
+            1,
+            "REF A / ALT C must atomize to exactly one SNV atom"
+        );
+        assert_eq!(decomposed.atoms[0].global_idx, 7);
+    }
+
+    #[test]
     fn pack_row_dense_calls_matches_the_raw_gt_loop() {
         // Guards the Task 4 migration: packing from Calls::Dense must reproduce, bit for
         // bit, what the old `&a.gt` loop produced. Any drift here is a store diff.
@@ -909,6 +955,7 @@ mod tests {
             seq: 0,
             info_vals: Vec::new(),
             format_vals: Arc::new(FormatVals::Dense(Vec::new())),
+            global_idx: -1,
         };
 
         let mut got = vec![0u64; 1];
@@ -940,6 +987,7 @@ mod tests {
             seq: 0,
             info_vals: Vec::new(),
             format_vals: Arc::new(FormatVals::Dense(Vec::new())),
+            global_idx: -1,
         };
 
         let mut dense_bits = vec![0u64; 1];
@@ -990,6 +1038,7 @@ mod tests {
             seq: 0,
             info_vals: Vec::new(),
             format_vals: Arc::new(FormatVals::Dense(Vec::new())),
+            global_idx: -1,
         };
         let words = (columns * 2).div_ceil(64);
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -76,6 +76,7 @@ mod tests {
         DenseChunk {
             chunk_id: 0,
             pos: vec![100],
+            global_idx: vec![-1],
             ilens: vec![0],
             alt: b"C".to_vec(),
             alt_offsets: vec![0, 1],

--- a/src/pgen_reader.rs
+++ b/src/pgen_reader.rs
@@ -300,6 +300,7 @@ impl RecordSource for PgenRecordSource {
                 // limited to the requested dosage fields (`format_raw` above).
                 info_raw: Vec::new(),
                 format_vals: crate::record_source::FormatVals::Dense(format_raw),
+                global_idx: -1, // task 1.2 populates this from PGEN's real global id
             }));
         }
     }

--- a/src/pgen_reader.rs
+++ b/src/pgen_reader.rs
@@ -203,6 +203,11 @@ impl RecordSource for PgenRecordSource {
             }
 
             // .pvar and .pgen advance in lockstep -- one metadata row per genotype row.
+            // Capture the absolute `.pvar` row index BEFORE calling
+            // `next_variant`: `vidx` is incremented inside that call before it
+            // returns, so this is the only point where it equals the row
+            // about to be returned rather than the one after it.
+            let gidx = self.pvar.current_vidx() as i32;
             let Some(meta) = self.pvar.next_variant()? else {
                 return Err(ConversionError::Input(
                     "pvar ran out of variants before the .pgen did; \
@@ -300,7 +305,7 @@ impl RecordSource for PgenRecordSource {
                 // limited to the requested dosage fields (`format_raw` above).
                 info_raw: Vec::new(),
                 format_vals: crate::record_source::FormatVals::Dense(format_raw),
-                global_idx: -1, // task 1.2 populates this from PGEN's real global id
+                global_idx: gidx, // absolute .pvar row index; survives region-overlap gaps
             }));
         }
     }

--- a/src/pvar.rs
+++ b/src/pvar.rs
@@ -28,8 +28,9 @@ pub struct PvarReader {
     pos_col: usize,
     ref_col: usize,
     alt_col: usize,
-    /// Global variant index of the next row to be returned. Only used for error
-    /// messages; the caller tracks its own range.
+    /// Global variant index of the next row to be returned. Used for error
+    /// messages and exposed via `current_vidx` for callers that need the
+    /// absolute `.pvar` row index of the record about to be returned.
     vidx: usize,
     buf: String,
 }
@@ -125,6 +126,11 @@ impl PvarReader {
             me.vidx += 1;
         }
         Ok(me)
+    }
+
+    /// Absolute `.pvar` row index of the NEXT row `next_variant` will return.
+    pub fn current_vidx(&self) -> usize {
+        self.vidx
     }
 
     fn read_line(&mut self) -> Result<usize, ConversionError> {
@@ -287,6 +293,42 @@ chr1\t7\t.\tC\tCAT
         let v = r.next_variant().unwrap().unwrap();
         assert_eq!(v.pos, 11);
         assert!(r.next_variant().unwrap().is_none());
+    }
+
+    #[test]
+    fn current_vidx_is_absolute_index_of_next_row() {
+        // BODY has 3 data rows (absolute indices 0, 1, 2).
+        let dir = write_tmp("x.pvar", BODY);
+        let p = dir.path().join("x.pvar");
+        let mut r = PvarReader::open(p.to_str().unwrap(), 0).unwrap();
+
+        // Before any `next_variant`, the next row to be returned is row 0.
+        assert_eq!(r.current_vidx(), 0);
+
+        // The call that returns row 0's record leaves `current_vidx` at 1 --
+        // the absolute index of the *next* row, not the one just returned.
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 2); // row 0: 1-based POS 3 -> 0-based 2
+        assert_eq!(r.current_vidx(), 1);
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 6); // row 1
+        assert_eq!(r.current_vidx(), 2);
+
+        let v = r.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 11); // row 2
+        assert_eq!(r.current_vidx(), 3);
+
+        assert!(r.next_variant().unwrap().is_none());
+
+        // With `var_start` skipping to index 2, the accessor reflects the
+        // skip immediately -- i.e. the value captured BEFORE a `next_variant`
+        // call equals the absolute row that call is about to return.
+        let mut r2 = PvarReader::open(p.to_str().unwrap(), 2).unwrap();
+        assert_eq!(r2.current_vidx(), 2);
+        let v = r2.next_variant().unwrap().unwrap();
+        assert_eq!(v.pos, 11); // row 2
+        assert_eq!(r2.current_vidx(), 3);
     }
 
     #[test]

--- a/src/record_source.rs
+++ b/src/record_source.rs
@@ -30,6 +30,10 @@ pub struct RawRecord {
     /// every sample (a multi-sample VCF, PGEN); `ByCarrier` for a k-way merge of
     /// single-sample files, where only the carrying samples have anything to say.
     pub format_vals: FormatVals,
+    /// Dataset-global variant id, threaded verbatim onto every atom this record
+    /// decomposes into. `-1` for sources that don't have one yet (everything but
+    /// PGEN, for now -- see `pgen_reader.rs`).
+    pub global_idx: i32,
 }
 
 /// A cursor over one contig's variant records, in file order.

--- a/src/rvk.rs
+++ b/src/rvk.rs
@@ -773,10 +773,12 @@ mod tests {
         }
 
         let pos: Vec<u32> = (0..n_variants as u32).map(|i| 100 + i * 10).collect();
+        let global_idx: Vec<i32> = vec![-1; n_variants];
 
         DenseChunk {
             chunk_id: 0,
             pos,
+            global_idx,
             ilens,
             alt: alt_buf,
             alt_offsets,

--- a/src/shard_exec.rs
+++ b/src/shard_exec.rs
@@ -96,6 +96,11 @@ impl ReorderBuffer {
 }
 
 /// One worker's report to the collector.
+// `DenseChunk` legitimately outgrew clippy's large-enum-variant threshold when
+// `global_idx: Vec<i32>` was added alongside `pos`/`ilens`/`alt_offsets`; every
+// worker already streams one owned `DenseChunk` per message on this channel,
+// so boxing it here would just move the allocation rather than avoid one.
+#[allow(clippy::large_enum_variant)]
 enum Msg {
     Chunk {
         unit_ordinal: usize,

--- a/src/svar1_reader.rs
+++ b/src/svar1_reader.rs
@@ -325,6 +325,7 @@ impl RecordSource for Svar1RecordSource {
                 calls: crate::record_source::Calls::Dense(gt),
                 info_raw: Vec::new(), // SVAR1 has no INFO fields
                 format_vals: crate::record_source::FormatVals::Dense(format_raw),
+                global_idx: -1,
             }));
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,6 +139,7 @@ pub struct DenseChunk {
 
     // Variant Metadata
     pub pos: Vec<u32>,
+    pub global_idx: Vec<i32>,
     // pub refe: Vec<u8>,
     // pub ref_offsets: Vec<I>,
     pub ilens: Vec<i32>, // Pre-calculated (ALT len - REF len)

--- a/src/vcf_list_reader.rs
+++ b/src/vcf_list_reader.rs
@@ -613,6 +613,7 @@ impl VcfListRecordSource {
             calls: Calls::Sparse(carriers),
             info_raw,
             format_vals: FormatVals::ByCarrier(cf),
+            global_idx: -1,
         })
     }
 }

--- a/src/vcf_reader.rs
+++ b/src/vcf_reader.rs
@@ -676,6 +676,7 @@ impl VcfRecordSource {
             calls: crate::record_source::Calls::Dense(gt),
             info_raw,
             format_vals: crate::record_source::FormatVals::Dense(format_raw),
+            global_idx: -1,
         }))
     }
 }


### PR DESCRIPTION
## Summary

Adds a per-variant `global_idx` carrier to `DenseChunk` so record-stream consumers
(GenVarLoader's `StreamingDataset`) can emit **dataset-global** variant ids rather than a
scalar base + window-local index. This is the genoray half of GenVarLoader #305.

- **`DenseChunk.global_idx: Vec<i32>`** — per-variant column parallel to `pos`/`ilens`/`alt_offsets`.
- **`RawRecord.global_idx: i32`** — source-supplied id, sentinel `-1` when the source does not set
  it (all non-record-stream sources default to `-1`, so existing callers are unaffected).
- Threaded through atomization: `RawRecord` → `PendingAtom` → `AtomMeta` → `DenseChunk`. A
  multiallelic record's N atoms all share that record's `global_idx` (correct — the 1:1
  record↔atom property is a GenVarLoader write-layer guarantee, not a genoray one).
- **PGEN** populates the real value from the `.pvar` absolute row index via a new
  `PvarReader::current_vidx()` accessor, captured **before** `next_variant()` (which increments
  the cursor before returning). Survivors keep their true, possibly-gapped row index across
  region-overlap exclusion, because the overlap `continue` happens after the cursor advances.

## Tests

- `decompose_threads_record_global_idx_onto_each_atom` — the record's id reaches each atom.
- `current_vidx_is_absolute_index_of_next_row` — pins the accessor's off-by-one semantics against
  the `.pvar` fixture (including `var_start` skipping).
- Full suite green: `pixi run -e lint test-rust` → 303 lib tests + integration binaries, 0 failed;
  clippy `-D warnings`, fmt, commitizen all clean.

VCF is intentionally not populated here (it cannot self-compute the id); GenVarLoader supplies VCF
ids from its `.gvi` oracle in a later, spike-gated phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
