### PR TITLE
test(svar2): pin carrier-subset max-end + add Rust carriage-filter coverage

### DIFF
--- a/python/genoray/_svar2_batch.py
+++ b/python/genoray/_svar2_batch.py
@@ -264,8 +264,11 @@ class _BatchQueryMixin:
         n_samples = int(header["n_samples"])
         ploidy = int(header["ploidy"])
 
-        # Both channels, 2 endpoints, int64. The 2x is slop for the transient
-        # the binding holds while handing the arrays back.
+        # `bytes_per_sample` is the real per-sample payload: both channels
+        # (snp + indel) x 2 endpoints x int64 x ploidy x regions. The extra
+        # `2 *` in the division below -- not this factor -- is the safety
+        # margin, covering the transient the binding holds while handing the
+        # freshly filled arrays back.
         bytes_per_sample = n_regions * ploidy * 2 * 8 * 2
         if max_mem is None:
             per = max(n_samples, 1)

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -240,6 +240,41 @@ fn synth_reader_dense_tie(out: &std::path::Path) -> ContigReader {
     ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
 }
 
+/// Two dense-routed indel variants (`x_calls = 2` each, so both stay `Dense`
+/// per `cost_model` at `np = 4`), each carried EXCLUSIVELY by one of the two
+/// samples -- unlike every other fixture in this file, where every dense
+/// variant is carried by both samples, which means a carriage probe that
+/// silently ignored `sample_cols` (or used the wrong per-sample hap stride)
+/// would coincidentally still agree with the correct one. See
+/// `test_dense_max_end_keys_excludes_uncarried_sample`'s doc comment.
+///
+/// INS@200 (ref "A" -> "AT", ext 1, end 201) is carried by S1 alone (both
+/// haps: `gt = [0, 0, 1, 1]`). DEL@300 (ref "AT" -> "A", ext 2, end 302) is
+/// carried by S0 alone (`gt = [1, 1, 0, 0]`). Neither ref allele is a
+/// homopolymer run (`normalize::left_align` rolls a deletion left only while
+/// `ref_seq[pos] == ref_seq[pos + ndel]`; "AT" has no repeated base to
+/// trigger that -- see `synth_reader_tiebreak`'s doc comment for the case
+/// where this bites), so both positions stay exactly where placed.
+fn synth_reader_carrier_subset(out: &std::path::Path) -> ContigReader {
+    let samples = ["S0", "S1"];
+    let records = vec![
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"A",
+            alts: vec![&b"AT"[..]],
+            gt: vec![0, 0, 1, 1],
+        },
+        SynthRecord {
+            pos: 300,
+            ref_allele: b"AT",
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 0, 0],
+        },
+    ];
+    build_contig(out, "chr1", &samples, 2, &records);
+    ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap()
+}
+
 /// `n_samples` samples at `ploidy` (flat gt layout `[s0_p0, s0_p1, ...]`),
 /// carrying three variants scattered across the hap axis (first hap, an
 /// interior hap, last hap) so per-hap max-end keys actually vary. Built for
