### PR TITLE
perf(query): make find_ranges O(total_variants) and add a chunked API

### DIFF
--- a/python/genoray/_svar2_batch.py
+++ b/python/genoray/_svar2_batch.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
@@ -11,6 +12,57 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
     from genoray import _core
+
+#: Bit width reserved for ``ext`` in a packed max-end key. Mirrors Rust's
+#: ``query::MAX_END_SHIFT``; consumers unpack with
+#: ``end = (key >> MAX_END_SHIFT) + (key & ((1 << MAX_END_SHIFT) - 1))``.
+MAX_END_SHIFT = 21
+
+
+@dataclass(frozen=True)
+class RangesChunk:
+    """One hap slice of a chunked ``_find_ranges``.
+
+    Attributes:
+        sample_start: Offset of this chunk on the SELECTED sample axis.
+        n_samples: Number of selected samples in this chunk.
+        vk_snp_range: Shape ``(n_samples, ploidy, n_regions, 2)``, hap-major.
+        vk_indel_range: Shape ``(n_samples, ploidy, n_regions, 2)``, hap-major.
+        max_end_keys: Shape ``(n_regions,)``. Packed ``(pos << MAX_END_SHIFT) |
+            ext`` maxima over this chunk's haps; ``0`` means no variant. Reduce
+            across chunks with an elementwise maximum BEFORE unpacking -- the
+            ordering rule is position first, end second, so reducing unpacked
+            ends would pick the wrong variant.
+    """
+
+    sample_start: int
+    n_samples: int
+    vk_snp_range: "np.ndarray"
+    vk_indel_range: "np.ndarray"
+    max_end_keys: "np.ndarray"
+
+
+@dataclass(frozen=True)
+class RangesStream:
+    """Memory-bounded, chunked form of ``_find_ranges``.
+
+    The ``O(n_regions)`` arrays are computed eagerly; the
+    ``O(n_regions * n_samples * ploidy)`` payload arrives via ``chunks``.
+    ``n_samples`` is the progress denominator and each ``RangesChunk`` reports
+    how many samples it advanced by.
+    """
+
+    n_regions: int
+    n_samples: int
+    ploidy: int
+    samples_per_chunk: int
+    region_starts: "np.ndarray"
+    dense_range: "np.ndarray"
+    dense_snp_range: "np.ndarray"
+    dense_indel_range: "np.ndarray"
+    sample_cols: "np.ndarray"
+    dense_max_end_keys: "np.ndarray"
+    chunks: "Iterator[RangesChunk]"
 
 
 class BatchResult(TypedDict):
@@ -166,3 +218,95 @@ class _BatchQueryMixin:
                     f"(got {want!r}, bundle has {have!r})"
                 )
         return self._reader(contig).gather_ranges(ranges)
+
+    def _find_ranges_chunked(
+        self,
+        contig: str,
+        starts: "ArrayLike",
+        ends: "ArrayLike",
+        samples: "ArrayLike | None" = None,
+        *,
+        max_mem: int | None = None,
+    ) -> RangesStream:
+        """Chunked, memory-bounded ``_find_ranges``.
+
+        ``starts``/``ends`` and ``samples`` behave as in :meth:`read_ranges`.
+
+        The var_key payload is ``n_regions * n_samples * ploidy * 2`` int64
+        pairs per channel, which is tens of GiB at cohort scale. This splits it
+        along the SAMPLE axis -- not the region axis -- because the search is
+        column-outer: chunking regions would re-sweep the whole packed store per
+        chunk, while chunking samples keeps a single sweep.
+
+        Args:
+            contig: Contig name.
+            starts: 0-based start positions of the query regions.
+            ends: 0-based, exclusive end positions of the query regions.
+            samples: Sample names selecting (and reordering) a subset.
+            max_mem: Approximate byte budget for one chunk's payload. ``None``
+                yields a single chunk covering every sample.
+
+        Returns:
+            A :class:`RangesStream` whose ``chunks`` generator yields
+            :class:`RangesChunk` in ascending ``sample_start`` order.
+
+        Raises:
+            ValueError: If ``max_mem`` cannot fit a single sample's payload, or
+                if the contig's largest deletion overflows the max-end key
+                packing width.
+        """
+        reg = self._regions(starts, ends)
+        sample_idxs = self._sample_idxs(samples)
+        reader = self._reader(contig)
+        header = reader.find_ranges_header(reg, sample_idxs)
+
+        n_regions = int(header["n_regions"])
+        n_samples = int(header["n_samples"])
+        ploidy = int(header["ploidy"])
+
+        # Both channels, 2 endpoints, int64. The 2x is slop for the transient
+        # the binding holds while handing the arrays back.
+        bytes_per_sample = n_regions * ploidy * 2 * 8 * 2
+        if max_mem is None:
+            per = max(n_samples, 1)
+        else:
+            per = (
+                int(max_mem) // (2 * bytes_per_sample)
+                if bytes_per_sample
+                else n_samples
+            )
+            if per < 1:
+                raise ValueError(
+                    f"max_mem ({int(max_mem)} bytes) is too small for even one "
+                    f"sample of {n_regions} regions at ploidy {ploidy}: needs at "
+                    f"least {2 * bytes_per_sample} bytes."
+                )
+            per = min(per, max(n_samples, 1))
+
+        def _gen() -> "Iterator[RangesChunk]":
+            for s0 in range(0, n_samples, per):
+                s1 = min(s0 + per, n_samples)
+                d = reader.find_ranges_chunk(reg, sample_idxs, s0 * ploidy, s1 * ploidy)
+                cs = s1 - s0
+                shape = (cs, ploidy, n_regions, 2)
+                yield RangesChunk(
+                    sample_start=s0,
+                    n_samples=cs,
+                    vk_snp_range=np.asarray(d["vk_snp_range"]).reshape(shape),
+                    vk_indel_range=np.asarray(d["vk_indel_range"]).reshape(shape),
+                    max_end_keys=np.asarray(d["max_end_keys"], np.int64),
+                )
+
+        return RangesStream(
+            n_regions=n_regions,
+            n_samples=n_samples,
+            ploidy=ploidy,
+            samples_per_chunk=per,
+            region_starts=np.asarray(header["region_starts"]),
+            dense_range=np.asarray(header["dense_range"]),
+            dense_snp_range=np.asarray(header["dense_snp_range"]),
+            dense_indel_range=np.asarray(header["dense_indel_range"]),
+            sample_cols=np.asarray(header["sample_cols"]),
+            dense_max_end_keys=np.asarray(header["dense_max_end_keys"], np.int64),
+            chunks=_gen(),
+        )

--- a/src/py_query_ranges.rs
+++ b/src/py_query_ranges.rs
@@ -17,13 +17,16 @@ use std::ops::Range;
 
 use ndarray::Array2;
 use numpy::{PyArray1, PyArray2, PyArrayMethods, ToPyArray};
-use pyo3::exceptions::{PyKeyError, PyTypeError};
+use pyo3::exceptions::{PyKeyError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyDictMethods};
 
 use crate::py_convert::{u8_to_pyarray, u32_to_i32_pyarray, usize_to_i64_pyarray};
 use crate::py_query::PyContigReader;
-use crate::query::{BatchResult, RangesBundle, find_ranges, gather_ranges, read_ranges};
+use crate::query::{
+    BatchResult, MAX_END_SHIFT, RangesBundle, dense_max_end_keys, find_ranges, find_ranges_haps,
+    gather_ranges, read_ranges,
+};
 
 /// Identical to `py_query_batch.rs::overlap_batch`'s dict assembly — the whole
 /// point of the search/gather split is that `read_ranges`/`gather_ranges`
