### PR TITLE
perf(query): hoist the last region-scaled SearchTree builds (#148)

### DIFF
--- a/docs/superpowers/specs/2026-07-31-searchtree-construction-audit-design.md
+++ b/docs/superpowers/specs/2026-07-31-searchtree-construction-audit-design.md
@@ -1,0 +1,189 @@
+# SearchTree construction audit (closes #148)
+
+**Date:** 2026-07-31
+**Issue:** [#148](https://github.com/d-laub/genoray/issues/148)
+**Predecessors:** #144 (`find_ranges` var_key hoist), #145 (dense union + dense
+class tables + `svar2_slice` hoist)
+
+## Problem
+
+`SearchTree::new` is `O(n)` in a channel's variant count and allocates two
+`Vec<u32>`s. It is region-independent: the tree over a channel's positions does
+not depend on the query. Building one per region therefore multiplies a fixed
+cost by the region count for no benefit — the `O(regions x channels)` shape that
+#144 and #145 removed from `find_ranges` and `svar2_slice`.
+
+This spec audits every remaining construction site and closes the one #145 left
+behind, plus two adjacent instances of the same defect class (a
+region-independent structure rebuilt when it could be built once or not at all).
+
+## Audit
+
+Every non-test construction site in `src/`, and its verdict:
+
+| Site | Shape | Verdict |
+| --- | --- | --- |
+| `overlap_batch_impl` -> `vk_slice` -> `spine::gather_keys` (`gather.rs:246`) | `2 x R x S x P` builds | **DEFECT — #148** |
+| `ContigReader::max_deletion_len` (`reader.rs:347`) | builds a whole `DenseUnion` to read a scalar field | **DEFECT — adjacent** |
+| `read_ranges` (`gather.rs:951`) | builds `DenseUnion` twice per query | **DEFECT — adjacent** |
+| `find_ranges` / `find_ranges_haps` (`gather.rs:365`, `466`) | one index per column/contig, above the region loop | clean (#144/#145) |
+| `svar2_slice::gather_var_key` / `gather_dense` (`svar2_slice.rs:554-592`) | one index per column/class, above the region loop | clean (#145) |
+| `py_query_ranges::find_ranges_header` (`py_query_ranges.rs:281-296`) | one index per dense channel per call | clean (#145) |
+| `svar1_query::var_ranges` (`svar1_query.rs:60`) | one tree per contig batch | clean |
+| `DenseUnion::index` (`union.rs:38`) | built only by callers that search it | clean |
+| `oracle::overlap_sample` (`oracle.rs:61`) | `2 x P` builds on ONE region | not a defect (see below) |
+
+### Why `overlap_sample` is not in scope
+
+It is the documented tree-per-query reference implementation, takes a single
+region, and its per-ploid builds are each over a distinct column — none are
+redundant. After Fix 1 it becomes the sole caller of
+`vk_slice`/`spine::gather_keys`, which is the correct end state: the oracle
+keeps an implementation independent of the optimized path it cross-checks.
+
+### The `#148` defect in detail
+
+`overlap_batch_impl` loops region -> sample -> ploid around
+`reader.vk_slice(col, s, p, qs, qe)`. `vk_slice` calls `spine::gather_keys`
+twice (snp + indel sub-streams), and `gather_keys` builds a fresh `SearchTree`
+**and** a fresh `v_ends` vector on every call (`spine.rs:136-141`). Cost is
+`2 x R x S x P` tree builds where `2 x S x P` suffice.
+
+The #145 design doc excluded the spine paths as "not region-looped here"
+(`2026-07-31-svar2-overlap-index-hoist-design.md:224`). That rationale is
+inaccurate for `overlap_batch_impl`, which is region-looped. The exclusion was
+still right for #145's scope; the reason was not.
+
+## Design
+
+### Fix 1 — route `overlap_batch_impl` through the search/gather split
+
+`gather.rs:944` already documents `read_ranges(reader, regions, None)` as
+byte-identical to `overlap_batch`, and `tests/test_ranges_split.rs:450` asserts
+it at the Python-binding layer. So the batch path does not need a second
+hoisting mechanism — it needs to stop reimplementing the one that exists.
+
+Make `gather_ranges` generic over `T: DenseSrcElem`, following the
+`gather_haps_readbound` / `gather_haps_readbound_impl` pattern already used
+twice in this file:
+
+```rust
+fn gather_ranges_impl<T: DenseSrcElem>(
+    reader: &ContigReader,
+    rb: &RangesBundle,
+    dense: &DenseUnion,
+) -> BatchResult
+```
+
+- `pub fn gather_ranges` = `gather_ranges_impl::<KeyRef>` with a freshly built
+  union (signature and behaviour unchanged).
+- `overlap_batch` = `find_ranges_with(.., None, &dense)` +
+  `gather_ranges_impl::<KeyRef>(.., &dense)`.
+- `overlap_batch_src` = the same with `SrcKeyRef`, which is what restores
+  `vk_src` (via `T::split`) and `dense_src` (via `T::CARRIES_SRC`).
+
+The duplicated inner loop in `overlap_batch_impl` is deleted, not rewritten.
+Tree builds drop to `O(S x P)`.
+
+Two accepted consequences:
+
+- **Threading.** The batch path inherits `find_ranges_haps`'s rayon fan-out
+  above `PAR_COLUMN_THRESHOLD` (64) haps. Deterministic: haps write disjoint
+  `par_chunks_mut` slices and the only reduction (`max_end_keys`) is a max that
+  `overlap_batch` discards. `overlap_batch`'s "Single-threaded" doc comment is
+  stale and must be updated. Consequence for tests: the
+  `search_tree_build_count` thread-local is only observable below the
+  threshold, so guards must use a small fixture.
+- **Memory.** A `RangesBundle` (~32 B/hap) is materialized where the old loop
+  streamed. `_overlap_batch` is a gvl test-oracle entry point, not a hot read
+  path, so this is acceptable.
+
+The rejected alternative — hand `gather_keys` a prebuilt `OverlapIndex`, per
+the issue's suggested approach — requires inverting `overlap_batch_impl` to
+column-outer (its `vk_off` CSR is region-major) plus a region-major
+reassembly pass, i.e. a *third* var_key gather implementation alongside
+`gather_vk` and the tuned inline merge in `gather_haps_readbound_impl`.
+Hoisting all `S x P` column indices while staying region-outer is also
+rejected: peak memory becomes `O(total var_key calls on the contig)`.
+
+### Fix 2 — build `DenseUnion` once per query
+
+`find_ranges` and `gather_ranges` each build their own union, so `read_ranges`
+(public API) builds it twice — an `O(dense variants log dense variants)` sort
+paid twice per query. Thread the union explicitly:
+
+- private `find_ranges_with(reader, regions, samples, dense: &DenseUnion)`
+- private `gather_ranges_impl(reader, rb, dense: &DenseUnion)`
+- public `find_ranges` / `gather_ranges` build their own and delegate
+  (signatures unchanged)
+- `read_ranges` / `overlap_batch` / `overlap_batch_src` build ONE and pass it to
+  both halves
+
+Explicit plumbing rather than a `OnceLock` cache on `ContigReader`: caching
+would hold an `O(dense variants)` derived structure for the reader's whole
+lifetime, which is a memory regression on the population-scale write path that
+never queries it.
+
+### Fix 3 — `max_deletion_len` stops building a union
+
+`DenseUnion::max_del` is unconditionally `self.dense_indel_max_del`
+(`union.rs:100`), so
+
+```rust
+vk.max(self.dense_union().max_del())
+```
+
+is exactly
+
+```rust
+vk.max(self.dense_indel_max_del)
+```
+
+with an `O(n log n)` sort over every dense variant on the contig in between.
+Read the field. This removes a whole union build from
+`py_query_ranges::find_ranges_header` — the chunked path gvl's writer uses —
+which currently builds one union for the overflow preflight and a second one
+nine lines later for the real work. Update `union.rs:33-37`, which names
+`max_deletion_len` as a union-building caller.
+
+## Testing
+
+Complexity guards, in the established style: exact zero growth in
+`search::search_tree_build_count()` between a 1-region and a 16-region query,
+with a `cost_one > 0` positive control so the assertion cannot pass vacuously.
+Fixture is `synth_reader_wide` (2 samples x 2 ploidy = 4 columns, well under
+`PAR_COLUMN_THRESHOLD`) so the serial path runs on the test thread and the
+thread-local stays observable.
+
+1. `overlap_batch_tree_builds_do_not_scale_with_regions`
+2. `overlap_batch_src_tree_builds_do_not_scale_with_regions` — a separate
+   monomorphization, so it needs its own guard
+3. `assert_eq!(overlap_batch(&reader, &regions), read_ranges(&reader, &regions, None))`
+   — `BatchResult: PartialEq`, so this is a direct byte-identity assertion at
+   the Rust level, complementing the existing Python-binding dict comparison
+4. A value test for `max_deletion_len` on a fixture carrying both a long
+   var_key indel and a long dense deletion, pinning the max across both
+   channels
+
+Existing coverage that must keep passing unchanged:
+`tests/test_batch.rs` (`test_overlap_batch_matches_overlap_sample`,
+`prop_overlap_batch_matches_overlap_sample`),
+`tests/test_ranges_split.rs`, `tests/test_field_provenance.rs`
+(`overlap_batch_src` provenance).
+
+## Non-goals
+
+- No change to `oracle::overlap_sample`, `vk_slice`, or `spine::gather_keys`
+  beyond doc comments recording that the oracle is now their only caller.
+- No removal of `overlap_batch` in favour of `read_ranges`. It keeps a distinct
+  Python binding (`_overlap_batch`) that gvl's test oracles call, and
+  `overlap_batch_src` has no `read_ranges` counterpart.
+- No `DenseUnion` build counter analogous to `search_tree_build_count`. Fix 2's
+  correctness is structural (one binding passed to both halves), not something
+  worth a new observability hook.
+
+## Public API impact
+
+None. No name reachable from `import genoray` without an underscore changes in
+signature, return shape, dtype, or semantics — `read_ranges` returns the same
+bytes, just faster. `skills/genoray-api/SKILL.md` therefore needs no update.

--- a/docs/superpowers/specs/2026-07-31-svar2-overlap-index-hoist-design.md
+++ b/docs/superpowers/specs/2026-07-31-svar2-overlap-index-hoist-design.md
@@ -223,5 +223,13 @@ precisely.
 
 - `src/spine.rs:141` and `src/svar1_query.rs:60` build trees on the SVAR1 /
   spine paths, which have a different call shape and are not region-looped here.
+
+  **Correction (#148, 2026-07-31):** the second half of that sentence is wrong
+  for `spine.rs:141`. `overlap_batch_impl` *was* region-looped around
+  `vk_slice` -> `spine::gather_keys`, so it kept an `O(regions x columns)` tree
+  build after this PR. Excluding it was still right for this PR's scope; the
+  stated reason was not. Fixed in
+  `2026-07-31-searchtree-construction-audit-design.md`. (`svar1_query.rs:60` is
+  correctly described — it builds one tree per contig batch.)
 - No public Python surface changes — `OverlapIndex` and every constructor are
   `pub(crate)`. `skills/genoray-api/SKILL.md` needs no update.

--- a/src/query/gather.rs
+++ b/src/query/gather.rs
@@ -15,6 +15,7 @@ use crate::spine::{self, KeyRef, SrcKeyRef, VkElem};
 use super::decode::{HapCalls, decode_keyref};
 use super::reader::ContigReader;
 use super::sidecar::{as_bytes, as_u32};
+use super::union::DenseUnion;
 
 /// CSR presence-bitmask accumulator: owns the `(bits, offsets)` pair, one row of
 /// `nbits` bits appended per hap. `offsets` starts `[0]`; after each `push_hap`,
@@ -180,14 +181,23 @@ pub(crate) fn gather_vk<T: VkElem>(
 }
 
 /// Batched multi-region × whole-cohort query. `regions` is a list of half-open
-/// `[q_start, q_end)`. Single-threaded; `rayon` over the H hap-slices and dense-
-/// window subsetting are M6b concerns (see the design spec's open questions).
+/// `[q_start, q_end)`.
 ///
-/// The no-provenance, zero-cost path (`T = KeyRef`; byte-identical to before
-/// `overlap_batch_impl` was introduced — `vk_src` stays empty and `KeyRef::make`
-/// discards the provenance args, so `spine::pack_vk_src` never runs).
+/// The no-provenance path (`T = KeyRef`): `vk_src` stays empty and
+/// `KeyRef::make` discards the provenance args, so `spine::pack_vk_src` never
+/// runs.
+///
+/// Exactly `read_ranges(reader, regions, None)` — the whole-cohort case of the
+/// search/gather split, which is what this has always been *documented* to be
+/// byte-identical to. It used to be a second, independent region-outer loop
+/// calling `vk_slice` per (region, sample, ploid), which rebuilt each column's
+/// `SearchTree` once per region (#148). Routing it through `find_ranges`
+/// instead of hoisting inside a duplicated loop is what drops that to one build
+/// per column AND removes the duplicate. Note the search half fans out over
+/// rayon above `PAR_COLUMN_THRESHOLD` haps, so this is no longer
+/// single-threaded.
 pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
-    overlap_batch_impl::<KeyRef>(reader, regions)
+    batch_impl::<KeyRef>(reader, regions, None)
 }
 
 /// As `overlap_batch`, but additionally populates `vk_src` so a consumer can
@@ -195,7 +205,7 @@ pub fn overlap_batch(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResu
 /// index)` and index a `FieldView`. This is the entry point
 /// `decode_batch_fields` uses to read fields over the whole-cohort batch path.
 pub fn overlap_batch_src(reader: &ContigReader, regions: &[(u32, u32)]) -> BatchResult {
-    overlap_batch_impl::<SrcKeyRef>(reader, regions)
+    batch_impl::<SrcKeyRef>(reader, regions, None)
 }
 
 /// Local extension of `spine::VkElem` (kept in `gather.rs` rather than
@@ -217,91 +227,23 @@ impl DenseSrcElem for SrcKeyRef {
     const CARRIES_SRC: bool = true;
 }
 
-/// Shared body of `overlap_batch`/`overlap_batch_src`, generic over `T: VkElem`
-/// the same way `gather_haps_readbound_impl` is (see that function's doc
-/// comment). The only difference from the original monomorphic
-/// `overlap_batch` is `reader.vk_slice::<T>(...)`, the final `T::split(vk)`,
-/// and (for `dense_src`) `T::CARRIES_SRC`.
-fn overlap_batch_impl<T: DenseSrcElem>(
+/// Shared body of `overlap_batch`/`overlap_batch_src`/`read_ranges`: the fused
+/// search+gather, generic over `T: DenseSrcElem` the same way
+/// `gather_haps_readbound_impl` is (see that function's doc comment).
+///
+/// The `DenseUnion` is built HERE, exactly once, and lent to the search half
+/// before being handed to the gather half by value. Letting `find_ranges` and
+/// `gather_ranges` each build their own — which is what the public wrappers do,
+/// since they are separately callable — costs a second
+/// `O(dense variants log dense variants)` sort per query.
+fn batch_impl<T: DenseSrcElem>(
     reader: &ContigReader,
     regions: &[(u32, u32)],
+    samples: Option<&[usize]>,
 ) -> BatchResult {
-    let ploidy = reader.ploidy;
-    let n_samples = reader.n_samples;
-    let n_regions = regions.len();
-
     let dense = reader.dense_union();
-    // Per-region dense index ranges — shared across all samples in the region.
-    // One index for the whole batch: `SearchTree::new` runs once, not per region.
-    let dense_ix = dense.index();
-    let ranges: Vec<Range<usize>> = regions
-        .iter()
-        .map(|&(qs, qe)| dense_ix.overlap(qs, qe))
-        .collect();
-
-    let mut vk: Vec<T> = Vec::new();
-    let mut vk_off: Vec<usize> = vec![0];
-    let mut presence = PresenceBitWriter::new();
-
-    for (r, &(qs, qe)) in regions.iter().enumerate() {
-        let (ds, de) = (ranges[r].start, ranges[r].end);
-        for s in 0..n_samples {
-            for p in 0..ploidy {
-                let col = s * ploidy + p;
-
-                // var_key channel slice for (region r, sample s, ploid p).
-                let slice: Vec<T> = reader.vk_slice(col, s, p, qs, qe);
-                vk.extend_from_slice(&slice);
-                vk_off.push(vk.len());
-
-                // dense presence bits over dense[ds..de].
-                let nbits = de - ds;
-                presence.push_hap(nbits, |k| {
-                    let j = ds + k;
-                    let (class, dcol) = dense.src[j];
-                    let carried = reader
-                        .dense_view(class)
-                        .expect("dense src implies table")
-                        .carried(col, dcol);
-                    carried && dense.v_ends[j] > qs
-                });
-            }
-        }
-    }
-
-    let (dense_present, dense_present_off) = presence.into_parts();
-    // Project the generic element back into the frozen (vk, vk_src) contract
-    // — see `gather_haps_readbound_impl`'s identical final step.
-    let (vk, vk_src) = T::split(vk);
-
-    // Capture dense provenance ONCE, here, where `dense` (the whole-contig
-    // union) is already built exactly once per query — this is what lets
-    // `decode_hap_src` avoid ever calling `dense_union()` itself. Only paid
-    // for on the provenance-carrying path (`T::CARRIES_SRC`); the plain path
-    // stays a `Vec::new()`.
-    let dense_src: Vec<(bool, u32)> = if T::CARRIES_SRC {
-        dense
-            .src
-            .iter()
-            .map(|&(class, col)| (matches!(class, crate::dense::DenseClass::Indel), col as u32))
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    BatchResult {
-        n_regions,
-        n_samples,
-        ploidy,
-        vk,
-        vk_off,
-        vk_src,
-        dense: dense.refs,
-        dense_range: ranges,
-        dense_present,
-        dense_present_off,
-        dense_src,
-    }
+    let rb = find_ranges_with(reader, regions, samples, &dense);
+    gather_ranges_impl::<T>(reader, &rb, dense)
 }
 
 /// Search-only half of the batch query: every `SearchTree::new` runs here, and
@@ -468,6 +410,19 @@ pub fn find_ranges(
     regions: &[(u32, u32)],
     samples: Option<&[usize]>,
 ) -> RangesBundle {
+    find_ranges_with(reader, regions, samples, &reader.dense_union())
+}
+
+/// `find_ranges` over a caller-supplied `DenseUnion`. Split out so `batch_impl`
+/// can build the union once and hand the SAME one to the gather half; the
+/// public `find_ranges` above builds its own, since it is separately callable
+/// (`_find_ranges` on the Python side) and its bundle is replayed later.
+fn find_ranges_with(
+    reader: &ContigReader,
+    regions: &[(u32, u32)],
+    samples: Option<&[usize]>,
+    dense: &DenseUnion,
+) -> RangesBundle {
     let ploidy = reader.ploidy;
     let sample_cols: Vec<usize> = match samples {
         Some(s) => s.to_vec(),
@@ -479,7 +434,6 @@ pub fn find_ranges(
 
     // Region-independent union and dense class indices, each built ONCE for the
     // whole batch — this is the O(regions x channels) -> O(channels) fix.
-    let dense = reader.dense_union();
     let dense_ix = dense.index();
     let dense_range: Vec<Range<usize>> = regions
         .iter()
@@ -544,23 +498,38 @@ pub fn find_ranges(
     }
 }
 
-/// Tree-free gather: replay a `RangesBundle` into the same `BatchResult` that
-/// `overlap_batch` produces. Contains NO `SearchTree::new` — the search
-/// already happened in `find_ranges`. Mirrors `overlap_batch`'s inner loop
-/// exactly, except the var_key channel is replayed from the precomputed
-/// ranges (no per-column `SearchTree` rebuild, no per-element `carried` test
-/// — `vk_slice`'s `carried` closure is `|_| true` for both channels, so only
-/// the `q_start < v_end` left-overlap re-check remains) and the loop runs
-/// over the *selected* sample slots.
+/// Tree-free gather: replay a `RangesBundle` into a `BatchResult`. Contains NO
+/// `SearchTree::new` — the search already happened in `find_ranges`. The
+/// var_key channel is replayed from the precomputed ranges (no per-column
+/// `SearchTree` rebuild, no per-element `carried` test — the oracle's
+/// `vk_slice` passes `|_| true` for both channels, so only the `q_start <
+/// v_end` left-overlap re-check remains), and the loop runs over the
+/// *selected* sample slots.
 pub fn gather_ranges(reader: &ContigReader, rb: &RangesBundle) -> BatchResult {
+    let dense = reader.dense_union();
+    gather_ranges_impl::<KeyRef>(reader, rb, dense)
+}
+
+/// Shared body of `gather_ranges` / the gather half of `batch_impl`, generic
+/// over `T: DenseSrcElem` exactly as `gather_haps_readbound_impl` is: `T =
+/// KeyRef` leaves `vk_src`/`dense_src` empty and compiles the provenance away,
+/// `T = SrcKeyRef` populates both.
+///
+/// Takes the `DenseUnion` BY VALUE: `BatchResult::dense` is `dense.refs` moved
+/// out, so borrowing here would force an `O(dense variants)` clone. The search
+/// half only ever needs `&DenseUnion`, and it always runs first, so
+/// lend-then-hand-over is the natural ordering.
+fn gather_ranges_impl<T: DenseSrcElem>(
+    reader: &ContigReader,
+    rb: &RangesBundle,
+    dense: DenseUnion,
+) -> BatchResult {
     let ploidy = rb.ploidy;
     let n_samples = rb.n_samples;
     let n_regions = rb.n_regions;
     let hpr = n_samples * ploidy; // haps per region
 
-    let dense = reader.dense_union();
-
-    let mut vk: Vec<KeyRef> = Vec::new();
+    let mut vk: Vec<T> = Vec::new();
     let mut vk_off: Vec<usize> = vec![0];
     let mut presence = PresenceBitWriter::new();
 
@@ -584,7 +553,7 @@ pub fn gather_ranges(reader: &ContigReader, rb: &RangesBundle) -> BatchResult {
                 vk.extend_from_slice(&merged);
                 vk_off.push(vk.len());
 
-                // --- dense presence bits (verbatim from overlap_batch) ---
+                // --- dense presence bits ---
                 let nbits = de - ds;
                 presence.push_hap(nbits, |k| {
                     let j = ds + k;
@@ -600,6 +569,24 @@ pub fn gather_ranges(reader: &ContigReader, rb: &RangesBundle) -> BatchResult {
     }
 
     let (dense_present, dense_present_off) = presence.into_parts();
+    // Project the generic element back into the frozen (vk, vk_src) contract
+    // — see `gather_haps_readbound_impl`'s identical final step.
+    let (vk, vk_src) = T::split(vk);
+
+    // Capture dense provenance ONCE, here, where `dense` (the whole-contig
+    // union) is already built exactly once per query — this is what lets
+    // `decode_hap_src` avoid ever calling `dense_union()` itself. Only paid
+    // for on the provenance-carrying path (`T::CARRIES_SRC`); the plain path
+    // stays a `Vec::new()`.
+    let dense_src: Vec<(bool, u32)> = if T::CARRIES_SRC {
+        dense
+            .src
+            .iter()
+            .map(|&(class, col)| (matches!(class, crate::dense::DenseClass::Indel), col as u32))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     BatchResult {
         n_regions,
@@ -607,12 +594,12 @@ pub fn gather_ranges(reader: &ContigReader, rb: &RangesBundle) -> BatchResult {
         ploidy,
         vk,
         vk_off,
-        vk_src: Vec::new(),
+        vk_src,
         dense: dense.refs,
         dense_range: rb.dense_range.clone(),
         dense_present,
         dense_present_off,
-        dense_src: Vec::new(),
+        dense_src,
     }
 }
 
@@ -940,15 +927,19 @@ pub fn dense_abs_row(on_disk: &Range<usize>, out: &Range<usize>, i: usize) -> us
     on_disk.start + (i - out.start)
 }
 
-/// Fused search+gather: `find_ranges` then `gather_ranges` in one call. The
+/// Fused search+gather: the search half then the gather half in one call. The
 /// public/live-query analog of the split; byte-identical to `overlap_batch`
-/// when `samples = None`, and the parity oracle for sample subsetting.
+/// when `samples = None` — literally the same code path — and the parity oracle
+/// for sample subsetting.
+///
+/// Not `gather_ranges(reader, &find_ranges(..))`: that spelling builds the
+/// `DenseUnion` twice, once in each half. `batch_impl` builds it once.
 pub fn read_ranges(
     reader: &ContigReader,
     regions: &[(u32, u32)],
     samples: Option<&[usize]>,
 ) -> BatchResult {
-    gather_ranges(reader, &find_ranges(reader, regions, samples))
+    batch_impl::<KeyRef>(reader, regions, samples)
 }
 
 impl BatchResult {

--- a/src/query/reader.rs
+++ b/src/query/reader.rs
@@ -149,6 +149,13 @@ impl ContigReader {
     /// Generic over `T: VkElem` so the no-provenance (`KeyRef`) and
     /// provenance-carrying (`SrcKeyRef`) callers share one body; `T = KeyRef`
     /// is zero-cost (`KeyRef::make` discards the provenance args).
+    ///
+    /// Search and gather are FUSED here: each call rebuilds the column's
+    /// `SearchTree` via `spine::gather_keys`. That is correct for the single
+    /// region `oracle::overlap_sample` asks for — now the only caller — and
+    /// deliberately independent of the optimized `find_ranges`/`gather_ranges`
+    /// path it cross-checks. Do NOT call it inside a region loop: that is the
+    /// `O(regions x columns)` shape #148 removed from `overlap_batch`.
     pub(crate) fn vk_slice<T: spine::VkElem>(
         &self,
         col: usize,
@@ -340,13 +347,21 @@ impl ContigReader {
 
 impl ContigReader {
     /// The largest deletion span on this contig across both the per-hap indel
-    /// channel and the dense union. Callers packing max-end keys must check
-    /// `1 + max_deletion_len() < (1 << MAX_END_SHIFT)` before doing so — a
-    /// pathological >~2 Mb deletion footprint would otherwise silently corrupt
-    /// the packed key.
+    /// channel and the dense class tables. Callers packing max-end keys must
+    /// check `1 + max_deletion_len() < (1 << MAX_END_SHIFT)` before doing so —
+    /// a pathological >~2 Mb deletion footprint would otherwise silently
+    /// corrupt the packed key.
+    ///
+    /// Reads `dense_indel_max_del` directly rather than going through
+    /// `dense_union().max_del()`: `DenseUnion::max_del` is unconditionally a
+    /// copy of this same field (`union.rs`), so the union build was an
+    /// `O(dense variants log dense variants)` sort over the whole contig for a
+    /// value already resident. That mattered on the chunked write path, where
+    /// `find_ranges_header` calls this for its overflow preflight and then
+    /// builds a union of its own for the real work.
     pub fn max_deletion_len(&self) -> u32 {
         let vk = self.vk_indel_max_del.iter().copied().max().unwrap_or(0);
-        vk.max(self.dense_union().max_del())
+        vk.max(self.dense_indel_max_del)
     }
 }
 

--- a/src/query/union.rs
+++ b/src/query/union.rs
@@ -30,11 +30,10 @@ impl DenseUnion {
     /// Region-independent search state over the union, built once by the
     /// callers that actually search it.
     ///
-    /// This is deliberately NOT built inside `dense_union()`: `gather_ranges`,
-    /// `dense_max_end_keys` and `ContigReader::max_deletion_len` all construct
-    /// a `DenseUnion` without ever overlapping it, and must not be charged a
-    /// `SearchTree::new` they never use. Borrows `v_ends`, so building an index
-    /// copies nothing.
+    /// This is deliberately NOT built inside `dense_union()`: `gather_ranges`
+    /// and `dense_max_end_keys` both take a `DenseUnion` without ever
+    /// overlapping it, and must not be charged a `SearchTree::new` they never
+    /// use. Borrows `v_ends`, so building an index copies nothing.
     pub(crate) fn index(&self) -> OverlapIndex<'_> {
         if self.refs.is_empty() {
             return OverlapIndex::empty(0);
@@ -45,11 +44,6 @@ impl DenseUnion {
             Cow::Borrowed(self.v_ends.as_slice()),
             self.max_del,
         )
-    }
-
-    /// The per-contig dense deletion bound, for the caller's overflow preflight.
-    pub(crate) fn max_del(&self) -> u32 {
-        self.max_del
     }
 }
 

--- a/src/spine.rs
+++ b/src/spine.rs
@@ -3,9 +3,13 @@
 //! `gather_keys` and `merge_keys` are the pure half of what M5's `query.rs`
 //! did inline: overlap-resolve a position run into undecoded `(position, key)`
 //! pairs, and merge already-sorted runs. They carry **uniform 32-bit keys** and
-//! never touch alleles or the LUT — decoding is the consumer's job. Splitting
-//! them out lets both `overlap_sample` and the batched `overlap_batch` share one
-//! gather/merge and one uniform-key convention.
+//! never touch alleles or the LUT — decoding is the consumer's job.
+//!
+//! `merge_by_position` is shared by every query path. `gather_keys` is NOT: it
+//! fuses a `SearchTree` build into each call, which only suits a single-region
+//! query, so since #148 its one caller is `ContigReader::vk_slice` ->
+//! `oracle::overlap_sample`. The batched paths hoist the search into
+//! `find_ranges` and replay it with `gather_vk`.
 
 use crate::search::{SearchTree, overlap_range};
 

--- a/tests/test_ranges_split.rs
+++ b/tests/test_ranges_split.rs
@@ -5,6 +5,7 @@ mod common;
 
 use common::{SynthRecord, build_contig};
 use genoray_core::py_query::PyContigReader;
+use genoray_core::query::gather::overlap_batch_src;
 use genoray_core::query::{
     ContigReader, MAX_END_SHIFT, PAR_COLUMN_THRESHOLD, dense_max_end_keys, find_ranges,
     find_ranges_haps, gather_ranges, overlap_batch, read_ranges,
@@ -771,4 +772,165 @@ fn test_max_end_keys_parallel_matches_serial_reduction() {
     // Sanity: the fixture actually carries a variant in [0, 1000), so this
     // isn't vacuously comparing two zero vectors.
     assert_ne!(whole[0], 0);
+}
+
+/// Companion to `test_find_ranges_tree_builds_do_not_scale_with_regions` for
+/// the batch entry point (#148). `overlap_batch` used to run its OWN
+/// region-outer loop calling `vk_slice` per (region, sample, ploid), and
+/// `vk_slice` -> `spine::gather_keys` rebuilds the column's `SearchTree` on
+/// every call — so tree builds were `O(regions x columns)` here long after
+/// #144/#145 had removed that shape from `find_ranges` and `svar2_slice`.
+///
+/// Same fixture and same reasoning as the `find_ranges` guard: `synth_reader`
+/// populates only one of the four `vk_snp` columns, which lets the unfixed
+/// growth tie a per-region allowance, so this uses `synth_reader_wide` (all 4
+/// columns non-empty). 4 columns is well under `PAR_COLUMN_THRESHOLD`, so the
+/// search half stays on this thread and `search::search_tree_build_count` — a
+/// thread-local — remains observable.
+///
+/// Exact equality, not an allowance: no channel may build a tree per region.
+#[test]
+fn test_overlap_batch_tree_builds_do_not_scale_with_regions() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader_wide(&out);
+
+    let one = vec![(0u32, 1_000_000u32)];
+    let many: Vec<(u32, u32)> = (0..16).map(|i| (i * 20, i * 20 + 1_000_000)).collect();
+
+    let b0 = search::search_tree_build_count();
+    let _ = overlap_batch(&reader, &one);
+    let cost_one = search::search_tree_build_count() - b0;
+
+    let b1 = search::search_tree_build_count();
+    let _ = overlap_batch(&reader, &many);
+    let cost_many = search::search_tree_build_count() - b1;
+
+    assert!(cost_one > 0, "fixture must build trees at all");
+    assert_eq!(
+        cost_many, cost_one,
+        "tree builds grew with region count: {cost_one} -> {cost_many}"
+    );
+}
+
+/// As above for `overlap_batch_src`. It is a separate monomorphization of the
+/// same body, so it needs its own guard: a regression could reintroduce the
+/// per-region search on the provenance path alone.
+#[test]
+fn test_overlap_batch_src_tree_builds_do_not_scale_with_regions() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader_wide(&out);
+
+    let one = vec![(0u32, 1_000_000u32)];
+    let many: Vec<(u32, u32)> = (0..16).map(|i| (i * 20, i * 20 + 1_000_000)).collect();
+
+    let b0 = search::search_tree_build_count();
+    let _ = overlap_batch_src(&reader, &one);
+    let cost_one = search::search_tree_build_count() - b0;
+
+    let b1 = search::search_tree_build_count();
+    let _ = overlap_batch_src(&reader, &many);
+    let cost_many = search::search_tree_build_count() - b1;
+
+    assert!(cost_one > 0, "fixture must build trees at all");
+    assert_eq!(
+        cost_many, cost_one,
+        "tree builds grew with region count: {cost_one} -> {cost_many}"
+    );
+}
+
+/// `overlap_batch` has always been DOCUMENTED as byte-identical to
+/// `read_ranges(.., None)`; since #148 it is literally the same code path.
+/// Asserted directly on `BatchResult` (which is `PartialEq`) rather than only
+/// through the Python dict comparison in
+/// `test_overlap_batch_matches_read_ranges_all_samples`, so a divergence is
+/// caught on every field of the struct, not just the payload keys the binding
+/// exposes.
+#[test]
+fn test_overlap_batch_equals_read_ranges_all_samples_struct() {
+    let tmp = tempdir().unwrap();
+    let out = tmp.path().join("out");
+    std::fs::create_dir_all(&out).unwrap();
+    let reader = synth_reader_wide(&out);
+
+    let regions = vec![(0u32, 250u32), (90u32, 310u32), (900u32, 950u32)];
+    let batch = overlap_batch(&reader, &regions);
+    // Not vacuous: the fixture carries variants in these regions.
+    assert!(!batch.vk.is_empty() || !batch.dense.is_empty());
+    assert_eq!(batch, read_ranges(&reader, &regions, None));
+}
+
+/// `max_deletion_len` must report the max deletion span across BOTH the
+/// per-hap var_key indel channel and the dense indel table. It used to reach
+/// the dense term via `dense_union().max_del()`, which built (and sorted) a
+/// whole-contig union to read a scalar the reader already holds; it now reads
+/// the field. This pins the value so that shortcut cannot silently drop a
+/// channel — `find_ranges_header` uses it as the packed-key overflow preflight,
+/// where under-reporting would corrupt a max-end key rather than fail loudly.
+///
+/// Two fixtures, one per channel, because the answer is a single number: each
+/// puts the LONGER deletion in a different channel. The `find_ranges` bundle
+/// assertions confirm the intended channel is actually populated, so neither
+/// case can pass while exercising only the other term.
+#[test]
+fn test_max_deletion_len_spans_both_indel_channels() {
+    // gt [1, 1, 0, 1] = 3 of 4 haps -> routed Dense; [1, 0, 0, 0] -> VarKey
+    // (see `synth_reader_wide`'s note on `cost_model::choose_representation`).
+    let dense_long = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"ATTTTTT", // ILEN -6
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 0, 1],
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"ATT", // ILEN -2
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+    ];
+    let vk_long = vec![
+        SynthRecord {
+            pos: 100,
+            ref_allele: b"ATTTTTT", // ILEN -6
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 0, 0, 0],
+        },
+        SynthRecord {
+            pos: 200,
+            ref_allele: b"ATT", // ILEN -2
+            alts: vec![&b"A"[..]],
+            gt: vec![1, 1, 0, 1],
+        },
+    ];
+
+    for (label, records) in [("dense", dense_long), ("var_key", vk_long)] {
+        let tmp = tempdir().unwrap();
+        let out = tmp.path().join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        build_contig(&out, "chr1", &["S0", "S1"], 2, &records);
+        let reader = ContigReader::open(out.to_str().unwrap(), "chr1", 2, 2).unwrap();
+
+        assert_eq!(
+            reader.max_deletion_len(),
+            6,
+            "{label} fixture: longest deletion is 6 bases"
+        );
+
+        // Coverage check: both channels must actually hold an indel, so
+        // neither case is silently testing the other term.
+        let rb = find_ranges(&reader, &[(0u32, 1_000u32)], None);
+        assert!(
+            rb.dense_indel_range.iter().any(|r| r.end > r.start),
+            "{label} fixture: dense indel table must be populated"
+        );
+        assert!(
+            rb.vk_indel_range.iter().any(|r| r.end > r.start),
+            "{label} fixture: var_key indel channel must be populated"
+        );
+    }
 }


### PR DESCRIPTION
Closes #148.

An audit of every `SearchTree` / `OverlapIndex` / `DenseUnion` construction site in `src/`, plus fixes for the three defects it found.

## Audit

| Site | Shape | Verdict |
| --- | --- | --- |
| `overlap_batch_impl` → `vk_slice` → `spine::gather_keys` | `2 × R × S × P` builds | **defect — #148** |
| `ContigReader::max_deletion_len` | builds a whole `DenseUnion` to read a scalar field | **defect — adjacent** |
| `read_ranges` | builds `DenseUnion` twice per query | **defect — adjacent** |
| `find_ranges` / `find_ranges_haps` | one index per column/contig, above the region loop | clean (#144/#145) |
| `svar2_slice::gather_var_key` / `gather_dense` | one index per column/class | clean (#145) |
| `py_query_ranges::find_ranges_header` | one index per dense channel per call | clean (#145) |
| `svar1_query::var_ranges` | one tree per contig batch | clean |
| `DenseUnion::index` | built only by callers that search it | clean |
| `oracle::overlap_sample` | `2 × P` builds on ONE region | not a defect — single-region reference impl |

## Fix 1 — `overlap_batch` (#148)

`overlap_batch`/`overlap_batch_src` ran their own region-outer loop calling `vk_slice` per (region, sample, ploid), and `vk_slice` → `spine::gather_keys` rebuilds the column's `SearchTree` *and* its `v_ends` on every call.

Rather than hoist inside the duplicated loop, this routes the batch path through the search/gather split it has always been documented as byte-identical to: `gather_ranges` becomes generic over the provenance element type, and `overlap_batch` / `overlap_batch_src` / `read_ranges` all share one `batch_impl`. Tree builds drop to one per column, and ~90 lines of duplicated gather loop are deleted.

The rejected alternative — handing `gather_keys` a prebuilt `OverlapIndex`, per the issue's suggested approach — needs the loop inverted to column-outer (`vk_off` is region-major CSR) plus a reassembly pass, i.e. a *third* var_key gather implementation.

`spine::gather_keys` is now reached only by `oracle::overlap_sample`, which is the right end state: the reference implementation keeps a search independent of the path it cross-checks.

Two consequences, both documented in the code: the batch path picks up `find_ranges_haps`'s rayon fan-out above `PAR_COLUMN_THRESHOLD` haps (so `overlap_batch`'s "single-threaded" doc is now corrected), and it materializes a `RangesBundle` (~32 B/hap) where the old loop streamed. `_overlap_batch` is a gvl test-oracle entry point, not a hot read path.

## Fix 2 — `DenseUnion` built once per query

`read_ranges` built it twice, once in each half. `batch_impl` now builds one, lends it to the search half, and hands it to the gather half by value (`BatchResult::dense` is `dense.refs` moved out, so borrowing would force an `O(dense variants)` clone). The public `find_ranges`/`gather_ranges` keep their signatures and build their own, since they are separately callable.

## Fix 3 — `max_deletion_len` stops building a union

`DenseUnion::max_del` is unconditionally a copy of `self.dense_indel_max_del`, so the call was an `O(dense variants log dense variants)` sort for a value already resident. This removes a whole union build from `find_ranges_header` — the chunked path gvl's writer uses, which was building one union for the overflow preflight and a second nine lines later. `DenseUnion::max_del` had no other caller and is deleted.

## Tests

Guards mirror `test_find_ranges_tree_builds_do_not_scale_with_regions`: exact zero growth in `search_tree_build_count()` from 1 to 16 regions, with a `cost_one > 0` positive control, on the 4-column `synth_reader_wide` fixture (under `PAR_COLUMN_THRESHOLD`, so the thread-local stays observable). On this fixture the pre-fix code went 5 → 65 builds.

- `test_overlap_batch_tree_builds_do_not_scale_with_regions`
- `test_overlap_batch_src_tree_builds_do_not_scale_with_regions` — separate monomorphization, own guard
- `test_overlap_batch_equals_read_ranges_all_samples_struct` — struct-level equality, so every field is covered, not just the payload keys the Python binding exposes
- `test_max_deletion_len_spans_both_indel_channels` — two fixtures, one per channel, with `find_ranges` bundle assertions confirming the intended channel is actually populated

Verified on a compute node: `cargo fmt --check`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo check --no-default-features`, `cargo test --no-default-features --features conversion` (all suites green, 4 new tests passing), `maturin develop --release`, and `pixi run test` — **809 passed, 5 skipped, 16 xfailed, 0 failed**.

## Docs

Design spec at `docs/superpowers/specs/2026-07-31-searchtree-construction-audit-design.md`. The #145 spec's "not region-looped here" rationale — the inaccuracy issue #148 called out — gets an inline correction.

No public API change, so `skills/genoray-api/SKILL.md` needs no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)