### PR TITLE
perf(query): build each SVAR2 search tree once per channel, not once per region

### DIFF
--- a/docs/roadmap/svar-2.md
+++ b/docs/roadmap/svar-2.md
@@ -283,11 +283,11 @@ Legend: `[ ]` not started · `[~]` in progress · `[x]` done
     dict exposes the two new `(R, 2)` **i32** range keys (matching the sibling `dense_range`;
     streamable via the existing generic `out=` path) for the gvl write cache.
     Perf note: because the two per-class ranges are computed unconditionally, `find_ranges`
-    (and therefore `read_ranges`) now builds **2 extra per-region `SearchTree`s**
+    (and therefore `read_ranges`) builds **2 extra `OverlapIndex`es**
     (dense_snp/dense_indel overlap) for *every* caller, including union-only readers that
-    never consume `dense_snp_range`/`dense_indel_range`. This is a small region-level cost —
-    comparable to the existing `dense_union` region overlap `SearchTree` — not the dominant
-    per-hap tree builds M6d already removed.
+    never consume `dense_snp_range`/`dense_indel_range`. Each is hoisted above the per-region
+    loop and built once per request, not once per region — comparable to the existing
+    `dense_union` overlap index — not the dominant per-hap tree builds M6d already removed.
   **Additive:** M6d's `find_ranges`/`gather_ranges`/`read_ranges`/`overlap_batch`/`BatchResult`
   stay byte-unchanged as the parity oracle. Parity is pinned per hap against both the union
   path and the `decode_hap` oracle, with a zero-`SearchTree` control test and both dense