@@ -249,5 +252,139 @@ impl PyContigReader {
         let rb = bundle_from_dict(&bundle)?;
         let br = gather_ranges(&self.inner, &rb);
         batch_result_to_dict(py, self.inner.lut_arrays(), &br)
+    }
+
+    /// Region-level half of a chunked `find_ranges`: everything whose size is
+    /// O(regions) rather than O(regions * samples * ploidy), plus the dense
+    /// channel's max-end contribution. Cheap enough to compute eagerly.
+    pub fn find_ranges_header<'py>(
+        &self,
+        py: Python<'py>,
+        regions: Vec<(u32, u32)>,
+        samples: Option<Vec<usize>>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        // Fail fast rather than silently corrupting a packed key. `ext` is
+        // 1 + deletion_len and must fit below the position field.
+        let max_del = self.inner.max_deletion_len();
+        if (1u64 + max_del as u64) >= (1u64 << MAX_END_SHIFT) {
+            return Err(PyValueError::new_err(
+                "variant footprint exceeds tie-break packing width",
+            ));
+        }
+
+        let all_samples = samples.is_none();
+        let sample_cols: Vec<usize> = match &samples {
+            Some(s) => s.clone(),
+            None => (0..self.inner.n_samples).collect(),
+        };
+
+        let dense = self.inner.dense_union();
+        let dense_range: Vec<Range<usize>> = regions
+            .iter()
+            .map(|&(qs, qe)| dense.overlap(qs, qe))
+            .collect();
+        let dense_snp_range: Vec<Range<usize>> = regions
+            .iter()
+            .map(|&(qs, qe)| self.inner.dense_snp_overlap(qs, qe))
+            .collect();
+        let dense_indel_range: Vec<Range<usize>> = regions
+            .iter()
+            .map(|&(qs, qe)| self.inner.dense_indel_overlap(qs, qe))
+            .collect();
+        let region_starts: Vec<u32> = regions.iter().map(|&(qs, _)| qs).collect();
+        let dmax = dense_max_end_keys(
+            &self.inner,
+            &regions,
+            &dense_range,
+            &sample_cols,
+            all_samples,
+        );
+
+        let pairs_i32 = |v: &[Range<usize>]| -> Vec<i32> {
+            let mut o = Vec::with_capacity(v.len() * 2);
+            for r in v {
+                o.push(r.start as i32);
+                o.push(r.end as i32);
+            }
+            o
+        };
+        let to2d = |v: Vec<i32>| {
+            Array2::from_shape_vec((regions.len(), 2), v)
+                .expect("region pair shape")
+                .to_pyarray(py)
+        };
+
+        let d = PyDict::new(py);
+        d.set_item("dense_range", to2d(pairs_i32(&dense_range)))?;
+        d.set_item("dense_snp_range", to2d(pairs_i32(&dense_snp_range)))?;
+        d.set_item("dense_indel_range", to2d(pairs_i32(&dense_indel_range)))?;
+        d.set_item("region_starts", u32_to_i32_pyarray(py, &region_starts))?;
+        let cols: Vec<i64> = sample_cols.iter().map(|&x| x as i64).collect();
+        d.set_item("sample_cols", PyArray1::from_slice(py, &cols))?;
+        let dmax_i64: Vec<i64> = dmax.iter().map(|&x| x as i64).collect();
+        d.set_item("dense_max_end_keys", PyArray1::from_slice(py, &dmax_i64))?;
+        d.set_item("n_regions", regions.len())?;
+        d.set_item("n_samples", sample_cols.len())?;
+        d.set_item("ploidy", self.inner.ploidy)?;
+        Ok(d)
+    }
+
+    /// One hap slice `[hap_lo, hap_hi)` of a chunked `find_ranges`. Fills freshly
+    /// allocated numpy arrays IN PLACE, so the payload exists exactly once —
+    /// unlike `find_ranges`, whose `Vec<Range<usize>>` -> `Vec<i64>` ->
+    /// `ToPyArray` chain holds three copies at peak. Releases the GIL for the
+    /// search so rayon and the caller's progress bar can both run.
+    ///
+    /// `vk_snp_range` / `vk_indel_range` come back hap-major, shape
+    /// `(n_haps * R, 2)`; reshape to `(n_haps_samples, ploidy, R, 2)` in Python.
+    pub fn find_ranges_chunk<'py>(
+        &self,
+        py: Python<'py>,
+        regions: Vec<(u32, u32)>,
+        samples: Option<Vec<usize>>,
+        hap_lo: usize,
+        hap_hi: usize,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let sample_cols: Vec<usize> = match &samples {
+            Some(s) => s.clone(),
+            None => (0..self.inner.n_samples).collect(),
+        };
+        let h_total = sample_cols.len() * self.inner.ploidy;
+        if hap_lo > hap_hi || hap_hi > h_total {
+            return Err(PyValueError::new_err(format!(
+                "hap slice [{hap_lo}, {hap_hi}) out of bounds for {h_total} haps"
+            )));
+        }
+        let n_haps = hap_hi - hap_lo;
+        let r = regions.len();
+
+        let snp = PyArray2::<i64>::zeros(py, [n_haps * r, 2], false);
+        let indel = PyArray2::<i64>::zeros(py, [n_haps * r, 2], false);
+        let max_keys = {
+            let mut snp_rw = snp.readwrite();
+            let mut indel_rw = indel.readwrite();
+            let snp_s = snp_rw.as_slice_mut()?;
+            let indel_s = indel_rw.as_slice_mut()?;
+            py.detach(|| {
+                find_ranges_haps(
+                    &self.inner,
+                    &regions,
+                    &sample_cols,
+                    hap_lo,
+                    hap_hi,
+                    snp_s,
+                    indel_s,
+                )
+            })
+        };
+
+        let keys_i64: Vec<i64> = max_keys.iter().map(|&x| x as i64).collect();
+        let d = PyDict::new(py);
+        d.set_item("vk_snp_range", snp)?;
+        d.set_item("vk_indel_range", indel)?;
+        d.set_item("max_end_keys", PyArray1::from_slice(py, &keys_i64))?;
+        d.set_item("hap_lo", hap_lo)?;
+        d.set_item("hap_hi", hap_hi)?;
+        Ok(d)
     }
 }

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -6,6 +6,8 @@
 
 use std::ops::Range;
 
+use rayon::prelude::*;
+
 use crate::bits;
 use crate::rvk;
 use crate::spine::{self, KeyRef, SrcKeyRef, VkElem};
@@ -331,6 +333,80 @@ pub struct RangesBundle {
     pub dense_indel_range: Vec<Range<usize>>,
 }
 
+/// Below this many columns the serial path runs instead of rayon's: fork/join
+/// overhead dominates for small batches, and staying on the caller's thread
+/// keeps `search::search_tree_build_count` (a thread-local) observable in tests.
+pub const PAR_COLUMN_THRESHOLD: usize = 64;
+
+/// Fill hap-major `[hap_lo, hap_hi)` slices of the two var_key range channels.
+///
+/// `out_snp` / `out_indel` are `(hap_hi - hap_lo, R, 2)` row-major `i64` — one
+/// contiguous `R * 2` run per hap, which is exactly what lets rayon hand each
+/// column a disjoint `par_chunks_mut` slice. The hap axis indexes the SELECTED
+/// samples: hap `h` is `(sample_cols[h / ploidy], h % ploidy)`, matching the
+/// sample-major-then-ploid order `find_ranges` has always produced.
+///
+/// Column-outer / region-inner, so each column's `VkColumnIndex` is built
+/// exactly once.
+pub fn find_ranges_haps(
+    reader: &ContigReader,
+    regions: &[(u32, u32)],
+    sample_cols: &[usize],
+    hap_lo: usize,
+    hap_hi: usize,
+    out_snp: &mut [i64],
+    out_indel: &mut [i64],
+) {
+    let ploidy = reader.ploidy;
+    let r = regions.len();
+    let n_haps = hap_hi - hap_lo;
+    assert_eq!(
+        out_snp.len(),
+        n_haps * r * 2,
+        "out_snp must be (n_haps, R, 2)"
+    );
+    assert_eq!(
+        out_indel.len(),
+        n_haps * r * 2,
+        "out_indel must be (n_haps, R, 2)"
+    );
+    if n_haps == 0 || r == 0 {
+        return;
+    }
+
+    let fill = |h_off: usize, snp_row: &mut [i64], indel_row: &mut [i64]| {
+        let h = hap_lo + h_off;
+        let s = sample_cols[h / ploidy];
+        let p = h % ploidy;
+        let snp_ix = reader.vk_snp_index(s * ploidy + p);
+        let indel_ix = reader.vk_indel_index(s, p);
+        for (ri, &(qs, qe)) in regions.iter().enumerate() {
+            let a = snp_ix.overlap(qs, qe);
+            snp_row[ri * 2] = a.start as i64;
+            snp_row[ri * 2 + 1] = a.end as i64;
+            let b = indel_ix.overlap(qs, qe);
+            indel_row[ri * 2] = b.start as i64;
+            indel_row[ri * 2 + 1] = b.end as i64;
+        }
+    };
+
+    if n_haps < PAR_COLUMN_THRESHOLD {
+        for (h_off, (snp_row, indel_row)) in out_snp
+            .chunks_mut(r * 2)
+            .zip(out_indel.chunks_mut(r * 2))
+            .enumerate()
+        {
+            fill(h_off, snp_row, indel_row);
+        }
+    } else {
+        out_snp
+            .par_chunks_mut(r * 2)
+            .zip(out_indel.par_chunks_mut(r * 2))
+            .enumerate()
+            .for_each(|(h_off, (snp_row, indel_row))| fill(h_off, snp_row, indel_row));
+    }
+}
+
 /// Search-only pass: run every `SearchTree::new` up front and record the
 /// resulting index ranges. `find_ranges` owns ALL tree builds for the batch
 /// query (region-level dense union overlap + per-hap var_key overlap);