@@ -648,6 +683,51 @@ fn test_dense_max_end_keys_scans_full_tied_run() {
         204,
         "must pick the longer deletion (ext=4, end=204), not the shorter tied \
          one (ext=2, end=202) the backward walk hits first"
+    );
+}
+
+/// `dense_max_end_keys`'s `all_samples = false` carriage-probe branch must
+/// actually restrict to the selected samples, not just execute the same code
+/// path and land on `all_samples`'s answer anyway. Every other fixture in
+/// this file has each dense variant carried by both samples, so a probe that
+/// silently ignored `sample_cols` -- or one with the wrong per-sample hap
+/// stride (`s * ploidy + p`) -- would coincidentally still agree with the
+/// correct one there; this is the only test (Rust or Python) that can tell
+/// the difference.
+///
+/// Selecting ONLY S1 (`sample_cols = [1]`) must exclude DEL@300 (S0-exclusive,
+/// the higher position) and fall back to INS@200's end (201). Selecting ONLY
+/// S0 is the mirror image. Selecting both is a sanity check that the fixture
+/// behaves like every other one here when nothing is excluded.
+#[test]
+fn test_dense_max_end_keys_excludes_uncarried_sample() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader_carrier_subset(&out);
+
+    let regions = vec![(0u32, 1_000u32)];
+    let dense_range = find_ranges(&reader, &regions, None).dense_range;
+
+    let both = dense_max_end_keys(&reader, &regions, &dense_range, &[0usize, 1usize], false);
+    assert_eq!(
+        unpack_end(both[0]),
+        302,
+        "with no exclusion, DEL@300 (higher position) wins, as in every other fixture here"
+    );
+
+    let s1_only = dense_max_end_keys(&reader, &regions, &dense_range, &[1usize], false);
+    assert_eq!(
+        unpack_end(s1_only[0]),
+        201,
+        "S1 does not carry DEL@300; the probe must fall back to its own INS@200"
+    );
+
+    let s0_only = dense_max_end_keys(&reader, &regions, &dense_range, &[0usize], false);
+    assert_eq!(
+        unpack_end(s0_only[0]),
+        302,
+        "S0 does not carry INS@200, but does carry DEL@300"
     );
 }
 

--- a/tests/test_svar2_ranges.py
+++ b/tests/test_svar2_ranges.py
@@ -202,7 +202,19 @@ def test_chunked_sample_subset(svar2_store: Path):
     bundle = sv._find_ranges("chr1", [0], [40], samples=sub)
     stream = sv._find_ranges_chunked("chr1", [0], [40], samples=sub)
     assert stream.n_samples == 1
-    snp, _, _ = _reassemble(stream)
+    snp, _, keys = _reassemble(stream)
     np.testing.assert_array_equal(
         snp.reshape(-1, 2), np.asarray(bundle["vk_snp_range"])
     )
+
+    # Pins the subset path's max-end output to a fixture-derived constant, so
+    # a gross regression in the carriage-probe branch (e.g. it stops firing,
+    # or returns garbage) doesn't go unnoticed. This does NOT verify genuine
+    # per-sample carrier filtering: on this fixture both dense-routed variants
+    # (INS@6, DEL@11) are carried by BOTH samples, so a probe that ignored
+    # `sample_cols` entirely would produce this exact same value. Real
+    # carrier-filtering coverage -- a fixture where the excluded sample's
+    # variant actually differs from the included one's -- lives in
+    # tests/test_ranges_split.rs::test_dense_max_end_keys_excludes_uncarried_sample.
+    expected_key = (11 << MAX_END_SHIFT) | 3  # DEL@11: ext = 1 + del_len(2) = 3, end 14
+    assert int(keys[0]) == expected_key


### PR DESCRIPTION
Follow-up to #146 (merged before this review round-trip landed): addresses
two findings from code review of that PR.

- `test_chunked_sample_subset` executed `dense_max_end_keys`'s
  `all_samples=false` carriage-probe branch but discarded `max_end_keys`,
  so a bug in that branch's output went unchecked. Pins the subset's `keys`
  to a fixture-derived constant to catch gross regressions, with a comment
  stating plainly that this fixture (both dense variants carried by both
  samples) cannot prove genuine per-sample carrier filtering.
- Adds `tests/test_ranges_split.rs::test_dense_max_end_keys_excludes_uncarried_sample`,
  a Rust fixture where one dense variant is carried by exactly one sample,
  to give real carriage-filtering coverage: selecting only one sample must
  exclude the other's exclusive, higher-position variant.
- Fixes a misattributed comment on `_find_ranges_chunked`'s `bytes_per_sample`
  calculation (the safety-margin note had been attached to the real payload
  term instead of the actual slop factor).

Relates to #144, mcvickerlab/GenVarLoader#333

🤖 Generated with [Claude Code](https://claude.com/claude-code)