--- a/docs/superpowers/plans/2026-07-31-svar2-overlap-index-hoist.md
+++ b/docs/superpowers/plans/2026-07-31-svar2-overlap-index-hoist.md
@@ -1,0 +1,857 @@
+# OverlapIndex Hoist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build every SVAR2 range-search tree once per channel instead of once per (region, channel), by unifying all five search-state constructors behind a single `OverlapIndex` type and hoisting its construction out of the per-region loops.
+
+**Architecture:** #144 introduced `VkColumnIndex` — region-independent search state (a `SearchTree` + parallel `v_ends` + a deletion bound) built once per var_key column. Three sibling channels still rebuild that state per region: the dense union (`DenseUnion::overlap`), the two dense class tables (`ContigReader::dense_snp_overlap` / `dense_indel_overlap`), and the var_key columns as consumed by `svar2_slice::gather_var_key`. This plan renames `VkColumnIndex` to `OverlapIndex<'a>` with a `Cow<'a, [u32]>` for `v_ends` (so the union can borrow the extents it already stores while the other channels own the ones they compute), adds the two dense class constructors plus `DenseUnion::index`, and hoists every construction above its region loop.
+
+**Tech Stack:** Rust, `pixi` for the toolchain, `cargo test` for the Rust suite. No Python surface changes.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-svar2-overlap-index-hoist-design.md`
+
+## Global Constraints
+
+- **`CARGO_TARGET_DIR` must point off NFS for every cargo invocation.** The repo's `./target` is NFS-backed and the linker bus-errors on it in debug builds. Prefix every cargo/pixi-cargo command with `CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target"` (or any node-local path).
+- **Rust tests run via `pixi run test-rust`**, which is `cargo test --no-default-features --features conversion`. A bare `cargo test` fails to link the pyo3 test binary (`undefined symbol: _Py_Dealloc`); dropping `--features conversion` fails to build the tests in this plan, because `tests/common::build_contig` calls `orchestrator::process_chromosome`.
+- **`pixi run test-rust <arg>` filters by TEST NAME, not file.** A non-matching argument vacuously passes 0 tests. Always select a file with `--test <file>`, e.g. `pixi run test-rust --test test_ranges_split`.
+- **`pixi run check-core` (`cargo check --no-default-features`) must pass** before each commit that touches `src/`. That is the query-only build gvl links as a path dependency, and CI's Rust job otherwise only builds with `conversion` on.
+- **Commits follow Conventional Commits** (`feat:`, `fix:`, `perf:`, `refactor:`, `test:`, `docs:`). Never edit `CHANGELOG.md` or bump the version by hand.
+- **Never change observable behavior.** Every task in this plan is a pure hoist: the same `(positions, v_ends, max_del, q_start, q_end)` reach `overlap_range`; only the moment the tree is built moves. Any diff in query output or written bytes is a bug in the change, not an accepted consequence.
+- All new/changed types and constructors stay `pub(crate)`. No public Python surface changes, so `skills/genoray-api/SKILL.md` is not touched.
+
+---
+
+## File Structure
+
+| File | Responsibility after this plan |
+| --- | --- |
+| `src/query/reader.rs` | Owns `OverlapIndex<'a>` (the one search-state type) and four of its five constructors: `vk_snp_index`, `vk_indel_index`, `dense_snp_index`, `dense_indel_index`. `dense_snp_overlap` / `dense_indel_overlap` are deleted. |
+| `src/query/union.rs` | `DenseUnion` stays a tree-free data struct; gains `index()` — the fifth `OverlapIndex` constructor, borrowing the union's stored `v_ends`. `DenseUnion::overlap` is deleted. |
+| `src/query/gather.rs` | `find_ranges` and `overlap_batch_impl` build each index once above their region loops. |
+| `src/py_query_ranges.rs` | Same hoist for the Python `find_ranges` binding. |
+| `src/query/oracle.rs` | Single-region caller; adapted to the new call convention, cost unchanged. |
+| `src/svar2_slice.rs` | `gather_var_key` takes a column-index factory instead of a range closure and builds one index per column; the two `gather_dense` calls get their dense index built once at the call site. |
+| `tests/test_ranges_split.rs` | Read-path complexity guard, tightened from "≤ 2 tree builds per extra region" to "zero growth". |
+| `tests/test_svar2_slice.rs` | New wide fixture + new slice-path complexity guard asserting zero growth. |
+
+**Task order is strictly sequential.** Task 2 needs the type from Task 1; Task 3 needs Task 2's dense hoist to have landed before its guard can assert *zero* growth. Tasks 2 and 3 also both edit `src/svar2_slice.rs`. There is no independent work to dispatch in parallel here.
+
+---
+
+### Task 1: Unify search state behind `OverlapIndex`
+
+Pure refactor. `VkColumnIndex` becomes `OverlapIndex<'a>` with a `Cow` for `v_ends` and two shared constructors (`new`, `empty`) that Tasks 2 and 3 build on. No behavior changes, so there is no new test — **the existing Rust suite is the gate**, and it must stay green. Do not add a test that asserts a rename.
+
+**Files:**
+- Modify: `src/query/reader.rs:240-315` (type + `vk_snp_index` + `vk_indel_index`)
+- Modify: `src/query/gather.rs:358-359`, `src/query/gather.rs:409` (doc comments naming the old type)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub(crate) struct OverlapIndex<'a>` with
+  - `pub(crate) fn new(o0: usize, positions: &[u32], v_ends: Cow<'a, [u32]>, max_del: u32) -> Self`
+  - `pub(crate) fn empty(o0: usize) -> Self`
+  - `pub(crate) fn overlap(&self, q_start: u32, q_end: u32) -> Range<usize>`
+  - `pub(crate) o0: usize` field
+  and the retargeted `ContigReader::vk_snp_index(col) -> OverlapIndex<'static>` /
+  `ContigReader::vk_indel_index(sample, p) -> OverlapIndex<'static>`.
+
+- [ ] **Step 1: Add the `Cow` import**
+
+In `src/query/reader.rs`, alongside the existing `use std::ops::Range;`:
+
+```rust
+use std::borrow::Cow;
+use std::ops::Range;
+use std::path::Path;
+```
+
+- [ ] **Step 2: Replace the `VkColumnIndex` type with `OverlapIndex`**
+
+In `src/query/reader.rs`, replace the whole `VkColumnIndex` struct and its `impl` block (currently lines 240-266) with:
+
+```rust
+/// Region-independent search state for one channel: a `SearchTree` over its
+/// positions, the parallel `v_ends` extents, and the deletion bound
+/// `overlap_range` needs.
+///
+/// Built ONCE per channel, then queried per region. Hoisting this out of the
+/// old per-region `vk_*_overlap` / `dense_*_overlap` methods is what turns
+/// `find_ranges` and `svar2_slice`'s gather from O(regions x channels) tree
+/// builds into O(channels): each packed store is swept once instead of once
+/// per region.
+///
+/// `v_ends` is a `Cow` because the two kinds of channel differ in who owns the
+/// extents: the var_key columns and the dense class tables COMPUTE theirs
+/// (`pos + 1`, `pos + 1 + deletion_len(key)`) and must own the result, while
+/// `DenseUnion` already stores its own and can lend them — which is what keeps
+/// `DenseUnion::index` from copying an O(dense variants) array per query.
+pub(crate) struct OverlapIndex<'a> {
+    /// Absolute base offset of this channel in the packed arrays. `0` for the
+    /// dense class tables and the dense union, whose ranges are already
+    /// absolute; the var_key columns pass their column's start offset.
+    pub(crate) o0: usize,
+    /// `None` for an empty channel — `SearchTree`/`overlap_range` are not
+    /// defined over an empty position array, matching the old early return.
+    inner: Option<(SearchTree, Cow<'a, [u32]>)>,
+    max_del: u32,
+}
+
+impl<'a> OverlapIndex<'a> {
+    /// Build the search state for a NON-EMPTY channel. `positions` must be
+    /// ascending and `v_ends[i]` must be the right extent of `positions[i]`.
+    pub(crate) fn new(
+        o0: usize,
+        positions: &[u32],
+        v_ends: Cow<'a, [u32]>,
+        max_del: u32,
+    ) -> Self {
+        debug_assert!(!positions.is_empty(), "use OverlapIndex::empty instead");
+        debug_assert_eq!(positions.len(), v_ends.len());
+        OverlapIndex {
+            o0,
+            inner: Some((SearchTree::new(positions), v_ends)),
+            max_del,
+        }
+    }
+
+    /// An index over an empty channel: `overlap` always returns `o0..o0`, and
+    /// no `SearchTree` is built.
+    pub(crate) fn empty(o0: usize) -> Self {
+        OverlapIndex {
+            o0,
+            inner: None,
+            max_del: 0,
+        }
+    }
+
+    /// Absolute `[start, end)` into the channel's packed positions/keys for one
+    /// region. Every element of the returned range truly overlaps
+    /// `[q_start, q_end)` — `overlap_range` does the left-overlap sub-scan.
+    pub(crate) fn overlap(&self, q_start: u32, q_end: u32) -> Range<usize> {
+        let Some((tree, v_ends)) = &self.inner else {
+            return self.o0..self.o0;
+        };
+        let (s, e) = overlap_range(tree, v_ends, self.max_del, q_start, q_end);
+        (self.o0 + s)..(self.o0 + e)
+    }
+}
+```
+
+- [ ] **Step 3: Retarget the two var_key constructors**
+
+In `src/query/reader.rs`, replace the bodies of `vk_snp_index` and `vk_indel_index` (currently lines 268-315) with:
+
+```rust
+impl ContigReader {
+    /// SNP-channel column index. SNP `v_end = pos + 1` and `max_region_length =
+    /// 0`, since a SNP spans exactly one base.
+    pub(crate) fn vk_snp_index(&self, col: usize) -> OverlapIndex<'static> {
+        let vk_range = self.vk_snp.column(col);
+        let (o0, o1) = (vk_range.start, vk_range.end);
+        let positions = &self.vk_snp.positions()[o0..o1];
+        if positions.is_empty() {
+            return OverlapIndex::empty(o0);
+        }
+        let v_ends: Vec<u32> = positions.iter().map(|&p| p + 1).collect();
+        OverlapIndex::new(o0, positions, Cow::Owned(v_ends), 0)
+    }
+
+    /// Indel-channel column index for `(sample, p)`. `v_end = pos + 1 +
+    /// deletion_len(key)`; the search bound is this column's `max_del`.
+    pub(crate) fn vk_indel_index(&self, sample: usize, p: usize) -> OverlapIndex<'static> {
+        let col = sample * self.ploidy + p;
+        let vk_range = self.vk_indel.column(col);
+        let (o0, o1) = (vk_range.start, vk_range.end);
+        let positions = &self.vk_indel.positions()[o0..o1];
+        if positions.is_empty() {
+            return OverlapIndex::empty(o0);
+        }
+        let keys = &as_u32(&self.vk_indel.keys)[o0..o1];
+        let v_ends: Vec<u32> = positions
+            .iter()
+            .enumerate()
+            .map(|(i, &pos)| pos + 1 + rvk::deletion_len(keys[i]))
+            .collect();
+        OverlapIndex::new(
+            o0,
+            positions,
+            Cow::Owned(v_ends),
+            self.vk_indel_max_del[[sample, p]],
+        )
+    }
+}
+```
+
+Note the behavior-preserving detail: the old empty-column path returned `max_del: 0`, and `OverlapIndex::empty` does the same. `max_del` is unused when `inner` is `None`.
+
+- [ ] **Step 4: Fix the doc comments that name the old type**
+
+In `src/query/gather.rs`, in the `find_ranges_haps` doc comment (~line 358), change:
+
+```
+/// Column-outer / region-inner, so each column's `VkColumnIndex` is built
+```
+
+to:
+
+```
+/// Column-outer / region-inner, so each column's `OverlapIndex` is built
+```
+
+and in the inline comment inside `fill` (~line 409), change `VkColumnIndex::last_overlapping` to `OverlapIndex::last_overlapping`.
+
+- [ ] **Step 5: Verify nothing else names the old type**
+
+Run:
+
+```bash
+rg -n 'VkColumnIndex' src/ tests/
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Run the full Rust suite**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" pixi run test-rust
+```
+
+Expected: PASS, same test count as before the change. This is a rename plus two shared constructors; a single failure here means the refactor changed behavior and must be corrected, not accommodated.
+
+- [ ] **Step 7: Verify the query-core build**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" pixi run check-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/query/reader.rs src/query/gather.rs
+git commit -m "refactor(query): generalize VkColumnIndex into a Cow-backed OverlapIndex
+
+One search-state type for every channel: shared new/empty constructors and
+a Cow v_ends so a channel that already stores its extents can lend them
+instead of copying. Pure rename plus constructors; no behavior change.
+
+Relates to #145"
+```
+
+---
+
+### Task 2: Hoist the dense union and dense class indices
+
+TDD proper: tighten the existing read-path complexity guard first (it goes red because the dense channels still rebuild per region), then make it green by adding the three dense constructors and hoisting all their call sites. `src/svar2_slice.rs`'s two `gather_dense` calls are updated here too, since this task deletes the methods they call.
+
+**Files:**
+- Modify: `tests/test_ranges_split.rs:443-470` (`test_find_ranges_tree_builds_do_not_scale_with_regions`)
+- Modify: `src/query/reader.rs:326-370` (delete `dense_snp_overlap` / `dense_indel_overlap`, add `dense_snp_index` / `dense_indel_index`)
+- Modify: `src/query/union.rs:17-43` (doc comment + `overlap` → `index`)
+- Modify: `src/query/gather.rs:233-238`, `src/query/gather.rs:477-493`
+- Modify: `src/py_query_ranges.rs:281-293`
+- Modify: `src/query/oracle.rs:54-55`
+- Modify: `src/svar2_slice.rs:576-597`
+
+**Interfaces:**
+- Consumes: `OverlapIndex::{new, empty, overlap}` from Task 1.
+- Produces: `ContigReader::dense_snp_index(&self) -> OverlapIndex<'static>`,
+  `ContigReader::dense_indel_index(&self) -> OverlapIndex<'static>`,
+  `DenseUnion::index(&self) -> OverlapIndex<'_>`.
+  `ContigReader::dense_snp_overlap`, `ContigReader::dense_indel_overlap` and
+  `DenseUnion::overlap` no longer exist.
+
+- [ ] **Step 1: Tighten the read-path guard to zero growth**
+
+In `tests/test_ranges_split.rs`, replace the assertion block at the end of `test_find_ranges_tree_builds_do_not_scale_with_regions` (currently the `let dense_growth = ...;` line and the `assert!` that follows) with:
+
+```rust
+    // After the dense hoist (#145) NO channel builds a tree per region: the
+    // var_key columns, the dense union and the two dense class tables are each
+    // swept once per call. So this is exact equality, not an allowance — a
+    // budget here is what let the dense leak survive #144.
+    assert_eq!(
+        cost_many, cost_one,
+        "tree builds grew with region count: {cost_one} -> {cost_many}"
+    );
+```
+
+Also update the test's doc comment (the paragraph above `#[test]` that explains the `3 * Δregions` / `2 * Δregions` allowance) to state that the expectation is now zero growth across all channels.
+
+- [ ] **Step 2: Run the guard to verify it fails**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" \
+  pixi run test-rust --test test_ranges_split test_find_ranges_tree_builds_do_not_scale_with_regions
+```
+
+Expected: FAIL, with `cost_many` exceeding `cost_one` by `2 * (16 - 1) = 30` — one dense-union tree and one dense-indel tree per extra region. (`synth_reader_wide` routes nothing Dense-SNP, so there is no third term.) If it passes, stop: the fixture is not exercising the dense channels and the guard is worthless.
+
+- [ ] **Step 3: Replace the dense class overlap methods with index constructors**
+
+In `src/query/reader.rs`, replace the entire `impl ContigReader` block containing `dense_snp_overlap` and `dense_indel_overlap` (currently lines 330-370) with:
+
+```rust
+impl ContigReader {
+    /// Dense SNP class index, over `dense/snp`'s positions/keys. SNP `v_end =
+    /// pos + 1` (`max_region_length = 0`). Empty if there is no snp table.
+    pub(crate) fn dense_snp_index(&self) -> OverlapIndex<'static> {
+        let Some(d) = &self.dense_snp else {
+            return OverlapIndex::empty(0);
+        };
+        let positions = d.positions();
+        if positions.is_empty() {
+            return OverlapIndex::empty(0);
+        }
+        let v_ends: Vec<u32> = positions.iter().map(|&p| p + 1).collect();
+        OverlapIndex::new(0, positions, Cow::Owned(v_ends), 0)
+    }
+
+    /// Dense indel class index, over `dense/indel`'s positions/keys. `v_end =
+    /// pos + 1 + deletion_len(key)`; the search bound is the per-contig dense
+    /// max_del. Empty if there is no indel table.
+    pub(crate) fn dense_indel_index(&self) -> OverlapIndex<'static> {
+        let Some(d) = &self.dense_indel else {
+            return OverlapIndex::empty(0);
+        };
+        let positions = d.positions();
+        if positions.is_empty() {
+            return OverlapIndex::empty(0);
+        }
+        let keys = as_u32(&d.keys);
+        // Fail fast on a corrupt sidecar rather than silently truncating.
+        debug_assert_eq!(positions.len(), keys.len());
+        let v_ends: Vec<u32> = positions
+            .iter()
+            .zip(keys.iter())
+            .map(|(&pos, &key)| pos + 1 + rvk::deletion_len(key))
+            .collect();
+        OverlapIndex::new(0, positions, Cow::Owned(v_ends), self.dense_indel_max_del)
+    }
+}
+```
+
+`o0` is `0` for both because the dense class ranges are already absolute — the old methods returned `s..e` unshifted.
+
+- [ ] **Step 4: Replace `DenseUnion::overlap` with `DenseUnion::index`**
+
+In `src/query/union.rs`, add `OverlapIndex` to the reader import and swap the method. The import line becomes:
+
+```rust
+use super::reader::{ContigReader, OverlapIndex};
+```
+
+and `std::borrow::Cow` joins the `std` imports:
+
+```rust
+use std::borrow::Cow;
+use std::ops::Range;
+```
+
+Replace the `impl DenseUnion` block's `overlap` method (currently lines 29-38) with:
+
+```rust
+    /// Region-independent search state over the union, built once by the
+    /// callers that actually search it.
+    ///
+    /// This is deliberately NOT built inside `dense_union()`: `gather_ranges`,
+    /// `dense_max_end_keys` and `ContigReader::max_deletion_len` all construct
+    /// a `DenseUnion` without ever overlapping it, and must not be charged a
+    /// `SearchTree::new` they never use. Borrows `v_ends`, so building an index
+    /// copies nothing.
+    pub(crate) fn index(&self) -> OverlapIndex<'_> {
+        if self.refs.is_empty() {
+            return OverlapIndex::empty(0);
+        }
+        OverlapIndex::new(
+            0,
+            &self.positions,
+            Cow::Borrowed(self.v_ends.as_slice()),
+            self.max_del,
+        )
+    }
+```
+
+`SearchTree` and `overlap_range` are no longer used in this file — drop them from `use crate::search::{SearchTree, overlap_range};` (the whole `use` goes if nothing else in the file needs it; let `cargo check` tell you).
+
+Also fix the now-false struct doc comment at `src/query/union.rs:17-20`: `overlap` no longer exists, so the sentence "Region-independent — built once per query; `overlap` derives each region's index range from it" becomes "Region-independent and tree-free — built once per query; `index()` adds the search state for callers that range-query it."
+
+- [ ] **Step 5: Hoist in `overlap_batch_impl`**
+
+In `src/query/gather.rs`, replace the union block in `overlap_batch_impl` (currently lines 233-238):
+
+```rust
+    let dense = reader.dense_union();
+    // Per-region dense index ranges — shared across all samples in the region.
+    // One index for the whole batch: `SearchTree::new` runs once, not per region.
+    let dense_ix = dense.index();
+    let ranges: Vec<Range<usize>> = regions
+        .iter()
+        .map(|&(qs, qe)| dense_ix.overlap(qs, qe))
+        .collect();
+```
+
+- [ ] **Step 6: Hoist in `find_ranges`**
+
+In `src/query/gather.rs`, replace the three per-region `map` blocks in `find_ranges` (currently lines 477-493):
+
+```rust
+    // Region-independent union and dense class indices, each built ONCE for the
+    // whole batch — this is the O(regions x channels) -> O(channels) fix.
+    let dense = reader.dense_union();
+    let dense_ix = dense.index();
+    let dense_range: Vec<Range<usize>> = regions
+        .iter()
+        .map(|&(qs, qe)| dense_ix.overlap(qs, qe))
+        .collect();
+    let region_starts: Vec<u32> = regions.iter().map(|&(qs, _)| qs).collect();
+
+    let dense_snp_ix = reader.dense_snp_index();
+    let dense_snp_range: Vec<Range<usize>> = regions
+        .iter()
+        .map(|&(qs, qe)| dense_snp_ix.overlap(qs, qe))
+        .collect();
+    let dense_indel_ix = reader.dense_indel_index();
+    let dense_indel_range: Vec<Range<usize>> = regions
+        .iter()
+        .map(|&(qs, qe)| dense_indel_ix.overlap(qs, qe))
+        .collect();
+```
+
+- [ ] **Step 7: Hoist in the Python binding**
+
+In `src/py_query_ranges.rs`, replace the three per-region `map` blocks (currently lines 281-293):
+
+```rust
+        let dense = self.inner.dense_union();
+        let dense_ix = dense.index();
+        let dense_range: Vec<Range<usize>> = regions
+            .iter()
+            .map(|&(qs, qe)| dense_ix.overlap(qs, qe))
+            .collect();
+        let dense_snp_ix = self.inner.dense_snp_index();
+        let dense_snp_range: Vec<Range<usize>> = regions
+            .iter()
+            .map(|&(qs, qe)| dense_snp_ix.overlap(qs, qe))
+            .collect();
+        let dense_indel_ix = self.inner.dense_indel_index();
+        let dense_indel_range: Vec<Range<usize>> = regions
+            .iter()
+            .map(|&(qs, qe)| dense_indel_ix.overlap(qs, qe))
+            .collect();
+```
+
+- [ ] **Step 8: Adapt the single-region oracle caller**
+
+In `src/query/oracle.rs`, replace line 55:
+
+```rust
+    let d_range = dense.index().overlap(q_start, q_end);
+```
+
+One region, so this builds exactly the one tree it built before — the edit exists only to keep a single call convention.
+
+- [ ] **Step 9: Hoist the two dense calls in the slice path**
+
+In `src/svar2_slice.rs`, in `slice_genos_inner`, build each dense index once above its `gather_dense` call. The two calls (currently lines 576-597) become:
+
+```rust
+    // One index per dense class for the whole request — `gather_dense` calls
+    // `region_hits` once per class, so building here is what keeps the
+    // per-region loop inside it tree-free.
+    let d_snp_ix = reader.dense_snp_index();
+    let d_snp_g = gather_dense(
+        reader.dense_snp.as_ref(),
+        true,
+        sample_orig_idx,
+        ploidy,
+        regions,
+        &query_regions,
+        overlap,
+        |qsw, qew| d_snp_ix.overlap(qsw, qew),
+    );
+
+    let d_indel_ix = reader.dense_indel_index();
+    let d_indel_g = gather_dense(
+        reader.dense_indel.as_ref(),
+        false,
+        sample_orig_idx,
+        ploidy,
+        regions,
+        &query_regions,
+        overlap,
+        |qsw, qew| d_indel_ix.overlap(qsw, qew),
+    );
+```
+
+- [ ] **Step 10: Run the guard to verify it passes**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" \
+  pixi run test-rust --test test_ranges_split test_find_ranges_tree_builds_do_not_scale_with_regions
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Run the full Rust suite and the core build**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" pixi run test-rust
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" pixi run check-core
+```
+
+Expected: both PASS. `test_gather_ranges_builds_no_search_tree` in the same file is the load-bearing one to watch — it asserts `gather_ranges` builds zero trees, which is exactly the invariant that would break if `dense_union()` had been made eager instead of adding `index()`.
+
+- [ ] **Step 12: Verify the deleted methods have no callers left**
+
+Run:
+
+```bash
+rg -n 'dense_snp_overlap|dense_indel_overlap|dense\.overlap|\.dense_union\(\)\.overlap' src/ tests/
+```
+
+Expected: no output.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/query/reader.rs src/query/union.rs src/query/gather.rs \
+        src/py_query_ranges.rs src/query/oracle.rs src/svar2_slice.rs \
+        tests/test_ranges_split.rs
+git commit -m "perf(query): build each dense channel's search tree once per request
+
+DenseUnion::overlap and the dense_snp/indel_overlap methods each rebuilt a
+SearchTree per region, so find_ranges, overlap_batch, the py binding and the
+slice gather all paid O(regions x channels) builds. Replace them with
+OverlapIndex constructors hoisted above every region loop; dense_union()
+stays tree-free for gather_ranges / dense_max_end_keys / max_deletion_len,
+which never search it.
+
+The find_ranges complexity guard drops its 2-builds-per-region allowance and
+now asserts exact zero growth.
+
+Relates to #145"
+```
+
+---
+
+### Task 3: Hoist the var_key column index in the slice path
+
+This is #145 as filed. `gather_var_key` is already column-outer, but the closure it hands `region_hits` constructs the index inside the per-region loop. Change the injection point from a range closure to an index factory. TDD: the new guard goes red on var_key growth alone, because Task 2 already took the dense channels to zero.
+
+**Files:**
+- Modify: `tests/test_svar2_slice.rs` (new fixture + new test, appended near the existing fixture helpers)
+- Modify: `src/svar2_slice.rs:707-770` (`region_hits` doc, `gather_var_key` signature/body)
+- Modify: `src/svar2_slice.rs:543-573` (the two `gather_var_key` call sites)
+
+**Interfaces:**
+- Consumes: `OverlapIndex` and `ContigReader::vk_snp_index` / `vk_indel_index` from Task 1.
+- Produces: `gather_var_key`'s `column_index: impl Fn(usize, usize) -> OverlapIndex<'static>` parameter, replacing `overlap_range: impl Fn(usize, usize, usize, u32, u32) -> Range<usize>`. `region_hits`'s signature is unchanged.
+
+- [ ] **Step 1: Add the wide fixture**
+
+In `tests/test_svar2_slice.rs`, add after `build_fixture_store`:
+
+```rust
+/// Ten records at n=2, ploidy=2 (np=4, flat gt order `[s0p0, s0p1, s1p0,
+/// s1p1]`) chosen so the tree-build guard below is actually discriminating:
+///
+/// * four single-carrier SNPs and four single-carrier indels, one per hap, so
+///   ALL FOUR columns of BOTH var_key channels are non-empty. An empty column
+///   early-returns without building a tree, so a fixture that populates only
+///   one column (as `fixture_records` does) barely moves the counter.
+/// * one x=2 SNP and one x=2 indel so both DENSE class tables exist. Without
+///   them the dense channels early-return and the guard would silently stop
+///   covering the dense hoist.
+///
+/// Single carrier vs. x=2 is what picks the route: at np=4 with no sidecar or
+/// field bits, `cost_model::choose_representation` keeps x=1 in VarKey and
+/// flips x=2 to Dense.
+///
+/// Used ONLY by `slice_tree_builds_do_not_scale_with_regions` — do not extend
+/// `fixture_records` for this, it is pinned by the byte-parity tests.
+fn wide_fixture_records() -> Vec<SynthRecord<'static>> {
+    let snp = |pos: i64, gt: Vec<i32>| SynthRecord {
+        pos,
+        ref_allele: b"A",
+        alts: vec![&b"C"[..]],
+        gt,
+    };
+    let del = |pos: i64, gt: Vec<i32>| SynthRecord {
+        pos,
+        ref_allele: b"ATG",
+        alts: vec![&b"A"[..]], // pure DEL, ilen = -2
+        gt,
+    };
+    vec![
+        // one single-carrier (VarKey) SNP per hap column
+        snp(10, vec![1, 0, 0, 0]),
+        snp(20, vec![0, 1, 0, 0]),
+        snp(30, vec![0, 0, 1, 0]),
+        snp(40, vec![0, 0, 0, 1]),
+        // one single-carrier (VarKey) indel per hap column
+        del(50, vec![1, 0, 0, 0]),
+        del(60, vec![0, 1, 0, 0]),
+        del(70, vec![0, 0, 1, 0]),
+        del(80, vec![0, 0, 0, 1]),
+        // x=2 => Dense, one per class, so both dense tables exist
+        snp(90, vec![1, 1, 0, 0]),
+        del(100, vec![0, 0, 1, 1]),
+    ]
+}
+
+fn build_wide_fixture_store(dir: &Path, samples: &[&str]) {
+    std::fs::create_dir_all(dir).unwrap();
+    let records = wide_fixture_records();
+    build_contig(dir, "chr1", samples, 2, &records);
+    // Same reason as `build_fixture_store`: `build_contig` overwrites max_del
+    // with a conservative fixture, so recompute the real routing-aware value.
+    genoray_core::max_del::write_max_del(&dir.join("chr1"), samples.len(), 2).unwrap();
+    write_meta(
+        dir,
+        FORMAT_VERSION,
+        &samples.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        &["chr1".to_string()],
+        2,
+        &[],
+    )
+    .unwrap();
+}
+```
+
+- [ ] **Step 2: Write the failing guard test**
+
+In `tests/test_svar2_slice.rs`, add the `search` import to the existing `use genoray_core::...` block:
+
+```rust
+use genoray_core::search;
+```
+
+and add the test:
+
+```rust
+/// `gather_var_key` is column-outer, but until #145 the closure it handed
+/// `region_hits` built a fresh `OverlapIndex` — `SearchTree::new` and all —
+/// INSIDE the per-region loop, for every column. That is the same
+/// O(regions x columns) shape #144 removed from `find_ranges`.
+///
+/// After the fix no channel in the slice path builds a tree per region: eight
+/// var_key columns (four per class, all populated by `wide_fixture_records`)
+/// and two dense classes are each swept once per request. So this asserts
+/// EXACT equality, not an allowance.
+///
+/// `src/svar2_slice.rs` contains no rayon, so the whole slice runs on this
+/// thread and `search::search_tree_build_count` — a thread-local — stays
+/// observable. Each call gets its own output directory because a slice writes
+/// `{out}/chr1` and would otherwise overwrite the previous run.
+#[test]
+fn slice_tree_builds_do_not_scale_with_regions() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let samples = ["S0", "S1"];
+    build_wide_fixture_store(&src, &samples);
+
+    let slice_with = |out: &Path, regions: &[(u32, u32)]| {
+        std::fs::create_dir_all(out).unwrap();
+        slice_contig_genos(
+            src.to_str().unwrap(),
+            out.to_str().unwrap(),
+            "chr1",
+            &(0..samples.len()).collect::<Vec<_>>(),
+            2,
+            regions,
+            OverlapMode::Variant,
+            Routing::Preserve,
+        )
+        .unwrap()
+    };
+
+    let one = vec![(0u32, 1_000u32)];
+    let many: Vec<(u32, u32)> = (0..16).map(|i| (i * 5, i * 5 + 1_000)).collect();
+
+    let out_one = tmp.path().join("out_one");
+    let b0 = search::search_tree_build_count();
+    let n_one = slice_with(&out_one, &one);
+    let cost_one = search::search_tree_build_count() - b0;
+
+    let out_many = tmp.path().join("out_many");
+    let b1 = search::search_tree_build_count();
+    let n_many = slice_with(&out_many, &many);
+    let cost_many = search::search_tree_build_count() - b1;
+
+    // Both region sets cover every fixture variant, so this is the same slice
+    // twice — any difference in tree builds is pure region-count overhead.
+    assert_eq!(n_one, 10, "the 1-region slice must keep all 10 variants");
+    assert_eq!(n_many, 10, "the 16-region slice must keep all 10 variants");
+    assert!(cost_one > 0, "fixture must build trees at all");
+    assert_eq!(
+        cost_many, cost_one,
+        "tree builds grew with region count: {cost_one} -> {cost_many}"
+    );
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" \
+  pixi run test-rust --test test_svar2_slice slice_tree_builds_do_not_scale_with_regions
+```
+
+Expected: FAIL on the final `assert_eq!`, with `cost_many` around `8 * 16 + 2 = 130` against `cost_one` around `8 + 2 = 10` — four var_key SNP columns plus four var_key indel columns rebuilt per region, over a constant 2 dense-class builds that Task 2 already hoisted. If instead it fails on `cost_one > 0` or on a variant count, the fixture is wrong; fix the fixture before touching `src/`.
+
+- [ ] **Step 4: Change `gather_var_key`'s injection point**
+
+In `src/svar2_slice.rs`, change the `overlap_range` parameter to a column-index factory and hoist the construction. Replace the parameter line and the `region_hits` call inside the column loop:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+fn gather_var_key(
+    positions: &[u32],
+    sample_orig_idx: &[usize],
+    ploidy: usize,
+    regions: &[(u32, u32)],
+    query_regions: &[(u32, u32)],
+    overlap: OverlapMode,
+    column_index: impl Fn(usize, usize) -> OverlapIndex<'static>,
+    key_of: impl Fn(usize) -> u32,
+    v_end_of: impl Fn(usize) -> u32,
+) -> Vec<GatheredCall> {
+    let mut out = Vec::new();
+    for (s_out, &s_orig) in sample_orig_idx.iter().enumerate() {
+        for p in 0..ploidy {
+            let col_out = s_out * ploidy + p;
+            // ONE index per column, built above the region loop inside
+            // `region_hits` — the #145 fix. Mirrors `find_ranges_haps`.
+            let ix = column_index(s_orig, p);
+            let hits = region_hits(
+                positions,
+                regions,
+                query_regions,
+                overlap,
+                |qsw, qew| ix.overlap(qsw, qew),
+                &v_end_of,
+            );
+            for i in hits {
+                out.push(GatheredCall {
+                    src: i,
+                    col_out,
+                    pos: positions[i],
+                    key: key_of(i),
+                });
+            }
+        }
+    }
+    out
+}
+```
+
+The old `col_src` local is gone — it was only ever passed to the closure, and both callers can derive it from `(s_orig, p)`. Remove the now-unused `let col_src = s_orig * ploidy + p;` line. Add `OverlapIndex` to the reader import at the top of the file:
+
+```rust
+use crate::query::reader::OverlapIndex;
+```
+
+Then update the doc comment above `gather_var_key`, whose last paragraph describes the old five-argument `overlap_range`:
+
+```
+/// `column_index(s_orig, p)` builds that column's search state ONCE, before the
+/// per-region loop; the SNP caller derives its flat column as `s_orig * ploidy
+/// + p`, the indel caller passes `(s_orig, p)` straight through because its
+/// `max_del` bound is per-(sample, ploid).
+```
+
+Also update `region_hits`'s doc comment, which names `overlap_range` as "the tree-based windowed search": it now receives an already-built index's `overlap`, so reword to "narrow via `overlap_range` (one region's window from the column's prebuilt `OverlapIndex` — identical to what `find_ranges` uses …)". Leave the rest of that comment, especially the load-bearing paragraph about the extent re-check, untouched.
+
+- [ ] **Step 5: Update the two call sites**
+
+In `src/svar2_slice.rs`, in `slice_genos_inner`, replace the two closures (currently lines 553 and 571):
+
+```rust
+        |s_orig, p| reader.vk_snp_index(s_orig * ploidy + p),
+```
+
+and
+
+```rust
+        // The indel channel's tree search needs a per-(sample, ploid) max_del
+        // bound — `s_orig` here must be the ORIGINAL column (`vk_indel_max_del`
+        // is indexed by the source cohort, not the subset), mirroring
+        // `find_ranges`'s `orig_s` usage.
+        |s_orig, p| reader.vk_indel_index(s_orig, p),
+```
+
+- [ ] **Step 6: Run the guard to verify it passes**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" \
+  pixi run test-rust --test test_svar2_slice slice_tree_builds_do_not_scale_with_regions
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the slice suite, then everything**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" pixi run test-rust --test test_svar2_slice
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" pixi run test-rust
+CARGO_TARGET_DIR="$CLAUDE_JOB_DIR/tmp/cargo-target" pixi run check-core
+```
+
+Expected: all PASS. The byte-parity tests (`slice_full_coverage_is_byte_identical_genos`, `preserve_identity_slice_is_byte_parity`) are the correctness net for this task — the slice must write identical bytes.
+
+- [ ] **Step 8: Run the Python suite**
+
+Run:
+
+```bash
+pixi run test
+```
+
+Expected: PASS. (`pixi run test` does NOT rebuild the Rust extension; that is fine here because no Python-visible behavior changed and the Python tests are only a regression net against accidental surface changes.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/svar2_slice.rs tests/test_svar2_slice.rs
+git commit -m "perf(svar2): build each var_key column's search tree once per slice
+
+gather_var_key was column-outer but built a fresh OverlapIndex inside the
+per-region loop, so a slice paid O(regions x columns) SearchTree builds —
+the shape #144 removed from find_ranges. Take a column-index factory instead
+of a range closure and build once per column.
+
+Guarded by a new slice-path tree-build test on a fixture wide enough to
+populate all four columns of both var_key channels plus both dense tables.
+
+Closes #145"
+```
+
+---
+
+## Verification Before Completion
+
+- [ ] `CARGO_TARGET_DIR=... pixi run test-rust` — full Rust suite green, test count unchanged except the one added test.
+- [ ] `CARGO_TARGET_DIR=... pixi run check-core` — query-core build green.
+- [ ] `pixi run test` — Python suite green.
+- [ ] `rg -n 'VkColumnIndex|dense_snp_overlap|dense_indel_overlap' src/ tests/` — no output.
+- [ ] Both complexity guards assert exact equality, and both were observed red before their fix landed.

--- a/docs/superpowers/specs/2026-07-31-svar2-overlap-index-hoist-design.md
+++ b/docs/superpowers/specs/2026-07-31-svar2-overlap-index-hoist-design.md
@@ -1,0 +1,227 @@
+# Hoist every per-region search-tree build behind one `OverlapIndex`
+
+Date: 2026-07-31
+Issue: [#145](https://github.com/d-laub/genoray/issues/145)
+Follow-up to: #144
+
+## Problem
+
+#144 removed the O(regions x columns) `SearchTree` rebuild from
+`query::find_ranges` by hoisting per-column state into `VkColumnIndex`. Three
+sibling sites still rebuild a search tree once per region.
+
+| Site | Rebuilt per call | Callers that loop over regions |
+| --- | --- | --- |
+| `VkColumnIndex` via `vk_snp_index` / `vk_indel_index` (`src/query/reader.rs:271`, `:292`) | `SearchTree` + a `v_ends` `Vec` sized to the column | `svar2_slice::gather_var_key` -> `region_hits` (`src/svar2_slice.rs:707`, `:737`) |
+| `DenseUnion::overlap` (`src/query/union.rs:31`) | `SearchTree` (`v_ends` / `max_del` already cached on the struct) | `find_ranges` (`src/query/gather.rs:479`), `overlap_batch_impl` (`src/query/gather.rs:233`), py `find_ranges` (`src/py_query_ranges.rs:281`), `oracle::overlap_sample` (single region) |
+| `ContigReader::dense_snp_overlap` / `dense_indel_overlap` (`src/query/reader.rs:333`, `:350`) | `SearchTree` + a `v_ends` `Vec` sized to the class table | `src/query/gather.rs:488`, `:492`; `src/py_query_ranges.rs:288`, `:292`; `svar2_slice::gather_dense` (`src/svar2_slice.rs:584`, `:595`) |
+
+The var_key row is #145 as filed: `gather_var_key` is column-outer, but the
+`overlap_range` closure it hands `region_hits` is
+`|qsw, qew| reader.vk_snp_index(col_src).overlap(qsw, qew)`, so a fresh index —
+including `SearchTree::new` — is constructed inside the per-region loop, per
+column. The dense rows are the same defect on a channel #144 did not touch, and
+they are shared with the read path: `find_ranges` still pays three tree builds
+per region (union, dense SNP, dense indel). #144's complexity guard budgets for
+exactly that (`allowed growth = 2 * Δregions`), so the leak is currently
+*asserted* rather than fixed.
+
+None of this is a regression. The pre-#144 methods rebuilt the same state on
+every call; #144 simply did not extend the fix past `find_ranges_haps`.
+
+Impact scales with regions per request, so it matters most for batch and
+read-bound callers.
+
+### Constraint that shapes the fix
+
+`dense_union()` has two classes of caller. `find_ranges`, `overlap_batch_impl`,
+py `find_ranges` and `oracle::overlap_sample` call `overlap` on the result.
+`gather_ranges` (`src/query/gather.rs:549`) and `ContigReader::max_deletion_len`
+(`src/query/reader.rs:324`) do not — `gather_ranges` advertises "Contains NO
+`SearchTree::new`" in its docstring, and `max_deletion_len` only wants
+`max_del`. Making the union's tree eager inside `dense_union()` would charge
+both of those a build they never use. The tree must therefore be built by an
+explicit, separately-constructed index, not by the union constructor.
+
+## Design
+
+### 1. One index type
+
+`VkColumnIndex` already models "region-independent search state over
+`(positions, v_ends, max_del)` at base offset `o0`". The dense class channels
+are the same thing with `o0 = 0`; the dense union is the same thing with
+`v_ends` already materialized on `DenseUnion`. Rename it `OverlapIndex` and make
+`v_ends` a `Cow`:
+
+```rust
+pub(crate) struct OverlapIndex<'a> {
+    /// Absolute base offset of this channel in the packed arrays (`0` for the
+    /// dense class tables and the union).
+    o0: usize,
+    /// `None` for an empty channel — `SearchTree` / `overlap_range` are not
+    /// defined over an empty position array.
+    inner: Option<(SearchTree, Cow<'a, [u32]>)>,
+    max_del: u32,
+}
+
+impl OverlapIndex<'_> {
+    pub(crate) fn overlap(&self, q_start: u32, q_end: u32) -> Range<usize>;
+}
+```
+
+Constructors:
+
+- `ContigReader::vk_snp_index(col) -> OverlapIndex<'static>` — body unchanged,
+  computed `v_ends` becomes `Cow::Owned`.
+- `ContigReader::vk_indel_index(sample, p) -> OverlapIndex<'static>` — same.
+- `ContigReader::dense_snp_index() -> OverlapIndex<'static>` — the body of the
+  deleted `dense_snp_overlap`, `o0 = 0`, `max_del = 0`.
+- `ContigReader::dense_indel_index() -> OverlapIndex<'static>` — the body of the
+  deleted `dense_indel_overlap`, `o0 = 0`, `max_del = self.dense_indel_max_del`.
+- `DenseUnion::index(&self) -> OverlapIndex<'_>` — borrows the union's existing
+  `v_ends` as `Cow::Borrowed`, so no per-query copy. `dense_union()` itself stays
+  tree-free.
+
+`dense_snp_overlap` and `dense_indel_overlap` are deleted; `DenseUnion::overlap`
+moves onto the index. The `Cow` is what lets one type serve both the channels
+that compute `v_ends` on the fly and the union that already stores it, without
+either a per-query `O(dense variants)` copy or a second near-identical struct.
+
+Rejected alternative: leave `VkColumnIndex` untouched and add `DenseClassIndex`
+plus `DenseUnionIndex`. That is three copies of the same six-line `overlap` body
+for no benefit.
+
+### 2. Hoist at every call site
+
+Every site becomes "build the index once, then map over regions".
+
+- `src/query/gather.rs:479-493` (`find_ranges`) — `dense.index()`,
+  `reader.dense_snp_index()`, `reader.dense_indel_index()` built once, above the
+  three `regions.iter().map(...).collect()` calls.
+- `src/query/gather.rs:233` (`overlap_batch_impl`) — union index built once
+  above the per-region `map`.
+- `src/py_query_ranges.rs:281-293` — same three indices as `find_ranges`.
+- `src/query/oracle.rs:54` — `dense.index().overlap(q_start, q_end)`. Single
+  region, so cost is unchanged; the edit is to keep one call convention.
+- `src/svar2_slice.rs` — `gather_var_key`'s injection point changes from a range
+  to an index:
+
+  ```rust
+  // was: overlap_range: impl Fn(usize, usize, usize, u32, u32) -> Range<usize>
+  column_index: impl Fn(usize, usize) -> OverlapIndex<'static>,   // (s_orig, p)
+  ```
+
+  built once inside the column loop, before `region_hits`:
+
+  ```rust
+  let ix = column_index(s_orig, p);
+  let hits = region_hits(
+      positions, regions, query_regions, overlap,
+      |qsw, qew| ix.overlap(qsw, qew), &v_end_of,
+  );
+  ```
+
+  Call sites in `slice_genos_inner` become
+  `|s_orig, p| reader.vk_snp_index(s_orig * ploidy + p)` and
+  `|s_orig, p| reader.vk_indel_index(s_orig, p)`, mirroring `find_ranges_haps`
+  (`src/query/gather.rs:393-394`). The `col_src` parameter is dropped — it is
+  derivable from `(s_orig, p)`, and both ignored-argument placeholders go with
+  it.
+
+- `src/svar2_slice.rs:576-597` — the two `gather_dense` calls get
+  `reader.dense_snp_index()` / `reader.dense_indel_index()` built once at the
+  call site in `slice_genos_inner`, passed as `|qsw, qew| ix.overlap(qsw, qew)`.
+  `gather_dense` calls `region_hits` exactly once per class, so hoisting to the
+  call site is sufficient; its signature does not change.
+
+`region_hits` itself is unchanged.
+
+### 3. Documentation corrections in the same pass
+
+- `src/query/union.rs:30-31` — "Builds a fresh search tree over `positions`
+  (cheap; one per region in a batch)" is no longer true.
+- `src/query/gather.rs:478` — "Region-independent union; `overlap` builds one
+  SearchTree per region".
+- `src/svar2_slice.rs` — `region_hits` and `gather_var_key` docstrings name the
+  old `overlap_range` parameter.
+- `src/query/reader.rs:243-246` — `VkColumnIndex`'s doc comment, which describes
+  only the var_key channel, generalizes to the renamed type.
+
+## Correctness
+
+Behavior is identical by construction: the same `(positions, v_ends, max_del,
+q_start, q_end)` reach `overlap_range`; only the point at which the tree is
+built moves. Outputs are byte-identical.
+
+Existing coverage is the net:
+
+- `tests/test_svar2_slice.rs` byte-parity tests
+  (`slice_full_coverage_is_byte_identical_genos`,
+  `preserve_identity_slice_is_byte_parity`,
+  `slice_one_sample_subset_decodes_equivalently_to_the_source`,
+  `the_three_overlap_modes_are_distinguishable`).
+- `tests/test_ranges_split.rs`, `tests/test_batch.rs`,
+  `tests/test_readbound_gather.rs` for the read paths, plus
+  `query::oracle::overlap_sample` parity.
+
+## Tests
+
+Both guards use `search::search_tree_build_count()` — the thread-local
+`SearchTree::new` counter already used by
+`test_find_ranges_tree_builds_do_not_scale_with_regions`.
+
+**Tighten the existing guard.**
+`tests/test_ranges_split.rs:443` currently allows `2 * Δregions` growth for the
+two legitimately-per-region dense trees. With all three sites hoisted, no
+channel builds a tree per region, so the assertion becomes exact equality:
+`cost_many == cost_one`. The allowance is removed, not widened.
+
+**New slice guard.** `tests/test_svar2_slice.rs` gets a sibling asserting the
+same exact equality across `slice_contig_genos` with 1 region vs. 16.
+`src/svar2_slice.rs` contains no rayon, so the counter stays observable on the
+test thread.
+
+**New wide fixture for that guard.** The existing `fixture_records()` populates
+only 1 of 4 var_key SNP columns and 1 of 4 indel columns. Following the lesson
+of commit 47be396 — a barely-discriminating guard guards little — the new test
+gets its own fixture:
+
+- one single-carrier SNP and one single-carrier indel per hap column (single
+  carrier so the cost model routes them VarKey, not Dense), so all four var_key
+  columns of both classes are populated; **and**
+- one multi-carrier (x=2) SNP and one multi-carrier indel, so both dense class
+  tables exist. Without these the slice guard would not exercise the dense
+  hoist at all — the dense channels would early-return on an absent table.
+
+Against unfixed code that fixture grows by 4 var_key SNP + 4 var_key indel +
+1 dense SNP + 1 dense indel = 10 tree builds per region, against an allowance
+of 0. It is a separate fixture so the byte-parity tests' expectations are
+untouched.
+
+The read-path guard in `tests/test_ranges_split.rs` already exercises the union
+and dense-indel channels on `synth_reader_wide` (its current allowance of 2 is
+exactly those two builds per region), so tightening it to 0 covers the union and
+dense-class hoists on that side.
+
+Both guards are verified red-then-green by stashing the fix, per the procedure
+recorded in 47be396's commit message.
+
+No separate benchmark. The build counters are the direct measurement of the
+complexity claim; a wall-clock benchmark would measure the same thing less
+precisely.
+
+## Build verification
+
+- `cargo test --no-default-features` (the pyo3 test binary fails to link
+  otherwise) with `CARGO_TARGET_DIR` off NFS.
+- `cargo check --no-default-features` specifically, because
+  `src/py_query_ranges.rs` is pyo3-gated and the query-core build has a known CI
+  coverage gap for changes that cross `lib.rs` module gating.
+- `pixi run test` for the Python suite.
+
+## Out of scope
+
+- `src/spine.rs:141` and `src/svar1_query.rs:60` build trees on the SVAR1 /
+  spine paths, which have a different call shape and are not region-looped here.
+- No public Python surface changes — `OverlapIndex` and every constructor are
+  `pub(crate)`. `skills/genoray-api/SKILL.md` needs no update.