@@ -366,15 +442,31 @@ pub fn find_ranges(
         .map(|&(qs, qe)| reader.dense_indel_overlap(qs, qe))
         .collect();
 
+    // `find_ranges_haps` fills hap-major because that is the layout rayon can
+    // split into disjoint slices. `RangesBundle` is region-major and is replayed
+    // by `gather_ranges` unchanged, so transpose here. This costs one extra copy
+    // of the payload; `find_ranges` is the small-batch read-path entry point,
+    // while the population-scale writer uses the chunked API and never builds a
+    // bundle at all.
+    let mut snp_flat = vec![0i64; h * n_regions * 2];
+    let mut indel_flat = vec![0i64; h * n_regions * 2];
+    find_ranges_haps(
+        reader,
+        regions,
+        &sample_cols,
+        0,
+        h,
+        &mut snp_flat,
+        &mut indel_flat,
+    );
+
     let mut vk_snp_range: Vec<Range<usize>> = Vec::with_capacity(n_regions * h);
     let mut vk_indel_range: Vec<Range<usize>> = Vec::with_capacity(n_regions * h);
-    for &(qs, qe) in regions {
-        for &orig_s in &sample_cols {
-            for p in 0..ploidy {
-                let col = orig_s * ploidy + p;
-                vk_snp_range.push(reader.vk_snp_overlap(col, qs, qe));
-                vk_indel_range.push(reader.vk_indel_overlap(col, orig_s, p, qs, qe));
-            }
+    for ri in 0..n_regions {
+        for hh in 0..h {
+            let k = (hh * n_regions + ri) * 2;
+            vk_snp_range.push(snp_flat[k] as usize..snp_flat[k + 1] as usize);
+            vk_indel_range.push(indel_flat[k] as usize..indel_flat[k + 1] as usize);
         }
     }
 

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -338,7 +338,16 @@ pub struct RangesBundle {
 /// keeps `search::search_tree_build_count` (a thread-local) observable in tests.
 pub const PAR_COLUMN_THRESHOLD: usize = 64;
 
-/// Fill hap-major `[hap_lo, hap_hi)` slices of the two var_key range channels.
+/// Bit width reserved for `ext` in the packed max-end key `(pos << SHIFT) | ext`,
+/// where `ext = 1 + deletion_len` so that `end = pos + ext`. Packing the small,
+/// bounded `ext` (rather than the absolute end) makes an integer max over the
+/// key order by position first and end second — the SVAR1 tie-break rule. Fixed
+/// by GenVarLoader's existing `_svar2_region_max_ends`; do not change.
+pub const MAX_END_SHIFT: u32 = 21;
+
+/// Fill hap-major `[hap_lo, hap_hi)` slices of the two var_key range channels,
+/// and return the per-region max `(pos << MAX_END_SHIFT) | ext` composite key
+/// over this hap slice (`0` when a region has no variant).
 ///
 /// `out_snp` / `out_indel` are `(hap_hi - hap_lo, R, 2)` row-major `i64` — one
 /// contiguous `R * 2` run per hap, which is exactly what lets rayon hand each
@@ -347,7 +356,10 @@ pub const PAR_COLUMN_THRESHOLD: usize = 64;
 /// sample-major-then-ploid order `find_ranges` has always produced.
 ///
 /// Column-outer / region-inner, so each column's `VkColumnIndex` is built
-/// exactly once.
+/// exactly once. The max-end key rides along in the same sweep: `VkColumnIndex`
+/// keeps positions sorted within a column with a contiguous overlap range, so
+/// the last element of each channel's range is the highest-position overlapping
+/// variant for that channel — no extra decode needed.
 pub fn find_ranges_haps(
     reader: &ContigReader,
     regions: &[(u32, u32)],
@@ -356,7 +368,7 @@ pub fn find_ranges_haps(
     hap_hi: usize,
     out_snp: &mut [i64],
     out_indel: &mut [i64],
-) {
+) -> Vec<u64> {
     let ploidy = reader.ploidy;
     let r = regions.len();
     let n_haps = hap_hi - hap_lo;
@@ -371,15 +383,18 @@ pub fn find_ranges_haps(
         "out_indel must be (n_haps, R, 2)"
     );
     if n_haps == 0 || r == 0 {
-        return;
+        return vec![0u64; r];
     }
 
-    let fill = |h_off: usize, snp_row: &mut [i64], indel_row: &mut [i64]| {
+    let fill = |h_off: usize, snp_row: &mut [i64], indel_row: &mut [i64], acc: &mut [u64]| {
         let h = hap_lo + h_off;
         let s = sample_cols[h / ploidy];
         let p = h % ploidy;
         let snp_ix = reader.vk_snp_index(s * ploidy + p);
         let indel_ix = reader.vk_indel_index(s, p);
+        let snp_pos = reader.vk_snp.positions();
+        let indel_pos = reader.vk_indel.positions();
+        let indel_keys = as_u32(&reader.vk_indel.keys);
         for (ri, &(qs, qe)) in regions.iter().enumerate() {
             let a = snp_ix.overlap(qs, qe);
             snp_row[ri * 2] = a.start as i64;
@@ -387,23 +402,54 @@ pub fn find_ranges_haps(
             let b = indel_ix.overlap(qs, qe);
             indel_row[ri * 2] = b.start as i64;
             indel_row[ri * 2 + 1] = b.end as i64;
+
+            // Positions are sorted within a column and the range is contiguous,
+            // so the last element is the highest-position overlapping variant.
+            let mut k = 0u64;
+            if let Some(i) = snp_ix.last_overlapping(qs, qe) {
+                let pos = snp_pos[i] as u64;
+                k = k.max((pos << MAX_END_SHIFT) | 1); // SNP/INS: ext = 1
+            }
+            if let Some(i) = indel_ix.last_overlapping(qs, qe) {
+                let pos = indel_pos[i] as u64;
+                let ext = 1 + rvk::deletion_len(indel_keys[i]) as u64;
+                k = k.max((pos << MAX_END_SHIFT) | ext);
+            }
+            acc[ri] = acc[ri].max(k);
         }
     };
 
     if n_haps < PAR_COLUMN_THRESHOLD {
+        let mut acc = vec![0u64; r];
         for (h_off, (snp_row, indel_row)) in out_snp
             .chunks_mut(r * 2)
             .zip(out_indel.chunks_mut(r * 2))
             .enumerate()
         {
-            fill(h_off, snp_row, indel_row);
+            fill(h_off, snp_row, indel_row, &mut acc);
         }
+        acc
     } else {
         out_snp
             .par_chunks_mut(r * 2)
             .zip(out_indel.par_chunks_mut(r * 2))
             .enumerate()
-            .for_each(|(h_off, (snp_row, indel_row))| fill(h_off, snp_row, indel_row));
+            .fold(
+                || vec![0u64; r],
+                |mut acc, (h_off, (snp_row, indel_row))| {
+                    fill(h_off, snp_row, indel_row, &mut acc);
+                    acc
+                },
+            )
+            .reduce(
+                || vec![0u64; r],
+                |mut a, b| {
+                    for i in 0..r {
+                        a[i] = a[i].max(b[i]);
+                    }
+                    a
+                },
+            )
     }
 }
 
@@ -450,7 +496,11 @@ pub fn find_ranges(
     // bundle at all.
     let mut snp_flat = vec![0i64; h * n_regions * 2];
     let mut indel_flat = vec![0i64; h * n_regions * 2];
-    find_ranges_haps(
+    // `find_ranges` (the tree-driven `RangesBundle` path) has no use yet for
+    // the per-region max-end keys `find_ranges_haps` now also computes;
+    // `dense_max_end_keys`'s caller combines them with this hap-major sweep's
+    // keys separately (see the writer's per-chunk reduction).
+    let _ = find_ranges_haps(
         reader,
         regions,
         &sample_cols,

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -405,12 +405,16 @@ pub fn find_ranges_haps(
 
             // Positions are sorted within a column and the range is contiguous,
             // so the last element is the highest-position overlapping variant.
+            // Reuses `a`/`b` (just computed above) instead of re-searching via
+            // `VkColumnIndex::last_overlapping` — that would double the
+            // `overlap()` calls in this hot loop for no benefit.
             let mut k = 0u64;
-            if let Some(i) = snp_ix.last_overlapping(qs, qe) {
-                let pos = snp_pos[i] as u64;
+            if a.end > a.start {
+                let pos = snp_pos[a.end - 1] as u64;
                 k = k.max((pos << MAX_END_SHIFT) | 1); // SNP/INS: ext = 1
             }
-            if let Some(i) = indel_ix.last_overlapping(qs, qe) {
+            if b.end > b.start {
+                let i = b.end - 1;
                 let pos = indel_pos[i] as u64;
                 let ext = 1 + rvk::deletion_len(indel_keys[i]) as u64;
                 k = k.max((pos << MAX_END_SHIFT) | ext);

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -36,7 +36,8 @@ pub use crate::spine::{KeyRef, SrcKeyRef, VK_SRC_INDEL_BIT, VkElem, pack_vk_src,
 pub use decode::{HapCalls, QueryResult};
 pub use field::{FieldValue, FieldView};
 pub use gather::{
-    BatchResult, BatchResultSplit, HapRanges, RangesBundle, dense_abs_row, find_ranges,
-    gather_haps_readbound, gather_haps_readbound_src, gather_ranges, overlap_batch, read_ranges,
+    BatchResult, BatchResultSplit, HapRanges, PAR_COLUMN_THRESHOLD, RangesBundle, dense_abs_row,
+    find_ranges, find_ranges_haps, gather_haps_readbound, gather_haps_readbound_src, gather_ranges,
+    overlap_batch, read_ranges,
 };
 pub use reader::{ContigReader, VariantStats};

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -36,8 +36,9 @@ pub use crate::spine::{KeyRef, SrcKeyRef, VK_SRC_INDEL_BIT, VkElem, pack_vk_src,
 pub use decode::{HapCalls, QueryResult};
 pub use field::{FieldValue, FieldView};
 pub use gather::{
-    BatchResult, BatchResultSplit, HapRanges, PAR_COLUMN_THRESHOLD, RangesBundle, dense_abs_row,
-    find_ranges, find_ranges_haps, gather_haps_readbound, gather_haps_readbound_src, gather_ranges,
-    overlap_batch, read_ranges,
+    BatchResult, BatchResultSplit, HapRanges, MAX_END_SHIFT, PAR_COLUMN_THRESHOLD, RangesBundle,
+    dense_abs_row, find_ranges, find_ranges_haps, gather_haps_readbound, gather_haps_readbound_src,
+    gather_ranges, overlap_batch, read_ranges,
 };
 pub use reader::{ContigReader, VariantStats};
+pub use union::dense_max_end_keys;

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -237,52 +237,95 @@ impl ContigReader {
     }
 }
 
+/// Region-independent per-column search state for one var_key channel.
+///
+/// Built ONCE per column, then queried per region. Hoisting this out of the old
+/// per-`(region, column)` `vk_*_overlap` methods is what turns `find_ranges`
+/// from O(regions x columns) tree builds into O(columns): the packed store is
+/// swept once instead of once per region.
+pub(crate) struct VkColumnIndex {
+    /// Absolute base offset of this column in the channel's packed arrays.
+    pub(crate) o0: usize,
+    /// `None` for an empty column — `SearchTree`/`overlap_range` are not
+    /// defined over an empty position array, matching the old early return.
+    inner: Option<(SearchTree, Vec<u32>)>,
+    max_del: u32,
+}
+
+impl VkColumnIndex {
+    /// Absolute `[start, end)` into the channel's packed positions/keys for one
+    /// region. Every element of the returned range truly overlaps
+    /// `[q_start, q_end)` — `overlap_range` does the left-overlap sub-scan.
+    pub(crate) fn overlap(&self, q_start: u32, q_end: u32) -> Range<usize> {
+        let Some((tree, v_ends)) = &self.inner else {
+            return self.o0..self.o0;
+        };
+        let (s, e) = overlap_range(tree, v_ends, self.max_del, q_start, q_end);
+        (self.o0 + s)..(self.o0 + e)
+    }
+
+    /// Absolute index of the highest-position variant overlapping the region,
+    /// or `None` when the region is empty for this column. Positions are sorted
+    /// within a column and the range is contiguous, so that is its last element.
+    /// Not yet called within this crate — exposed for a follow-up consumer.
+    #[allow(dead_code)]
+    pub(crate) fn last_overlapping(&self, q_start: u32, q_end: u32) -> Option<usize> {
+        let r = self.overlap(q_start, q_end);
+        (r.end > r.start).then(|| r.end - 1)
+    }
+}
+
 impl ContigReader {
-    /// Absolute `[start, end)` into `vk_snp`'s packed positions/keys for
-    /// `(col, region)` — the SNP channel's search half (`max_region_length =
-    /// 0`, since a SNP always spans exactly one base). No gather.
-    pub(crate) fn vk_snp_overlap(&self, col: usize, q_start: u32, q_end: u32) -> Range<usize> {
+    /// SNP-channel column index. SNP `v_end = pos + 1` and `max_region_length =
+    /// 0`, since a SNP spans exactly one base.
+    pub(crate) fn vk_snp_index(&self, col: usize) -> VkColumnIndex {
         let vk_range = self.vk_snp.column(col);
         let (o0, o1) = (vk_range.start, vk_range.end);
         let positions = &self.vk_snp.positions()[o0..o1];
         if positions.is_empty() {
-            return o0..o0;
+            return VkColumnIndex {
+                o0,
+                inner: None,
+                max_del: 0,
+            };
         }
         let v_ends: Vec<u32> = positions.iter().map(|&p| p + 1).collect();
-        let tree = SearchTree::new(positions);
-        let (s, e) = overlap_range(&tree, &v_ends, 0, q_start, q_end);
-        (o0 + s)..(o0 + e)
+        VkColumnIndex {
+            o0,
+            inner: Some((SearchTree::new(positions), v_ends)),
+            max_del: 0,
+        }
     }
 
-    /// Absolute `[start, end)` into `vk_indel`'s packed positions/keys for
-    /// `(col, region)` — the indel channel's search half (per-column
-    /// `max_del` bound). No gather.
-    pub(crate) fn vk_indel_overlap(
-        &self,
-        col: usize,
-        sample: usize,
-        p: usize,
-        q_start: u32,
-        q_end: u32,
-    ) -> Range<usize> {
+    /// Indel-channel column index for `(sample, p)`. `v_end = pos + 1 +
+    /// deletion_len(key)`; the search bound is this column's `max_del`.
+    pub(crate) fn vk_indel_index(&self, sample: usize, p: usize) -> VkColumnIndex {
+        let col = sample * self.ploidy + p;
         let vk_range = self.vk_indel.column(col);
         let (o0, o1) = (vk_range.start, vk_range.end);
         let positions = &self.vk_indel.positions()[o0..o1];
         if positions.is_empty() {
-            return o0..o0;
+            return VkColumnIndex {
+                o0,
+                inner: None,
+                max_del: 0,
+            };
         }
         let keys = &as_u32(&self.vk_indel.keys)[o0..o1];
-        let max_del = self.vk_indel_max_del[[sample, p]];
         let v_ends: Vec<u32> = positions
             .iter()
             .enumerate()
             .map(|(i, &pos)| pos + 1 + rvk::deletion_len(keys[i]))
             .collect();
-        let tree = SearchTree::new(positions);
-        let (s, e) = overlap_range(&tree, &v_ends, max_del, q_start, q_end);
-        (o0 + s)..(o0 + e)
+        VkColumnIndex {
+            o0,
+            inner: Some((SearchTree::new(positions), v_ends)),
+            max_del: self.vk_indel_max_del[[sample, p]],
+        }
     }
+}
 
+impl ContigReader {
     /// Absolute `[s, e)` into `dense/snp`'s positions/keys for one region.
     /// SNP v_end = pos + 1 (max_region_length = 0). `(0, 0)` if no snp table.
     pub(crate) fn dense_snp_overlap(&self, q_start: u32, q_end: u32) -> Range<usize> {

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -263,16 +263,6 @@ impl VkColumnIndex {
         let (s, e) = overlap_range(tree, v_ends, self.max_del, q_start, q_end);
         (self.o0 + s)..(self.o0 + e)
     }
-
-    /// Absolute index of the highest-position variant overlapping the region,
-    /// or `None` when the region is empty for this column. Positions are sorted
-    /// within a column and the range is contiguous, so that is its last element.
-    /// Used by `find_ranges_haps`'s per-region max-end sweep, alongside the
-    /// `overlap` call it already makes for the range channel.
-    pub(crate) fn last_overlapping(&self, q_start: u32, q_end: u32) -> Option<usize> {
-        let r = self.overlap(q_start, q_end);
-        (r.end > r.start).then(|| r.end - 1)
-    }
 }
 
 impl ContigReader {

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -267,8 +267,8 @@ impl VkColumnIndex {
     /// Absolute index of the highest-position variant overlapping the region,
     /// or `None` when the region is empty for this column. Positions are sorted
     /// within a column and the range is contiguous, so that is its last element.
-    /// Not yet called within this crate — exposed for a follow-up consumer.
-    #[allow(dead_code)]
+    /// Used by `find_ranges_haps`'s per-region max-end sweep, alongside the
+    /// `overlap` call it already makes for the range channel.
     pub(crate) fn last_overlapping(&self, q_start: u32, q_end: u32) -> Option<usize> {
         let r = self.overlap(q_start, q_end);
         (r.end > r.start).then(|| r.end - 1)
@@ -322,6 +322,18 @@ impl ContigReader {
             inner: Some((SearchTree::new(positions), v_ends)),
             max_del: self.vk_indel_max_del[[sample, p]],
         }
+    }
+}
+
+impl ContigReader {
+    /// The largest deletion span on this contig across both the per-hap indel
+    /// channel and the dense union. Callers packing max-end keys must check
+    /// `1 + max_deletion_len() < (1 << MAX_END_SHIFT)` before doing so — a
+    /// pathological >~2 Mb deletion footprint would otherwise silently corrupt
+    /// the packed key.
+    pub fn max_deletion_len(&self) -> u32 {
+        let vk = self.vk_indel_max_del.iter().copied().max().unwrap_or(0);
+        vk.max(self.dense_union().max_del())
     }
 }
 

--- a/src/query/union.rs
+++ b/src/query/union.rs
@@ -5,6 +5,7 @@
 use std::ops::Range;
 
 use crate::dense::DenseClass;
+use crate::query::gather::MAX_END_SHIFT;
 use crate::rvk;
 use crate::search::{SearchTree, overlap_range};
 use crate::spine::KeyRef;
@@ -35,6 +36,11 @@ impl DenseUnion {
         let tree = SearchTree::new(&self.positions);
         let (s, e) = overlap_range(&tree, &self.v_ends, self.max_del, q_start, q_end);
         s..e
+    }
+
+    /// The per-contig dense deletion bound, for the caller's overflow preflight.
+    pub(crate) fn max_del(&self) -> u32 {
+        self.max_del
     }
 }
 
@@ -85,4 +91,69 @@ impl ContigReader {
             max_del: self.dense_indel_max_del,
         }
     }
+}
+
+/// Per-region max `(pos << MAX_END_SHIFT) | ext` over the DENSE channel,
+/// restricted to variants carried by at least one selected hap. `0` when the
+/// region has no such variant.
+///
+/// The dense genotype matrix is hap-major (`hap * n_dense_variants + col`), so a
+/// "is this variant carried by anyone selected?" probe is strided across haps.
+/// Two things keep that cheap:
+///
+/// * The walk runs BACKWARD from the end of the region's dense window and stops
+///   once it drops below the position of the first carried variant it found.
+///   Dense variants are common by construction, so this almost always terminates
+///   on the first index.
+/// * `all_samples` skips the carriage probe entirely: every dense variant in the
+///   store has at least one carrier among all samples, so the last truly
+///   overlapping variant is the answer. This is the path `gvl.write` takes.
+///
+/// The whole tied run at the winning position is scanned rather than stopping at
+/// the first hit: within a class the table's order is not by `ext`, so a later
+/// same-position variant can carry a longer deletion.
+pub fn dense_max_end_keys(
+    reader: &ContigReader,
+    regions: &[(u32, u32)],
+    dense_range: &[Range<usize>],
+    sample_cols: &[usize],
+    all_samples: bool,
+) -> Vec<u64> {
+    let ploidy = reader.ploidy;
+    let dense = reader.dense_union();
+    let mut out = vec![0u64; regions.len()];
+
+    for (ri, &(qs, _)) in regions.iter().enumerate() {
+        let (ds, de) = (dense_range[ri].start, dense_range[ri].end);
+        let mut best = 0u64;
+        let mut best_pos: Option<u32> = None;
+        let mut j = de;
+        while j > ds {
+            j -= 1;
+            let pos = dense.refs[j].position;
+            if let Some(bp) = best_pos
+                && pos < bp
+            {
+                break; // every remaining index has a lower position
+            }
+            if dense.v_ends[j] <= qs {
+                continue; // no true left-overlap
+            }
+            let carried = all_samples || {
+                let (class, dcol) = dense.src[j];
+                let view = reader.dense_view(class).expect("dense src implies table");
+                sample_cols
+                    .iter()
+                    .any(|&s| (0..ploidy).any(|p| view.carried(s * ploidy + p, dcol)))
+            };
+            if !carried {
+                continue;
+            }
+            let ext = (dense.v_ends[j] - pos) as u64;
+            best = best.max(((pos as u64) << MAX_END_SHIFT) | ext);
+            best_pos = Some(pos);
+        }
+        out[ri] = best;
+    }
+    out
 }

--- a/src/svar2_slice.rs
+++ b/src/svar2_slice.rs
@@ -550,7 +550,7 @@ fn slice_genos_inner(
         regions,
         &query_regions,
         overlap,
-        |col_src, _s_orig, _p, qsw, qew| reader.vk_snp_overlap(col_src, qsw, qew),
+        |col_src, _s_orig, _p, qsw, qew| reader.vk_snp_index(col_src).overlap(qsw, qew),
         |i| snp_code_to_key(unpack_snp_key_at(vk_snp_keys, i)),
         |i| vk_snp_positions[i] + 1,
     );
@@ -568,7 +568,7 @@ fn slice_genos_inner(
         // bound — `sample` here must be the ORIGINAL column
         // (`vk_indel_max_del` is indexed by the source cohort, not the
         // subset), mirroring `find_ranges`'s `orig_s` usage.
-        |col_src, s_orig, p, qsw, qew| reader.vk_indel_overlap(col_src, s_orig, p, qsw, qew),
+        |_col_src, s_orig, p, qsw, qew| reader.vk_indel_index(s_orig, p).overlap(qsw, qew),
         |i| vk_indel_keys[i],
         |i| vk_indel_positions[i] + 1 + deletion_len(vk_indel_keys[i]),
     );

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -78,6 +78,69 @@ fn synth_reader(out: &std::path::Path) -> ContigReader {
     ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
 }
 
+/// Like `synth_reader`, but with three extra single-carrier SNPs (positions
+/// 10, 20, 30 — each carried by exactly one distinct hap) so that all 4
+/// `vk_snp` columns are non-empty instead of just column 0.
+///
+/// `synth_reader` alone can't distinguish the region-outer bug from the fix:
+/// with only column 0 populated, the old code's var_key tree-build growth is
+/// 1/region, which happens to exactly match this test's dense-tree allowance
+/// (a tie passes `<=`). Widening carrier coverage across all columns while
+/// keeping each new record single-carrier (so the cost model still routes it
+/// `VarKey`, not `Dense` — 3 carriers flips the routing, see
+/// `cost_model::choose_representation`) makes the var_key term actually show
+/// up in the old code's growth.
+///
+/// Positions 10/20/30 are deliberately below 100/200/300 and outside
+/// `[90, 110)` / `[900, 950)`, so a reader who later reuses this fixture
+/// won't disturb `synth_reader`'s own max-end / empty-region expectations
+/// (Task 2 depends on those). Used ONLY by
+/// `test_find_ranges_tree_builds_do_not_scale_with_regions` — do not extend
+/// `synth_reader` itself for this purpose, it's shared by other tests here.
+fn synth_reader_wide(out: &std::path::Path) -> ContigReader {
+    let samples = ["S0", "S1"];
+    let records = vec![
+        SynthRecord {
+            pos: 10,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![0, 1, 0, 0],
+        },
+        SynthRecord {
+            pos: 20,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![0, 0, 1, 0],
+        },
+        SynthRecord {
+            pos: 30,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![0, 0, 0, 1],
+        },
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: vec![0, 1, 1, 1],
+        },
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"AT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 0, 1],
+        },
+    ];
+    build_contig(out, "chr1", &samples, 2, &records);
+    ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
+}
+
 #[test]
 fn test_find_ranges_dense_range_matches_overlap_batch() {
     let tmp = tempdir().unwrap();
@@ -216,6 +279,22 @@ fn test_py_read_ranges_dict_matches_overlap_batch_dict() {
 /// many regions are queried. Before the column-outer rewrite this was
 /// O(regions x columns): each `vk_*_overlap` call rebuilt the column's tree.
 ///
+/// Uses `synth_reader_wide`, NOT `synth_reader`: `synth_reader` populates only
+/// one of the four `vk_snp` columns (the other three are empty and early-
+/// return without ever calling `SearchTree::new`), so on that fixture the old
+/// code's growth is exactly 1 (dense union) + 1 (dense indel) + 1 (the one
+/// populated `vk_snp` column) = 3/region — which exactly *ties* a `3 *
+/// Δregions` allowance instead of exceeding it, so the guard would pass even
+/// against the unfixed region-outer code. `synth_reader_wide` gives all 4
+/// `vk_snp` columns a variant, so the old code's growth is 4 (var_key columns)
+/// plus 1 (dense union) plus 1 (dense indel) = 6/region (this fixture builds
+/// no dense-snp tree at all — nothing routes Dense-SNP — so there are only 2
+/// legitimate per-region dense trees, not 3). Over the 15 extra regions below
+/// that's 90 actual tree builds against an allowance of 30: a real ~3x
+/// separation, not a tie. After the column-outer fix, var_key columns are
+/// built once total (hoisted out of the region loop), so growth is only the
+/// 2 dense trees/region = 30, comfortably within the allowance.
+///
 /// The fixture is deliberately small (2 samples x 2 ploidy = 4 columns, well
 /// under `PAR_COLUMN_THRESHOLD`) so the serial path runs on this thread and
 /// `search::search_tree_build_count` — a thread-local — stays observable.
@@ -224,7 +303,7 @@ fn test_find_ranges_tree_builds_do_not_scale_with_regions() {
     let tmp = tempdir().unwrap();
     let out = tmp.path().join("out");
     std::fs::create_dir_all(&out).unwrap();
-    let reader = synth_reader(&out);
+    let reader = synth_reader_wide(&out);
 
     let one = vec![(0u32, 1_000_000u32)];
     let many: Vec<(u32, u32)> = (0..16).map(|i| (i * 20, i * 20 + 1_000_000)).collect();
@@ -237,10 +316,11 @@ fn test_find_ranges_tree_builds_do_not_scale_with_regions() {
     let _ = find_ranges(&reader, &many, None);
     let cost_many = search::search_tree_build_count() - b1;
 
-    // Per-region dense-union/dense-snp/dense-indel trees are still built once
-    // per region (3 per region, cheap and cohort-shared). The var_key channels
-    // — the R*H term that made this O(regions x total_variants) — must not grow.
-    let dense_growth = 3 * (many.len() - one.len());
+    // Only the per-region dense-union and dense-indel trees are legitimately
+    // per-region (this fixture builds no dense-snp tree, since nothing routes
+    // Dense-SNP). The var_key channels — the R*H term that made this
+    // O(regions x total_variants) — must not grow at all after the fix.
+    let dense_growth = 2 * (many.len() - one.len());
     assert!(
         cost_many <= cost_one + dense_growth,
         "tree builds grew with region count: {cost_one} -> {cost_many} \

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -212,6 +212,42 @@ fn test_py_read_ranges_dict_matches_overlap_batch_dict() {
     });
 }
 
+/// `find_ranges` must build a bounded number of search trees regardless of how
+/// many regions are queried. Before the column-outer rewrite this was
+/// O(regions x columns): each `vk_*_overlap` call rebuilt the column's tree.
+///
+/// The fixture is deliberately small (2 samples x 2 ploidy = 4 columns, well
+/// under `PAR_COLUMN_THRESHOLD`) so the serial path runs on this thread and
+/// `search::search_tree_build_count` — a thread-local — stays observable.
+#[test]
+fn test_find_ranges_tree_builds_do_not_scale_with_regions() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader(&out);
+
+    let one = vec![(0u32, 1_000_000u32)];
+    let many: Vec<(u32, u32)> = (0..16).map(|i| (i * 20, i * 20 + 1_000_000)).collect();
+
+    let b0 = search::search_tree_build_count();
+    let _ = find_ranges(&reader, &one, None);
+    let cost_one = search::search_tree_build_count() - b0;
+
+    let b1 = search::search_tree_build_count();
+    let _ = find_ranges(&reader, &many, None);
+    let cost_many = search::search_tree_build_count() - b1;
+
+    // Per-region dense-union/dense-snp/dense-indel trees are still built once
+    // per region (3 per region, cheap and cohort-shared). The var_key channels
+    // — the R*H term that made this O(regions x total_variants) — must not grow.
+    let dense_growth = 3 * (many.len() - one.len());
+    assert!(
+        cost_many <= cost_one + dense_growth,
+        "tree builds grew with region count: {cost_one} -> {cost_many} \
+         (allowed growth {dense_growth})"
+    );
+}
+
 #[test]
 fn test_py_gather_of_find_matches_read_dict() {
     let tmp = tempdir().unwrap();

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -5,7 +5,10 @@ mod common;
 
 use common::{SynthRecord, build_contig};
 use genoray_core::py_query::PyContigReader;
-use genoray_core::query::{ContigReader, find_ranges, gather_ranges, overlap_batch, read_ranges};
+use genoray_core::query::{
+    ContigReader, MAX_END_SHIFT, dense_max_end_keys, find_ranges, find_ranges_haps, gather_ranges,
+    overlap_batch, read_ranges,
+};
 use genoray_core::search;
 use numpy::{PyArray1, PyArray2, PyArrayMethods};
 use pyo3::prelude::*;
@@ -344,4 +347,98 @@ fn test_py_gather_of_find_matches_read_dict() {
         let d_read = pr.read_ranges(py, regions.clone(), None).unwrap();
         assert_payload_dicts_eq(&d_gather, &d_read);
     });
+}
+
+fn unpack_end(key: u64) -> u32 {
+    ((key >> MAX_END_SHIFT) + (key & ((1 << MAX_END_SHIFT) - 1))) as u32
+}
+
+/// The per-region max end must be the end of the HIGHEST-POSITION overlapping
+/// variant (ties broken by the larger end), not the largest end overall — this
+/// is the SVAR1-parity rule GenVarLoader's `_svar2_region_max_ends` implements.
+#[test]
+fn test_max_end_keys_pick_highest_position_variant() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader(&out);
+
+    // Region covering all three variants; the DEL at 300 is highest-position.
+    let regions = vec![(0u32, 1_000u32)];
+    let sample_cols: Vec<usize> = (0..2).collect();
+    let h = 2 * reader.ploidy();
+    let mut snp = vec![0i64; h * 2];
+    let mut indel = vec![0i64; h * 2];
+    let vk_keys = find_ranges_haps(&reader, &regions, &sample_cols, 0, h, &mut snp, &mut indel);
+
+    // `dense_union`/`DenseUnion::overlap` are pub(crate); this integration
+    // test crate is external to `genoray_core`, so the per-region dense range
+    // is obtained via `find_ranges`'s public `dense_range` field instead —
+    // it's computed the same way (`reader.dense_union().overlap(qs, qe)`),
+    // independent of the sample subset.
+    let dense_range = find_ranges(&reader, &regions, None).dense_range;
+    let dense_keys = dense_max_end_keys(&reader, &regions, &dense_range, &sample_cols, true);
+
+    let key = vk_keys[0].max(dense_keys[0]);
+    assert_ne!(key, 0, "region has variants, so the key must be non-zero");
+    assert_eq!(
+        unpack_end(key),
+        302,
+        "DEL@300 with deletion_len 1 ends at 302"
+    );
+}
+
+/// A region containing only the SNP must report that SNP's end, and an empty
+/// region must report the 0 sentinel so the caller keeps its original chromEnd.
+#[test]
+fn test_max_end_keys_snp_only_and_empty_region() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader(&out);
+
+    let regions = vec![(90u32, 110u32), (900u32, 950u32)];
+    let sample_cols: Vec<usize> = (0..2).collect();
+    let h = 2 * reader.ploidy();
+    let mut snp = vec![0i64; h * regions.len() * 2];
+    let mut indel = vec![0i64; h * regions.len() * 2];
+    let vk_keys = find_ranges_haps(&reader, &regions, &sample_cols, 0, h, &mut snp, &mut indel);
+
+    let dense_range = find_ranges(&reader, &regions, None).dense_range;
+    let dense_keys = dense_max_end_keys(&reader, &regions, &dense_range, &sample_cols, true);
+
+    let k0 = vk_keys[0].max(dense_keys[0]);
+    assert_eq!(unpack_end(k0), 101, "SNP@100 ends at 101");
+    assert_eq!(
+        vk_keys[1].max(dense_keys[1]),
+        0,
+        "no variants in [900, 950)"
+    );
+}
+
+/// Splitting the hap axis must not change the reduced result — the writer
+/// reduces per-chunk keys with an elementwise max.
+#[test]
+fn test_max_end_keys_reduce_across_hap_slices() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader(&out);
+
+    let regions = vec![(0u32, 1_000u32)];
+    let sample_cols: Vec<usize> = (0..2).collect();
+    let h = 2 * reader.ploidy();
+
+    let mut snp = vec![0i64; h * 2];
+    let mut indel = vec![0i64; h * 2];
+    let whole = find_ranges_haps(&reader, &regions, &sample_cols, 0, h, &mut snp, &mut indel);
+
+    let mut reduced = vec![0u64; 1];
+    for lo in (0..h).step_by(1) {
+        let mut s = vec![0i64; 2];
+        let mut i = vec![0i64; 2];
+        let part = find_ranges_haps(&reader, &regions, &sample_cols, lo, lo + 1, &mut s, &mut i);
+        reduced[0] = reduced[0].max(part[0]);
+    }
+    assert_eq!(whole, reduced);
 }

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -6,8 +6,8 @@ mod common;
 use common::{SynthRecord, build_contig};
 use genoray_core::py_query::PyContigReader;
 use genoray_core::query::{
-    ContigReader, MAX_END_SHIFT, dense_max_end_keys, find_ranges, find_ranges_haps, gather_ranges,
-    overlap_batch, read_ranges,
+    ContigReader, MAX_END_SHIFT, PAR_COLUMN_THRESHOLD, dense_max_end_keys, find_ranges,
+    find_ranges_haps, gather_ranges, overlap_batch, read_ranges,
 };
 use genoray_core::search;
 use numpy::{PyArray1, PyArray2, PyArrayMethods};
@@ -142,6 +142,144 @@ fn synth_reader_wide(out: &std::path::Path) -> ContigReader {
     ];
     build_contig(out, "chr1", &samples, 2, &records);
     ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
+}
+
+/// Built specifically to distinguish the SVAR1 tie-break rule (max by
+/// POSITION first, end second) from a buggy "max by absolute end" rule that
+/// `test_max_end_keys_pick_highest_position_variant` cannot catch — on
+/// `synth_reader`, position and end rise together across all three variants
+/// (100/101, 200/201, 300/302), so both rules agree there.
+///
+/// Here a DEL@200 with a long deletion (ext = 1 + 150 = 151, end = 351) sits
+/// at a LOWER position than a SNP@300 (ext = 1, end = 301) whose own end is
+/// smaller. The correct packed-key ordering `(pos << SHIFT) | ext` picks the
+/// SNP (higher position) — unpacked end 301; a "max by absolute end" bug
+/// would instead return 351 (the DEL's larger end, at a lower position).
+///
+/// The DEL's ref allele is 151 'A's with the LAST byte forced to 'T'
+/// (`del_ref[150] = b'T'`), not a pure homopolymer: `normalize::left_align`
+/// rolls a deletion left while `ref_seq[pos] == ref_seq[pos + ndel]`, and a
+/// pure 151 x 'A' run trivially satisfies that against itself (position 350,
+/// the deleted span's last base, is also 'A'), silently shifting the variant
+/// to pos 199 instead of the intended 200. Breaking the last byte makes
+/// `ref_seq[200] != ref_seq[350]`, so the deletion stays put. (Found by this
+/// test failing with an off-by-one before the fix — see the fix commit.)
+///
+/// Each variant is single-carrier (`x_calls = 1`), so per `cost_model`'s
+/// `np = n_samples * ploidy = 4`: indel dense_bits = 68 > var_key_bits = 64,
+/// SNP dense_bits = 38 > var_key_bits = 34 — both stay `VarKey`, so this
+/// fixture only exercises `find_ranges_haps`, like `synth_reader`.
+///
+/// Used ONLY by the tie-break test below — do not extend `synth_reader`
+/// itself for this purpose.
+fn synth_reader_tiebreak(out: &std::path::Path) -> ContigReader {
+    let samples = ["S0", "S1"];
+    let mut del_ref = vec![b'A'; 151];
+    del_ref[150] = b'T'; // break the homopolymer so left-align doesn't roll it
+    let records = vec![
+        SynthRecord {
+            pos: 200,
+            ref_allele: &del_ref,
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: vec![0, 1, 0, 0],
+        },
+    ];
+    build_contig(out, "chr1", &samples, 2, &records);
+    ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
+}
+
+/// Two indel variants at the SAME position (200), both routed to `Dense`
+/// (`x_calls = 2` each, `np = 4`: indel dense_bits = 68 < var_key_bits = 128),
+/// with different deletion lengths — for exercising
+/// `dense_max_end_keys`'s claim that it scans the WHOLE tied run at a winning
+/// position rather than stopping at the first carried hit.
+///
+/// File order (and therefore dense-table column order: `rvk`'s per-chunk
+/// classify loop pushes dense variants in encounter order, and
+/// `DenseUnion`'s position sort is stable, so same-position ties keep that
+/// order) is: the LONGER deletion (ref "ATCG" -> alt "A", deletion_len 3,
+/// ext 4, end 204) FIRST, then the SHORTER one (ref "AT" -> alt "A",
+/// deletion_len 1, ext 2, end 202) SECOND. `dense_max_end_keys`'s backward
+/// walk visits the HIGHER table index first, i.e. the shorter/later one —
+/// so a scan that stopped at that first hit would report 202 instead of the
+/// correct 204.
+///
+/// Deliberately NOT a homopolymer run (unlike a first draft of this fixture,
+/// which used all-'A' refs): `normalize::left_align` rolls a deletion left
+/// while `ref_seq[pos] == ref_seq[pos + ndel]`, which a homopolymer run
+/// trivially satisfies against its own last base, silently shifting both
+/// variants' positions by 1 (see `synth_reader_tiebreak`'s doc comment for
+/// the same gotcha). "ATCG" and "AT" both start with 'A' but each ends on a
+/// distinct base different from the anchor, so neither rolls. Both records
+/// still agree on the reference at every position they share ("AT" is a
+/// prefix of "ATCG"), so `build_fasta_with_index`'s last-record-wins
+/// stamping never conflicts.
+fn synth_reader_dense_tie(out: &std::path::Path) -> ContigReader {
+    let samples = ["S0", "S1"];
+    let records = vec![
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"ATCG",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 0, 0],
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"AT",
+            alts: vec![&b"A"[..]],
+            gt: vec![0, 0, 1, 1],
+        },
+    ];
+    build_contig(out, "chr1", &samples, 2, &records);
+    ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
+}
+
+/// `n_samples` samples at `ploidy` (flat gt layout `[s0_p0, s0_p1, ...]`),
+/// carrying three variants scattered across the hap axis (first hap, an
+/// interior hap, last hap) so per-hap max-end keys actually vary. Built for
+/// `test_max_end_keys_parallel_matches_serial_reduction`, which needs
+/// `n_samples * ploidy >= PAR_COLUMN_THRESHOLD` to force
+/// `find_ranges_haps`'s rayon `fold`/`reduce` branch.
+fn synth_reader_many_haps(out: &std::path::Path, n_samples: usize, ploidy: usize) -> ContigReader {
+    let sample_names: Vec<String> = (0..n_samples).map(|i| format!("S{i}")).collect();
+    let samples: Vec<&str> = sample_names.iter().map(String::as_str).collect();
+    let h = n_samples * ploidy;
+
+    let mut gt_snp = vec![0i32; h];
+    gt_snp[0] = 1; // hap 0
+    let mut gt_ins = vec![0i32; h];
+    gt_ins[h / 2] = 1; // an interior hap
+    let mut gt_del = vec![0i32; h];
+    gt_del[h - 1] = 1; // last hap
+
+    let records = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"A",
+            alts: vec![&b"C"[..]],
+            gt: gt_snp,
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: gt_ins,
+        },
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"AT",
+            alts: vec![&b"A"[..]],
+            gt: gt_del,
+        },
+    ];
+    build_contig(out, "chr1", &samples, ploidy, &records);
+    ContigReader::open(out.to_str().unwrap(), "chr1", n_samples, ploidy).unwrap()
 }
 
 #[test]
@@ -441,4 +579,104 @@ fn test_max_end_keys_reduce_across_hap_slices() {
         reduced[0] = reduced[0].max(part[0]);
     }
     assert_eq!(whole, reduced);
+}
+
+/// The per-region max end must order by POSITION first, end second — not by
+/// absolute end. `synth_reader_tiebreak`'s DEL@200 has a larger end (351)
+/// than its SNP@300 (301), but the SNP is at the higher position, so it must
+/// win. A "max by absolute end" bug would report 351 here; this fixture (see
+/// its doc comment) is specifically built so that bug and the correct rule
+/// disagree, unlike `test_max_end_keys_pick_highest_position_variant`'s
+/// `synth_reader`, where they happen to coincide.
+#[test]
+fn test_max_end_keys_position_beats_larger_end_at_lower_position() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader_tiebreak(&out);
+
+    let regions = vec![(0u32, 1_000u32)];
+    let sample_cols: Vec<usize> = (0..2).collect();
+    let h = 2 * reader.ploidy();
+    let mut snp = vec![0i64; h * 2];
+    let mut indel = vec![0i64; h * 2];
+    let vk_keys = find_ranges_haps(&reader, &regions, &sample_cols, 0, h, &mut snp, &mut indel);
+
+    let dense_range = find_ranges(&reader, &regions, None).dense_range;
+    let dense_keys = dense_max_end_keys(&reader, &regions, &dense_range, &sample_cols, true);
+
+    let key = vk_keys[0].max(dense_keys[0]);
+    assert_eq!(
+        unpack_end(key),
+        301,
+        "SNP@300 (higher position) must win over DEL@200's larger end (351)"
+    );
+}
+
+/// `dense_max_end_keys` must scan the WHOLE tied run at a winning position,
+/// not stop at the first carried hit it finds — see `synth_reader_dense_tie`'s
+/// doc comment for the exact table-order argument. A scan that stopped early
+/// would report 202 (the shorter deletion, hit first by the backward walk);
+/// the correct answer is 204 (the longer one, filed earlier in the table but
+/// visited second).
+#[test]
+fn test_dense_max_end_keys_scans_full_tied_run() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader_dense_tie(&out);
+
+    let regions = vec![(0u32, 1_000u32)];
+    let sample_cols: Vec<usize> = (0..2).collect();
+    let dense_range = find_ranges(&reader, &regions, None).dense_range;
+    let dense_keys = dense_max_end_keys(&reader, &regions, &dense_range, &sample_cols, true);
+
+    assert_eq!(
+        unpack_end(dense_keys[0]),
+        204,
+        "must pick the longer deletion (ext=4, end=204), not the shorter tied \
+         one (ext=2, end=202) the backward walk hits first"
+    );
+}
+
+/// The rayon `fold`/`reduce` accumulation of per-region max-end keys (taken
+/// when `n_haps >= PAR_COLUMN_THRESHOLD`) must agree with the serial
+/// single-hap-slice reduction the smaller fixtures above exercise. 32 samples
+/// x ploidy 2 = 64 haps forces the parallel branch for the whole-slice call;
+/// each single-hap call (`hap_hi = hap_lo + 1`) has `n_haps = 1`, well under
+/// the threshold, so it takes the serial path — this compares the two
+/// branches directly instead of trusting the fold/reduce closures by
+/// inspection.
+#[test]
+fn test_max_end_keys_parallel_matches_serial_reduction() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let n_samples = 32;
+    let ploidy = 2;
+    let reader = synth_reader_many_haps(&out, n_samples, ploidy);
+
+    let regions = vec![(0u32, 1_000u32)];
+    let sample_cols: Vec<usize> = (0..n_samples).collect();
+    let h = n_samples * ploidy;
+    assert!(
+        h >= PAR_COLUMN_THRESHOLD,
+        "fixture must exercise the parallel branch"
+    );
+
+    let mut snp = vec![0i64; h * 2];
+    let mut indel = vec![0i64; h * 2];
+    let whole = find_ranges_haps(&reader, &regions, &sample_cols, 0, h, &mut snp, &mut indel);
+
+    let mut reduced = vec![0u64; 1];
+    for lo in 0..h {
+        let mut s = vec![0i64; 2];
+        let mut i = vec![0i64; 2];
+        let part = find_ranges_haps(&reader, &regions, &sample_cols, lo, lo + 1, &mut s, &mut i);
+        reduced[0] = reduced[0].max(part[0]);
+    }
+    assert_eq!(whole, reduced);
+    // Sanity: the fixture actually carries a variant in [0, 1000), so this
+    // isn't vacuously comparing two zero vectors.
+    assert_ne!(whole[0], 0);
 }

--- a/tests/test_svar2_ranges.py
+++ b/tests/test_svar2_ranges.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from genoray import SparseVar2
+from genoray._svar2_batch import MAX_END_SHIFT
 
 
 def _assert_dicts_equal(a: dict[str, Any], b: dict[str, Any], keys: Iterable[str]):
@@ -134,4 +135,74 @@ def test_find_ranges_chunk_matches_find_ranges(svar2_store: Path):
     np.testing.assert_array_equal(
         indel.transpose(1, 0, 2).reshape(R * H, 2),
         np.asarray(bundle["vk_indel_range"]),
+    )
+
+
+def _reassemble(stream) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    R, P, S = stream.n_regions, stream.ploidy, stream.n_samples
+    snp = np.empty((S, P, R, 2), np.int64)
+    indel = np.empty((S, P, R, 2), np.int64)
+    keys = stream.dense_max_end_keys.copy()
+    for ch in stream.chunks:
+        s0, s1 = ch.sample_start, ch.sample_start + ch.n_samples
+        snp[s0:s1] = ch.vk_snp_range
+        indel[s0:s1] = ch.vk_indel_range
+        np.maximum(keys, ch.max_end_keys, out=keys)
+    return snp, indel, keys
+
+
+@pytest.mark.parametrize("max_mem", [None, 1 << 30, 1])
+def test_chunked_matches_find_ranges(svar2_store: Path, max_mem):
+    """Every chunking, including one sample per chunk, reassembles identically."""
+    sv = SparseVar2(svar2_store)
+    starts, ends = [0, 5], [40, 20]
+    bundle = sv._find_ranges("chr1", starts, ends)
+    R, P, S = 2, sv.ploidy, sv.n_samples
+
+    if max_mem == 1:
+        # 1 byte cannot fit a sample; the API must say so rather than silently
+        # producing a zero-sized chunk.
+        with pytest.raises(ValueError, match="max_mem"):
+            sv._find_ranges_chunked("chr1", starts, ends, max_mem=max_mem)
+        return
+
+    stream = sv._find_ranges_chunked("chr1", starts, ends, max_mem=max_mem)
+    snp, indel, _ = _reassemble(stream)
+    np.testing.assert_array_equal(
+        snp.reshape(S * P, R, 2).transpose(1, 0, 2).reshape(R * S * P, 2),
+        np.asarray(bundle["vk_snp_range"]),
+    )
+    np.testing.assert_array_equal(
+        indel.reshape(S * P, R, 2).transpose(1, 0, 2).reshape(R * S * P, 2),
+        np.asarray(bundle["vk_indel_range"]),
+    )
+
+
+def test_chunked_max_end_keys_unpack_to_variant_ends(svar2_store: Path):
+    """The reduced key unpacks to the end of the highest-position variant.
+
+    The fixture's chr1 carries SNP@2, INS@6 and DEL@11 (ilen -2, so it ends at
+    11 + 1 + 2 = 14). Region [0, 40) therefore ends at 14; region [0, 5) sees
+    only SNP@2, which ends at 3.
+    """
+    sv = SparseVar2(svar2_store)
+    stream = sv._find_ranges_chunked("chr1", [0, 0], [40, 5])
+    _, _, keys = _reassemble(stream)
+    mask = (1 << MAX_END_SHIFT) - 1
+    ends = (keys >> MAX_END_SHIFT) + (keys & mask)
+    assert keys[0] != 0 and keys[1] != 0
+    assert int(ends[0]) == 14
+    assert int(ends[1]) == 3
+
+
+def test_chunked_sample_subset(svar2_store: Path):
+    """A sample subset takes the carriage-probing dense path, not the fast path."""
+    sub = [SparseVar2(svar2_store).available_samples[1]]
+    sv = SparseVar2(svar2_store)
+    bundle = sv._find_ranges("chr1", [0], [40], samples=sub)
+    stream = sv._find_ranges_chunked("chr1", [0], [40], samples=sub)
+    assert stream.n_samples == 1
+    snp, _, _ = _reassemble(stream)
+    np.testing.assert_array_equal(
+        snp.reshape(-1, 2), np.asarray(bundle["vk_snp_range"])
     )

--- a/tests/test_svar2_ranges.py
+++ b/tests/test_svar2_ranges.py
@@ -95,3 +95,43 @@ def test_find_ranges_out_streaming(svar2_store: Path):
         np.testing.assert_array_equal(np.asarray(ranges2[k]), np.asarray(ranges[k]))
         # out= wrote in place: returned array shares the buffer.
         assert np.asarray(ranges2[k]).base is out[k] or ranges2[k] is out[k]
+
+
+def test_find_ranges_chunk_matches_find_ranges(svar2_store: Path):
+    """Chunked hap slices must reassemble into the region-major bundle exactly."""
+    sv = SparseVar2(svar2_store)
+    starts, ends = [0, 5], [40, 20]
+    reg = list(zip(starts, ends))
+    reader = sv._reader("chr1")
+    bundle = sv._find_ranges("chr1", starts, ends)
+
+    R = len(reg)
+    P = sv.ploidy
+    S = sv.n_samples
+    H = S * P
+
+    header = reader.find_ranges_header(reg, None)
+    np.testing.assert_array_equal(
+        np.asarray(header["dense_snp_range"]), np.asarray(bundle["dense_snp_range"])
+    )
+    np.testing.assert_array_equal(
+        np.asarray(header["sample_cols"]), np.asarray(bundle["sample_cols"])
+    )
+
+    # One hap per call: the most adversarial chunking.
+    snp = np.empty((H, R, 2), np.int64)
+    indel = np.empty((H, R, 2), np.int64)
+    for h in range(H):
+        d = reader.find_ranges_chunk(reg, None, h, h + 1)
+        snp[h] = np.asarray(d["vk_snp_range"]).reshape(1, R, 2)
+        indel[h] = np.asarray(d["vk_indel_range"]).reshape(1, R, 2)
+
+    # bundle vk ranges are region-major (R*H, 2); ours are hap-major (H, R, 2).
+    np.testing.assert_array_equal(
+        snp.transpose(1, 0, 2).reshape(R * H, 2),
+        np.asarray(bundle["vk_snp_range"]),
+    )
+    np.testing.assert_array_equal(
+        indel.transpose(1, 0, 2).reshape(R * H, 2),
+        np.asarray(bundle["vk_indel_range"]),
+    )


### PR DESCRIPTION
Fixes the O(regions x total_variants) tree rebuild in `find_ranges`, adds a memory-bounded chunked API, and folds per-region max-end computation into the same sweep.

- Hoist per-column search state into `VkColumnIndex`; invert `find_ranges` to column-outer; parallelize with rayon. Tree builds drop from R*H*2 to H*2.
- `find_ranges_haps` also returns per-region packed max-end keys, so consumers no longer decode every sample to extend chromEnd.
- `_find_ranges_chunked` yields hap slices sized from `max_mem`; the chunk binding fills numpy in place and releases the GIL.

Closes #144
Unblocks mcvickerlab/GenVarLoader#333

🤖 Generated with [Claude Code](https://claude.com/claude-code)