--- a/src/py_query_ranges.rs
+++ b/src/py_query_ranges.rs
@@ -279,17 +279,20 @@ impl PyContigReader {
         };
 
         let dense = self.inner.dense_union();
+        let dense_ix = dense.index();
         let dense_range: Vec<Range<usize>> = regions
             .iter()
-            .map(|&(qs, qe)| dense.overlap(qs, qe))
+            .map(|&(qs, qe)| dense_ix.overlap(qs, qe))
             .collect();
+        let dense_snp_ix = self.inner.dense_snp_index();
         let dense_snp_range: Vec<Range<usize>> = regions
             .iter()
-            .map(|&(qs, qe)| self.inner.dense_snp_overlap(qs, qe))
+            .map(|&(qs, qe)| dense_snp_ix.overlap(qs, qe))
             .collect();
+        let dense_indel_ix = self.inner.dense_indel_index();
         let dense_indel_range: Vec<Range<usize>> = regions
             .iter()
-            .map(|&(qs, qe)| self.inner.dense_indel_overlap(qs, qe))
+            .map(|&(qs, qe)| dense_indel_ix.overlap(qs, qe))
             .collect();
         let region_starts: Vec<u32> = regions.iter().map(|&(qs, _)| qs).collect();
         let dmax = dense_max_end_keys(

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -355,8 +355,8 @@ pub const MAX_END_SHIFT: u32 = 21;
 /// samples: hap `h` is `(sample_cols[h / ploidy], h % ploidy)`, matching the
 /// sample-major-then-ploid order `find_ranges` has always produced.
 ///
-/// Column-outer / region-inner, so each column's `VkColumnIndex` is built
-/// exactly once. The max-end key rides along in the same sweep: `VkColumnIndex`
+/// Column-outer / region-inner, so each column's `OverlapIndex` is built
+/// exactly once. The max-end key rides along in the same sweep: `OverlapIndex`
 /// keeps positions sorted within a column with a contiguous overlap range, so
 /// the last element of each channel's range is the highest-position overlapping
 /// variant for that channel — no extra decode needed.
@@ -406,7 +406,7 @@ pub fn find_ranges_haps(
             // Positions are sorted within a column and the range is contiguous,
             // so the last element is the highest-position overlapping variant.
             // Reuses `a`/`b` (just computed above) instead of re-searching via
-            // `VkColumnIndex::last_overlapping` — that would double the
+            // `OverlapIndex::last_overlapping` — that would double the
             // `overlap()` calls in this hot loop for no benefit.
             let mut k = 0u64;
             if a.end > a.start {

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -232,9 +232,11 @@ fn overlap_batch_impl<T: DenseSrcElem>(
 
     let dense = reader.dense_union();
     // Per-region dense index ranges — shared across all samples in the region.
+    // One index for the whole batch: `SearchTree::new` runs once, not per region.
+    let dense_ix = dense.index();
     let ranges: Vec<Range<usize>> = regions
         .iter()
-        .map(|&(qs, qe)| dense.overlap(qs, qe))
+        .map(|&(qs, qe)| dense_ix.overlap(qs, qe))
         .collect();
 
     let mut vk: Vec<T> = Vec::new();
@@ -475,21 +477,25 @@ pub fn find_ranges(
     let n_regions = regions.len();
     let h = n_samples * ploidy;
 
-    // Region-independent union; `overlap` builds one SearchTree per region.
+    // Region-independent union and dense class indices, each built ONCE for the
+    // whole batch — this is the O(regions x channels) -> O(channels) fix.
     let dense = reader.dense_union();
+    let dense_ix = dense.index();
     let dense_range: Vec<Range<usize>> = regions
         .iter()
-        .map(|&(qs, qe)| dense.overlap(qs, qe))
+        .map(|&(qs, qe)| dense_ix.overlap(qs, qe))
         .collect();
     let region_starts: Vec<u32> = regions.iter().map(|&(qs, _)| qs).collect();
 
+    let dense_snp_ix = reader.dense_snp_index();
     let dense_snp_range: Vec<Range<usize>> = regions
         .iter()
-        .map(|&(qs, qe)| reader.dense_snp_overlap(qs, qe))
+        .map(|&(qs, qe)| dense_snp_ix.overlap(qs, qe))
         .collect();
+    let dense_indel_ix = reader.dense_indel_index();
     let dense_indel_range: Vec<Range<usize>> = regions
         .iter()
-        .map(|&(qs, qe)| reader.dense_indel_overlap(qs, qe))
+        .map(|&(qs, qe)| dense_indel_ix.overlap(qs, qe))
         .collect();
 
     // `find_ranges_haps` fills hap-major because that is the layout rayon can

--- a/src/query/oracle.rs
+++ b/src/query/oracle.rs
@@ -52,7 +52,7 @@ pub fn overlap_sample(
     let ploidy = reader.ploidy;
     let lut = reader.lut.as_ref();
     let dense = reader.dense_union();
-    let d_range = dense.overlap(q_start, q_end);
+    let d_range = dense.index().overlap(q_start, q_end);
     let (ds, de) = (d_range.start, d_range.end);
 
     let mut per_hap = Vec::with_capacity(ploidy);

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -351,44 +351,40 @@ impl ContigReader {
 }
 
 impl ContigReader {
-    /// Absolute `[s, e)` into `dense/snp`'s positions/keys for one region.
-    /// SNP v_end = pos + 1 (max_region_length = 0). `(0, 0)` if no snp table.
-    pub(crate) fn dense_snp_overlap(&self, q_start: u32, q_end: u32) -> Range<usize> {
-        let d = match &self.dense_snp {
-            Some(d) => d,
-            None => return 0..0,
+    /// Dense SNP class index, over `dense/snp`'s positions/keys. SNP `v_end =
+    /// pos + 1` (`max_region_length = 0`). Empty if there is no snp table.
+    pub(crate) fn dense_snp_index(&self) -> OverlapIndex<'static> {
+        let Some(d) = &self.dense_snp else {
+            return OverlapIndex::empty(0);
         };
         let positions = d.positions();
         if positions.is_empty() {
-            return 0..0;
+            return OverlapIndex::empty(0);
         }
         let v_ends: Vec<u32> = positions.iter().map(|&p| p + 1).collect();
-        let tree = SearchTree::new(positions);
-        let (s, e) = overlap_range(&tree, &v_ends, 0, q_start, q_end);
-        s..e
+        OverlapIndex::new(0, positions, Cow::Owned(v_ends), 0)
     }
 
-    /// Absolute `[s, e)` into `dense/indel`'s positions/keys for one region.
-    /// Indel v_end = pos + 1 + deletion_len(key); per-contig dense max_del bound.
-    pub(crate) fn dense_indel_overlap(&self, q_start: u32, q_end: u32) -> Range<usize> {
-        let d = match &self.dense_indel {
-            Some(d) => d,
-            None => return 0..0,
+    /// Dense indel class index, over `dense/indel`'s positions/keys. `v_end =
+    /// pos + 1 + deletion_len(key)`; the search bound is the per-contig dense
+    /// max_del. Empty if there is no indel table.
+    pub(crate) fn dense_indel_index(&self) -> OverlapIndex<'static> {
+        let Some(d) = &self.dense_indel else {
+            return OverlapIndex::empty(0);
         };
         let positions = d.positions();
         if positions.is_empty() {
-            return 0..0;
+            return OverlapIndex::empty(0);
         }
         let keys = as_u32(&d.keys);
+        // Fail fast on a corrupt sidecar rather than silently truncating.
         debug_assert_eq!(positions.len(), keys.len());
         let v_ends: Vec<u32> = positions
             .iter()
             .zip(keys.iter())
             .map(|(&pos, &key)| pos + 1 + rvk::deletion_len(key))
             .collect();
-        let tree = SearchTree::new(positions);
-        let (s, e) = overlap_range(&tree, &v_ends, self.dense_indel_max_del, q_start, q_end);
-        s..e
+        OverlapIndex::new(0, positions, Cow::Owned(v_ends), self.dense_indel_max_del)
     }
 }
 

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -2,6 +2,7 @@
 //! provides the per-hap var_key slice + search-range helpers that back both
 //! the union (`union.rs`) and gather (`gather.rs`) query paths.
 
+use std::borrow::Cow;
 use std::ops::Range;
 use std::path::Path;
 
@@ -237,22 +238,55 @@ impl ContigReader {
     }
 }
 
-/// Region-independent per-column search state for one var_key channel.
+/// Region-independent search state for one channel: a `SearchTree` over its
+/// positions, the parallel `v_ends` extents, and the deletion bound
+/// `overlap_range` needs.
 ///
-/// Built ONCE per column, then queried per region. Hoisting this out of the old
-/// per-`(region, column)` `vk_*_overlap` methods is what turns `find_ranges`
-/// from O(regions x columns) tree builds into O(columns): the packed store is
-/// swept once instead of once per region.
-pub(crate) struct VkColumnIndex {
-    /// Absolute base offset of this column in the channel's packed arrays.
+/// Built ONCE per channel, then queried per region. Hoisting this out of the
+/// old per-region `vk_*_overlap` / `dense_*_overlap` methods is what turns
+/// `find_ranges` and `svar2_slice`'s gather from O(regions x channels) tree
+/// builds into O(channels): each packed store is swept once instead of once
+/// per region.
+///
+/// `v_ends` is a `Cow` because the two kinds of channel differ in who owns the
+/// extents: the var_key columns and the dense class tables COMPUTE theirs
+/// (`pos + 1`, `pos + 1 + deletion_len(key)`) and must own the result, while
+/// `DenseUnion` already stores its own and can lend them — which is what keeps
+/// `DenseUnion::index` from copying an O(dense variants) array per query.
+pub(crate) struct OverlapIndex<'a> {
+    /// Absolute base offset of this channel in the packed arrays. `0` for the
+    /// dense class tables and the dense union, whose ranges are already
+    /// absolute; the var_key columns pass their column's start offset.
     pub(crate) o0: usize,
-    /// `None` for an empty column — `SearchTree`/`overlap_range` are not
+    /// `None` for an empty channel — `SearchTree`/`overlap_range` are not
     /// defined over an empty position array, matching the old early return.
-    inner: Option<(SearchTree, Vec<u32>)>,
+    inner: Option<(SearchTree, Cow<'a, [u32]>)>,
     max_del: u32,
 }
 
-impl VkColumnIndex {
+impl<'a> OverlapIndex<'a> {
+    /// Build the search state for a NON-EMPTY channel. `positions` must be
+    /// ascending and `v_ends[i]` must be the right extent of `positions[i]`.
+    pub(crate) fn new(o0: usize, positions: &[u32], v_ends: Cow<'a, [u32]>, max_del: u32) -> Self {
+        debug_assert!(!positions.is_empty(), "use OverlapIndex::empty instead");
+        debug_assert_eq!(positions.len(), v_ends.len());
+        OverlapIndex {
+            o0,
+            inner: Some((SearchTree::new(positions), v_ends)),
+            max_del,
+        }
+    }
+
+    /// An index over an empty channel: `overlap` always returns `o0..o0`, and
+    /// no `SearchTree` is built.
+    pub(crate) fn empty(o0: usize) -> Self {
+        OverlapIndex {
+            o0,
+            inner: None,
+            max_del: 0,
+        }
+    }
+
     /// Absolute `[start, end)` into the channel's packed positions/keys for one
     /// region. Every element of the returned range truly overlaps
     /// `[q_start, q_end)` — `overlap_range` does the left-overlap sub-scan.
@@ -268,38 +302,26 @@ impl VkColumnIndex {
 impl ContigReader {
     /// SNP-channel column index. SNP `v_end = pos + 1` and `max_region_length =
     /// 0`, since a SNP spans exactly one base.
-    pub(crate) fn vk_snp_index(&self, col: usize) -> VkColumnIndex {
+    pub(crate) fn vk_snp_index(&self, col: usize) -> OverlapIndex<'static> {
         let vk_range = self.vk_snp.column(col);
         let (o0, o1) = (vk_range.start, vk_range.end);
         let positions = &self.vk_snp.positions()[o0..o1];
         if positions.is_empty() {
-            return VkColumnIndex {
-                o0,
-                inner: None,
-                max_del: 0,
-            };
+            return OverlapIndex::empty(o0);
         }
         let v_ends: Vec<u32> = positions.iter().map(|&p| p + 1).collect();
-        VkColumnIndex {
-            o0,
-            inner: Some((SearchTree::new(positions), v_ends)),
-            max_del: 0,
-        }
+        OverlapIndex::new(o0, positions, Cow::Owned(v_ends), 0)
     }
 
     /// Indel-channel column index for `(sample, p)`. `v_end = pos + 1 +
     /// deletion_len(key)`; the search bound is this column's `max_del`.
-    pub(crate) fn vk_indel_index(&self, sample: usize, p: usize) -> VkColumnIndex {
+    pub(crate) fn vk_indel_index(&self, sample: usize, p: usize) -> OverlapIndex<'static> {
         let col = sample * self.ploidy + p;
         let vk_range = self.vk_indel.column(col);
         let (o0, o1) = (vk_range.start, vk_range.end);
         let positions = &self.vk_indel.positions()[o0..o1];
         if positions.is_empty() {
-            return VkColumnIndex {
-                o0,
-                inner: None,
-                max_del: 0,
-            };
+            return OverlapIndex::empty(o0);
         }
         let keys = &as_u32(&self.vk_indel.keys)[o0..o1];
         let v_ends: Vec<u32> = positions
@@ -307,11 +329,12 @@ impl ContigReader {
             .enumerate()
             .map(|(i, &pos)| pos + 1 + rvk::deletion_len(keys[i]))
             .collect();
-        VkColumnIndex {
+        OverlapIndex::new(
             o0,
-            inner: Some((SearchTree::new(positions), v_ends)),
-            max_del: self.vk_indel_max_del[[sample, p]],
-        }
+            positions,
+            Cow::Owned(v_ends),
+            self.vk_indel_max_del[[sample, p]],
+        )
     }
 }
 

--- a/src/query/union.rs
+++ b/src/query/union.rs
@@ -2,22 +2,22 @@
 //! position-sorted, used by the union-based (non-read-bound) query paths
 //! (`oracle::overlap_sample`, `gather::overlap_batch`, `gather::gather_ranges`).
 
+use std::borrow::Cow;
 use std::ops::Range;
 
 use crate::dense::DenseClass;
 use crate::query::gather::MAX_END_SHIFT;
 use crate::rvk;
-use crate::search::{SearchTree, overlap_range};
 use crate::spine::KeyRef;
 
-use super::reader::ContigReader;
+use super::reader::{ContigReader, OverlapIndex};
 use super::sidecar::{as_bytes, as_u32};
 
 /// The per-contig dense table unioned across `snp`+`indel`, position-sorted,
 /// carrying uniform keys plus the `(DenseClass, col)` needed to test carriage.
-/// Region-independent — built once per query; `overlap` derives each region's
-/// index range from it. `src[i] = (DenseClass, col)` addresses the original
-/// dense class table for the genotype-bit test.
+/// Region-independent and tree-free — built once per query; `index()` adds
+/// the search state for callers that range-query it. `src[i] = (DenseClass,
+/// col)` addresses the original dense class table for the genotype-bit test.
 pub(crate) struct DenseUnion {
     pub(crate) refs: Vec<KeyRef>,
     pub(crate) src: Vec<(DenseClass, usize)>,
@@ -27,15 +27,24 @@ pub(crate) struct DenseUnion {
 }
 
 impl DenseUnion {
-    /// `[s, e)` into `refs`/`src` for `[q_start, q_end)`, deletion-aware. Builds a
-    /// fresh search tree over `positions` (cheap; one per region in a batch).
-    pub(crate) fn overlap(&self, q_start: u32, q_end: u32) -> Range<usize> {
+    /// Region-independent search state over the union, built once by the
+    /// callers that actually search it.
+    ///
+    /// This is deliberately NOT built inside `dense_union()`: `gather_ranges`,
+    /// `dense_max_end_keys` and `ContigReader::max_deletion_len` all construct
+    /// a `DenseUnion` without ever overlapping it, and must not be charged a
+    /// `SearchTree::new` they never use. Borrows `v_ends`, so building an index
+    /// copies nothing.
+    pub(crate) fn index(&self) -> OverlapIndex<'_> {
         if self.refs.is_empty() {
-            return 0..0;
+            return OverlapIndex::empty(0);
         }
-        let tree = SearchTree::new(&self.positions);
-        let (s, e) = overlap_range(&tree, &self.v_ends, self.max_del, q_start, q_end);
-        s..e
+        OverlapIndex::new(
+            0,
+            &self.positions,
+            Cow::Borrowed(self.v_ends.as_slice()),
+            self.max_del,
+        )
     }
 
     /// The per-contig dense deletion bound, for the caller's overflow preflight.

--- a/src/svar2_slice.rs
+++ b/src/svar2_slice.rs
@@ -573,6 +573,10 @@ fn slice_genos_inner(
         |i| vk_indel_positions[i] + 1 + deletion_len(vk_indel_keys[i]),
     );
 
+    // One index per dense class for the whole request — `gather_dense` calls
+    // `region_hits` once per class, so building here is what keeps the
+    // per-region loop inside it tree-free.
+    let d_snp_ix = reader.dense_snp_index();
     let d_snp_g = gather_dense(
         reader.dense_snp.as_ref(),
         true,
@@ -581,9 +585,10 @@ fn slice_genos_inner(
         regions,
         &query_regions,
         overlap,
-        |qsw, qew| reader.dense_snp_overlap(qsw, qew),
+        |qsw, qew| d_snp_ix.overlap(qsw, qew),
     );
 
+    let d_indel_ix = reader.dense_indel_index();
     let d_indel_g = gather_dense(
         reader.dense_indel.as_ref(),
         false,
@@ -592,7 +597,7 @@ fn slice_genos_inner(
         regions,
         &query_regions,
         overlap,
-        |qsw, qew| reader.dense_indel_overlap(qsw, qew),
+        |qsw, qew| d_indel_ix.overlap(qsw, qew),
     );
 
     // ---- route ----

--- a/src/svar2_slice.rs
+++ b/src/svar2_slice.rs
@@ -46,6 +46,7 @@ use crate::layout::{self, ContigPaths, FieldSub};
 use crate::max_del;
 use crate::query::ContigReader;
 use crate::query::field::FieldView;
+use crate::query::reader::OverlapIndex;
 use crate::query::sidecar::{DenseView, as_bytes, as_u32};
 use crate::rvk::{deletion_len, pack_snp_keys, unpack_snp_key_at};
 use crate::svar2_view::{OverlapMode, keeps, query_window, read_n_samples};
@@ -550,7 +551,7 @@ fn slice_genos_inner(
         regions,
         &query_regions,
         overlap,
-        |col_src, _s_orig, _p, qsw, qew| reader.vk_snp_index(col_src).overlap(qsw, qew),
+        |s_orig, p| reader.vk_snp_index(s_orig * ploidy + p),
         |i| snp_code_to_key(unpack_snp_key_at(vk_snp_keys, i)),
         |i| vk_snp_positions[i] + 1,
     );
@@ -565,10 +566,10 @@ fn slice_genos_inner(
         &query_regions,
         overlap,
         // The indel channel's tree search needs a per-(sample, ploid) max_del
-        // bound — `sample` here must be the ORIGINAL column
+        // bound — `s_orig` here must be the ORIGINAL column
         // (`vk_indel_max_del` is indexed by the source cohort, not the
         // subset), mirroring `find_ranges`'s `orig_s` usage.
-        |_col_src, s_orig, p, qsw, qew| reader.vk_indel_index(s_orig, p).overlap(qsw, qew),
+        |s_orig, p| reader.vk_indel_index(s_orig, p),
         |i| vk_indel_keys[i],
         |i| vk_indel_positions[i] + 1 + deletion_len(vk_indel_keys[i]),
     );
@@ -688,9 +689,9 @@ fn slice_genos_inner(
 }
 
 /// Region-overlap hit indices into `positions` (ascending, deduped): for each
-/// region, narrow via `overlap_range` (the tree-based windowed search over
-/// `query_regions[i]`'s widened bounds — identical to what `find_ranges` uses
-/// for this same region/column/class), then keep the calls that pass BOTH the
+/// region, narrow via `overlap_range` (one region's window from the column's
+/// prebuilt `OverlapIndex` — identical to what `find_ranges` uses for this
+/// same region/column/class), then keep the calls that pass BOTH the
 /// `keeps` POS-precision filter (against the ORIGINAL, unwidened region bounds)
 /// AND the per-element left-extent re-check `q_start < v_end`. Multiple regions
 /// may re-discover the same call; `dedup` after sorting collapses that (mirrors
@@ -734,10 +735,12 @@ fn region_hits(
 /// reads the source call's key into the uniform 32-bit key space (a SNP code
 /// re-expanded via `snp_code_to_key`, or an indel key verbatim); `v_end_of(i)`
 /// its right extent. Column order is the OUTPUT order (`sample_orig_idx` x
-/// ploidy) so the CSR emit stays a simple scan. `overlap_range` takes `(col_src,
-/// s_orig, p, q_start_widened, q_end_widened)` — the SNP caller ignores
-/// `s_orig`/`p` (its window doesn't depend on them), the indel caller needs
-/// both for the per-(sample, ploid) `max_del` bound.
+/// ploidy) so the CSR emit stays a simple scan.
+///
+/// `column_index(s_orig, p)` builds that column's search state ONCE, before the
+/// per-region loop; the SNP caller derives its flat column as `s_orig * ploidy
+/// + p`, the indel caller passes `(s_orig, p)` straight through because its
+/// `max_del` bound is per-(sample, ploid).
 #[allow(clippy::too_many_arguments)]
 fn gather_var_key(
     positions: &[u32],
@@ -746,21 +749,23 @@ fn gather_var_key(
     regions: &[(u32, u32)],
     query_regions: &[(u32, u32)],
     overlap: OverlapMode,
-    overlap_range: impl Fn(usize, usize, usize, u32, u32) -> Range<usize>,
+    column_index: impl Fn(usize, usize) -> OverlapIndex<'static>,
     key_of: impl Fn(usize) -> u32,
     v_end_of: impl Fn(usize) -> u32,
 ) -> Vec<GatheredCall> {
     let mut out = Vec::new();
     for (s_out, &s_orig) in sample_orig_idx.iter().enumerate() {
         for p in 0..ploidy {
-            let col_src = s_orig * ploidy + p;
             let col_out = s_out * ploidy + p;
+            // ONE index per column, built above the region loop inside
+            // `region_hits` — the #145 fix. Mirrors `find_ranges_haps`.
+            let ix = column_index(s_orig, p);
             let hits = region_hits(
                 positions,
                 regions,
                 query_regions,
                 overlap,
-                |qsw, qew| overlap_range(col_src, s_orig, p, qsw, qew),
+                |qsw, qew| ix.overlap(qsw, qew),
                 &v_end_of,
             );
             for i in hits {

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -432,9 +432,12 @@ fn test_py_read_ranges_dict_matches_overlap_batch_dict() {
 /// no dense-snp tree at all — nothing routes Dense-SNP — so there are only 2
 /// legitimate per-region dense trees, not 3). Over the 15 extra regions below
 /// that's 90 actual tree builds against an allowance of 30: a real ~3x
-/// separation, not a tie. After the column-outer fix, var_key columns are
-/// built once total (hoisted out of the region loop), so growth is only the
-/// 2 dense trees/region = 30, comfortably within the allowance.
+/// separation, not a tie.
+///
+/// After the dense hoist (#145) NO channel builds a tree per region: the
+/// var_key columns, the dense union and the two dense class tables are each
+/// swept once per call, so `cost_many` must equal `cost_one` exactly — zero
+/// growth across all channels, not just the var_key ones.
 ///
 /// The fixture is deliberately small (2 samples x 2 ploidy = 4 columns, well
 /// under `PAR_COLUMN_THRESHOLD`) so the serial path runs on this thread and
@@ -457,15 +460,13 @@ fn test_find_ranges_tree_builds_do_not_scale_with_regions() {
     let _ = find_ranges(&reader, &many, None);
     let cost_many = search::search_tree_build_count() - b1;
 
-    // Only the per-region dense-union and dense-indel trees are legitimately
-    // per-region (this fixture builds no dense-snp tree, since nothing routes
-    // Dense-SNP). The var_key channels — the R*H term that made this
-    // O(regions x total_variants) — must not grow at all after the fix.
-    let dense_growth = 2 * (many.len() - one.len());
-    assert!(
-        cost_many <= cost_one + dense_growth,
-        "tree builds grew with region count: {cost_one} -> {cost_many} \
-         (allowed growth {dense_growth})"
+    // After the dense hoist (#145) NO channel builds a tree per region: the
+    // var_key columns, the dense union and the two dense class tables are each
+    // swept once per call. So this is exact equality, not an allowance — a
+    // budget here is what let the dense leak survive #144.
+    assert_eq!(
+        cost_many, cost_one,
+        "tree builds grew with region count: {cost_one} -> {cost_many}"
     );
 }
 
@@ -509,10 +510,10 @@ fn test_max_end_keys_pick_highest_position_variant() {
     let mut indel = vec![0i64; h * 2];
     let vk_keys = find_ranges_haps(&reader, &regions, &sample_cols, 0, h, &mut snp, &mut indel);
 
-    // `dense_union`/`DenseUnion::overlap` are pub(crate); this integration
+    // `dense_union`/`DenseUnion::index` are pub(crate); this integration
     // test crate is external to `genoray_core`, so the per-region dense range
     // is obtained via `find_ranges`'s public `dense_range` field instead —
-    // it's computed the same way (`reader.dense_union().overlap(qs, qe)`),
+    // it's computed the same way (`reader.dense_union().index().overlap(qs, qe)`),
     // independent of the sample subset.
     let dense_range = find_ranges(&reader, &regions, None).dense_range;
     let dense_keys = dense_max_end_keys(&reader, &regions, &dense_range, &sample_cols, true);

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -442,6 +442,16 @@ fn test_py_read_ranges_dict_matches_overlap_batch_dict() {
 /// The fixture is deliberately small (2 samples x 2 ploidy = 4 columns, well
 /// under `PAR_COLUMN_THRESHOLD`) so the serial path runs on this thread and
 /// `search::search_tree_build_count` — a thread-local — stays observable.
+///
+/// Coverage gap: `synth_reader_wide` has no multi-carrier SNP, so it builds
+/// no dense-SNP table, and both of its indels are multi-carrier and route
+/// Dense, so `vk_indel` is never populated either. `dense_snp_index()` and
+/// all four `vk_indel_index()` calls therefore return `OverlapIndex::empty`
+/// without ever building a tree, and this guard would NOT catch a regression
+/// that moved `reader.dense_snp_index()` (or a `vk_indel_index()` call) back
+/// inside the per-region loop in `find_ranges`. `slice_tree_builds_do_not_scale_with_regions`
+/// in `tests/test_svar2_slice.rs` covers both dense-class constructors on a
+/// fixture (`wide_fixture_records`) that populates them.
 #[test]
 fn test_find_ranges_tree_builds_do_not_scale_with_regions() {
     let tmp = tempdir().unwrap();
@@ -464,6 +474,7 @@ fn test_find_ranges_tree_builds_do_not_scale_with_regions() {
     // var_key columns, the dense union and the two dense class tables are each
     // swept once per call. So this is exact equality, not an allowance — a
     // budget here is what let the dense leak survive #144.
+    assert!(cost_one > 0, "fixture must build trees at all");
     assert_eq!(
         cost_many, cost_one,
         "tree builds grew with region count: {cost_one} -> {cost_many}"

--- a/tests/test_svar2_slice.rs
+++ b/tests/test_svar2_slice.rs
@@ -19,6 +19,7 @@ use genoray_core::mutcat::annotate::annotate_contig;
 use genoray_core::query::field::{FieldValue, FieldView};
 use genoray_core::query::{ContigReader, oracle::overlap_sample};
 use genoray_core::run_slice_view;
+use genoray_core::search;
 use genoray_core::svar2_slice::{Routing, slice_contig, slice_contig_genos};
 use genoray_core::svar2_view::OverlapMode;
 use pyo3::Python;
@@ -79,6 +80,71 @@ fn build_fixture_store(dir: &Path, samples: &[&str]) {
     // real value too for the full-coverage byte-parity check below to be
     // meaningful — recompute it here to undo the fixture's conservative
     // overwrite.
+    genoray_core::max_del::write_max_del(&dir.join("chr1"), samples.len(), 2).unwrap();
+    write_meta(
+        dir,
+        FORMAT_VERSION,
+        &samples.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        &["chr1".to_string()],
+        2,
+        &[],
+    )
+    .unwrap();
+}
+
+/// Ten records at n=2, ploidy=2 (np=4, flat gt order `[s0p0, s0p1, s1p0,
+/// s1p1]`) chosen so the tree-build guard below is actually discriminating:
+///
+/// * four single-carrier SNPs and four single-carrier indels, one per hap, so
+///   ALL FOUR columns of BOTH var_key channels are non-empty. An empty column
+///   early-returns without building a tree, so a fixture that populates only
+///   one column (as `fixture_records` does) barely moves the counter.
+/// * one x=2 SNP and one x=2 indel so both DENSE class tables exist. Without
+///   them the dense channels early-return and the guard would silently stop
+///   covering the dense hoist.
+///
+/// Single carrier vs. x=2 is what picks the route: at np=4 with no sidecar or
+/// field bits, `cost_model::choose_representation` keeps x=1 in VarKey and
+/// flips x=2 to Dense.
+///
+/// Used ONLY by `slice_tree_builds_do_not_scale_with_regions` — do not extend
+/// `fixture_records` for this, it is pinned by the byte-parity tests.
+fn wide_fixture_records() -> Vec<SynthRecord<'static>> {
+    let snp = |pos: i64, gt: Vec<i32>| SynthRecord {
+        pos,
+        ref_allele: b"A",
+        alts: vec![&b"C"[..]],
+        gt,
+    };
+    let del = |pos: i64, gt: Vec<i32>| SynthRecord {
+        pos,
+        ref_allele: b"ATG",
+        alts: vec![&b"A"[..]], // pure DEL, ilen = -2
+        gt,
+    };
+    vec![
+        // one single-carrier (VarKey) SNP per hap column
+        snp(10, vec![1, 0, 0, 0]),
+        snp(20, vec![0, 1, 0, 0]),
+        snp(30, vec![0, 0, 1, 0]),
+        snp(40, vec![0, 0, 0, 1]),
+        // one single-carrier (VarKey) indel per hap column
+        del(50, vec![1, 0, 0, 0]),
+        del(60, vec![0, 1, 0, 0]),
+        del(70, vec![0, 0, 1, 0]),
+        del(80, vec![0, 0, 0, 1]),
+        // x=2 => Dense, one per class, so both dense tables exist
+        snp(90, vec![1, 1, 0, 0]),
+        del(100, vec![0, 0, 1, 1]),
+    ]
+}
+
+fn build_wide_fixture_store(dir: &Path, samples: &[&str]) {
+    std::fs::create_dir_all(dir).unwrap();
+    let records = wide_fixture_records();
+    build_contig(dir, "chr1", samples, 2, &records);
+    // Same reason as `build_fixture_store`: `build_contig` overwrites max_del
+    // with a conservative fixture, so recompute the real routing-aware value.
     genoray_core::max_del::write_max_del(&dir.join("chr1"), samples.len(), 2).unwrap();
     write_meta(
         dir,
@@ -1875,4 +1941,64 @@ fn multi_contig_slice_is_thread_invariant() {
     for chrom in ["chr1", "chr2", "chr3"] {
         assert_sidecars_byte_equal(&out_a, &out_b, chrom);
     }
+}
+
+/// `gather_var_key` is column-outer, but until #145 the closure it handed
+/// `region_hits` built a fresh `OverlapIndex` — `SearchTree::new` and all —
+/// INSIDE the per-region loop, for every column. That is the same
+/// O(regions x columns) shape #144 removed from `find_ranges`.
+///
+/// After the fix no channel in the slice path builds a tree per region: eight
+/// var_key columns (four per class, all populated by `wide_fixture_records`)
+/// and two dense classes are each swept once per request. So this asserts
+/// EXACT equality, not an allowance.
+///
+/// `src/svar2_slice.rs` contains no rayon, so the whole slice runs on this
+/// thread and `search::search_tree_build_count` — a thread-local — stays
+/// observable. Each call gets its own output directory because a slice writes
+/// `{out}/chr1` and would otherwise overwrite the previous run.
+#[test]
+fn slice_tree_builds_do_not_scale_with_regions() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let samples = ["S0", "S1"];
+    build_wide_fixture_store(&src, &samples);
+
+    let slice_with = |out: &Path, regions: &[(u32, u32)]| {
+        std::fs::create_dir_all(out).unwrap();
+        slice_contig_genos(
+            src.to_str().unwrap(),
+            out.to_str().unwrap(),
+            "chr1",
+            &(0..samples.len()).collect::<Vec<_>>(),
+            2,
+            regions,
+            OverlapMode::Variant,
+            Routing::Preserve,
+        )
+        .unwrap()
+    };
+
+    let one = vec![(0u32, 1_000u32)];
+    let many: Vec<(u32, u32)> = (0..16).map(|i| (i * 5, i * 5 + 1_000)).collect();
+
+    let out_one = tmp.path().join("out_one");
+    let b0 = search::search_tree_build_count();
+    let n_one = slice_with(&out_one, &one);
+    let cost_one = search::search_tree_build_count() - b0;
+
+    let out_many = tmp.path().join("out_many");
+    let b1 = search::search_tree_build_count();
+    let n_many = slice_with(&out_many, &many);
+    let cost_many = search::search_tree_build_count() - b1;
+
+    // Both region sets cover every fixture variant, so this is the same slice
+    // twice — any difference in tree builds is pure region-count overhead.
+    assert_eq!(n_one, 10, "the 1-region slice must keep all 10 variants");
+    assert_eq!(n_many, 10, "the 16-region slice must keep all 10 variants");
+    assert!(cost_one > 0, "fixture must build trees at all");
+    assert_eq!(
+        cost_many, cost_one,
+        "tree builds grew with region count: {cost_one} -> {cost_many}"
+    );
 }


### PR DESCRIPTION
## Summary

Builds every SVAR2 range-search tree **once per channel** instead of once per
(region, channel), by unifying all five search-state constructors behind a single
`OverlapIndex` type and hoisting construction above every per-region loop.

#144 introduced `VkColumnIndex` — region-independent search state built once per
var_key column. Three sibling channels still rebuilt that state per region: the
dense union (`DenseUnion::overlap`), the two dense class tables
(`dense_snp_overlap` / `dense_indel_overlap`), and the var_key columns as consumed
by `svar2_slice::gather_var_key`. This turns those O(regions × channels)
`SearchTree::new` calls into O(channels).

Closes #145.

### What changed

| Commit | Change |
| --- | --- |
| `6772640` | `VkColumnIndex` → `OverlapIndex<'a>` with a `Cow<'a, [u32]>` for `v_ends` and shared `new`/`empty` constructors. Pure refactor. |
| `5b3184c` | Adds `dense_snp_index`, `dense_indel_index`, `DenseUnion::index()`; deletes the three `*_overlap` methods; hoists every call site (`gather.rs`, `py_query_ranges.rs`, `oracle.rs`, `svar2_slice.rs`). |
| `e924771` | `gather_var_key` takes a per-column `OverlapIndex` factory instead of a per-region range closure. |
| `ba9e486` | Roadmap correction + a positive control on the read-path guard. |

The `Cow` exists because the two kinds of channel differ in who owns the extents:
the var_key columns and dense class tables *compute* theirs and must own the
result, while `DenseUnion` already stores its own and can lend them — which keeps
`DenseUnion::index` from copying an O(dense variants) array.

`dense_union()` deliberately stays **tree-free**: `gather_ranges`,
`dense_max_end_keys` and `max_deletion_len` all build a `DenseUnion` without ever
searching it, and must not be charged a `SearchTree::new` they never use. The
search state is added by the separate `index()` method, only by callers that
range-query it.

### Behavior

No observable behavior change by construction — the same
`(positions, v_ends, max_del, q_start, q_end)` reach `overlap_range`; only the
moment the tree is built moves. No public Python surface change, so
`skills/genoray-api/SKILL.md` is untouched.

### Tests

Both complexity guards were **observed red before their fix landed**, and both
now assert exact zero growth (not an allowance) plus a `cost_one > 0` positive
control so neither can pass vacuously:

- `test_find_ranges_tree_builds_do_not_scale_with_regions` — dropped its
  2-builds-per-region allowance. Observed RED at `6 → 36` (growth `2 × 15`), GREEN at equality.
- `slice_tree_builds_do_not_scale_with_regions` (new, with a wide fixture that
  populates all four columns of both var_key channels plus both dense tables) —
  observed RED at `10 → 130`, GREEN at equality.

Full verification on a dedicated Slurm allocation against `ba9e486`:
`pixi run test-rust` all binaries 0 failed · `pixi run check-core` pass ·
`pixi run test` **809 passed, 5 skipped, 16 xfailed**.

### Known non-goals

`overlap_batch` still rebuilds a tree per (region, sample, ploid) via
`spine::gather_keys` — pre-existing, on the parity-oracle path rather than the hot
read path, and filed separately as #148. Note the design doc's stated reason for
excluding the spine paths ("not region-looped here") is inaccurate for
`overlap_batch_impl`, which *is* region-looped; the exclusion was still right for
this PR's scope.

## SVAR 2.0 roadmap check

- [x] Re-read `svar-2.md`, `data-model.md`, and `architecture.md`.
- [x] Milestone checkboxes/statuses updated to match reality (`[ ]` / `[~]` / `[x]`).
      No milestone changed state — this is a perf follow-up within an already-landed
      milestone, not a new one.
- [x] Any data-model or architecture change reconciled with the supplements **in this
      PR** — if the code now disagrees with a doc, the doc is wrong; fix it here.
      There is no data-model or architecture change: both docs' `SearchTree` /
      `overlap_range` references (`data-model.md:377`, `architecture.md:117`) describe
      the search core itself, which is unchanged — "Built once, queried many times" is
      simply more true now. The one doc that *had* gone stale was `svar-2.md:285-290`,
      which still described the dense-class indices as per-region; corrected in `ba9e486`.
- [x] New open questions recorded in the relevant "Open questions" section rather than
      left in your head. The one open question found (the `overlap_batch` spine path)
      is filed as #148 rather than as roadmap prose, since it is actionable work.
